### PR TITLE
refactor(api): add x3 request context adapter

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,9 +1,8 @@
 import os
-from uuid import uuid4
 
 from apispec import APISpec
 from apispec.ext.marshmallow import MarshmallowPlugin
-from flask import Flask, Response, g
+from flask import Flask
 from flask_apispec import FlaskApiSpec
 from flask_jwt_extended import JWTManager
 from flask_marshmallow import Marshmallow
@@ -27,6 +26,7 @@ from app.extensions.audit_trail import register_audit_trail
 from app.extensions.database import db
 from app.extensions.error_handlers import register_error_handlers
 from app.extensions.integration_metrics_cli import register_integration_metrics_commands
+from app.http.request_context import register_request_context_adapter
 from app.middleware.cors import register_cors
 from app.middleware.docs_access import register_docs_access_guard
 from app.middleware.security_headers import register_security_headers
@@ -63,15 +63,6 @@ def create_app() -> Flask:
             app.config.setdefault("SQLALCHEMY_ENGINE_OPTIONS", {})
             app.config["SQLALCHEMY_ENGINE_OPTIONS"].update({"poolclass": NullPool})
     validate_security_configuration()
-
-    @app.before_request
-    def bind_request_id() -> None:
-        g.request_id = uuid4().hex
-
-    @app.after_request
-    def append_request_id_header(response: Response) -> Response:
-        response.headers["X-Request-Id"] = str(getattr(g, "request_id", "n/a"))
-        return response
 
     # Inicializa extensões
     db.init_app(app)
@@ -127,6 +118,7 @@ def create_app() -> Flask:
     register_user_dependencies(app)
     register_transaction_dependencies(app)
     register_goal_dependencies(app)
+    register_request_context_adapter(app)
     register_cors(app)
     register_security_headers(app)
     register_docs_access_guard(app)

--- a/app/controllers/auth/forgot_password_resource.py
+++ b/app/controllers/auth/forgot_password_resource.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 from typing import Any
 
-from flask import Response, current_app, request
+from flask import Response, current_app
 from flask_apispec.views import MethodResource
 
 from app.application.services.password_reset_service import (
     PASSWORD_RESET_NEUTRAL_MESSAGE,
 )
+from app.http.request_context import get_request_context
 from app.schemas.auth_schema import ForgotPasswordSchema
 from app.utils.typed_decorators import typed_doc as doc
 from app.utils.typed_decorators import typed_use_kwargs as use_kwargs
@@ -18,12 +19,13 @@ from .guard import guard_login_check, guard_register_failure
 
 
 def _build_password_reset_context(*, dependencies: Any, email: str) -> Any:
+    request_context = get_request_context()
     return dependencies.build_login_attempt_context(
         principal=f"password-reset:{email}",
-        remote_addr=request.remote_addr,
-        user_agent=request.headers.get("User-Agent"),
-        forwarded_for=request.headers.get("X-Forwarded-For"),
-        real_ip=request.headers.get("X-Real-IP"),
+        remote_addr=request_context.client_ip,
+        user_agent=request_context.user_agent,
+        forwarded_for=request_context.headers.get("x-forwarded-for"),
+        real_ip=request_context.headers.get("x-real-ip"),
         known_principal=False,
     )
 

--- a/app/controllers/auth/login_resource.py
+++ b/app/controllers/auth/login_resource.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 from typing import Any
 
-from flask import Response, current_app, request
+from flask import Response, current_app
 from flask_apispec.views import MethodResource
 
 from app.extensions.database import db
+from app.http.request_context import get_request_context
 from app.schemas.auth_schema import AuthSchema
 from app.utils.typed_decorators import typed_doc as doc
 from app.utils.typed_decorators import typed_use_kwargs as use_kwargs
@@ -105,6 +106,7 @@ class AuthResource(MethodResource):
         dependencies = get_auth_dependencies()
         auth_policy = dependencies.get_auth_security_policy()
         principal = str(email or name or "")
