### PR TITLE
fix(ci): split risky dependabot toolchain updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,10 +12,6 @@ updates:
       pip-patch-updates:
         update-types:
           - patch
-      pip-dev-minor-updates:
-        dependency-type: development
-        update-types:
-          - minor
     labels:
       - "dependencies"
       - "security"

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -142,6 +142,10 @@ Política:
 - merge automático só conclui com checks obrigatórios da branch protection em verde.
 - jobs dependentes de secrets externos devem ficar `skipped` quando o token não estiver
   disponível em PRs automatizados (ex.: Dependabot), nunca `failed`.
+- no ecossistema Python do backend, updates `minor` de dependências de desenvolvimento
+  não são agrupados. Ferramentas como `mypy`, `pre-commit`, `bandit`, `pip-audit`,
+  `schemathesis`, `flake8` e stubs tipados devem abrir PRs individuais para isolar
+  regressões de toolchain e evitar lotes com centenas de erros não atribuíveis.
 
 ## Reproducao local (CI-like)
 


### PR DESCRIPTION
## Contexto
O PR `dependabot/pip/pip-dev-minor-updates-14aac2a286` agrupou 7 updates de tooling Python, incluindo `mypy 1.11.2 -> 1.19.1`.

Isso fez o CI perder granularidade: o upgrade de tipagem passou a falhar com `115 errors in 17 files`, principalmente `untyped-decorator` e `unused-ignore`, mas o lote também continha `pre-commit`, `bandit`, `pip-audit`, `schemathesis`, `flake8` e `pyflakes`.

## O que muda
- remove o agrupamento `pip-dev-minor-updates` do Dependabot no backend;
- mantém agrupamento apenas para `patch`;
- documenta a política no `docs/CI_CD.md`.

## Resultado esperado
- updates `minor` de ferramentas como `mypy`, `pre-commit`, `schemathesis`, `bandit`, `flake8` e stubs tipados passam a abrir PRs individuais;
- o CI volta a apontar a causa real do bloqueio;
- auto-merge continua funcionando para PRs que ficarem verdes.

## Validação
- parse YAML de `.github/dependabot.yml`
- commit local com hooks verdes (`mypy`, `pip-audit`, `security-evidence`)
