### PR TITLE
feat(ai-squad): add read-before-write pipeline and project file disco…

### DIFF
--- a/ai_squad/tools/__init__.py
+++ b/ai_squad/tools/__init__.py
@@ -9,10 +9,13 @@ dependencies) can be imported and tested even when crewai is not installed.
 try:
     from .project_tools import (  # noqa: F401
         AWSStatusTool,
+        GetLatestMigrationTool,
         GitOpsTool,
+        ListProjectFilesTool,
         ReadContextFileTool,
         ReadGovernanceFileTool,
         ReadPendingTasksTool,
+        ReadProjectFileTool,
         ReadSchemaTool,
         ReadTasksSectionTool,
         ReadTasksTool,


### PR DESCRIPTION
…very tools

Root cause of previous failure: Backend Dev agent was writing files without reading what already existed, causing complete overwrites of existing models, schemas and service code.

New tools in project_tools.py:
- ReadProjectFileTool (read_project_file): reads any file relative to project root with anti-escape guard. Returns FILE_NOT_FOUND if file does not exist yet, so agent knows whether to create or modify.
- ListProjectFilesTool (list_project_files): lists files in any project directory (excluding __pycache__). Used to discover what exists before creating new files.
- GetLatestMigrationTool (get_latest_migration): reads migrations/versions/, finds the latest .py file, and extracts its revision ID. Prevents broken Alembic chains from wrong down_revision values.

Pipeline refactor in main.py (3 tasks → 4 tasks):
- task_plan: PM reads pending tasks and produces concrete plan with exact paths
- task_read (NEW): Backend Dev reads every file in the plan before touching anything. Produces a reading report with current content and latest migration revision. This task is read-only — no writes allowed.
- task_code: Backend Dev integrates new code into what was read. Explicit rules: db.Model style (not declarative Base), Graphene not Ariadne, add don't replace. Includes branch creation and commit.
- task_test: QA runs pytest and reports exact pass/fail counts and coverage.

BRIEFING updated with explicit file-level instructions for B8 so the agent knows exactly what to ADD to which existing files.