+        request_context = get_request_context()
         user = _resolve_login_user(
             dependencies=dependencies,
             email=email,
@@ -112,10 +114,10 @@ class AuthResource(MethodResource):
         )
         login_context = dependencies.build_login_attempt_context(
             principal=principal,
-            remote_addr=request.remote_addr,
-            user_agent=request.headers.get("User-Agent"),
-            forwarded_for=request.headers.get("X-Forwarded-For"),
-            real_ip=request.headers.get("X-Real-IP"),
+            remote_addr=request_context.client_ip,
+            user_agent=request_context.user_agent,
+            forwarded_for=request_context.headers.get("x-forwarded-for"),
+            real_ip=request_context.headers.get("x-real-ip"),
             known_principal=(
                 user is not None and auth_policy.login_guard.expose_known_principal
             ),

--- a/app/controllers/user/profile_resource.py
+++ b/app/controllers/user/profile_resource.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 from typing import Any
 from uuid import UUID
 
-from flask import Response, current_app, g
+from flask import Response, current_app
 from flask_apispec.views import MethodResource
 
 from app.application.services.user_profile_service import update_user_profile
 from app.auth import get_active_auth_context
 from app.extensions.database import db
+from app.http.request_context import current_request_id
 from app.schemas.user_schemas import UserProfileSchema
 from app.utils.typed_decorators import typed_doc as doc
 from app.utils.typed_decorators import typed_jwt_required as jwt_required
@@ -187,7 +188,7 @@ class UserProfileResource(MethodResource):
             "request_id=%s status=%s",
             user_id,
             ",".join(changed_fields),
-            str(getattr(g, "request_id", "n/a")),
+            current_request_id(),
             200,
         )
 

--- a/app/extensions/audit_trail.py
+++ b/app/extensions/audit_trail.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import os
 from typing import Any
 
-from flask import Flask, Response, current_app, g, request
+from flask import Flask, Response, current_app
 
 from app.auth import get_current_auth_context
 from app.extensions.database import db
