### PR TITLE
[API] OPS-11 - dual edge mode para cutover ALB HTTP-only

### DIFF
--- a/.context/handoffs/API-OPS-11.md
+++ b/.context/handoffs/API-OPS-11.md
@@ -1,0 +1,30 @@
+# API-OPS-11
+
+## O que foi feito
+
+- introduzido `EDGE_TLS_MODE=alb_dual` no runtime para cutover seguro de `HTTPS origin` para `HTTP origin`
+- adicionado template novo em `deploy/nginx/default.alb_dual.conf`
+- atualizado `scripts/ensure_tls_runtime.sh` para:
+  - renderizar `80` e `443` ao mesmo tempo em modo transitório
+  - exigir certificado local existente antes de ativar `alb_dual`
+- atualizado `scripts/aws_deploy_i6.py` para bootstrapar o novo template/modo em hosts legados
+- documentado o fluxo em `docs/RUNBOOK.md` e `docs/DEPLOYMENT_ENVIRONMENTS.md`
+
+## O que foi validado
+
+- `sh -n scripts/ensure_tls_runtime.sh`
+- `python3 -m py_compile scripts/aws_deploy_i6.py`
+- revisão do diff do recorte alterado
+
+## Riscos pendentes
+
+- o cutover real em `prod` ainda precisa ser executado com essa versão já deployada no host
+- o modo `alb_dual` depende de certificado local ainda presente durante a janela de transição
+
+## Próximo passo
+
+- abrir PR e mergear essa melhoria
+- deployar em `prod`
+- aquecer target group `HTTP:80` com `EDGE_TLS_MODE=alb_dual`
+- só então trocar o listener do ALB para origem HTTP
+- após estabilização, trocar o host para `EDGE_TLS_MODE=alb`

--- a/deploy/nginx/default.alb_dual.conf
+++ b/deploy/nginx/default.alb_dual.conf
@@ -1,0 +1,48 @@
+server {
+    listen 80;
+    server_name __DOMAIN__;
+
+    client_max_body_size 10m;
+
+    location / {
+        proxy_pass http://web:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Port $http_x_forwarded_port;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+        proxy_set_header Connection "";
+    }
+}
+
+server {
+    listen 443 ssl http2;
+    server_name __DOMAIN__;
+
+    ssl_certificate /etc/letsencrypt/live/__DOMAIN__/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/__DOMAIN__/privkey.pem;
+
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers off;
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_timeout 1d;
+
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+    client_max_body_size 10m;
+
+    location / {
+        proxy_pass http://web:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Connection "";
+    }
+}

--- a/docs/DEPLOYMENT_ENVIRONMENTS.md
+++ b/docs/DEPLOYMENT_ENVIRONMENTS.md
@@ -36,6 +36,7 @@ docker compose -f docker-compose.dev.yml up --build
 - Exposes app on `localhost:80`.
 - Supports TLS with Certbot + Nginx (`443`) using shared challenge/certificate volumes.
 - Supports an ALB edge mode with TLS termination in ACM/ALB and HTTP-only origin on the instance (`EDGE_TLS_MODE=alb`).
