### PR TITLE
chore(deps): add pydantic to dev requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,7 @@ pre-commit==4.5.1
 bandit==1.8.6
 cosmic-ray==8.4.4
 pip-audit==2.9.0
+pydantic>=2.0
 schemathesis==3.35.0
 types-requests==2.32.4.20260107
 types-python-dateutil==2.9.0.20260305


### PR DESCRIPTION
## Summary
- Adds `pydantic>=2.0` explicitly to `requirements-dev.txt`
- Fixes `ModuleNotFoundError: No module named 'pydantic'` in agent worktrees
- pydantic is a transitive dep of schemathesis but wasn't pinned, causing failures in fresh venv installs

## Why
Agent worktrees create isolated venvs via `pip install -r requirements*.txt`. Without pydantic in the requirements, integration tests fail with `No module named 'pydantic'`, blocking the agent from committing its work.

## Test plan
- [ ] Confirm `pip install -r requirements-dev.txt` installs pydantic
- [ ] Run integration tests in a fresh venv — should pass without ModuleNotFoundError