### PR TITLE
chore(governance): align versioned branch protection

### DIFF
--- a/config/github_master_ruleset.json
+++ b/config/github_master_ruleset.json
@@ -34,7 +34,7 @@
         "strict_required_status_checks_policy": true,
         "required_status_checks": [
           {
-            "context": "Quality (Lint + Type Check)"
+            "context": "Dependency Review (PR gate)"
           },
           {
             "context": "Secret Scan (Gitleaks)"
@@ -55,13 +55,10 @@
             "context": "Container Security (Trivy)"
           },
           {
-            "context": "Security Scan (Snyk)"
-          },
-          {
             "context": "Security Evidence (S3)"
           },
           {
-            "context": "Dependency Review (PR gate)"
+            "context": "Quality (Ruff + Type Check)"
           },
           {
             "context": "SonarQube Cloud"


### PR DESCRIPTION
## Resumo
- alinha `config/github_master_ruleset.json` com o branch protection real atual do `master`
- substitui o check legado `Quality (Lint + Type Check)` pelo nome oficial `Quality (Ruff + Type Check)`
- remove `Security Scan (Snyk)` da lista declarativa de required checks, já que nao faz parte do conjunto bloqueante oficial atual
- preserva a decisao atual: Ruff como stack unica de lint/format/import-sort, mantendo `mypy` como gate de tipagem estatica

## Contexto
O PR #634 destravou o merge removendo o check fantasma `Type Check (mypy, py3.13)` do branch protection real. O merge aconteceu, mas o arquivo versionado de governanca ficou para tras e ainda descrevia um estado antigo.

Este PR fecha esse drift para que a configuracao declarativa volte a ser fonte confiavel de manutencao e auditoria.

## Validacao
- `python3 -m json.tool config/github_master_ruleset.json >/dev/null`
- comparacao do arquivo versionado com `gh api repos/italofelipe/auraxis-api/branches/master/protection`
- hooks de `pre-push` passaram no push da branch

## Riscos
- baixo: mudanca declarativa, sem impacto de runtime ou produto

Closes #635