+from app.http.request_context import RequestContext, get_request_context
 from app.models.audit_event import AuditEvent
 
 DEFAULT_AUDIT_PATH_PREFIXES = (
@@ -52,25 +53,18 @@ def _extract_user_id_safely() -> str | None:
         return None
 
 
-def _extract_client_ip() -> str | None:
-    forwarded_for = request.headers.get("X-Forwarded-For", "").strip()
-    if forwarded_for:
-        first_hop = forwarded_for.split(",")[0].strip()
-        return first_hop or None
-    remote_addr = request.remote_addr
-    return str(remote_addr) if remote_addr else None
-
-
-def _build_event_payload(response: Response) -> dict[str, Any]:
+def _build_event_payload(
+    response: Response, request_context: RequestContext
+) -> dict[str, Any]:
     return {
         "event": "http.audit",
-        "method": request.method,
-        "path": request.path,
+        "method": request_context.method,
+        "path": request_context.path,
         "status": response.status_code,
-        "request_id": getattr(g, "request_id", None),
+        "request_id": request_context.request_id,
         "user_id": _extract_user_id_safely(),
-        "ip": _extract_client_ip(),
-        "user_agent": request.headers.get("User-Agent", ""),
+        "ip": request_context.client_ip,
+        "user_agent": request_context.user_agent or "",
     }
 
 
@@ -119,22 +113,24 @@ def register_audit_trail(app: Flask) -> None:
 
     @app.after_request
     def _emit_audit_event(response: Response) -> Response:
-        if request.method == "OPTIONS":
+        request_context = get_request_context(optional=True)
+        if request_context is None:
             return response
-        if not _is_sensitive_path(request.path, prefixes):
+        if request_context.method == "OPTIONS":
+            return response
+        if not _is_sensitive_path(request_context.path, prefixes):
             return response
 
-        payload = _build_event_payload(response)
-        endpoint = request.endpoint or "unknown"
+        payload = _build_event_payload(response, request_context)
         message = (
             "audit_trail event=http.audit method=%s endpoint=%s status=%s request_id=%s"
         )
         current_app.logger.info(
             message,
-            request.method,
-            endpoint,
+            request_context.method,
+            request_context.endpoint or "unknown",
             response.status_code,
-            getattr(g, "request_id", None),
+            request_context.request_id,
         )
         if _is_audit_persistence_enabled():
             _persist_audit_event(payload)

--- a/app/extensions/error_handlers.py
+++ b/app/extensions/error_handlers.py
@@ -1,7 +1,8 @@
-from flask import Flask, Response, g
+from flask import Flask, Response
 from werkzeug.exceptions import HTTPException, RequestEntityTooLarge
 
 from app.exceptions import APIError
+from app.http.request_context import current_request_id
 from app.utils.response_builder import error_payload, json_response
 
 
@@ -49,7 +50,7 @@ def register_error_handlers(app: Flask) -> None:
 
     @app.errorhandler(Exception)
     def handle_generic_exception(e: Exception) -> Response:
-        request_id = str(getattr(g, "request_id", "n/a"))
+        request_id = current_request_id()
         app.logger.exception("Unhandled exception. request_id=%s", request_id)
         payload = error_payload(
             message="An unexpected error occurred.",

--- a/app/http/__init__.py
+++ b/app/http/__init__.py
@@ -1,0 +1,17 @@
+from .request_context import (
+    RequestContext,
+    apply_request_context_headers,
+    bind_request_context,
+    current_request_id,
+    get_request_context,
+    register_request_context_adapter,
+)
+
+__all__ = [
+    "RequestContext",
+    "apply_request_context_headers",
+    "bind_request_context",
+    "current_request_id",
+    "get_request_context",
+    "register_request_context_adapter",
+]

--- a/app/http/request_context.py
+++ b/app/http/request_context.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Literal, overload
+from uuid import uuid4
+
+from flask import Flask, Response, g, has_request_context, request
+
+
+@dataclass(frozen=True)
+class RequestContext:
+    request_id: str
+    method: str
+    path: str
+    endpoint: str | None
+    client_ip: str | None
+    user_agent: str | None
+    headers: Mapping[str, str]
+    trace_id: str | None
+    source_framework: Literal["flask", "fastapi"]
+
+
+def _read_bool_env(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _normalized_headers() -> dict[str, str]:
+    return {
+        str(key).lower(): str(value)
+        for key, value in request.headers.items()
+        if isinstance(key, str)
+    }
+
+
+def _resolve_client_ip(headers: Mapping[str, str]) -> str | None:
+    trust_proxy = _read_bool_env("REQUEST_CONTEXT_TRUST_PROXY_HEADERS", True)
+    if trust_proxy:
+        forwarded_for = str(headers.get("x-forwarded-for", "")).strip()
+        if forwarded_for:
+            first_hop = forwarded_for.split(",")[0].strip()
+            if first_hop:
+                return first_hop
+        real_ip = str(headers.get("x-real-ip", "")).strip()
+        if real_ip:
+            return real_ip
+    remote_addr = request.remote_addr
+    return str(remote_addr) if remote_addr else None
+
+
+def _resolve_trace_id(headers: Mapping[str, str]) -> str | None:
+    for key in ("x-trace-id", "traceparent", "x-request-id"):
+        value = str(headers.get(key, "")).strip()
+        if value:
+            return value[:512]
+    return None
+
+
+def _build_request_context() -> RequestContext:
+    headers = _normalized_headers()
+    request_id = str(getattr(g, "request_id", "") or uuid4().hex)
+    g.request_id = request_id
+    return RequestContext(
+        request_id=request_id,
+        method=request.method,
+        path=request.path,
+        endpoint=request.endpoint,
+        client_ip=_resolve_client_ip(headers),
+        user_agent=str(headers.get("user-agent", "")).strip() or None,
+        headers=headers,
+        trace_id=_resolve_trace_id(headers),
+        source_framework="flask",
+    )
+
+
+def bind_request_context() -> None:
+    g.request_id = uuid4().hex
+    g.request_context = _build_request_context()
+
+
+def apply_request_context_headers(response: Response) -> Response:
+    response.headers["X-Request-Id"] = current_request_id(default="n/a")
+    return response
+
+
+@overload
+def get_request_context(*, optional: Literal[False] = False) -> RequestContext: ...
+
+
+@overload
+def get_request_context(*, optional: Literal[True]) -> RequestContext | None: ...
+
+
+def get_request_context(*, optional: bool = False) -> RequestContext | None:
+    if not has_request_context():
+        if optional:
+            return None
+        raise RuntimeError("Active request context is required.")
+    cached = getattr(g, "request_context", None)
+    if isinstance(cached, RequestContext):
+        return cached
+    context = _build_request_context()
+    g.request_context = context
+    return context
+
+
+def current_request_id(*, default: str = "n/a") -> str:
+    context = get_request_context(optional=True)
+    if context is None:
+        return default
+    return context.request_id
+
+
+def register_request_context_adapter(app: Flask) -> None:
+    @app.before_request
+    def _bind_request_context() -> None:
+        bind_request_context()
+
+    @app.after_request
+    def _append_request_id_header(response: Response) -> Response:
+        return apply_request_context_headers(response)
+
+
+__all__ = [
+    "RequestContext",
+    "apply_request_context_headers",
+    "bind_request_context",
+    "current_request_id",
+    "get_request_context",
+    "register_request_context_adapter",
+]

--- a/app/utils/response_builder.py
+++ b/app/utils/response_builder.py
@@ -3,6 +3,8 @@ from typing import Any, Dict, Optional
 
 from flask import Response, current_app, has_app_context, jsonify
 
+from app.http.request_context import current_request_id
+
 SENSITIVE_DATA_FIELDS = {
     "password",
     "password_hash",
@@ -57,7 +59,7 @@ def error_payload(
     if code == "INTERNAL_ERROR" and not _is_debug_or_testing():
         request_id = (
             (details or {}).get("request_id") if isinstance(details, dict) else None
-        )
+        ) or current_request_id(default="")
         sanitized_details: Dict[str, Any] = (
             {"request_id": request_id} if request_id else {}
         )

--- a/tests/test_request_context_adapter.py
+++ b/tests/test_request_context_adapter.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from flask import Flask
+
+from app.http.request_context import (
+    RequestContext,
+    current_request_id,
+    get_request_context,
+    register_request_context_adapter,
+)
+
+
+def test_request_context_adapter_binds_request_metadata() -> None:
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+
+    @app.get("/ping")
+    def _ping() -> tuple[str, int]:
+        context = get_request_context()
+        assert isinstance(context, RequestContext)
+        assert context.method == "GET"
+        assert context.path == "/ping"
+        assert context.endpoint == "_ping"
+        assert context.source_framework == "flask"
+        assert context.user_agent == "pytest-agent"
+        assert context.client_ip == "203.0.113.10"
+        assert context.headers["x-real-ip"] == "203.0.113.10"
+        assert context.trace_id == "trace-123"
+        return "ok", 200
+
+    register_request_context_adapter(app)
+
+    client = app.test_client()
+    response = client.get(
+        "/ping",
+        headers={
+            "User-Agent": "pytest-agent",
+            "X-Real-IP": "203.0.113.10",
+            "X-Trace-Id": "trace-123",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["X-Request-Id"]
+
+
+def test_current_request_id_returns_default_outside_request() -> None:
+    assert current_request_id() == "n/a"


### PR DESCRIPTION
## Summary
- add typed Flask request-context adapter for request id, IP, headers and trace metadata
- migrate auth/login reset, audit trail, error handling and response payloads to the adapter
- add request-context tests and preserve existing quality gates

## Validation
- bash scripts/run_ci_quality_local.sh --local
- ./.venv/bin/python -m pytest tests/test_request_context_adapter.py tests/test_audit_trail.py tests/test_response_sanitization.py -q
- ./.venv/bin/python -m mypy app
