### PR TITLE
chore(dx): enable safe dependabot auto-merge policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,25 @@ updates:
       time: "09:00"
       timezone: "America/Sao_Paulo"
     open-pull-requests-limit: 5
+    groups:
+      pip-patch-updates:
+        update-types:
+          - patch
+      pip-dev-minor-updates:
+        dependency-type: development
+        update-types:
+          - minor
     labels:
       - "dependencies"
       - "security"
+      - "auto-merge"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -23,3 +39,12 @@ updates:
     labels:
       - "dependencies"
       - "security"
+      - "github-actions"
+      - "auto-merge"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,37 @@
+name: Auto-merge Dependabot PRs
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+jobs:
+  auto-merge:
+    name: Enable auto-merge for Dependabot PRs
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    if: |
+      github.actor == 'dependabot[bot]' &&
+      contains(github.event.pull_request.labels.*.name, 'auto-merge')
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge (patch / minor only)
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Skip — major version update (manual review required)
+        if: steps.metadata.outputs.update-type == 'version-update:semver-major'
+        run: |
+          echo "Major update detected. Auto-merge skipped."
+          echo "PR: ${{ github.event.pull_request.html_url }}"

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -130,6 +130,17 @@ Política do `sonar-local-check`:
 - CI: `SONAR_LOCAL_MODE=enforce` automaticamente quando `CI=true`.
 - Override local estrito: `AURAXIS_ENFORCE_LOCAL_SONAR=true`.
 
+## Dependabot + auto-merge (dependências)
+
+Arquivos:
+- `.github/dependabot.yml`
+- `.github/workflows/auto-merge.yml`
+
+Política:
+- auto-merge apenas para updates `patch` e `minor`;
+- updates `major` exigem revisão manual;
+- merge automático só conclui com checks obrigatórios da branch protection em verde.
+
 ## Reproducao local (CI-like)
 
 Script oficial:


### PR DESCRIPTION
## Summary

<!-- What changed and why -->

## Task Reference

- Task ID: `A/B/C/...` (ex.: `B11`, `PLT1`)
- Backlog updated in `/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-api/TASKS.md`: [ ] yes

## Validation

- [ ] `bash scripts/run_ci_like_actions_local.sh --local --fast`
- [ ] `pytest` for affected domain(s)
- [ ] `mypy` for affected module(s)

## API Contract Checklist (Mandatory)

- [ ] OpenAPI/Swagger was validated for changed endpoints.
- [ ] REST and GraphQL parity reviewed when applicable.
- [ ] Backward compatibility policy respected (`.context/16_contract_compatibility_policy.md`).

## Backend -> Frontend Handoff (Mandatory when contract changed)

- [ ] `Feature Contract Pack` published (`.context/feature_contracts/<TASK_ID>.json/.md`).
- [ ] `auth`, `error_contract`, `examples` and rollout notes included in the pack.

## Risks / Follow-ups

<!-- Residual risk, technical debt, and next action -->
