### PR TITLE
docs: add explicit max-complexity=10 threshold to C90 ruff rule

### DIFF
--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -43,7 +43,11 @@ from config.settings import Settings
   - `E/F/W` para erros base
   - `I` para ordenação de imports
   - `B` para bugbear
-  - `C90` para complexidade ciclomática
+  - `C90` para complexidade ciclomática — **`max-complexity = 10`** (configurado em `pyproject.toml`).
+    Funções com mais de 10 caminhos de execução (if/elif/for/while/except/with/case)
+    são **bloqueadas pelo ruff e não podem ser auto-corrigidas**.
+    Solução: extraia helpers privados (`_build_questions`, `_score_responses`, etc.)
+    até que cada função individual fique abaixo do limite.
 - `E203` e `W503` continuam ignorados por compatibilidade com formatter
 
 ---


### PR DESCRIPTION
## Why

`CODING_STANDARDS.md` mentioned `C90` (McCabe complexity) as a ruff rule but never stated the numeric threshold. The ruff config in `pyproject.toml` enforces `max-complexity = 10`, but agents reading `CODING_STANDARDS.md` had no way to know that value.

This caused agents to write functions with cyclomatic complexity > 10, which ruff flags as `C901` — a violation that **cannot be auto-fixed** — silently blocking every commit attempt.

## Change

Added the threshold and a concrete remediation strategy directly to the docs:
```
- `C90` para complexidade ciclomática — max-complexity = 10.
  Funções com mais de 10 caminhos de execução são bloqueadas pelo ruff.
  Solução: extraia helpers privados até que cada função fique abaixo do limite.
```

## Impact

AI agents that read `CODING_STANDARDS.md` (step 0 of the write phase) will now know the numeric limit before writing code, preventing C901 violations on the first attempt.