### PR TITLE
refactor(api): add shared error contract layer

### DIFF
--- a/app/controllers/response_contract.py
+++ b/app/controllers/response_contract.py
@@ -2,11 +2,22 @@ from __future__ import annotations
 
 from typing import Any
 
-from flask import Response
+from flask import Response, current_app, has_app_context
 
 from app.exceptions import APIError
+from app.http import ErrorContract, flask_error_response, serialize_error_contract
 from app.utils.api_contract import CONTRACT_HEADER, CONTRACT_V2, is_v2_contract_request
-from app.utils.response_builder import error_payload, json_response, success_payload
+from app.utils.response_builder import (
+    SENSITIVE_DATA_FIELDS,
+    json_response,
+    success_payload,
+)
+
+
+def _debug_or_testing() -> bool:
+    if not has_app_context():
+        return False
+    return bool(current_app.config.get("DEBUG") or current_app.config.get("TESTING"))
 
 
 class ResponseContractError(APIError):
@@ -58,7 +69,17 @@ def compat_error_response(
 ) -> Response:
     payload = legacy_payload
     if is_v2_contract():
-        payload = error_payload(message=message, code=error_code, details=details)
+        return flask_error_response(
+            ErrorContract(
+                message=message,
+                code=error_code,
+                status_code=status_code,
+                details=details,
+            ),
+            debug_or_testing=_debug_or_testing(),
+            sensitive_fields=SENSITIVE_DATA_FIELDS,
+            response_factory=json_response,
+        )
     return json_response(payload, status_code=status_code)
 
 
@@ -86,7 +107,16 @@ def compat_error_tuple(
 ) -> tuple[dict[str, Any], int]:
     payload = legacy_payload
     if is_v2_contract():
-        payload = error_payload(message=message, code=error_code, details=details)
+        payload = serialize_error_contract(
+            ErrorContract(
+                message=message,
+                code=error_code,
+                status_code=status_code,
+                details=details,
+            ),
+            debug_or_testing=_debug_or_testing(),
+            sensitive_fields=SENSITIVE_DATA_FIELDS,
+        )
     return payload, status_code
 
 

--- a/app/extensions/error_handlers.py
+++ b/app/extensions/error_handlers.py
@@ -2,59 +2,63 @@ from flask import Flask, Response
 from werkzeug.exceptions import HTTPException, RequestEntityTooLarge
 
 from app.exceptions import APIError
-from app.http.request_context import current_request_id
-from app.utils.response_builder import error_payload, json_response
+from app.http import (
+    error_contract_from_api_error,
+    error_contract_from_http_exception,
+    error_contract_from_request_too_large,
+    error_contract_from_unhandled_exception,
+    flask_error_response,
+)
+from app.utils.response_builder import SENSITIVE_DATA_FIELDS, json_response
 
 
-def _http_status_to_error_code(status_code: int) -> str:
-    mapping = {
-        400: "VALIDATION_ERROR",
-        401: "UNAUTHORIZED",
-        403: "FORBIDDEN",
-        404: "NOT_FOUND",
-        409: "CONFLICT",
-        422: "UNPROCESSABLE_ENTITY",
-    }
-    return mapping.get(status_code, "HTTP_ERROR")
+def _debug_or_testing(app: Flask) -> bool:
+    return bool(app.config.get("DEBUG") or app.config.get("TESTING"))
 
 
 def register_error_handlers(app: Flask) -> None:
     @app.errorhandler(RequestEntityTooLarge)
     def handle_request_too_large(e: RequestEntityTooLarge) -> Response:
-        payload = error_payload(
-            message="Request body is too large.",
-            code="PAYLOAD_TOO_LARGE",
-            details={"max_bytes": app.config.get("MAX_CONTENT_LENGTH")},
+        del e
+        contract = error_contract_from_request_too_large(
+            app.config.get("MAX_CONTENT_LENGTH")
         )
-        return json_response(payload, status_code=413)
+        return flask_error_response(
+            contract,
+            debug_or_testing=_debug_or_testing(app),
+            sensitive_fields=SENSITIVE_DATA_FIELDS,
+            response_factory=json_response,
+        )
 
     @app.errorhandler(APIError)
     def handle_api_error(e: APIError) -> Response:
-        payload = error_payload(
-            message=e.message,
-            code=e.code,
-            details=e.details,
+        contract = error_contract_from_api_error(e)
+        return flask_error_response(
+            contract,
+            debug_or_testing=_debug_or_testing(app),
+            sensitive_fields=SENSITIVE_DATA_FIELDS,
+            response_factory=json_response,
         )
-        return json_response(payload, status_code=e.status_code)
 
     @app.errorhandler(HTTPException)
     def handle_http_exception(e: HTTPException) -> Response:
-        status_code = e.code if e.code is not None else 500
-        message = e.description or "HTTP error"
-        payload = error_payload(
-            message=message,
-            code=_http_status_to_error_code(status_code),
-            details={"http_error": e.name},
+        contract = error_contract_from_http_exception(e)
+        return flask_error_response(
+            contract,
+            debug_or_testing=_debug_or_testing(app),
+            sensitive_fields=SENSITIVE_DATA_FIELDS,
+            response_factory=json_response,
         )
-        return json_response(payload, status_code=status_code)
 
     @app.errorhandler(Exception)
     def handle_generic_exception(e: Exception) -> Response:
-        request_id = current_request_id()
-        app.logger.exception("Unhandled exception. request_id=%s", request_id)
-        payload = error_payload(
-            message="An unexpected error occurred.",
-            code="INTERNAL_ERROR",
-            details={"request_id": request_id},
+        contract = error_contract_from_unhandled_exception(e)
+        app.logger.exception(
+            "Unhandled exception. request_id=%s", contract.request_id or "n/a"
         )
-        return json_response(payload, status_code=500)
+        return flask_error_response(
+            contract,
+            debug_or_testing=_debug_or_testing(app),
+            sensitive_fields=SENSITIVE_DATA_FIELDS,
+            response_factory=json_response,
+        )

--- a/app/http/__init__.py
+++ b/app/http/__init__.py
@@ -1,3 +1,14 @@
+from .error_contract import (
+    HTTP_ERROR_CATALOG,
+    ErrorCatalogEntry,
+    ErrorContract,
+    error_contract_from_api_error,
+    error_contract_from_http_exception,
+    error_contract_from_request_too_large,
+    error_contract_from_unhandled_exception,
+    flask_error_response,
+    serialize_error_contract,
+)
 from .request_context import (
     RequestContext,
     apply_request_context_headers,
@@ -9,9 +20,18 @@ from .request_context import (
 
 __all__ = [
     "RequestContext",
+    "ErrorCatalogEntry",
+    "ErrorContract",
+    "HTTP_ERROR_CATALOG",
     "apply_request_context_headers",
     "bind_request_context",
     "current_request_id",
+    "error_contract_from_api_error",
+    "error_contract_from_http_exception",
+    "error_contract_from_request_too_large",
+    "error_contract_from_unhandled_exception",
+    "flask_error_response",
     "get_request_context",
     "register_request_context_adapter",
+    "serialize_error_contract",
 ]

--- a/app/http/error_contract.py
+++ b/app/http/error_contract.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping
+
+from flask import Response
+from werkzeug.exceptions import HTTPException
+
+from app.exceptions import APIError
+from app.http.request_context import current_request_id
+
+
+@dataclass(frozen=True)
+class ErrorCatalogEntry:
+    code: str
+    status_code: int
+    default_message: str
+
+
+@dataclass(frozen=True)
+class ErrorContract:
+    message: str
+    code: str
+    status_code: int
+    details: Mapping[str, Any] | None = None
+    request_id: str | None = None
+    docs_url: str | None = None
+
+
+HTTP_ERROR_CATALOG: dict[int, ErrorCatalogEntry] = {
+    400: ErrorCatalogEntry(
+        code="VALIDATION_ERROR",
+        status_code=400,
+        default_message="Validation error",
+    ),
+    401: ErrorCatalogEntry(
+        code="UNAUTHORIZED",
+        status_code=401,
+        default_message="Unauthorized",
+    ),
+    403: ErrorCatalogEntry(
+        code="FORBIDDEN",
+        status_code=403,
+        default_message="Forbidden",
+    ),
+    404: ErrorCatalogEntry(
+        code="NOT_FOUND",
+        status_code=404,
+        default_message="Not found",
+    ),
+    409: ErrorCatalogEntry(
+        code="CONFLICT",
+        status_code=409,
+        default_message="Conflict",
+    ),
+    413: ErrorCatalogEntry(
+        code="PAYLOAD_TOO_LARGE",
+        status_code=413,
+        default_message="Request body is too large.",
+    ),
+    422: ErrorCatalogEntry(
+        code="UNPROCESSABLE_ENTITY",
+        status_code=422,
+        default_message="Unprocessable entity",
+    ),
+    500: ErrorCatalogEntry(
+        code="INTERNAL_ERROR",
+        status_code=500,
+        default_message="An unexpected error occurred.",
+    ),
+}
+
+
+def _sanitize_value(value: Any, *, sensitive_fields: set[str]) -> Any:
+    if isinstance(value, dict):
+        sanitized: dict[str, Any] = {}
+        for key, item in value.items():
+            normalized_key = str(key).strip().lower()
+            if normalized_key in sensitive_fields:
+                continue
+            sanitized[key] = _sanitize_value(item, sensitive_fields=sensitive_fields)
+        return sanitized
+    if isinstance(value, list):
+        return [
+            _sanitize_value(item, sensitive_fields=sensitive_fields) for item in value
+        ]
+    return value
+
+
+def serialize_error_contract(
+    contract: ErrorContract,
+    *,
+    debug_or_testing: bool,
+    sensitive_fields: set[str],
+) -> dict[str, Any]:
+    if contract.code == "INTERNAL_ERROR" and not debug_or_testing:
+        request_id = contract.request_id or current_request_id(default="")
+        sanitized_details: dict[str, Any] = (
+            {"request_id": request_id} if request_id else {}
+        )
+    else:
+        details = dict(contract.details or {})
+        sanitized_details = _sanitize_value(details, sensitive_fields=sensitive_fields)
+
+    error_payload: dict[str, Any] = {
+        "code": contract.code,
+        "details": sanitized_details,
+    }
+    if contract.docs_url:
+        error_payload["docs_url"] = contract.docs_url
+
+    return {
+        "success": False,
+        "message": contract.message,
+        "error": error_payload,
+    }
+
+
+def error_contract_from_api_error(error: APIError) -> ErrorContract:
+    return ErrorContract(
+        message=error.message,
+        code=error.code,
+        status_code=error.status_code,
+        details=error.details,
+    )
+
+
+def error_contract_from_http_exception(error: HTTPException) -> ErrorContract:
+    status_code = error.code if error.code is not None else 500
+    catalog_entry = HTTP_ERROR_CATALOG.get(
+        status_code,
+        ErrorCatalogEntry(
+            code="HTTP_ERROR",
+            status_code=status_code,
+            default_message="HTTP error",
+        ),
+    )
+    message = error.description or catalog_entry.default_message
+    return ErrorContract(
+        message=message,
+        code=catalog_entry.code,
+        status_code=status_code,
+        details={"http_error": error.name},
+    )
+
+
+def error_contract_from_unhandled_exception(
+    error: Exception, *, request_id: str | None = None
+) -> ErrorContract:
+    del error
+    catalog_entry = HTTP_ERROR_CATALOG[500]
+    return ErrorContract(
+        message=catalog_entry.default_message,
+        code=catalog_entry.code,
+        status_code=catalog_entry.status_code,
+        request_id=request_id or current_request_id(default=""),
+    )
+
+
+def error_contract_from_request_too_large(max_bytes: int | None) -> ErrorContract:
+    catalog_entry = HTTP_ERROR_CATALOG[413]
+    return ErrorContract(
+        message=catalog_entry.default_message,
+        code=catalog_entry.code,
+        status_code=catalog_entry.status_code,
+        details={"max_bytes": max_bytes},
+    )
+
+
+def flask_error_response(
+    contract: ErrorContract,
+    *,
+    debug_or_testing: bool,
+    sensitive_fields: set[str],
+    response_factory: Callable[[dict[str, Any], int], Response],
+) -> Response:
+    payload = serialize_error_contract(
+        contract,
+        debug_or_testing=debug_or_testing,
+        sensitive_fields=sensitive_fields,
+    )
+    return response_factory(payload, contract.status_code)
+
+
+__all__ = [
+    "ErrorCatalogEntry",
+    "ErrorContract",
+    "HTTP_ERROR_CATALOG",
+    "error_contract_from_api_error",
+    "error_contract_from_http_exception",
+    "error_contract_from_request_too_large",
+    "error_contract_from_unhandled_exception",
+    "flask_error_response",
+    "serialize_error_contract",
+]

--- a/app/utils/response_builder.py
+++ b/app/utils/response_builder.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Optional
 
 from flask import Response, current_app, has_app_context, jsonify
 
-from app.http.request_context import current_request_id
+from app.http.error_contract import ErrorContract, serialize_error_contract
 
 SENSITIVE_DATA_FIELDS = {
     "password",
@@ -56,24 +56,19 @@ def error_payload(
     details: Optional[Dict[str, Any]] = None,
     meta: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
-    if code == "INTERNAL_ERROR" and not _is_debug_or_testing():
-        request_id = (
-            (details or {}).get("request_id") if isinstance(details, dict) else None
-        ) or current_request_id(default="")
-        sanitized_details: Dict[str, Any] = (
-            {"request_id": request_id} if request_id else {}
-        )
-    else:
-        sanitized_details = _sanitize_value(details or {})
-
-    payload: Dict[str, Any] = {
-        "success": False,
-        "message": message,
-        "error": {
-            "code": code,
-            "details": sanitized_details,
-        },
-    }
+    payload: Dict[str, Any] = serialize_error_contract(
+        ErrorContract(
+            message=message,
+            code=code,
+            status_code=0,
+            details=details,
+            request_id=(
+                (details or {}).get("request_id") if isinstance(details, dict) else None
+            ),
+        ),
+        debug_or_testing=_is_debug_or_testing(),
+        sensitive_fields=SENSITIVE_DATA_FIELDS,
+    )
     if meta is not None:
         payload["meta"] = _sanitize_value(meta)
     return payload

--- a/tests/test_http_error_contract.py
+++ b/tests/test_http_error_contract.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from flask import Flask
+from werkzeug.exceptions import NotFound
+
+from app.exceptions import ValidationAPIError
+from app.http.error_contract import (
+    HTTP_ERROR_CATALOG,
+    error_contract_from_api_error,
+    error_contract_from_http_exception,
+    error_contract_from_request_too_large,
+    error_contract_from_unhandled_exception,
+    serialize_error_contract,
+)
+from app.utils.response_builder import SENSITIVE_DATA_FIELDS
+
+
+def test_http_error_catalog_exposes_expected_rest_codes() -> None:
+    assert HTTP_ERROR_CATALOG[400].code == "VALIDATION_ERROR"
+    assert HTTP_ERROR_CATALOG[401].code == "UNAUTHORIZED"
+    assert HTTP_ERROR_CATALOG[404].code == "NOT_FOUND"
+    assert HTTP_ERROR_CATALOG[500].code == "INTERNAL_ERROR"
+
+
+def test_error_contract_from_api_error_keeps_status_and_details() -> None:
+    contract = error_contract_from_api_error(
+        ValidationAPIError(details={"field": ["required"]})
+    )
+
+    assert contract.status_code == 400
+    assert contract.code == "VALIDATION_ERROR"
+    assert dict(contract.details or {}) == {"field": ["required"]}
+
+
+def test_error_contract_from_http_exception_maps_not_found() -> None:
+    contract = error_contract_from_http_exception(NotFound("Missing"))
+
+    assert contract.status_code == 404
+    assert contract.code == "NOT_FOUND"
+    assert dict(contract.details or {}) == {"http_error": "Not Found"}
+
+
+def test_error_contract_from_unhandled_exception_injects_request_id(app: Flask) -> None:
+    with app.test_request_context("/boom"):
+        contract = error_contract_from_unhandled_exception(
+            RuntimeError("boom"),
+            request_id="req-123",
+        )
+        payload = serialize_error_contract(
+            contract,
+            debug_or_testing=False,
+            sensitive_fields=SENSITIVE_DATA_FIELDS,
+        )
+
+    assert contract.status_code == 500
+    assert payload["error"]["code"] == "INTERNAL_ERROR"
+    assert payload["error"]["details"] == {"request_id": "req-123"}
+
+
+def test_error_contract_from_request_too_large_exposes_max_bytes() -> None:
+    contract = error_contract_from_request_too_large(1024)
+    payload = serialize_error_contract(
+        contract,
+        debug_or_testing=False,
+        sensitive_fields=SENSITIVE_DATA_FIELDS,
+    )
+
+    assert contract.status_code == 413
+    assert payload["error"]["code"] == "PAYLOAD_TOO_LARGE"
+    assert payload["error"]["details"] == {"max_bytes": 1024}


### PR DESCRIPTION
## Summary
- add a shared REST error contract layer for Flask/FastAPI coexistence work
- route Flask error handlers and controller compatibility helpers through the shared serializer
- add regression tests for the shared contract and preserve current payload shape

## Validation
- bash scripts/run_ci_quality_local.sh --local
- ./.venv/bin/python -m pytest tests/test_response_contract.py tests/test_response_sanitization.py tests/test_http_error_contract.py -q
- ./.venv/bin/python -m pytest tests/test_graphql_controller_utils.py tests/test_graphql_error_catalog.py -q
- ./.venv/bin/python -m mypy app
