### PR TITLE
chore(dx): harden pre-commit runtime and local sonar defaults

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
   hooks:
   - id: mypy
     name: mypy
-    entry: bash -c '.venv/bin/mypy app || python -m mypy app'
+    entry: bash -c '.venv/bin/python -m mypy app || python3 -m mypy app'
     language: system
     pass_filenames: false
   - id: sonar-local-check
@@ -55,7 +55,7 @@ repos:
     stages: [pre-push]
   - id: pip-audit
     name: pip-audit (dependencies)
-    entry: bash -c '.venv/bin/pip-audit -r requirements.txt || pip-audit -r requirements.txt'
+    entry: bash -c '.venv/bin/python -m pip_audit -r requirements.txt || python3 -m pip_audit -r requirements.txt'
     language: system
     pass_filenames: false
     stages: [pre-push]

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -121,11 +121,12 @@ Hooks:
 - `gitleaks` com `.gitleaks.toml`
 - `detect-private-key`
 - `mypy`
-- `sonar-local-check` (modo `advisory` local por padrão; `enforce` em CI ou com override)
+- `sonar-local-check` (opt-in local; `enforce` em CI ou com override)
 - pre-push: `security-evidence`, `pip-audit`
 
 Política do `sonar-local-check`:
-- Local (default): `SONAR_LOCAL_MODE=advisory` para não bloquear push por quality gate remoto.
+- Local (default): `AURAXIS_ENABLE_LOCAL_SONAR=false` (skip não bloqueante para evitar latência alta no fluxo diário).
+- Local opt-in: `AURAXIS_ENABLE_LOCAL_SONAR=true` para executar scanner e rating checks.
 - CI: `SONAR_LOCAL_MODE=enforce` automaticamente quando `CI=true`.
 - Override local estrito: `AURAXIS_ENFORCE_LOCAL_SONAR=true`.
 

--- a/scripts/bootstrap_local_env.sh
+++ b/scripts/bootstrap_local_env.sh
@@ -17,11 +17,11 @@ fi
 
 echo "Installing dependencies in ${VENV_DIR}"
 "${VENV_DIR}/bin/python" -m pip install --upgrade pip
-"${VENV_DIR}/bin/pip" install -r "${ROOT_DIR}/requirements.txt" -r "${ROOT_DIR}/requirements-dev.txt"
+"${VENV_DIR}/bin/python" -m pip install -r "${ROOT_DIR}/requirements.txt" -r "${ROOT_DIR}/requirements-dev.txt"
 
 echo "Installing pre-commit hooks"
-"${VENV_DIR}/bin/pre-commit" install
-"${VENV_DIR}/bin/pre-commit" install --hook-type pre-push
+"${VENV_DIR}/bin/python" -m pre_commit install
+"${VENV_DIR}/bin/python" -m pre_commit install --hook-type pre-push
 
 echo
 echo "Bootstrap completed."

--- a/scripts/sonar_local_check.sh
+++ b/scripts/sonar_local_check.sh
@@ -6,6 +6,7 @@ cd "$ROOT_DIR"
 
 SONAR_HOST_URL="${SONAR_HOST_URL:-https://sonarcloud.io}"
 SONAR_LOCAL_MODE="${SONAR_LOCAL_MODE:-advisory}"
+AURAXIS_ENABLE_LOCAL_SONAR="${AURAXIS_ENABLE_LOCAL_SONAR:-false}"
 
 if [[ "${CI:-false}" == "true" ]]; then
   SONAR_LOCAL_MODE="enforce"
@@ -13,6 +14,13 @@ fi
 
 if [[ "${AURAXIS_ENFORCE_LOCAL_SONAR:-false}" == "true" ]]; then
   SONAR_LOCAL_MODE="enforce"
+fi
+
+if [[ "$AURAXIS_ENABLE_LOCAL_SONAR" != "true" ]]; then
+  echo "[sonar-local] advisory: local sonar check is disabled by default (AURAXIS_ENABLE_LOCAL_SONAR=false)."
+  echo "[sonar-local] advisory: set AURAXIS_ENABLE_LOCAL_SONAR=true to run local sonar scanner."
+  echo "[sonar-local] advisory: CI Sonar gate remains mandatory."
+  exit 0
 fi
 
 normalize_env_var() {


### PR DESCRIPTION
## Summary

<!-- What changed and why -->

## Task Reference

- Task ID: `A/B/C/...` (ex.: `B11`, `PLT1`)
- Backlog updated in `/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-api/TASKS.md`: [ ] yes

## Validation

- [ ] `bash scripts/run_ci_like_actions_local.sh --local --fast`
- [ ] `pytest` for affected domain(s)
- [ ] `mypy` for affected module(s)

## API Contract Checklist (Mandatory)

- [ ] OpenAPI/Swagger was validated for changed endpoints.
- [ ] REST and GraphQL parity reviewed when applicable.
- [ ] Backward compatibility policy respected (`.context/16_contract_compatibility_policy.md`).

## Backend -> Frontend Handoff (Mandatory when contract changed)

- [ ] `Feature Contract Pack` published (`.context/feature_contracts/<TASK_ID>.json/.md`).
- [ ] `auth`, `error_contract`, `examples` and rollout notes included in the pack.

## Risks / Follow-ups

<!-- Residual risk, technical debt, and next action -->