+- Supports a transitional dual-edge mode for safe origin cutover (`EDGE_TLS_MODE=alb_dual`).
 
 ### Commands
 ```bash
@@ -65,6 +66,20 @@ Operational expectations:
 - target group forwards HTTP to the instance
 - Route 53 points `api.auraxis.com.br` to the ALB
 - host-level Certbot is no longer part of the public edge for that domain
+
+### ALB transitional cutover mode
+Use when moving a live environment from `HTTPS origin` to `HTTP origin` behind the ALB:
+
+```bash
+echo 'EDGE_TLS_MODE=alb_dual' >> .env.prod
+docker compose --env-file .env.prod -f docker-compose.prod.yml up -d --force-recreate reverse-proxy
+```
+
+Operational expectations:
+- requires an existing local certificate on the host
+- keeps `443` alive for the current ALB target group
+- exposes `80` at the same time so the new HTTP target group can warm up
+- after the ALB listener cutover is stable, switch the host from `alb_dual` to `alb`
 
 Detailed runbook:
 - `docs/RUNBOOK.md`

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -67,6 +67,7 @@ Notas:
   - `EDGE_TLS_MODE=instance_tls` tenta emitir cert em PROD quando possível
   - `EDGE_TLS_MODE=instance_tls` mantém HTTP sem derrubar proxy quando cert ainda não existe
   - `EDGE_TLS_MODE=alb` renderiza config HTTP-only para ALB com TLS terminando no ACM
+  - `EDGE_TLS_MODE=alb_dual` serve `80` e `443` ao mesmo tempo para cutover seguro de `HTTPS origin -> HTTP origin`
 - O deploy normal (`mode=deploy`) ainda depende de acesso Git remoto no host.
 - O rollback (`mode=rollback`) **não** depende de `git fetch` remoto; usa o commit local salvo no estado.
 - O deploy bloqueia se detectar drift real entre `/opt/auraxis` e `/opt/flask_expenses` para evitar update na copia errada.
@@ -135,6 +136,12 @@ Nesse modo:
 - o host nao emite nem renova certificados para `api.auraxis.com.br`
 - o `nginx` preserva `X-Forwarded-Proto` e `X-Forwarded-Port` vindos do ALB
 - o cutover de DNS deve apontar `api.auraxis.com.br` para o ALB, nao para EIP
+
+Para migracao segura de `HTTPS origin` para `HTTP origin` sem depender de timing fragil:
+- usar `EDGE_TLS_MODE=alb_dual` no host com certificado local ainda presente
+- registrar e aquecer o target group `HTTP:80` ate ficar `healthy`
+- so entao trocar o listener do ALB para o target group HTTP
+- depois do cutover estavel, trocar o host para `EDGE_TLS_MODE=alb` e remover a dependencia do certificado local
 
 ## Backups PostgreSQL (S3) e Restore Drill
 

--- a/scripts/aws_deploy_i6.py
+++ b/scripts/aws_deploy_i6.py
@@ -475,6 +475,61 @@ CONF
   echo "[i6] bootstrapped deploy/nginx/default.alb.conf"
 fi
 
+if [ ! -f "deploy/nginx/default.alb_dual.conf" ]; then
+  mkdir -p deploy/nginx
+  cat > deploy/nginx/default.alb_dual.conf <<'CONF'
+server {{
+    listen 80;
+    server_name __DOMAIN__;
+
+    client_max_body_size 10m;
+
+    location / {{
+        proxy_pass http://web:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Port $http_x_forwarded_port;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+        proxy_set_header Connection "";
+    }}
+}}
+
+server {{
+    listen 443 ssl http2;
+    server_name __DOMAIN__;
+
+    ssl_certificate /etc/letsencrypt/live/__DOMAIN__/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/__DOMAIN__/privkey.pem;
+
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers off;
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_timeout 1d;
+
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+    client_max_body_size 10m;
+
+    location / {{
+        proxy_pass http://web:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Connection "";
+    }}
+}}
+CONF
+  echo "[i6] bootstrapped deploy/nginx/default.alb_dual.conf"
+fi
+
 if [ ! -f "scripts/ensure_tls_runtime.sh" ]; then
   mkdir -p scripts
   cat > scripts/ensure_tls_runtime.sh <<'SH'
@@ -484,6 +539,10 @@ set -eu
 # - EDGE_TLS_MODE=alb:
 #   - renders HTTP-only nginx config suitable for ALB TLS termination
 #   - skips local certificate issuance entirely
+# - EDGE_TLS_MODE=alb_dual:
+#   - transitional mode for safe cutover to ALB HTTP origins
+#   - requires an existing local certificate
+#   - serves HTTP:80 for the new ALB target group while keeping HTTPS:443 alive
 # - EDGE_TLS_MODE=instance_tls (default):
 #   - if cert exists for DOMAIN: renders TLS nginx config and recreates reverse-proxy
 #   - if cert does not exist:
@@ -531,6 +590,11 @@ render_alb_config() {{
     deploy/nginx/default.alb.conf > deploy/nginx/default.conf
 }}
 
+render_alb_dual_config() {{
+  sed "s/__DOMAIN__/${{DOMAIN}}/g" \\
+    deploy/nginx/default.alb_dual.conf > deploy/nginx/default.conf
+}}
+
 recreate_proxy() {{
   docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" \\
     up -d --force-recreate reverse-proxy
@@ -554,6 +618,16 @@ if [ "${{EDGE_TLS_MODE}}" = "alb" ]; then
   render_alb_config
   recreate_proxy
   exit 0
+fi
+
+if [ "${{EDGE_TLS_MODE}}" = "alb_dual" ]; then
+  if cert_exists; then
+    render_alb_dual_config
+    recreate_proxy
+    exit 0
+  fi
+  echo "[tls] EDGE_TLS_MODE=alb_dual requires an existing certificate for ${{DOMAIN}}."
+  exit 4
 fi
 
 if cert_exists; then

--- a/scripts/ensure_tls_runtime.sh
+++ b/scripts/ensure_tls_runtime.sh
@@ -5,6 +5,10 @@ set -eu
 # - EDGE_TLS_MODE=alb:
 #   - renders HTTP-only nginx config suitable for ALB TLS termination
 #   - skips local certificate issuance entirely
+# - EDGE_TLS_MODE=alb_dual:
+#   - transitional mode for safe cutover to ALB HTTP origins
+#   - requires an existing local certificate
+#   - serves HTTP:80 for the new ALB target group while keeping HTTPS:443 alive
 # - EDGE_TLS_MODE=instance_tls (default):
 #   - if cert exists for DOMAIN: renders TLS nginx config and recreates reverse-proxy
 #   - if cert does not exist:
@@ -35,7 +39,7 @@ if [ -z "${DOMAIN}" ]; then
   exit 2
 fi
 
-if [ ! -f "deploy/nginx/default.tls.conf" ] || [ ! -f "deploy/nginx/default.http.conf" ] || [ ! -f "deploy/nginx/default.alb.conf" ]; then
+if [ ! -f "deploy/nginx/default.tls.conf" ] || [ ! -f "deploy/nginx/default.http.conf" ] || [ ! -f "deploy/nginx/default.alb.conf" ] || [ ! -f "deploy/nginx/default.alb_dual.conf" ]; then
   echo "[tls] missing nginx templates in deploy/nginx/."
   exit 3
 fi
@@ -58,6 +62,11 @@ render_tls_config() {
 render_alb_config() {
   sed "s/__DOMAIN__/${DOMAIN}/g" deploy/nginx/default.alb.conf > deploy/nginx/default.conf
   echo "[tls] mode=alb domain=${DOMAIN}"
+}
+
+render_alb_dual_config() {
+  sed "s/__DOMAIN__/${DOMAIN}/g" deploy/nginx/default.alb_dual.conf > deploy/nginx/default.conf
+  echo "[tls] mode=alb_dual domain=${DOMAIN}"
 }
 
 recreate_proxy() {
@@ -84,6 +93,16 @@ if [ "${EDGE_TLS_MODE}" = "alb" ]; then
   render_alb_config
   recreate_proxy
   exit 0
+fi
+
+if [ "${EDGE_TLS_MODE}" = "alb_dual" ]; then
+  if cert_exists; then
+    render_alb_dual_config
+    recreate_proxy
+    exit 0
+  fi
+  echo "[tls] EDGE_TLS_MODE=alb_dual requires an existing certificate for ${DOMAIN}."
+  exit 4
 fi
 
 if cert_exists; then


### PR DESCRIPTION
## Resumo
- adiciona `EDGE_TLS_MODE=alb_dual` para manter `80` e `443` vivos durante o cutover de origem do ALB
- bootstrapa o novo modo em hosts legados via `aws_deploy_i6.py`
- documenta o procedimento seguro de migracao `HTTPS origin -> HTTP origin`

## Validacao
- `sh -n scripts/ensure_tls_runtime.sh`
- `python3 -m py_compile scripts/aws_deploy_i6.py`
- pre-commit no commit local

## Contexto
- follow-up do incidente operacional registrado em #660