### PR TITLE
feat(testing): establish canonical Postman/Newman E2E suite

### DIFF
--- a/api-tests/postman/README.md
+++ b/api-tests/postman/README.md
@@ -1,15 +1,59 @@
 # postman
 
 ## Objetivo
-Suite de smoke/regressao REST + GraphQL para validacao rapida de saude funcional da API.
+Suite canonica black-box da API Auraxis para importacao direta no Postman e execucao automatizada com Newman.
 
-## Arquivos
-- `auraxis.postman_collection.json`: colecao principal.
-- `environments/local.postman_environment.json`: ambiente local.
-- `environments/dev.postman_environment.json`: ambiente DEV.
-- `environments/prod.postman_environment.json`: ambiente PROD.
+Ela cobre as superficies REST criticas por dominio e um smoke representativo de GraphQL. A colecao oficial fica em:
+- `api-tests/postman/auraxis.postman_collection.json`
 
-## Convencoes
-- Variaveis de ambiente devem manter nomes estaveis (`baseUrl`, `testPassword`, etc.).
-- Cenarios de erro GraphQL devem validar codigo publico e nao expor `INTERNAL_ERROR` para erros de credencial invalida.
-- Novas requests devem incluir assertions minimas de status e contrato.
+## Estrutura oficial
+- `00 - Auth and User Bootstrap`
+- `01 - Transactions`
+- `02 - Goals`
+- `03 - Wallet`
+- `04 - Simulations`
+- `05 - GraphQL`
+
+## Ambientes versionados
+- `environments/local.postman_environment.json`
+- `environments/dev.postman_environment.json`
+- `environments/prod.postman_environment.json`
+
+Os environments devem conter apenas valores seguros para versionamento:
+- `baseUrl`
+- `testPassword`
+- `testPasswordWrong`
+- `enablePrivilegedFlows`
+- `adminToken`
+
+## Regras operacionais
+- Existe uma unica collection canonica. Nao manter exports duplicados, mocks soltos ou snapshots antigos fora desta arvore.
+- Requests devem usar assertions minimas de status + contrato.
+- IDs e tokens devem ser encadeados por collection variables.
+- Fluxos privilegiados devem ser opcionais e gateados por `enablePrivilegedFlows=true` e `adminToken`.
+- O subset padrao que roda no CI deve continuar deterministico e seguro sem token administrativo.
+
+## Execucao
+Gerar/regravar a collection oficial:
+```bash
+npm run postman:build
+```
+
+Rodar localmente com Newman:
+```bash
+npm ci
+npm run postman:local
+```
+
+Rodar com outro environment:
+```bash
+./scripts/run_postman_suite.sh ./api-tests/postman/environments/dev.postman_environment.json
+./scripts/run_postman_suite.sh ./api-tests/postman/environments/prod.postman_environment.json
+```
+
+Rodar fluxos privilegiados:
+```bash
+POSTMAN_ENABLE_PRIVILEGED_FLOWS=true \
+POSTMAN_ADMIN_TOKEN=<token-admin> \
+./scripts/run_postman_suite.sh ./api-tests/postman/environments/dev.postman_environment.json
+```

--- a/api-tests/postman/auraxis.postman_collection.json
+++ b/api-tests/postman/auraxis.postman_collection.json
@@ -1,762 +1,3083 @@
 {
   "info": {
     "_postman_id": "3fd49b04-3416-4cf2-9048-b58abf132a20",
-    "name": "Auraxis API - Smoke and Regression",
+    "name": "Auraxis API - Canonical E2E and Smoke",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "description": "Reliable smoke/regression suite for REST + GraphQL. Importable in Postman and API Dog."
+    "description": "Canonical black-box suite for Auraxis API. Organized by domain, validated by Newman in CI, and designed for direct Postman import. Privileged flows are optional and gated by adminToken + enablePrivilegedFlows."
   },
   "item": [
     {
-      "name": "01 - Healthz",
-      "request": {
-        "method": "GET",
-        "header": [],
-        "url": {
-          "raw": "{{baseUrl}}/healthz",
-          "host": [
-            "{{baseUrl}}"
-          ],
-          "path": [
-            "healthz"
-          ]
-        }
-      },
-      "event": [
+      "name": "00 - Auth and User Bootstrap",
+      "item": [
         {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test('healthz status 200', function () {",
-              "  pm.response.to.have.status(200);",
-              "});"
+          "name": "01 - Healthz",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/healthz",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "healthz"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('healthz status 200', function () { pm.response.to.have.status(200); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "02 - Register user (REST v2)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
             ],
-            "type": "text/javascript"
-          }
+            "url": {
+              "raw": "{{baseUrl}}/auth/register",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "auth",
+                "register"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"name\": \"{{runName}}\",\n                      \"email\": \"{{runEmail}}\",\n                      \"password\": \"{{testPassword}}\"\n                    }\n"
+            }
+          },
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "exec": [
+                  "var now = new Date();",
+                  "var seed = String(now.getTime());",
+                  "function isoDate(offsetDays) {",
+                  "  var d = new Date(now);",
+                  "  d.setUTCDate(d.getUTCDate() + offsetDays);",
+                  "  return d.toISOString().slice(0, 10);",
+                  "}",
+                  "function isoMonth(offsetMonths) {",
+                  "  var d = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + offsetMonths, 1));",
+                  "  return d.toISOString().slice(0, 7);",
+                  "}",
+                  "pm.collectionVariables.set('runSeed', seed);",
+                  "pm.collectionVariables.set('runEmail', 'auraxis+' + seed + '@example.com');",
+                  "pm.collectionVariables.set('runName', 'auraxis_' + seed);",
+                  "pm.collectionVariables.set('runToday', isoDate(0));",
+                  "pm.collectionVariables.set('runYesterday', isoDate(-1));",
+                  "pm.collectionVariables.set('runTomorrow', isoDate(1));",
+                  "pm.collectionVariables.set('runIn30Days', isoDate(30));",
+                  "pm.collectionVariables.set('runIn45Days', isoDate(45));",
+                  "pm.collectionVariables.set('runIn60Days', isoDate(60));",
+                  "pm.collectionVariables.set('runIn180Days', isoDate(180));",
+                  "pm.collectionVariables.set('runIn365Days', isoDate(365));",
+                  "pm.collectionVariables.set('runMonthRef', isoMonth(0));",
+                  "pm.collectionVariables.set('graphSimulationLabel', 'Notebook ' + seed);",
+                  "['authToken', 'userId', 'transactionId', 'goalId', 'investmentId', 'operationId', 'simulationId', 'advancedSimulationId', 'feeSimulationId', 'entitlementId'].forEach(function (key) { pm.collectionVariables.unset(key); });"
+                ],
+                "type": "text/javascript"
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('register returns 201', function () { pm.response.to.have.status(201); });",
+                  "var body = pm.response.json();",
+                  "pm.test('register returns canonical success payload', function () {",
+                  "  pm.expect(body.success).to.eql(true);",
+                  "  pm.expect(body.message).to.be.a('string').and.not.empty;",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "03 - Login user (REST v2)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/auth/login",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "auth",
+                "login"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"email\": \"{{runEmail}}\",\n                      \"password\": \"{{testPassword}}\"\n                    }\n"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('login returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('login returns token and user', function () {",
+                  "  pm.expect(body.success).to.eql(true);",
+                  "  pm.expect(body.data.token).to.be.a('string').and.not.empty;",
+                  "  pm.expect(body.data.user.id).to.be.a('string').and.not.empty;",
+                  "});",
+                  "pm.collectionVariables.set('authToken', body.data.token);",
+                  "pm.collectionVariables.set('userId', body.data.user.id);"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "04 - Login invalid credentials returns safe error",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/auth/login",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "auth",
+                "login"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"email\": \"{{runEmail}}\",\n                      \"password\": \"{{testPasswordWrong}}\"\n                    }\n"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "var allowed = [401, 429, 503];",
+                  "pm.test('invalid login returns controlled status', function () { pm.expect(allowed).to.include(pm.response.code); });",
+                  "var body = pm.response.json();",
+                  "var code = body && body.error ? body.error.code : null;",
+                  "pm.test('invalid login never leaks INTERNAL_ERROR', function () { pm.expect(code).to.not.eql('INTERNAL_ERROR'); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "05 - Me (REST v2)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/user/me?page=1&limit=10",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "user",
+                "me"
+              ],
+              "query": [
+                {
+                  "key": "page",
+                  "value": "1"
+                },
+                {
+                  "key": "limit",
+                  "value": "10"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('me returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('me returns canonical authenticated user data', function () {",
+                  "  pm.expect(body.success).to.eql(true);",
+                  "  pm.expect(body.data.user.email).to.eql(pm.collectionVariables.get('runEmail'));",
+                  "});",
+                  "pm.collectionVariables.set('userId', body.data.user.id);"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "06 - Profile GET (REST v2)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/user/profile",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "user",
+                "profile"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('profile GET returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('profile GET returns user payload', function () {",
+                  "  pm.expect(body.success).to.eql(true);",
+                  "  pm.expect(body.data.user.email).to.eql(pm.collectionVariables.get('runEmail'));",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "07 - Profile UPDATE (REST v2)",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/user/profile",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "user",
+                "profile"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"gender\": \"outro\",\n                      \"monthly_income\": \"9000.00\",\n                      \"monthly_expenses\": \"5000.00\",\n                      \"monthly_investment\": \"1200.00\",\n                      \"investment_goal_date\": \"{{runIn365Days}}\"\n                    }\n"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('profile update returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('profile update persists canonical fields', function () {",
+                  "  pm.expect(body.success).to.eql(true);",
+                  "  pm.expect(body.data.user.gender).to.eql('outro');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "08 - Questionnaire GET (REST v2)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/user/profile/questionnaire",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "user",
+                "profile",
+                "questionnaire"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('questionnaire GET returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('questionnaire exposes five questions', function () {",
+                  "  pm.expect(body.data.questions).to.be.an('array').with.lengthOf(5);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "09 - Questionnaire POST valid answers (REST v2)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/user/profile/questionnaire",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "user",
+                "profile",
+                "questionnaire"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"answers\": [3, 2, 3, 2, 1]\n                    }\n"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('questionnaire POST valid returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('questionnaire POST returns suggested profile', function () {",
+                  "  pm.expect(body.success).to.eql(true);",
+                  "  pm.expect(body.data.suggested_profile).to.be.a('string').and.not.empty;",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "10 - Questionnaire POST invalid answers (REST v2)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/user/profile/questionnaire",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "user",
+                "profile",
+                "questionnaire"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"answers\": [\n                        {\"question_id\": 1, \"score\": 3}\n                      ]\n                    }\n"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('questionnaire invalid payload returns controlled client error', function () {",
+                  "  pm.expect([400, 422]).to.include(pm.response.code);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "11 - Logout (REST v2)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/auth/logout",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "auth",
+                "logout"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('logout returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('logout returns canonical success payload', function () { pm.expect(body.success).to.eql(true); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "12 - Login again after logout (REST v2)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/auth/login",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "auth",
+                "login"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"email\": \"{{runEmail}}\",\n                      \"password\": \"{{testPassword}}\"\n                    }\n"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('re-login returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.collectionVariables.set('authToken', body.data.token);"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "13 - Password forgot unknown email (REST v2)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/auth/password/forgot",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "auth",
+                "password",
+                "forgot"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"email\": \"unknown-{{runSeed}}@example.com\"\n                    }\n"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('password forgot unknown returns neutral 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('password forgot unknown stays neutral', function () { pm.expect(body.success).to.eql(true); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "14 - Password forgot known email (REST v2)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/auth/password/forgot",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "auth",
+                "password",
+                "forgot"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"email\": \"{{runEmail}}\"\n                    }\n"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('password forgot known returns neutral 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('password forgot known does not expose token', function () {",
+                  "  pm.expect(body.success).to.eql(true);",
+                  "  pm.expect(JSON.stringify(body)).to.not.include('token');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "15 - Password reset invalid token (REST v2)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/auth/password/reset",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "auth",
+                "password",
+                "reset"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"token\": \"invalid-token-value-with-sufficient-length-123456\",\n                      \"new_password\": \"NovaSenha@123\"\n                    }\n"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('password reset invalid token returns 400', function () { pm.response.to.have.status(400); });",
+                  "var body = pm.response.json();",
+                  "pm.test('password reset invalid token is a validation error', function () {",
+                  "  pm.expect(body.success).to.eql(false);",
+                  "  pm.expect(body.error.code).to.eql('VALIDATION_ERROR');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
         }
       ]
     },
     {
-      "name": "02 - Register (REST)",
-      "event": [
+      "name": "01 - Transactions",
+      "item": [
         {
-          "listen": "prerequest",
-          "script": {
-            "exec": [
-              "var ts = Date.now().toString();",
-              "pm.collectionVariables.set('runEmail', 'auraxis+' + ts + '@example.com');",
-              "pm.collectionVariables.set('runName', 'auraxis_' + ts);"
+          "name": "01 - Create transaction (REST v2)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
             ],
-            "type": "text/javascript"
-          }
-        },
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test('register returns 201', function () {",
-              "  pm.response.to.have.status(201);",
-              "});",
-              "var body = pm.response.json();",
-              "pm.test('register response has message', function () {",
-              "  pm.expect(body.message).to.be.a('string');",
-              "});"
-            ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "method": "POST",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json"
-          },
-          {
-            "key": "X-API-Contract",
-            "value": "v2"
-          }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": "{\n  \"name\": \"{{runName}}\",\n  \"email\": \"{{runEmail}}\",\n  \"password\": \"{{testPassword}}\"\n}"
-        },
-        "url": {
-          "raw": "{{baseUrl}}/auth/register",
-          "host": [
-            "{{baseUrl}}"
-          ],
-          "path": [
-            "auth",
-            "register"
-          ]
-        }
-      }
-    },
-    {
-      "name": "03 - Login (REST)",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test('login returns 200', function () {",
-              "  pm.response.to.have.status(200);",
-              "});",
-              "var body = pm.response.json();",
-              "var token = body && body.data ? body.data.token : null;",
-              "pm.test('login returns jwt token', function () {",
-              "  pm.expect(token).to.be.a('string').and.not.empty;",
-              "});",
-              "pm.collectionVariables.set('authToken', token);"
-            ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "method": "POST",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json"
-          },
-          {
-            "key": "X-API-Contract",
-            "value": "v2"
-          }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": "{\n  \"email\": \"{{runEmail}}\",\n  \"password\": \"{{testPassword}}\"\n}"
-        },
-        "url": {
-          "raw": "{{baseUrl}}/auth/login",
-          "host": [
-            "{{baseUrl}}"
-          ],
-          "path": [
-            "auth",
-            "login"
-          ]
-        }
-      }
-    },
-    {
-      "name": "04 - Me (REST auth required)",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test('me returns 200', function () {",
-              "  pm.response.to.have.status(200);",
-              "});",
-              "var body = pm.response.json();",
-              "pm.test('me returns authenticated user data', function () {",
-              "  pm.expect(body.data).to.be.an('object');",
-              "});"
-            ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "method": "GET",
-        "header": [
-          {
-            "key": "Authorization",
-            "value": "Bearer {{authToken}}"
-          },
-          {
-            "key": "X-API-Contract",
-            "value": "v2"
-          }
-        ],
-        "url": {
-          "raw": "{{baseUrl}}/user/me?page=1&limit=10",
-          "host": [
-            "{{baseUrl}}"
-          ],
-          "path": [
-            "user",
-            "me"
-          ],
-          "query": [
-            {
-              "key": "page",
-              "value": "1"
+            "url": {
+              "raw": "{{baseUrl}}/transactions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "transactions"
+              ]
             },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"title\": \"Conta de luz {{runSeed}}\",\n                      \"amount\": \"150.50\",\n                      \"type\": \"expense\",\n                      \"status\": \"pending\",\n                      \"due_date\": \"{{runToday}}\"\n                    }\n"
+            }
+          },
+          "event": [
             {
-              "key": "limit",
-              "value": "10"
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('transaction create returns 201', function () { pm.response.to.have.status(201); });",
+                  "var body = pm.response.json();",
+                  "var transaction = Array.isArray(body.data.transaction) ? body.data.transaction[0] : body.data.transaction;",
+                  "pm.test('transaction create returns transaction id', function () { pm.expect(transaction.id).to.be.a('string').and.not.empty; });",
+                  "pm.collectionVariables.set('transactionId', transaction.id);"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "02 - Update transaction by id (REST v2)",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/transactions/{{transactionId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "transactions",
+                "{{transactionId}}"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"title\": \"Conta de luz ajustada {{runSeed}}\",\n                      \"amount\": \"175.90\"\n                    }\n"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('transaction update returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('transaction update reflects new title', function () {",
+                  "  pm.expect(body.success).to.eql(true);",
+                  "  pm.expect(body.data.transaction.title).to.include('ajustada');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "03 - Create income transaction for reports (REST v2)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/transactions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "transactions"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"title\": \"Freelance {{runSeed}}\",\n                      \"amount\": \"1200.00\",\n                      \"type\": \"income\",\n                      \"status\": \"paid\",\n                      \"due_date\": \"{{runTomorrow}}\"\n                    }\n"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('supporting transaction returns 201', function () { pm.response.to.have.status(201); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "04 - List active transactions (REST v2)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/transactions/list?page=1&per_page=20",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "transactions",
+                "list"
+              ],
+              "query": [
+                {
+                  "key": "page",
+                  "value": "1"
+                },
+                {
+                  "key": "per_page",
+                  "value": "20"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('transaction list returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('transaction list returns pagination', function () {",
+                  "  pm.expect(body.success).to.eql(true);",
+                  "  pm.expect(body.meta.pagination.total).to.be.at.least(1);",
+                  "  pm.expect(body.data.transactions).to.be.an('array');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "05 - Transaction summary by month (REST v2)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/transactions/summary?month={{runMonthRef}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "transactions",
+                "summary"
+              ],
+              "query": [
+                {
+                  "key": "month",
+                  "value": "{{runMonthRef}}"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('transaction summary returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('summary includes canonical totals', function () {",
+                  "  pm.expect(body.success).to.eql(true);",
+                  "  pm.expect(body.data).to.have.property('income_total');",
+                  "  pm.expect(body.data).to.have.property('expense_total');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "06 - Transaction dashboard by month (REST v2)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/transactions/dashboard?month={{runMonthRef}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "transactions",
+                "dashboard"
+              ],
+              "query": [
+                {
+                  "key": "month",
+                  "value": "{{runMonthRef}}"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('transaction dashboard returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('dashboard includes totals and counts', function () {",
+                  "  pm.expect(body.success).to.eql(true);",
+                  "  pm.expect(body.data).to.have.property('totals');",
+                  "  pm.expect(body.data).to.have.property('counts');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "07 - Transaction expenses by period (REST v2)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/transactions/expenses?startDate={{runYesterday}}&finalDate={{runTomorrow}}&page=1&per_page=20",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "transactions",
+                "expenses"
+              ],
+              "query": [
+                {
+                  "key": "startDate",
+                  "value": "{{runYesterday}}"
+                },
+                {
+                  "key": "finalDate",
+                  "value": "{{runTomorrow}}"
+                },
+                {
+                  "key": "page",
+                  "value": "1"
+                },
+                {
+                  "key": "per_page",
+                  "value": "20"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('transaction expenses returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('expenses include data and pagination', function () {",
+                  "  pm.expect(body.success).to.eql(true);",
+                  "  pm.expect(body.data.expenses).to.be.an('array');",
+                  "  pm.expect(body.meta.pagination).to.be.an('object');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "08 - Transaction due range (REST v2)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/transactions/due-range?initialDate={{runYesterday}}&finalDate={{runIn30Days}}&page=1&per_page=20",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "transactions",
+                "due-range"
+              ],
+              "query": [
+                {
+                  "key": "initialDate",
+                  "value": "{{runYesterday}}"
+                },
+                {
+                  "key": "finalDate",
+                  "value": "{{runIn30Days}}"
+                },
+                {
+                  "key": "page",
+                  "value": "1"
+                },
+                {
+                  "key": "per_page",
+                  "value": "20"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('transaction due range returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('due range includes canonical items and counts', function () {",
+                  "  pm.expect(body.success).to.eql(true);",
+                  "  pm.expect(body.data.transactions).to.be.an('array');",
+                  "  pm.expect(body.data.counts).to.be.an('object');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "09 - Delete transaction by id (REST v2)",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/transactions/{{transactionId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "transactions",
+                "{{transactionId}}"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('transaction delete returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('transaction delete returns canonical success', function () { pm.expect(body.success).to.eql(true); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "10 - List deleted transactions (REST v2)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/transactions/deleted",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "transactions",
+                "deleted"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('deleted transactions returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('deleted transactions includes previously deleted item', function () {",
+                  "  pm.expect(body.success).to.eql(true);",
+                  "  pm.expect(body.data.deleted_transactions).to.be.an('array');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "11 - Restore transaction by id (REST v2)",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/transactions/restore/{{transactionId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "transactions",
+                "restore",
+                "{{transactionId}}"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('transaction restore returns 200', function () { pm.response.to.have.status(200); });",
+                  "pm.test('transaction restore canonical success', function () { pm.expect(pm.response.json().success).to.eql(true); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "12 - Delete transaction again (REST v2)",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/transactions/{{transactionId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "transactions",
+                "{{transactionId}}"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('transaction delete again returns 200', function () { pm.response.to.have.status(200); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "13 - Force delete transaction by id (REST v2)",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/transactions/{{transactionId}}/force",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "transactions",
+                "{{transactionId}}",
+                "force"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('transaction force delete returns 200', function () { pm.response.to.have.status(200); });",
+                  "pm.test('transaction force delete canonical success', function () { pm.expect(pm.response.json().success).to.eql(true); });"
+                ],
+                "type": "text/javascript"
+              }
             }
           ]
         }
-      }
+      ]
     },
     {
-      "name": "05 - Login invalid credentials (REST safe error)",
-      "event": [
+      "name": "02 - Goals",
+      "item": [
         {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "var allowed = [401, 429, 503];",
-              "pm.test('invalid REST login returns controlled status', function () {",
-              "  pm.expect(allowed).to.include(pm.response.code);",
-              "});",
-              "var body = pm.response.json();",
-              "var code = body && body.error ? body.error.code : null;",
-              "pm.test('invalid REST login does not expose INTERNAL_ERROR', function () {",
-              "  pm.expect(code).to.not.eql('INTERNAL_ERROR');",
-              "});"
+          "name": "01 - Create goal (REST v2)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
             ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "method": "POST",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json"
+            "url": {
+              "raw": "{{baseUrl}}/goals",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "goals"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"title\": \"Reserva de emergencia {{runSeed}}\",\n                      \"description\": \"Cobrir despesas fixas\",\n                      \"category\": \"reserva\",\n                      \"target_amount\": \"15000.00\",\n                      \"current_amount\": \"2500.00\",\n                      \"priority\": 1,\n                      \"target_date\": \"{{runIn365Days}}\"\n                    }\n"
+            }
           },
-          {
-            "key": "X-API-Contract",
-            "value": "v2"
-          }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": "{\n  \"email\": \"{{runEmail}}\",\n  \"password\": \"{{testPasswordWrong}}\"\n}"
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('goal create returns 201', function () { pm.response.to.have.status(201); });",
+                  "var body = pm.response.json();",
+                  "pm.collectionVariables.set('goalId', body.data.goal.id);",
+                  "pm.test('goal create captures goal id', function () { pm.expect(body.data.goal.id).to.be.a('string').and.not.empty; });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
         },
-        "url": {
-          "raw": "{{baseUrl}}/auth/login",
-          "host": [
-            "{{baseUrl}}"
-          ],
-          "path": [
-            "auth",
-            "login"
-          ]
-        }
-      }
-    },
-    {
-      "name": "06 - GraphQL empty query (validation error)",
-      "event": [
         {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test('graphql empty query returns 400', function () {",
-              "  pm.response.to.have.status(400);",
-              "});",
-              "var body = pm.response.json();",
-              "var firstErr = body.errors && body.errors[0] ? body.errors[0] : {};",
-              "var code = firstErr.extensions ? firstErr.extensions.code : null;",
-              "pm.test('graphql empty query uses VALIDATION_ERROR code', function () {",
-              "  pm.expect(code).to.eql('VALIDATION_ERROR');",
-              "});"
+          "name": "02 - List goals (REST v2)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
             ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "method": "POST",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json"
-          }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": "{\n  \"query\": \"   \"\n}"
+            "url": {
+              "raw": "{{baseUrl}}/goals?page=1&per_page=10&status=active",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "goals"
+              ],
+              "query": [
+                {
+                  "key": "page",
+                  "value": "1"
+                },
+                {
+                  "key": "per_page",
+                  "value": "10"
+                },
+                {
+                  "key": "status",
+                  "value": "active"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('goal list returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('goal list includes pagination', function () {",
+                  "  pm.expect(body.success).to.eql(true);",
+                  "  pm.expect(body.meta.pagination.total).to.be.at.least(1);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
         },
-        "url": {
-          "raw": "{{baseUrl}}/graphql",
-          "host": [
-            "{{baseUrl}}"
-          ],
-          "path": [
-            "graphql"
-          ]
-        }
-      }
-    },
-    {
-      "name": "07 - GraphQL login invalid credentials (safe error)",
-      "event": [
         {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test('graphql invalid login transport status is 200', function () {",
-              "  pm.response.to.have.status(200);",
-              "});",
-              "var body = pm.response.json();",
-              "var firstErr = body.errors && body.errors[0] ? body.errors[0] : {};",
-              "var code = firstErr.extensions ? firstErr.extensions.code : null;",
-              "pm.test('graphql returns public auth error code', function () {",
-              "  pm.expect(code).to.eql('UNAUTHORIZED');",
-              "});",
-              "pm.test('graphql does not expose INTERNAL_ERROR for invalid credentials', function () {",
-              "  pm.expect(code).to.not.eql('INTERNAL_ERROR');",
-              "});"
+          "name": "03 - Get goal by id (REST v2)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
             ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "method": "POST",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json"
-          }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": "{\n  \"query\": \"mutation Login($email: String, $password: String!) { login(email: $email, password: $password) { token message } }\",\n  \"variables\": {\n    \"email\": \"{{runEmail}}\",\n    \"password\": \"{{testPasswordWrong}}\"\n  }\n}"
+            "url": {
+              "raw": "{{baseUrl}}/goals/{{goalId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "goals",
+                "{{goalId}}"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('goal get returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('goal get returns requested id', function () { pm.expect(body.data.goal.id).to.eql(pm.collectionVariables.get('goalId')); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
         },
-        "url": {
-          "raw": "{{baseUrl}}/graphql",
-          "host": [
-            "{{baseUrl}}"
-          ],
-          "path": [
-            "graphql"
-          ]
-        }
-      }
-    },
-    {
-      "name": "08 - GraphQL me query (auth required)",
-      "event": [
         {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test('graphql me returns 200', function () {",
-              "  pm.response.to.have.status(200);",
-              "});",
-              "var body = pm.response.json();",
-              "pm.test('graphql me has data and no errors', function () {",
-              "  pm.expect(body.data).to.be.an('object');",
-              "  pm.expect(body.errors).to.eql(undefined);",
-              "});",
-              "pm.test('graphql me email matches runEmail', function () {",
-              "  pm.expect(body.data.me.email).to.eql(pm.collectionVariables.get('runEmail'));",
-              "});"
+          "name": "04 - Goal plan by id (REST v2)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
             ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "method": "POST",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json"
+            "url": {
+              "raw": "{{baseUrl}}/goals/{{goalId}}/plan",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "goals",
+                "{{goalId}}",
+                "plan"
+              ]
+            }
           },
-          {
-            "key": "Authorization",
-            "value": "Bearer {{authToken}}"
-          }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": "{\n  \"query\": \"query Me { me { id email name } }\"\n}"
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('goal plan returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('goal plan includes recommendation payload', function () {",
+                  "  pm.expect(body.success).to.eql(true);",
+                  "  pm.expect(body.data.goal_plan.recommendations).to.be.an('array');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
         },
-        "url": {
-          "raw": "{{baseUrl}}/graphql",
-          "host": [
-            "{{baseUrl}}"
-          ],
-          "path": [
-            "graphql"
-          ]
-        }
-      }
-    },
-    {
-      "name": "09 - Questionnaire GET (REST auth required)",
-      "event": [
         {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test('questionnaire GET returns 200', function () {",
-              "  pm.response.to.have.status(200);",
-              "});",
-              "var body = pm.response.json();",
-              "pm.test('questionnaire response has data.questions array', function () {",
-              "  pm.expect(body.data.questions).to.be.an('array');",
-              "});",
-              "pm.test('questionnaire has exactly 5 questions', function () {",
-              "  pm.expect(body.data.questions).to.have.lengthOf(5);",
-              "});",
-              "pm.test('each question has id, text and options', function () {",
-              "  body.data.questions.forEach(function (q) {",
-              "    pm.expect(q).to.have.property('id');",
-              "    pm.expect(q).to.have.property('text');",
-              "    pm.expect(q.options).to.be.an('array').with.lengthOf(3);",
-              "  });",
-              "});",
-              "pm.test('option points are between 1 and 3', function () {",
-              "  body.data.questions.forEach(function (q) {",
-              "    q.options.forEach(function (o) {",
-              "      pm.expect(o.points).to.be.within(1, 3);",
-              "    });",
-              "  });",
-              "});"
+          "name": "05 - Goal simulate (REST v2)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
             ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "method": "GET",
-        "header": [
-          {
-            "key": "Authorization",
-            "value": "Bearer {{authToken}}"
+            "url": {
+              "raw": "{{baseUrl}}/goals/simulate",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "goals",
+                "simulate"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"target_amount\": \"50000.00\",\n                      \"current_amount\": \"10000.00\",\n                      \"monthly_income\": \"12000.00\",\n                      \"monthly_expenses\": \"7000.00\",\n                      \"monthly_contribution\": \"2000.00\",\n                      \"target_date\": \"{{runIn365Days}}\"\n                    }\n"
+            }
           },
-          {
-            "key": "X-API-Contract",
-            "value": "v2"
-          }
-        ],
-        "url": {
-          "raw": "{{baseUrl}}/user/profile/questionnaire",
-          "host": [
-            "{{baseUrl}}"
-          ],
-          "path": [
-            "user",
-            "profile",
-            "questionnaire"
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('goal simulate returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('goal simulate returns goal plan payload', function () {",
+                  "  pm.expect(body.success).to.eql(true);",
+                  "  pm.expect(body.data.goal_plan).to.be.an('object');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
           ]
-        }
-      }
-    },
-    {
-      "name": "10 - Questionnaire POST valid answers (REST auth required)",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test('questionnaire POST returns 200', function () {",
-              "  pm.response.to.have.status(200);",
-              "});",
-              "var body = pm.response.json();",
-              "pm.test('questionnaire result has suggested_profile', function () {",
-              "  pm.expect(body.data.suggested_profile).to.be.oneOf(['conservador', 'explorador', 'entusiasta']);",
-              "});",
-              "pm.test('questionnaire score equals sum of answers', function () {",
-              "  pm.expect(body.data.score).to.eql(10);",
-              "});",
-              "pm.test('suggested_profile is explorador for score 10', function () {",
-              "  pm.expect(body.data.suggested_profile).to.eql('explorador');",
-              "});"
-            ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "method": "POST",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json"
-          },
-          {
-            "key": "Authorization",
-            "value": "Bearer {{authToken}}"
-          },
-          {
-            "key": "X-API-Contract",
-            "value": "v2"
-          }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": "{\n  \"answers\": [2, 2, 2, 2, 2]\n}"
         },
-        "url": {
-          "raw": "{{baseUrl}}/user/profile/questionnaire",
-          "host": [
-            "{{baseUrl}}"
-          ],
-          "path": [
-            "user",
-            "profile",
-            "questionnaire"
+        {
+          "name": "06 - Update goal by id (REST v2)",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/goals/{{goalId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "goals",
+                "{{goalId}}"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"current_amount\": \"5000.00\",\n                      \"status\": \"paused\"\n                    }\n"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('goal update returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('goal update reflects paused status', function () {",
+                  "  pm.expect(body.success).to.eql(true);",
+                  "  pm.expect(body.data.goal.status).to.eql('paused');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "07 - Delete goal by id (REST v2)",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/goals/{{goalId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "goals",
+                "{{goalId}}"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('goal delete returns 200', function () { pm.response.to.have.status(200); });",
+                  "pm.test('goal delete canonical success', function () { pm.expect(pm.response.json().success).to.eql(true); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
           ]
         }
-      }
+      ]
     },
     {
-      "name": "11 - Questionnaire POST invalid payload (validation error)",
-      "event": [
+      "name": "03 - Wallet",
+      "item": [
         {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test('questionnaire invalid answers returns 422', function () {",
-              "  pm.response.to.have.status(422);",
-              "});",
-              "var body = pm.response.json();",
-              "pm.test('questionnaire validation error has error.code', function () {",
-              "  pm.expect(body.error.code).to.eql('VALIDATION_ERROR');",
-              "});",
-              "pm.test('questionnaire error does not expose INTERNAL_ERROR', function () {",
-              "  pm.expect(body.error.code).to.not.eql('INTERNAL_ERROR');",
-              "});"
+          "name": "01 - Create wallet investment (REST v2)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
             ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "method": "POST",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json"
+            "url": {
+              "raw": "{{baseUrl}}/wallet",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "wallet"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"name\": \"Reserva {{runSeed}}\",\n                      \"value\": \"1500.00\",\n                      \"quantity\": 2,\n                      \"register_date\": \"{{runYesterday}}\",\n                      \"should_be_on_wallet\": true\n                    }\n"
+            }
           },
-          {
-            "key": "Authorization",
-            "value": "Bearer {{authToken}}"
-          },
-          {
-            "key": "X-API-Contract",
-            "value": "v2"
-          }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": "{\n  \"answers\": [4, 1, 1]\n}"
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('wallet create returns 201', function () { pm.response.to.have.status(201); });",
+                  "var body = pm.response.json();",
+                  "pm.collectionVariables.set('investmentId', body.data.investment.id);",
+                  "pm.test('wallet create captures investment id', function () { pm.expect(body.data.investment.id).to.be.a('string').and.not.empty; });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
         },
-        "url": {
-          "raw": "{{baseUrl}}/user/profile/questionnaire",
-          "host": [
-            "{{baseUrl}}"
-          ],
-          "path": [
-            "user",
-            "profile",
-            "questionnaire"
+        {
+          "name": "02 - List wallet investments (REST v2)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/wallet?page=1&per_page=10",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "wallet"
+              ],
+              "query": [
+                {
+                  "key": "page",
+                  "value": "1"
+                },
+                {
+                  "key": "per_page",
+                  "value": "10"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('wallet list returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('wallet list includes pagination and items', function () {",
+                  "  pm.expect(body.success).to.eql(true);",
+                  "  pm.expect(body.data.items).to.be.an('array');",
+                  "  pm.expect(body.meta.pagination).to.be.an('object');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "03 - Update wallet investment (REST v2)",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/wallet/{{investmentId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "wallet",
+                "{{investmentId}}"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"value\": \"2000.00\"\n                    }\n"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('wallet update returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('wallet update keeps history', function () {",
+                  "  pm.expect(body.success).to.eql(true);",
+                  "  pm.expect(body.data.investment.history).to.be.an('array');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "04 - Wallet investment history (REST v2)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/wallet/{{investmentId}}/history?page=1&per_page=10",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "wallet",
+                "{{investmentId}}",
+                "history"
+              ],
+              "query": [
+                {
+                  "key": "page",
+                  "value": "1"
+                },
+                {
+                  "key": "per_page",
+                  "value": "10"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('wallet history returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('wallet history includes pagination', function () {",
+                  "  pm.expect(body.success).to.eql(true);",
+                  "  pm.expect(body.data.items).to.be.an('array');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "05 - Wallet portfolio valuation (REST v2)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/wallet/valuation",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "wallet",
+                "valuation"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('wallet valuation returns 200', function () { pm.response.to.have.status(200); });",
+                  "pm.test('wallet valuation returns canonical payload', function () { pm.expect(pm.response.json().success).to.eql(true); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "06 - Wallet portfolio valuation history (REST v2)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/wallet/valuation/history?startDate={{runYesterday}}&finalDate={{runToday}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "wallet",
+                "valuation",
+                "history"
+              ],
+              "query": [
+                {
+                  "key": "startDate",
+                  "value": "{{runYesterday}}"
+                },
+                {
+                  "key": "finalDate",
+                  "value": "{{runToday}}"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('wallet valuation history returns 200', function () { pm.response.to.have.status(200); });",
+                  "pm.test('wallet valuation history returns canonical payload', function () { pm.expect(pm.response.json().success).to.eql(true); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "07 - Wallet investment valuation (REST v2)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/wallet/{{investmentId}}/valuation",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "wallet",
+                "{{investmentId}}",
+                "valuation"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('wallet investment valuation returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('wallet investment valuation returns valuation object', function () {",
+                  "  pm.expect(body.success).to.eql(true);",
+                  "  pm.expect(body.data.valuation).to.be.an('object');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "08 - Create wallet operation (REST v2)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/wallet/{{investmentId}}/operations",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "wallet",
+                "{{investmentId}}",
+                "operations"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"operation_type\": \"buy\",\n                      \"quantity\": \"2.5\",\n                      \"unit_price\": \"35.40\",\n                      \"fees\": \"1.20\",\n                      \"executed_at\": \"{{runYesterday}}\",\n                      \"notes\": \"Compra inicial {{runSeed}}\"\n                    }\n"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('wallet operation create returns 201', function () { pm.response.to.have.status(201); });",
+                  "var body = pm.response.json();",
+                  "pm.collectionVariables.set('operationId', body.data.operation.id);",
+                  "pm.test('wallet operation create captures operation id', function () { pm.expect(body.data.operation.id).to.be.a('string').and.not.empty; });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "09 - List wallet operations (REST v2)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/wallet/{{investmentId}}/operations?page=1&per_page=10",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "wallet",
+                "{{investmentId}}",
+                "operations"
+              ],
+              "query": [
+                {
+                  "key": "page",
+                  "value": "1"
+                },
+                {
+                  "key": "per_page",
+                  "value": "10"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('wallet operation list returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('wallet operation list includes items', function () {",
+                  "  pm.expect(body.success).to.eql(true);",
+                  "  pm.expect(body.data.items).to.be.an('array');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "10 - Wallet operation summary (REST v2)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/wallet/{{investmentId}}/operations/summary",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "wallet",
+                "{{investmentId}}",
+                "operations",
+                "summary"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('wallet operation summary returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('wallet operation summary returns summary object', function () {",
+                  "  pm.expect(body.success).to.eql(true);",
+                  "  pm.expect(body.data.summary).to.be.an('object');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "11 - Wallet operation position (REST v2)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/wallet/{{investmentId}}/operations/position",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "wallet",
+                "{{investmentId}}",
+                "operations",
+                "position"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('wallet operation position returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('wallet operation position returns position object', function () {",
+                  "  pm.expect(body.success).to.eql(true);",
+                  "  pm.expect(body.data.position).to.be.an('object');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "12 - Wallet invested amount by date (REST v2)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/wallet/{{investmentId}}/operations/invested-amount?date={{runToday}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "wallet",
+                "{{investmentId}}",
+                "operations",
+                "invested-amount"
+              ],
+              "query": [
+                {
+                  "key": "date",
+                  "value": "{{runToday}}"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('wallet invested amount returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('wallet invested amount returns result object', function () {",
+                  "  pm.expect(body.success).to.eql(true);",
+                  "  pm.expect(body.data.result).to.be.an('object');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "13 - Update wallet operation (REST v2)",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/wallet/{{investmentId}}/operations/{{operationId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "wallet",
+                "{{investmentId}}",
+                "operations",
+                "{{operationId}}"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"notes\": \"Atualizada {{runSeed}}\",\n                      \"fees\": \"2.00\"\n                    }\n"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('wallet operation update returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('wallet operation update reflects notes', function () {",
+                  "  pm.expect(body.success).to.eql(true);",
+                  "  pm.expect(body.data.operation.notes).to.include('Atualizada');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "14 - Delete wallet operation (REST v2)",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/wallet/{{investmentId}}/operations/{{operationId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "wallet",
+                "{{investmentId}}",
+                "operations",
+                "{{operationId}}"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('wallet operation delete returns 200', function () { pm.response.to.have.status(200); });",
+                  "pm.test('wallet operation delete canonical success', function () { pm.expect(pm.response.json().success).to.eql(true); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "15 - Delete wallet investment (REST v2)",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/wallet/{{investmentId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "wallet",
+                "{{investmentId}}"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('wallet delete returns 200', function () { pm.response.to.have.status(200); });",
+                  "pm.test('wallet delete canonical success', function () { pm.expect(pm.response.json().success).to.eql(true); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
           ]
         }
-      }
+      ]
     },
     {
-      "name": "12 - Installment vs Cash calculate (REST public)",
-      "event": [
+      "name": "04 - Simulations",
+      "item": [
         {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test('installment vs cash calculate returns 200', function () {",
-              "  pm.response.to.have.status(200);",
-              "});",
-              "var body = pm.response.json();",
-              "pm.test('installment vs cash uses v2 success envelope', function () {",
-              "  pm.expect(body.success).to.eql(true);",
-              "  pm.expect(body.data.tool_id).to.eql('installment_vs_cash');",
-              "});",
-              "pm.test('installment vs cash returns recommendation', function () {",
-              "  pm.expect(body.data.result.recommended_option).to.be.oneOf(['cash', 'installment', 'equivalent']);",
-              "});"
+          "name": "01 - Installment vs cash calculate (REST public)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
             ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "method": "POST",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json"
+            "url": {
+              "raw": "{{baseUrl}}/simulations/installment-vs-cash/calculate",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "simulations",
+                "installment-vs-cash",
+                "calculate"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"cash_price\": \"900.00\",\n                      \"installment_count\": 3,\n                      \"installment_total\": \"990.00\",\n                      \"first_payment_delay_days\": 30,\n                      \"opportunity_rate_type\": \"manual\",\n                      \"opportunity_rate_annual\": \"12.00\",\n                      \"inflation_rate_annual\": \"4.50\",\n                      \"fees_enabled\": false,\n                      \"fees_upfront\": \"0.00\"\n                    }\n"
+            }
           },
-          {
-            "key": "X-API-Contract",
-            "value": "v2"
-          }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": "{\n  \"cash_price\": \"900.00\",\n  \"installment_count\": 3,\n  \"installment_total\": \"990.00\",\n  \"first_payment_delay_days\": 30,\n  \"opportunity_rate_type\": \"manual\",\n  \"opportunity_rate_annual\": \"12.00\",\n  \"inflation_rate_annual\": \"4.50\",\n  \"fees_enabled\": false,\n  \"fees_upfront\": \"0.00\"\n}"
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('simulation calculate returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('simulation calculate returns canonical result', function () {",
+                  "  pm.expect(body.success).to.eql(true);",
+                  "  pm.expect(body.data.tool_id).to.eql('installment_vs_cash');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
         },
-        "url": {
-          "raw": "{{baseUrl}}/simulations/installment-vs-cash/calculate",
-          "host": [
-            "{{baseUrl}}"
-          ],
-          "path": [
-            "simulations",
-            "installment-vs-cash",
-            "calculate"
+        {
+          "name": "02 - Installment vs cash save (REST auth required)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/simulations/installment-vs-cash/save",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "simulations",
+                "installment-vs-cash",
+                "save"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"cash_price\": \"900.00\",\n                      \"installment_count\": 3,\n                      \"installment_total\": \"990.00\",\n                      \"first_payment_delay_days\": 30,\n                      \"opportunity_rate_type\": \"manual\",\n                      \"opportunity_rate_annual\": \"12.00\",\n                      \"inflation_rate_annual\": \"4.50\",\n                      \"fees_enabled\": false,\n                      \"fees_upfront\": \"0.00\",\n                      \"scenario_label\": \"{{graphSimulationLabel}}\"\n                    }\n"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('simulation save returns 201', function () { pm.response.to.have.status(201); });",
+                  "var body = pm.response.json();",
+                  "pm.collectionVariables.set('simulationId', body.data.simulation.id);",
+                  "pm.test('simulation save returns persisted simulation id', function () { pm.expect(body.data.simulation.id).to.be.a('string').and.not.empty; });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "03 - Simulation goal bridge without entitlement returns 403",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/simulations/{{simulationId}}/goal",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "simulations",
+                "{{simulationId}}",
+                "goal"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"title\": \"Notebook novo {{runSeed}}\",\n                      \"selected_option\": \"cash\"\n                    }\n"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('simulation goal bridge without entitlement returns 403', function () { pm.response.to.have.status(403); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "04 - Grant advanced simulations entitlement (optional admin)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{adminToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/entitlements/admin",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "entitlements",
+                "admin"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"user_id\": \"{{userId}}\",\n                      \"feature_key\": \"advanced_simulations\",\n                      \"source\": \"postman_e2e\"\n                    }\n"
+            }
+          },
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "exec": [
+                  "var enabled = String(pm.environment.get('enablePrivilegedFlows') || pm.collectionVariables.get('enablePrivilegedFlows') || 'false').toLowerCase();",
+                  "var adminToken = pm.environment.get('adminToken') || pm.collectionVariables.get('adminToken') || '';",
+                  "if (enabled !== 'true' || !adminToken) {",
+                  "  console.log('Skipping privileged request because enablePrivilegedFlows/adminToken is not configured.');",
+                  "  pm.execution.skipRequest();",
+                  "}"
+                ],
+                "type": "text/javascript"
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('entitlement grant returns 201', function () { pm.response.to.have.status(201); });",
+                  "var body = pm.response.json();",
+                  "pm.collectionVariables.set('entitlementId', body.data.entitlement.id);"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "05 - Save advanced simulation for success bridges (optional admin)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/simulations/installment-vs-cash/save",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "simulations",
+                "installment-vs-cash",
+                "save"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"cash_price\": \"1500.00\",\n                      \"installment_count\": 5,\n                      \"installment_total\": \"1650.00\",\n                      \"first_payment_delay_days\": 30,\n                      \"opportunity_rate_type\": \"manual\",\n                      \"opportunity_rate_annual\": \"12.00\",\n                      \"inflation_rate_annual\": \"4.50\",\n                      \"fees_enabled\": false,\n                      \"fees_upfront\": \"0.00\",\n                      \"scenario_label\": \"Bridge {{runSeed}}\"\n                    }\n"
+            }
+          },
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "exec": [
+                  "var enabled = String(pm.environment.get('enablePrivilegedFlows') || pm.collectionVariables.get('enablePrivilegedFlows') || 'false').toLowerCase();",
+                  "var adminToken = pm.environment.get('adminToken') || pm.collectionVariables.get('adminToken') || '';",
+                  "if (enabled !== 'true' || !adminToken) {",
+                  "  console.log('Skipping privileged request because enablePrivilegedFlows/adminToken is not configured.');",
+                  "  pm.execution.skipRequest();",
+                  "}"
+                ],
+                "type": "text/javascript"
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('advanced simulation save returns 201', function () { pm.response.to.have.status(201); });",
+                  "pm.collectionVariables.set('advancedSimulationId', pm.response.json().data.simulation.id);"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "06 - Simulation goal bridge success (optional admin)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/simulations/{{advancedSimulationId}}/goal",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "simulations",
+                "{{advancedSimulationId}}",
+                "goal"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"title\": \"Notebook premium {{runSeed}}\",\n                      \"selected_option\": \"cash\"\n                    }\n"
+            }
+          },
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "exec": [
+                  "var enabled = String(pm.environment.get('enablePrivilegedFlows') || pm.collectionVariables.get('enablePrivilegedFlows') || 'false').toLowerCase();",
+                  "var adminToken = pm.environment.get('adminToken') || pm.collectionVariables.get('adminToken') || '';",
+                  "if (enabled !== 'true' || !adminToken) {",
+                  "  console.log('Skipping privileged request because enablePrivilegedFlows/adminToken is not configured.');",
+                  "  pm.execution.skipRequest();",
+                  "}"
+                ],
+                "type": "text/javascript"
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('simulation goal bridge success returns 201', function () { pm.response.to.have.status(201); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "07 - Save fee simulation for planned expense bridge (optional admin)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/simulations/installment-vs-cash/save",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "simulations",
+                "installment-vs-cash",
+                "save"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"cash_price\": \"900.00\",\n                      \"installment_count\": 3,\n                      \"installment_total\": \"990.00\",\n                      \"first_payment_delay_days\": 30,\n                      \"opportunity_rate_type\": \"manual\",\n                      \"opportunity_rate_annual\": \"12.00\",\n                      \"inflation_rate_annual\": \"4.50\",\n                      \"fees_enabled\": true,\n                      \"fees_upfront\": \"60.00\",\n                      \"scenario_label\": \"Fees {{runSeed}}\"\n                    }\n"
+            }
+          },
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "exec": [
+                  "var enabled = String(pm.environment.get('enablePrivilegedFlows') || pm.collectionVariables.get('enablePrivilegedFlows') || 'false').toLowerCase();",
+                  "var adminToken = pm.environment.get('adminToken') || pm.collectionVariables.get('adminToken') || '';",
+                  "if (enabled !== 'true' || !adminToken) {",
+                  "  console.log('Skipping privileged request because enablePrivilegedFlows/adminToken is not configured.');",
+                  "  pm.execution.skipRequest();",
+                  "}"
+                ],
+                "type": "text/javascript"
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('fee simulation save returns 201', function () { pm.response.to.have.status(201); });",
+                  "pm.collectionVariables.set('feeSimulationId', pm.response.json().data.simulation.id);"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "08 - Simulation planned expense bridge success (optional admin)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/simulations/{{feeSimulationId}}/planned-expense",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "simulations",
+                "{{feeSimulationId}}",
+                "planned-expense"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"title\": \"Notebook novo {{runSeed}}\",\n                      \"selected_option\": \"installment\",\n                      \"first_due_date\": \"{{runIn30Days}}\"\n                    }\n"
+            }
+          },
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "exec": [
+                  "var enabled = String(pm.environment.get('enablePrivilegedFlows') || pm.collectionVariables.get('enablePrivilegedFlows') || 'false').toLowerCase();",
+                  "var adminToken = pm.environment.get('adminToken') || pm.collectionVariables.get('adminToken') || '';",
+                  "if (enabled !== 'true' || !adminToken) {",
+                  "  console.log('Skipping privileged request because enablePrivilegedFlows/adminToken is not configured.');",
+                  "  pm.execution.skipRequest();",
+                  "}"
+                ],
+                "type": "text/javascript"
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('simulation planned expense bridge success returns 201', function () { pm.response.to.have.status(201); });",
+                  "var body = pm.response.json();",
+                  "pm.test('simulation planned expense returns generated transactions', function () {",
+                  "  pm.expect(body.transactions).to.be.an('array').and.not.empty;",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "09 - Revoke advanced simulations entitlement (optional admin)",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{adminToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/entitlements/admin/{{entitlementId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "entitlements",
+                "admin",
+                "{{entitlementId}}"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "exec": [
+                  "var enabled = String(pm.environment.get('enablePrivilegedFlows') || pm.collectionVariables.get('enablePrivilegedFlows') || 'false').toLowerCase();",
+                  "var adminToken = pm.environment.get('adminToken') || pm.collectionVariables.get('adminToken') || '';",
+                  "if (enabled !== 'true' || !adminToken) {",
+                  "  console.log('Skipping privileged request because enablePrivilegedFlows/adminToken is not configured.');",
+                  "  pm.execution.skipRequest();",
+                  "}"
+                ],
+                "type": "text/javascript"
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('entitlement revoke returns 200', function () { pm.response.to.have.status(200); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
           ]
         }
-      }
+      ]
     },
     {
-      "name": "13 - Installment vs Cash save (REST auth required)",
-      "event": [
+      "name": "05 - GraphQL",
+      "item": [
         {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test('installment vs cash save returns 201', function () {",
-              "  pm.response.to.have.status(201);",
-              "});",
-              "var body = pm.response.json();",
-              "pm.test('installment vs cash save persists simulation', function () {",
-              "  pm.expect(body.success).to.eql(true);",
-              "  pm.expect(body.data.simulation.tool_id).to.eql('installment_vs_cash');",
-              "  pm.expect(body.data.simulation.saved).to.eql(true);",
-              "});"
+          "name": "01 - GraphQL empty query (validation error)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
             ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "method": "POST",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json"
+            "url": {
+              "raw": "{{baseUrl}}/graphql",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "graphql"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"query\": \"   \"\n                    }\n"
+            }
           },
-          {
-            "key": "Authorization",
-            "value": "Bearer {{authToken}}"
-          },
-          {
-            "key": "X-API-Contract",
-            "value": "v2"
-          }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": "{\n  \"cash_price\": \"900.00\",\n  \"installment_count\": 3,\n  \"installment_total\": \"990.00\",\n  \"first_payment_delay_days\": 30,\n  \"opportunity_rate_type\": \"manual\",\n  \"opportunity_rate_annual\": \"12.00\",\n  \"inflation_rate_annual\": \"4.50\",\n  \"fees_enabled\": true,\n  \"fees_upfront\": \"60.00\",\n  \"scenario_label\": \"Notebook\"\n}"
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('graphql empty query returns 400', function () { pm.response.to.have.status(400); });",
+                  "var body = pm.response.json();",
+                  "var firstErr = body.errors && body.errors[0] ? body.errors[0] : {};",
+                  "pm.test('graphql empty query uses VALIDATION_ERROR', function () { pm.expect(firstErr.extensions.code).to.eql('VALIDATION_ERROR'); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
         },
-        "url": {
-          "raw": "{{baseUrl}}/simulations/installment-vs-cash/save",
-          "host": [
-            "{{baseUrl}}"
-          ],
-          "path": [
-            "simulations",
-            "installment-vs-cash",
-            "save"
+        {
+          "name": "02 - GraphQL login invalid credentials (safe error)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/graphql",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "graphql"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"query\": \"mutation Login($email: String, $password: String!) { login(email: $email, password: $password) { token message } }\",\n                      \"variables\": {\n                        \"email\": \"{{runEmail}}\",\n                        \"password\": \"{{testPasswordWrong}}\"\n                      }\n                    }\n"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('graphql invalid login transport status is 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "var firstErr = body.errors && body.errors[0] ? body.errors[0] : {};",
+                  "pm.test('graphql invalid login exposes public UNAUTHORIZED code', function () { pm.expect(firstErr.extensions.code).to.eql('UNAUTHORIZED'); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "03 - GraphQL me query (auth required)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/graphql",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "graphql"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"query\": \"query Me { me { id email name } }\"\n                    }\n"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('graphql me returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('graphql me returns authenticated user', function () {",
+                  "  pm.expect(body.errors).to.eql(undefined);",
+                  "  pm.expect(body.data.me.email).to.eql(pm.collectionVariables.get('runEmail'));",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "04 - GraphQL installment vs cash calculate (public)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/graphql",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "graphql"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"query\": \"query InstallmentVsCashCalculate { installmentVsCashCalculate(cashPrice: \\\"900.00\\\", installmentCount: 3, installmentTotal: \\\"990.00\\\", firstPaymentDelayDays: 30, opportunityRateType: \\\"manual\\\", opportunityRateAnnual: \\\"12.00\\\", inflationRateAnnual: \\\"4.50\\\", feesEnabled: false, feesUpfront: \\\"0.00\\\") { toolId result { recommendedOption } } }\"\n                    }\n"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('graphql installment calculate returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('graphql installment calculate returns tool id', function () { pm.expect(body.data.installmentVsCashCalculate.toolId).to.eql('installment_vs_cash'); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "05 - GraphQL installment vs cash save (auth required)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/graphql",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "graphql"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"query\": \"mutation SaveInstallmentVsCashSimulation { saveInstallmentVsCashSimulation(cashPrice: \\\"900.00\\\", installmentCount: 3, installmentTotal: \\\"990.00\\\", firstPaymentDelayDays: 30, opportunityRateType: \\\"manual\\\", opportunityRateAnnual: \\\"12.00\\\", inflationRateAnnual: \\\"4.50\\\", feesEnabled: true, feesUpfront: \\\"60.00\\\", scenarioLabel: \\\"Notebook {{runSeed}}\\\") { message simulation { id toolId saved } calculation { toolId } } }\"\n                    }\n"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('graphql installment save returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('graphql installment save persists simulation', function () {",
+                  "  pm.expect(body.errors).to.eql(undefined);",
+                  "  pm.expect(body.data.saveInstallmentVsCashSimulation.simulation.saved).to.eql(true);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
           ]
         }
-      }
-    },
-    {
-      "name": "14 - GraphQL installment vs cash calculate (public)",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test('graphql installment vs cash calculate returns 200', function () {",
-              "  pm.response.to.have.status(200);",
-              "});",
-              "var body = pm.response.json();",
-              "pm.test('graphql installment vs cash calculate has data and no errors', function () {",
-              "  pm.expect(body.errors).to.eql(undefined);",
-              "  pm.expect(body.data.installmentVsCashCalculate.toolId).to.eql('installment_vs_cash');",
-              "});"
-            ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "method": "POST",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json"
-          }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": "{\n  \"query\": \"query InstallmentVsCashCalculate { installmentVsCashCalculate(cashPrice: \\\"900.00\\\", installmentCount: 3, installmentTotal: \\\"990.00\\\", firstPaymentDelayDays: 30, opportunityRateType: \\\"manual\\\", opportunityRateAnnual: \\\"12.00\\\", inflationRateAnnual: \\\"4.50\\\", feesEnabled: false, feesUpfront: \\\"0.00\\\") { toolId result { recommendedOption } } }\"\n}"
-        },
-        "url": {
-          "raw": "{{baseUrl}}/graphql",
-          "host": [
-            "{{baseUrl}}"
-          ],
-          "path": [
-            "graphql"
-          ]
-        }
-      }
-    },
-    {
-      "name": "15 - GraphQL installment vs cash save (auth required)",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test('graphql installment vs cash save returns 200', function () {",
-              "  pm.response.to.have.status(200);",
-              "});",
-              "var body = pm.response.json();",
-              "pm.test('graphql installment vs cash save has data and no errors', function () {",
-              "  pm.expect(body.errors).to.eql(undefined);",
-              "  pm.expect(body.data.saveInstallmentVsCashSimulation.simulation.toolId).to.eql('installment_vs_cash');",
-              "});"
-            ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "method": "POST",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json"
-          },
-          {
-            "key": "Authorization",
-            "value": "Bearer {{authToken}}"
-          }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": "{\n  \"query\": \"mutation SaveInstallmentVsCashSimulation { saveInstallmentVsCashSimulation(cashPrice: \\\"900.00\\\", installmentCount: 3, installmentTotal: \\\"990.00\\\", firstPaymentDelayDays: 30, opportunityRateType: \\\"manual\\\", opportunityRateAnnual: \\\"12.00\\\", inflationRateAnnual: \\\"4.50\\\", feesEnabled: true, feesUpfront: \\\"60.00\\\", scenarioLabel: \\\"Notebook\\\") { message simulation { id toolId saved } calculation { toolId } } }\"\n}"
-        },
-        "url": {
-          "raw": "{{baseUrl}}/graphql",
-          "host": [
-            "{{baseUrl}}"
-          ],
-          "path": [
-            "graphql"
-          ]
-        }
-      }
+      ]
     }
   ],
   "variable": [
+    {
+      "key": "runSeed",
+      "value": ""
+    },
     {
       "key": "runEmail",
       "value": ""
@@ -767,6 +3088,42 @@
     },
     {
       "key": "authToken",
+      "value": ""
+    },
+    {
+      "key": "userId",
+      "value": ""
+    },
+    {
+      "key": "transactionId",
+      "value": ""
+    },
+    {
+      "key": "goalId",
+      "value": ""
+    },
+    {
+      "key": "investmentId",
+      "value": ""
+    },
+    {
+      "key": "operationId",
+      "value": ""
+    },
+    {
+      "key": "simulationId",
+      "value": ""
+    },
+    {
+      "key": "advancedSimulationId",
+      "value": ""
+    },
+    {
+      "key": "feeSimulationId",
+      "value": ""
+    },
+    {
+      "key": "entitlementId",
       "value": ""
     }
   ]

--- a/api-tests/postman/environments/dev.postman_environment.json
+++ b/api-tests/postman/environments/dev.postman_environment.json
@@ -4,19 +4,31 @@
   "values": [
     {
       "key": "baseUrl",
-      "value": "https://dev.api.auraxis.com.br",
+      "value": "http://dev.api.auraxis.com.br",
       "type": "default",
       "enabled": true
     },
     {
       "key": "testPassword",
-      "value": "CHANGE_ME_IN_POSTMAN",
+      "value": "StrongPass@123",
       "type": "secret",
       "enabled": true
     },
     {
       "key": "testPasswordWrong",
-      "value": "CHANGE_ME_IN_POSTMAN_wrong",
+      "value": "WrongPass@123",
+      "type": "secret",
+      "enabled": true
+    },
+    {
+      "key": "enablePrivilegedFlows",
+      "value": "false",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "adminToken",
+      "value": "",
       "type": "secret",
       "enabled": true
     }

--- a/api-tests/postman/environments/local.postman_environment.json
+++ b/api-tests/postman/environments/local.postman_environment.json
@@ -10,13 +10,25 @@
     },
     {
       "key": "testPassword",
-      "value": "3672120Felipe*",
+      "value": "StrongPass@123",
       "type": "secret",
       "enabled": true
     },
     {
       "key": "testPasswordWrong",
-      "value": "3672120Felipe*_wrong",
+      "value": "WrongPass@123",
+      "type": "secret",
+      "enabled": true
+    },
+    {
+      "key": "enablePrivilegedFlows",
+      "value": "false",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "adminToken",
+      "value": "",
       "type": "secret",
       "enabled": true
     }

--- a/api-tests/postman/environments/prod.postman_environment.json
+++ b/api-tests/postman/environments/prod.postman_environment.json
@@ -10,13 +10,25 @@
     },
     {
       "key": "testPassword",
-      "value": "CHANGE_ME_IN_POSTMAN",
+      "value": "StrongPass@123",
       "type": "secret",
       "enabled": true
     },
     {
       "key": "testPasswordWrong",
-      "value": "CHANGE_ME_IN_POSTMAN_wrong",
+      "value": "WrongPass@123",
+      "type": "secret",
+      "enabled": true
+    },
+    {
+      "key": "enablePrivilegedFlows",
+      "value": "false",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "adminToken",
+      "value": "",
       "type": "secret",
       "enabled": true
     }

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -18,7 +18,7 @@ scripts/repo_bin.sh pytest
 scripts/repo_bin.sh pytest tests/test_response_contract.py
 ```
 
-## Suíte Postman / API Dog (Smoke + Regression)
+## Suite Postman / Newman (Canonica E2E + Smoke)
 
 Coleção versionada:
 - `api-tests/postman/auraxis.postman_collection.json`
@@ -33,9 +33,14 @@ Bootstrap do runner:
 npm ci
 ```
 
+Gerar/regravar a collection oficial:
+```bash
+npm run postman:build
+```
+
 Runner local (Newman):
 ```bash
-npm run smoke:local
+npm run postman:local
 ```
 
 Runner com environment específico:
@@ -44,13 +49,21 @@ Runner com environment específico:
 ./scripts/run_postman_suite.sh ./api-tests/postman/environments/prod.postman_environment.json
 ```
 
-Cobertura inicial da coleção:
-- `GET /healthz`
-- `POST /auth/register`
-- `POST /auth/login`
-- `GET /user/me` (autenticado)
-- `POST /graphql` login inválido (garante erro público seguro)
-- `POST /graphql` query `me` (autenticado)
+Fluxos privilegiados opcionais:
+```bash
+POSTMAN_ENABLE_PRIVILEGED_FLOWS=true \
+POSTMAN_ADMIN_TOKEN=<token-admin> \
+./scripts/run_postman_suite.sh ./api-tests/postman/environments/dev.postman_environment.json
+```
+
+Cobertura canonica atual:
+- Auth: register, login, logout, forgot/reset invalid token
+- User: me, profile, questionnaire
+- Transactions: create, update, list, summary, dashboard, expenses, due-range, delete/restore/force-delete
+- Goals: create, list, get, plan, simulate, update, delete
+- Wallet: create, list, update, history, valuation, operations CRUD, position, invested amount
+- Simulations: installment-vs-cash calculate/save e bridges com subset privilegiado opcional
+- GraphQL: validation, auth-safe errors, me, installment-vs-cash calculate/save
 
 ## Como a suíte está configurada
 - `pytest.ini` define padrão de descoberta dos testes.
@@ -58,9 +71,11 @@ Cobertura inicial da coleção:
 - `tests/conftest.py` isola variáveis de ambiente por teste e restaura o estado original ao final.
 - A aplicação usa `DATABASE_URL` quando definida (ambiente de teste),
   e mantém fallback para PostgreSQL nos demais ambientes.
+- `tests/test_postman_collection_contract.py` trava a paridade entre a collection canônica e as rotas REST críticas do contrato.
 
 ## Observações
-- A suíte não depende de `.env.test`.
+- A suite não depende de `.env.test`.
 - Cada teste roda com schema limpo (`create_all`/`drop_all`).
 - Ao final de cada teste, a sessão SQLAlchemy é removida, o engine é `dispose()` e o arquivo SQLite temporário é limpo.
-- Newman é a trilha oficial de smoke black-box pré-merge no CI; o smoke pós-deploy oficial fica em `scripts/http_smoke_check.py`.
+- Newman e Postman sao a trilha oficial de validacao black-box da API; o smoke pós-deploy oficial continua em `scripts/http_smoke_check.py`.
+- O environment `prod` deve ser usado apenas com total consciencia de que a collection cria dados de teste reais via registro/login e recursos associados.

--- a/package.json
+++ b/package.json
@@ -1,9 +1,12 @@
 {
-  "name": "auraxis-api-smoke",
+  "name": "auraxis-api-postman-suite",
   "version": "1.0.0",
-  "description": "Newman smoke test runner for Auraxis API CI validation",
+  "description": "Canonical Postman/Newman E2E runner for Auraxis API",
   "private": true,
   "scripts": {
+    "postman:build": "python3 scripts/build_postman_collection.py",
+    "postman:local": "bash scripts/run_postman_suite.sh",
+    "postman:ci": "bash scripts/run_postman_suite.sh api-tests/postman/environments/local.postman_environment.json",
     "smoke:local": "bash scripts/run_postman_suite.sh",
     "smoke:ci": "bash scripts/run_postman_suite.sh api-tests/postman/environments/local.postman_environment.json"
   },

--- a/scripts/build_postman_collection.py
+++ b/scripts/build_postman_collection.py
@@ -1,0 +1,1504 @@
+#!/usr/bin/env python3
+# ruff: noqa: E501
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+COLLECTION_PATH = ROOT / "api-tests" / "postman" / "auraxis.postman_collection.json"
+
+
+def _js(lines: list[str]) -> dict[str, Any]:
+    return {"exec": lines, "type": "text/javascript"}
+
+
+def _test_event(lines: list[str]) -> dict[str, Any]:
+    return {"listen": "test", "script": _js(lines)}
+
+
+def _prerequest_event(lines: list[str]) -> dict[str, Any]:
+    return {"listen": "prerequest", "script": _js(lines)}
+
+
+def _headers(*items: tuple[str, str]) -> list[dict[str, str]]:
+    return [{"key": key, "value": value} for key, value in items]
+
+
+def _url(raw: str, *, query: list[tuple[str, str]] | None = None) -> dict[str, Any]:
+    path = [
+        segment
+        for segment in raw.split("{{baseUrl}}", 1)[1].split("?")[0].split("/")
+        if segment
+    ]
+    payload: dict[str, Any] = {
+        "raw": raw,
+        "host": ["{{baseUrl}}"],
+        "path": path,
+    }
+    if query:
+        payload["query"] = [{"key": key, "value": value} for key, value in query]
+    return payload
+
+
+def _request(
+    *,
+    method: str,
+    raw_url: str,
+    headers: list[dict[str, str]] | None = None,
+    body: str | None = None,
+    query: list[tuple[str, str]] | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "method": method,
+        "header": headers or [],
+        "url": _url(raw_url, query=query),
+    }
+    if body is not None:
+        payload["body"] = {"mode": "raw", "raw": body}
+    return payload
+
+
+def _item(
+    name: str,
+    request: dict[str, Any],
+    *,
+    test_lines: list[str] | None = None,
+    prerequest_lines: list[str] | None = None,
+) -> dict[str, Any]:
+    events: list[dict[str, Any]] = []
+    if prerequest_lines:
+        events.append(_prerequest_event(prerequest_lines))
+    if test_lines:
+        events.append(_test_event(test_lines))
+    payload: dict[str, Any] = {"name": name, "request": request}
+    if events:
+        payload["event"] = events
+    return payload
+
+
+def _folder(name: str, items: list[dict[str, Any]]) -> dict[str, Any]:
+    return {"name": name, "item": items}
+
+
+def _skip_if_privileged_flows_disabled() -> list[str]:
+    return [
+        "var enabled = String(pm.environment.get('enablePrivilegedFlows') || pm.collectionVariables.get('enablePrivilegedFlows') || 'false').toLowerCase();",
+        "var adminToken = pm.environment.get('adminToken') || pm.collectionVariables.get('adminToken') || '';",
+        "if (enabled !== 'true' || !adminToken) {",
+        "  console.log('Skipping privileged request because enablePrivilegedFlows/adminToken is not configured.');",
+        "  pm.execution.skipRequest();",
+        "}",
+    ]
+
+
+def _bootstrap_prerequest() -> list[str]:
+    return [
+        "var now = new Date();",
+        "var seed = String(now.getTime());",
+        "function isoDate(offsetDays) {",
+        "  var d = new Date(now);",
+        "  d.setUTCDate(d.getUTCDate() + offsetDays);",
+        "  return d.toISOString().slice(0, 10);",
+        "}",
+        "function isoMonth(offsetMonths) {",
+        "  var d = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + offsetMonths, 1));",
+        "  return d.toISOString().slice(0, 7);",
+        "}",
+        "pm.collectionVariables.set('runSeed', seed);",
+        "pm.collectionVariables.set('runEmail', 'auraxis+' + seed + '@example.com');",
+        "pm.collectionVariables.set('runName', 'auraxis_' + seed);",
+        "pm.collectionVariables.set('runToday', isoDate(0));",
+        "pm.collectionVariables.set('runYesterday', isoDate(-1));",
+        "pm.collectionVariables.set('runTomorrow', isoDate(1));",
+        "pm.collectionVariables.set('runIn30Days', isoDate(30));",
+        "pm.collectionVariables.set('runIn45Days', isoDate(45));",
+        "pm.collectionVariables.set('runIn60Days', isoDate(60));",
+        "pm.collectionVariables.set('runIn180Days', isoDate(180));",
+        "pm.collectionVariables.set('runIn365Days', isoDate(365));",
+        "pm.collectionVariables.set('runMonthRef', isoMonth(0));",
+        "pm.collectionVariables.set('graphSimulationLabel', 'Notebook ' + seed);",
+        "['authToken', 'userId', 'transactionId', 'goalId', 'investmentId', 'operationId', 'simulationId', 'advancedSimulationId', 'feeSimulationId', 'entitlementId'].forEach(function (key) { pm.collectionVariables.unset(key); });",
+    ]
+
+
+def _json_body(raw: str) -> str:
+    return raw.strip() + "\n"
+
+
+def build_collection() -> dict[str, Any]:
+    contract_headers = _headers(
+        ("Content-Type", "application/json"), ("X-API-Contract", "v2")
+    )
+    auth_json_headers = _headers(
+        ("Content-Type", "application/json"),
+        ("Authorization", "Bearer {{authToken}}"),
+        ("X-API-Contract", "v2"),
+    )
+    auth_contract_headers = _headers(
+        ("Authorization", "Bearer {{authToken}}"), ("X-API-Contract", "v2")
+    )
+    graphql_headers = _headers(("Content-Type", "application/json"))
+    graphql_auth_headers = _headers(
+        ("Content-Type", "application/json"),
+        ("Authorization", "Bearer {{authToken}}"),
+    )
+
+    auth_items = [
+        _item(
+            "01 - Healthz",
+            _request(method="GET", raw_url="{{baseUrl}}/healthz"),
+            test_lines=[
+                "pm.test('healthz status 200', function () { pm.response.to.have.status(200); });",
+            ],
+        ),
+        _item(
+            "02 - Register user (REST v2)",
+            _request(
+                method="POST",
+                raw_url="{{baseUrl}}/auth/register",
+                headers=contract_headers,
+                body=_json_body(
+                    """
+                    {
+                      "name": "{{runName}}",
+                      "email": "{{runEmail}}",
+                      "password": "{{testPassword}}"
+                    }
+                    """
+                ),
+            ),
+            prerequest_lines=_bootstrap_prerequest(),
+            test_lines=[
+                "pm.test('register returns 201', function () { pm.response.to.have.status(201); });",
+                "var body = pm.response.json();",
+                "pm.test('register returns canonical success payload', function () {",
+                "  pm.expect(body.success).to.eql(true);",
+                "  pm.expect(body.message).to.be.a('string').and.not.empty;",
+                "});",
+            ],
+        ),
+        _item(
+            "03 - Login user (REST v2)",
+            _request(
+                method="POST",
+                raw_url="{{baseUrl}}/auth/login",
+                headers=contract_headers,
+                body=_json_body(
+                    """
+                    {
+                      "email": "{{runEmail}}",
+                      "password": "{{testPassword}}"
+                    }
+                    """
+                ),
+            ),
+            test_lines=[
+                "pm.test('login returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('login returns token and user', function () {",
+                "  pm.expect(body.success).to.eql(true);",
+                "  pm.expect(body.data.token).to.be.a('string').and.not.empty;",
+                "  pm.expect(body.data.user.id).to.be.a('string').and.not.empty;",
+                "});",
+                "pm.collectionVariables.set('authToken', body.data.token);",
+                "pm.collectionVariables.set('userId', body.data.user.id);",
+            ],
+        ),
+        _item(
+            "04 - Login invalid credentials returns safe error",
+            _request(
+                method="POST",
+                raw_url="{{baseUrl}}/auth/login",
+                headers=contract_headers,
+                body=_json_body(
+                    """
+                    {
+                      "email": "{{runEmail}}",
+                      "password": "{{testPasswordWrong}}"
+                    }
+                    """
+                ),
+            ),
+            test_lines=[
+                "var allowed = [401, 429, 503];",
+                "pm.test('invalid login returns controlled status', function () { pm.expect(allowed).to.include(pm.response.code); });",
+                "var body = pm.response.json();",
+                "var code = body && body.error ? body.error.code : null;",
+                "pm.test('invalid login never leaks INTERNAL_ERROR', function () { pm.expect(code).to.not.eql('INTERNAL_ERROR'); });",
+            ],
+        ),
+        _item(
+            "05 - Me (REST v2)",
+            _request(
+                method="GET",
+                raw_url="{{baseUrl}}/user/me?page=1&limit=10",
+                headers=auth_contract_headers,
+                query=[("page", "1"), ("limit", "10")],
+            ),
+            test_lines=[
+                "pm.test('me returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('me returns canonical authenticated user data', function () {",
+                "  pm.expect(body.success).to.eql(true);",
+                "  pm.expect(body.data.user.email).to.eql(pm.collectionVariables.get('runEmail'));",
+                "});",
+                "pm.collectionVariables.set('userId', body.data.user.id);",
+            ],
+        ),
+        _item(
+            "06 - Profile GET (REST v2)",
+            _request(
+                method="GET",
+                raw_url="{{baseUrl}}/user/profile",
+                headers=auth_contract_headers,
+            ),
+            test_lines=[
+                "pm.test('profile GET returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('profile GET returns user payload', function () {",
+                "  pm.expect(body.success).to.eql(true);",
+                "  pm.expect(body.data.user.email).to.eql(pm.collectionVariables.get('runEmail'));",
+                "});",
+            ],
+        ),
+        _item(
+            "07 - Profile UPDATE (REST v2)",
+            _request(
+                method="PUT",
+                raw_url="{{baseUrl}}/user/profile",
+                headers=auth_json_headers,
+                body=_json_body(
+                    """
+                    {
+                      "gender": "outro",
+                      "monthly_income": "9000.00",
+                      "monthly_expenses": "5000.00",
+                      "monthly_investment": "1200.00",
+                      "investment_goal_date": "{{runIn365Days}}"
+                    }
+                    """
+                ),
+            ),
+            test_lines=[
+                "pm.test('profile update returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('profile update persists canonical fields', function () {",
+                "  pm.expect(body.success).to.eql(true);",
+                "  pm.expect(body.data.user.gender).to.eql('outro');",
+                "});",
+            ],
+        ),
+        _item(
+            "08 - Questionnaire GET (REST v2)",
+            _request(
+                method="GET",
+                raw_url="{{baseUrl}}/user/profile/questionnaire",
+                headers=auth_contract_headers,
+            ),
+            test_lines=[
+                "pm.test('questionnaire GET returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('questionnaire exposes five questions', function () {",
+                "  pm.expect(body.data.questions).to.be.an('array').with.lengthOf(5);",
+                "});",
+            ],
+        ),
+        _item(
+            "09 - Questionnaire POST valid answers (REST v2)",
+            _request(
+                method="POST",
+                raw_url="{{baseUrl}}/user/profile/questionnaire",
+                headers=auth_json_headers,
+                body=_json_body(
+                    """
+                    {
+                      "answers": [3, 2, 3, 2, 1]
+                    }
+                    """
+                ),
+            ),
+            test_lines=[
+                "pm.test('questionnaire POST valid returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('questionnaire POST returns suggested profile', function () {",
+                "  pm.expect(body.success).to.eql(true);",
+                "  pm.expect(body.data.suggested_profile).to.be.a('string').and.not.empty;",
+                "});",
+            ],
+        ),
+        _item(
+            "10 - Questionnaire POST invalid answers (REST v2)",
+            _request(
+                method="POST",
+                raw_url="{{baseUrl}}/user/profile/questionnaire",
+                headers=auth_json_headers,
+                body=_json_body(
+                    """
+                    {
+                      "answers": [
+                        {"question_id": 1, "score": 3}
+                      ]
+                    }
+                    """
+                ),
+            ),
+            test_lines=[
+                "pm.test('questionnaire invalid payload returns controlled client error', function () {",
+                "  pm.expect([400, 422]).to.include(pm.response.code);",
+                "});",
+            ],
+        ),
+        _item(
+            "11 - Logout (REST v2)",
+            _request(
+                method="POST",
+                raw_url="{{baseUrl}}/auth/logout",
+                headers=auth_contract_headers,
+            ),
+            test_lines=[
+                "pm.test('logout returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('logout returns canonical success payload', function () { pm.expect(body.success).to.eql(true); });",
+            ],
+        ),
+        _item(
+            "12 - Login again after logout (REST v2)",
+            _request(
+                method="POST",
+                raw_url="{{baseUrl}}/auth/login",
+                headers=contract_headers,
+                body=_json_body(
+                    """
+                    {
+                      "email": "{{runEmail}}",
+                      "password": "{{testPassword}}"
+                    }
+                    """
+                ),
+            ),
+            test_lines=[
+                "pm.test('re-login returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.collectionVariables.set('authToken', body.data.token);",
+            ],
+        ),
+        _item(
+            "13 - Password forgot unknown email (REST v2)",
+            _request(
+                method="POST",
+                raw_url="{{baseUrl}}/auth/password/forgot",
+                headers=contract_headers,
+                body=_json_body(
+                    """
+                    {
+                      "email": "unknown-{{runSeed}}@example.com"
+                    }
+                    """
+                ),
+            ),
+            test_lines=[
+                "pm.test('password forgot unknown returns neutral 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('password forgot unknown stays neutral', function () { pm.expect(body.success).to.eql(true); });",
+            ],
+        ),
+        _item(
+            "14 - Password forgot known email (REST v2)",
+            _request(
+                method="POST",
+                raw_url="{{baseUrl}}/auth/password/forgot",
+                headers=contract_headers,
+                body=_json_body(
+                    """
+                    {
+                      "email": "{{runEmail}}"
+                    }
+                    """
+                ),
+            ),
+            test_lines=[
+                "pm.test('password forgot known returns neutral 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('password forgot known does not expose token', function () {",
+                "  pm.expect(body.success).to.eql(true);",
+                "  pm.expect(JSON.stringify(body)).to.not.include('token');",
+                "});",
+            ],
+        ),
+        _item(
+            "15 - Password reset invalid token (REST v2)",
+            _request(
+                method="POST",
+                raw_url="{{baseUrl}}/auth/password/reset",
+                headers=contract_headers,
+                body=_json_body(
+                    """
+                    {
+                      "token": "invalid-token-value-with-sufficient-length-123456",
+                      "new_password": "NovaSenha@123"
+                    }
+                    """
+                ),
+            ),
+            test_lines=[
+                "pm.test('password reset invalid token returns 400', function () { pm.response.to.have.status(400); });",
+                "var body = pm.response.json();",
+                "pm.test('password reset invalid token is a validation error', function () {",
+                "  pm.expect(body.success).to.eql(false);",
+                "  pm.expect(body.error.code).to.eql('VALIDATION_ERROR');",
+                "});",
+            ],
+        ),
+    ]
+
+    transaction_items = [
+        _item(
+            "01 - Create transaction (REST v2)",
+            _request(
+                method="POST",
+                raw_url="{{baseUrl}}/transactions",
+                headers=auth_json_headers,
+                body=_json_body(
+                    """
+                    {
+                      "title": "Conta de luz {{runSeed}}",
+                      "amount": "150.50",
+                      "type": "expense",
+                      "status": "pending",
+                      "due_date": "{{runToday}}"
+                    }
+                    """
+                ),
+            ),
+            test_lines=[
+                "pm.test('transaction create returns 201', function () { pm.response.to.have.status(201); });",
+                "var body = pm.response.json();",
+                "var transaction = Array.isArray(body.data.transaction) ? body.data.transaction[0] : body.data.transaction;",
+                "pm.test('transaction create returns transaction id', function () { pm.expect(transaction.id).to.be.a('string').and.not.empty; });",
+                "pm.collectionVariables.set('transactionId', transaction.id);",
+            ],
+        ),
+        _item(
+            "02 - Update transaction by id (REST v2)",
+            _request(
+                method="PUT",
+                raw_url="{{baseUrl}}/transactions/{{transactionId}}",
+                headers=auth_json_headers,
+                body=_json_body(
+                    """
+                    {
+                      "title": "Conta de luz ajustada {{runSeed}}",
+                      "amount": "175.90"
+                    }
+                    """
+                ),
+            ),
+            test_lines=[
+                "pm.test('transaction update returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('transaction update reflects new title', function () {",
+                "  pm.expect(body.success).to.eql(true);",
+                "  pm.expect(body.data.transaction.title).to.include('ajustada');",
+                "});",
+            ],
+        ),
+        _item(
+            "03 - Create income transaction for reports (REST v2)",
+            _request(
+                method="POST",
+                raw_url="{{baseUrl}}/transactions",
+                headers=auth_json_headers,
+                body=_json_body(
+                    """
+                    {
+                      "title": "Freelance {{runSeed}}",
+                      "amount": "1200.00",
+                      "type": "income",
+                      "status": "paid",
+                      "due_date": "{{runTomorrow}}"
+                    }
+                    """
+                ),
+            ),
+            test_lines=[
+                "pm.test('supporting transaction returns 201', function () { pm.response.to.have.status(201); });",
+            ],
+        ),
+        _item(
+            "04 - List active transactions (REST v2)",
+            _request(
+                method="GET",
+                raw_url="{{baseUrl}}/transactions/list?page=1&per_page=20",
+                headers=auth_contract_headers,
+                query=[("page", "1"), ("per_page", "20")],
+            ),
+            test_lines=[
+                "pm.test('transaction list returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('transaction list returns pagination', function () {",
+                "  pm.expect(body.success).to.eql(true);",
+                "  pm.expect(body.meta.pagination.total).to.be.at.least(1);",
+                "  pm.expect(body.data.transactions).to.be.an('array');",
+                "});",
+            ],
+        ),
+        _item(
+            "05 - Transaction summary by month (REST v2)",
+            _request(
+                method="GET",
+                raw_url="{{baseUrl}}/transactions/summary?month={{runMonthRef}}",
+                headers=auth_contract_headers,
+                query=[("month", "{{runMonthRef}}")],
+            ),
+            test_lines=[
+                "pm.test('transaction summary returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('summary includes canonical totals', function () {",
+                "  pm.expect(body.success).to.eql(true);",
+                "  pm.expect(body.data).to.have.property('income_total');",
+                "  pm.expect(body.data).to.have.property('expense_total');",
+                "});",
+            ],
+        ),
+        _item(
+            "06 - Transaction dashboard by month (REST v2)",
+            _request(
+                method="GET",
+                raw_url="{{baseUrl}}/transactions/dashboard?month={{runMonthRef}}",
+                headers=auth_contract_headers,
+                query=[("month", "{{runMonthRef}}")],
+            ),
+            test_lines=[
+                "pm.test('transaction dashboard returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('dashboard includes totals and counts', function () {",
+                "  pm.expect(body.success).to.eql(true);",
+                "  pm.expect(body.data).to.have.property('totals');",
+                "  pm.expect(body.data).to.have.property('counts');",
+                "});",
+            ],
+        ),
+        _item(
+            "07 - Transaction expenses by period (REST v2)",
+            _request(
+                method="GET",
+                raw_url="{{baseUrl}}/transactions/expenses?startDate={{runYesterday}}&finalDate={{runTomorrow}}&page=1&per_page=20",
+                headers=auth_contract_headers,
+                query=[
+                    ("startDate", "{{runYesterday}}"),
+                    ("finalDate", "{{runTomorrow}}"),
+                    ("page", "1"),
+                    ("per_page", "20"),
+                ],
+            ),
+            test_lines=[
+                "pm.test('transaction expenses returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('expenses include data and pagination', function () {",
+                "  pm.expect(body.success).to.eql(true);",
+                "  pm.expect(body.data.expenses).to.be.an('array');",
+                "  pm.expect(body.meta.pagination).to.be.an('object');",
+                "});",
+            ],
+        ),
+        _item(
+            "08 - Transaction due range (REST v2)",
+            _request(
+                method="GET",
+                raw_url="{{baseUrl}}/transactions/due-range?initialDate={{runYesterday}}&finalDate={{runIn30Days}}&page=1&per_page=20",
+                headers=auth_contract_headers,
+                query=[
+                    ("initialDate", "{{runYesterday}}"),
+                    ("finalDate", "{{runIn30Days}}"),
+                    ("page", "1"),
+                    ("per_page", "20"),
+                ],
+            ),
+            test_lines=[
+                "pm.test('transaction due range returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('due range includes canonical items and counts', function () {",
+                "  pm.expect(body.success).to.eql(true);",
+                "  pm.expect(body.data.transactions).to.be.an('array');",
+                "  pm.expect(body.data.counts).to.be.an('object');",
+                "});",
+            ],
+        ),
+        _item(
+            "09 - Delete transaction by id (REST v2)",
+            _request(
+                method="DELETE",
+                raw_url="{{baseUrl}}/transactions/{{transactionId}}",
+                headers=auth_contract_headers,
+            ),
+            test_lines=[
+                "pm.test('transaction delete returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('transaction delete returns canonical success', function () { pm.expect(body.success).to.eql(true); });",
+            ],
+        ),
+        _item(
+            "10 - List deleted transactions (REST v2)",
+            _request(
+                method="GET",
+                raw_url="{{baseUrl}}/transactions/deleted",
+                headers=auth_contract_headers,
+            ),
+            test_lines=[
+                "pm.test('deleted transactions returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('deleted transactions includes previously deleted item', function () {",
+                "  pm.expect(body.success).to.eql(true);",
+                "  pm.expect(body.data.deleted_transactions).to.be.an('array');",
+                "});",
+            ],
+        ),
+        _item(
+            "11 - Restore transaction by id (REST v2)",
+            _request(
+                method="PATCH",
+                raw_url="{{baseUrl}}/transactions/restore/{{transactionId}}",
+                headers=auth_contract_headers,
+            ),
+            test_lines=[
+                "pm.test('transaction restore returns 200', function () { pm.response.to.have.status(200); });",
+                "pm.test('transaction restore canonical success', function () { pm.expect(pm.response.json().success).to.eql(true); });",
+            ],
+        ),
+        _item(
+            "12 - Delete transaction again (REST v2)",
+            _request(
+                method="DELETE",
+                raw_url="{{baseUrl}}/transactions/{{transactionId}}",
+                headers=auth_contract_headers,
+            ),
+            test_lines=[
+                "pm.test('transaction delete again returns 200', function () { pm.response.to.have.status(200); });",
+            ],
+        ),
+        _item(
+            "13 - Force delete transaction by id (REST v2)",
+            _request(
+                method="DELETE",
+                raw_url="{{baseUrl}}/transactions/{{transactionId}}/force",
+                headers=auth_contract_headers,
+            ),
+            test_lines=[
+                "pm.test('transaction force delete returns 200', function () { pm.response.to.have.status(200); });",
+                "pm.test('transaction force delete canonical success', function () { pm.expect(pm.response.json().success).to.eql(true); });",
+            ],
+        ),
+    ]
+
+    goal_items = [
+        _item(
+            "01 - Create goal (REST v2)",
+            _request(
+                method="POST",
+                raw_url="{{baseUrl}}/goals",
+                headers=auth_json_headers,
+                body=_json_body(
+                    """
+                    {
+                      "title": "Reserva de emergencia {{runSeed}}",
+                      "description": "Cobrir despesas fixas",
+                      "category": "reserva",
+                      "target_amount": "15000.00",
+                      "current_amount": "2500.00",
+                      "priority": 1,
+                      "target_date": "{{runIn365Days}}"
+                    }
+                    """
+                ),
+            ),
+            test_lines=[
+                "pm.test('goal create returns 201', function () { pm.response.to.have.status(201); });",
+                "var body = pm.response.json();",
+                "pm.collectionVariables.set('goalId', body.data.goal.id);",
+                "pm.test('goal create captures goal id', function () { pm.expect(body.data.goal.id).to.be.a('string').and.not.empty; });",
+            ],
+        ),
+        _item(
+            "02 - List goals (REST v2)",
+            _request(
+                method="GET",
+                raw_url="{{baseUrl}}/goals?page=1&per_page=10&status=active",
+                headers=auth_contract_headers,
+                query=[("page", "1"), ("per_page", "10"), ("status", "active")],
+            ),
+            test_lines=[
+                "pm.test('goal list returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('goal list includes pagination', function () {",
+                "  pm.expect(body.success).to.eql(true);",
+                "  pm.expect(body.meta.pagination.total).to.be.at.least(1);",
+                "});",
+            ],
+        ),
+        _item(
+            "03 - Get goal by id (REST v2)",
+            _request(
+                method="GET",
+                raw_url="{{baseUrl}}/goals/{{goalId}}",
+                headers=auth_contract_headers,
+            ),
+            test_lines=[
+                "pm.test('goal get returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('goal get returns requested id', function () { pm.expect(body.data.goal.id).to.eql(pm.collectionVariables.get('goalId')); });",
+            ],
+        ),
+        _item(
+            "04 - Goal plan by id (REST v2)",
+            _request(
+                method="GET",
+                raw_url="{{baseUrl}}/goals/{{goalId}}/plan",
+                headers=auth_contract_headers,
+            ),
+            test_lines=[
+                "pm.test('goal plan returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('goal plan includes recommendation payload', function () {",
+                "  pm.expect(body.success).to.eql(true);",
+                "  pm.expect(body.data.goal_plan.recommendations).to.be.an('array');",
+                "});",
+            ],
+        ),
+        _item(
+            "05 - Goal simulate (REST v2)",
+            _request(
+                method="POST",
+                raw_url="{{baseUrl}}/goals/simulate",
+                headers=auth_json_headers,
+                body=_json_body(
+                    """
+                    {
+                      "target_amount": "50000.00",
+                      "current_amount": "10000.00",
+                      "monthly_income": "12000.00",
+                      "monthly_expenses": "7000.00",
+                      "monthly_contribution": "2000.00",
+                      "target_date": "{{runIn365Days}}"
+                    }
+                    """
+                ),
+            ),
+            test_lines=[
+                "pm.test('goal simulate returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('goal simulate returns goal plan payload', function () {",
+                "  pm.expect(body.success).to.eql(true);",
+                "  pm.expect(body.data.goal_plan).to.be.an('object');",
+                "});",
+            ],
+        ),
+        _item(
+            "06 - Update goal by id (REST v2)",
+            _request(
+                method="PUT",
+                raw_url="{{baseUrl}}/goals/{{goalId}}",
+                headers=auth_json_headers,
+                body=_json_body(
+                    """
+                    {
+                      "current_amount": "5000.00",
+                      "status": "paused"
+                    }
+                    """
+                ),
+            ),
+            test_lines=[
+                "pm.test('goal update returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('goal update reflects paused status', function () {",
+                "  pm.expect(body.success).to.eql(true);",
+                "  pm.expect(body.data.goal.status).to.eql('paused');",
+                "});",
+            ],
+        ),
+        _item(
+            "07 - Delete goal by id (REST v2)",
+            _request(
+                method="DELETE",
+                raw_url="{{baseUrl}}/goals/{{goalId}}",
+                headers=auth_contract_headers,
+            ),
+            test_lines=[
+                "pm.test('goal delete returns 200', function () { pm.response.to.have.status(200); });",
+                "pm.test('goal delete canonical success', function () { pm.expect(pm.response.json().success).to.eql(true); });",
+            ],
+        ),
+    ]
+
+    wallet_items = [
+        _item(
+            "01 - Create wallet investment (REST v2)",
+            _request(
+                method="POST",
+                raw_url="{{baseUrl}}/wallet",
+                headers=auth_json_headers,
+                body=_json_body(
+                    """
+                    {
+                      "name": "Reserva {{runSeed}}",
+                      "value": "1500.00",
+                      "quantity": 2,
+                      "register_date": "{{runYesterday}}",
+                      "should_be_on_wallet": true
+                    }
+                    """
+                ),
+            ),
+            test_lines=[
+                "pm.test('wallet create returns 201', function () { pm.response.to.have.status(201); });",
+                "var body = pm.response.json();",
+                "pm.collectionVariables.set('investmentId', body.data.investment.id);",
+                "pm.test('wallet create captures investment id', function () { pm.expect(body.data.investment.id).to.be.a('string').and.not.empty; });",
+            ],
+        ),
+        _item(
+            "02 - List wallet investments (REST v2)",
+            _request(
+                method="GET",
+                raw_url="{{baseUrl}}/wallet?page=1&per_page=10",
+                headers=auth_contract_headers,
+                query=[("page", "1"), ("per_page", "10")],
+            ),
+            test_lines=[
+                "pm.test('wallet list returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('wallet list includes pagination and items', function () {",
+                "  pm.expect(body.success).to.eql(true);",
+                "  pm.expect(body.data.items).to.be.an('array');",
+                "  pm.expect(body.meta.pagination).to.be.an('object');",
+                "});",
+            ],
+        ),
+        _item(
+            "03 - Update wallet investment (REST v2)",
+            _request(
+                method="PUT",
+                raw_url="{{baseUrl}}/wallet/{{investmentId}}",
+                headers=auth_json_headers,
+                body=_json_body(
+                    """
+                    {
+                      "value": "2000.00"
+                    }
+                    """
+                ),
+            ),
+            test_lines=[
+                "pm.test('wallet update returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('wallet update keeps history', function () {",
+                "  pm.expect(body.success).to.eql(true);",
+                "  pm.expect(body.data.investment.history).to.be.an('array');",
+                "});",
+            ],
+        ),
+        _item(
+            "04 - Wallet investment history (REST v2)",
+            _request(
+                method="GET",
+                raw_url="{{baseUrl}}/wallet/{{investmentId}}/history?page=1&per_page=10",
+                headers=auth_contract_headers,
+                query=[("page", "1"), ("per_page", "10")],
+            ),
+            test_lines=[
+                "pm.test('wallet history returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('wallet history includes pagination', function () {",
+                "  pm.expect(body.success).to.eql(true);",
+                "  pm.expect(body.data.items).to.be.an('array');",
+                "});",
+            ],
+        ),
+        _item(
+            "05 - Wallet portfolio valuation (REST v2)",
+            _request(
+                method="GET",
+                raw_url="{{baseUrl}}/wallet/valuation",
+                headers=auth_contract_headers,
+            ),
+            test_lines=[
+                "pm.test('wallet valuation returns 200', function () { pm.response.to.have.status(200); });",
+                "pm.test('wallet valuation returns canonical payload', function () { pm.expect(pm.response.json().success).to.eql(true); });",
+            ],
+        ),
+        _item(
+            "06 - Wallet portfolio valuation history (REST v2)",
+            _request(
+                method="GET",
+                raw_url="{{baseUrl}}/wallet/valuation/history?startDate={{runYesterday}}&finalDate={{runToday}}",
+                headers=auth_contract_headers,
+                query=[
+                    ("startDate", "{{runYesterday}}"),
+                    ("finalDate", "{{runToday}}"),
+                ],
+            ),
+            test_lines=[
+                "pm.test('wallet valuation history returns 200', function () { pm.response.to.have.status(200); });",
+                "pm.test('wallet valuation history returns canonical payload', function () { pm.expect(pm.response.json().success).to.eql(true); });",
+            ],
+        ),
+        _item(
+            "07 - Wallet investment valuation (REST v2)",
+            _request(
+                method="GET",
+                raw_url="{{baseUrl}}/wallet/{{investmentId}}/valuation",
+                headers=auth_contract_headers,
+            ),
+            test_lines=[
+                "pm.test('wallet investment valuation returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('wallet investment valuation returns valuation object', function () {",
+                "  pm.expect(body.success).to.eql(true);",
+                "  pm.expect(body.data.valuation).to.be.an('object');",
+                "});",
+            ],
+        ),
+        _item(
+            "08 - Create wallet operation (REST v2)",
+            _request(
+                method="POST",
+                raw_url="{{baseUrl}}/wallet/{{investmentId}}/operations",
+                headers=auth_json_headers,
+                body=_json_body(
+                    """
+                    {
+                      "operation_type": "buy",
+                      "quantity": "2.5",
+                      "unit_price": "35.40",
+                      "fees": "1.20",
+                      "executed_at": "{{runYesterday}}",
+                      "notes": "Compra inicial {{runSeed}}"
+                    }
+                    """
+                ),
+            ),
+            test_lines=[
+                "pm.test('wallet operation create returns 201', function () { pm.response.to.have.status(201); });",
+                "var body = pm.response.json();",
+                "pm.collectionVariables.set('operationId', body.data.operation.id);",
+                "pm.test('wallet operation create captures operation id', function () { pm.expect(body.data.operation.id).to.be.a('string').and.not.empty; });",
+            ],
+        ),
+        _item(
+            "09 - List wallet operations (REST v2)",
+            _request(
+                method="GET",
+                raw_url="{{baseUrl}}/wallet/{{investmentId}}/operations?page=1&per_page=10",
+                headers=auth_contract_headers,
+                query=[("page", "1"), ("per_page", "10")],
+            ),
+            test_lines=[
+                "pm.test('wallet operation list returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('wallet operation list includes items', function () {",
+                "  pm.expect(body.success).to.eql(true);",
+                "  pm.expect(body.data.items).to.be.an('array');",
+                "});",
+            ],
+        ),
+        _item(
+            "10 - Wallet operation summary (REST v2)",
+            _request(
+                method="GET",
+                raw_url="{{baseUrl}}/wallet/{{investmentId}}/operations/summary",
+                headers=auth_contract_headers,
+            ),
+            test_lines=[
+                "pm.test('wallet operation summary returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('wallet operation summary returns summary object', function () {",
+                "  pm.expect(body.success).to.eql(true);",
+                "  pm.expect(body.data.summary).to.be.an('object');",
+                "});",
+            ],
+        ),
+        _item(
+            "11 - Wallet operation position (REST v2)",
+            _request(
+                method="GET",
+                raw_url="{{baseUrl}}/wallet/{{investmentId}}/operations/position",
+                headers=auth_contract_headers,
+            ),
+            test_lines=[
+                "pm.test('wallet operation position returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('wallet operation position returns position object', function () {",
+                "  pm.expect(body.success).to.eql(true);",
+                "  pm.expect(body.data.position).to.be.an('object');",
+                "});",
+            ],
+        ),
+        _item(
+            "12 - Wallet invested amount by date (REST v2)",
+            _request(
+                method="GET",
+                raw_url="{{baseUrl}}/wallet/{{investmentId}}/operations/invested-amount?date={{runToday}}",
+                headers=auth_contract_headers,
+                query=[("date", "{{runToday}}")],
+            ),
+            test_lines=[
+                "pm.test('wallet invested amount returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('wallet invested amount returns result object', function () {",
+                "  pm.expect(body.success).to.eql(true);",
+                "  pm.expect(body.data.result).to.be.an('object');",
+                "});",
+            ],
+        ),
+        _item(
+            "13 - Update wallet operation (REST v2)",
+            _request(
+                method="PUT",
+                raw_url="{{baseUrl}}/wallet/{{investmentId}}/operations/{{operationId}}",
+                headers=auth_json_headers,
+                body=_json_body(
+                    """
+                    {
+                      "notes": "Atualizada {{runSeed}}",
+                      "fees": "2.00"
+                    }
+                    """
+                ),
+            ),
+            test_lines=[
+                "pm.test('wallet operation update returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('wallet operation update reflects notes', function () {",
+                "  pm.expect(body.success).to.eql(true);",
+                "  pm.expect(body.data.operation.notes).to.include('Atualizada');",
+                "});",
+            ],
+        ),
+        _item(
+            "14 - Delete wallet operation (REST v2)",
+            _request(
+                method="DELETE",
+                raw_url="{{baseUrl}}/wallet/{{investmentId}}/operations/{{operationId}}",
+                headers=auth_contract_headers,
+            ),
+            test_lines=[
+                "pm.test('wallet operation delete returns 200', function () { pm.response.to.have.status(200); });",
+                "pm.test('wallet operation delete canonical success', function () { pm.expect(pm.response.json().success).to.eql(true); });",
+            ],
+        ),
+        _item(
+            "15 - Delete wallet investment (REST v2)",
+            _request(
+                method="DELETE",
+                raw_url="{{baseUrl}}/wallet/{{investmentId}}",
+                headers=auth_contract_headers,
+            ),
+            test_lines=[
+                "pm.test('wallet delete returns 200', function () { pm.response.to.have.status(200); });",
+                "pm.test('wallet delete canonical success', function () { pm.expect(pm.response.json().success).to.eql(true); });",
+            ],
+        ),
+    ]
+
+    simulation_items = [
+        _item(
+            "01 - Installment vs cash calculate (REST public)",
+            _request(
+                method="POST",
+                raw_url="{{baseUrl}}/simulations/installment-vs-cash/calculate",
+                headers=contract_headers,
+                body=_json_body(
+                    """
+                    {
+                      "cash_price": "900.00",
+                      "installment_count": 3,
+                      "installment_total": "990.00",
+                      "first_payment_delay_days": 30,
+                      "opportunity_rate_type": "manual",
+                      "opportunity_rate_annual": "12.00",
+                      "inflation_rate_annual": "4.50",
+                      "fees_enabled": false,
+                      "fees_upfront": "0.00"
+                    }
+                    """
+                ),
+            ),
+            test_lines=[
+                "pm.test('simulation calculate returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('simulation calculate returns canonical result', function () {",
+                "  pm.expect(body.success).to.eql(true);",
+                "  pm.expect(body.data.tool_id).to.eql('installment_vs_cash');",
+                "});",
+            ],
+        ),
+        _item(
+            "02 - Installment vs cash save (REST auth required)",
+            _request(
+                method="POST",
+                raw_url="{{baseUrl}}/simulations/installment-vs-cash/save",
+                headers=auth_json_headers,
+                body=_json_body(
+                    """
+                    {
+                      "cash_price": "900.00",
+                      "installment_count": 3,
+                      "installment_total": "990.00",
+                      "first_payment_delay_days": 30,
+                      "opportunity_rate_type": "manual",
+                      "opportunity_rate_annual": "12.00",
+                      "inflation_rate_annual": "4.50",
+                      "fees_enabled": false,
+                      "fees_upfront": "0.00",
+                      "scenario_label": "{{graphSimulationLabel}}"
+                    }
+                    """
+                ),
+            ),
+            test_lines=[
+                "pm.test('simulation save returns 201', function () { pm.response.to.have.status(201); });",
+                "var body = pm.response.json();",
+                "pm.collectionVariables.set('simulationId', body.data.simulation.id);",
+                "pm.test('simulation save returns persisted simulation id', function () { pm.expect(body.data.simulation.id).to.be.a('string').and.not.empty; });",
+            ],
+        ),
+        _item(
+            "03 - Simulation goal bridge without entitlement returns 403",
+            _request(
+                method="POST",
+                raw_url="{{baseUrl}}/simulations/{{simulationId}}/goal",
+                headers=_headers(
+                    ("Content-Type", "application/json"),
+                    ("Authorization", "Bearer {{authToken}}"),
+                ),
+                body=_json_body(
+                    """
+                    {
+                      "title": "Notebook novo {{runSeed}}",
+                      "selected_option": "cash"
+                    }
+                    """
+                ),
+            ),
+            test_lines=[
+                "pm.test('simulation goal bridge without entitlement returns 403', function () { pm.response.to.have.status(403); });",
+            ],
+        ),
+        _item(
+            "04 - Grant advanced simulations entitlement (optional admin)",
+            _request(
+                method="POST",
+                raw_url="{{baseUrl}}/entitlements/admin",
+                headers=_headers(
+                    ("Content-Type", "application/json"),
+                    ("Authorization", "Bearer {{adminToken}}"),
+                    ("X-API-Contract", "v2"),
+                ),
+                body=_json_body(
+                    """
+                    {
+                      "user_id": "{{userId}}",
+                      "feature_key": "advanced_simulations",
+                      "source": "postman_e2e"
+                    }
+                    """
+                ),
+            ),
+            prerequest_lines=_skip_if_privileged_flows_disabled(),
+            test_lines=[
+                "pm.test('entitlement grant returns 201', function () { pm.response.to.have.status(201); });",
+                "var body = pm.response.json();",
+                "pm.collectionVariables.set('entitlementId', body.data.entitlement.id);",
+            ],
+        ),
+        _item(
+            "05 - Save advanced simulation for success bridges (optional admin)",
+            _request(
+                method="POST",
+                raw_url="{{baseUrl}}/simulations/installment-vs-cash/save",
+                headers=auth_json_headers,
+                body=_json_body(
+                    """
+                    {
+                      "cash_price": "1500.00",
+                      "installment_count": 5,
+                      "installment_total": "1650.00",
+                      "first_payment_delay_days": 30,
+                      "opportunity_rate_type": "manual",
+                      "opportunity_rate_annual": "12.00",
+                      "inflation_rate_annual": "4.50",
+                      "fees_enabled": false,
+                      "fees_upfront": "0.00",
+                      "scenario_label": "Bridge {{runSeed}}"
+                    }
+                    """
+                ),
+            ),
+            prerequest_lines=_skip_if_privileged_flows_disabled(),
+            test_lines=[
+                "pm.test('advanced simulation save returns 201', function () { pm.response.to.have.status(201); });",
+                "pm.collectionVariables.set('advancedSimulationId', pm.response.json().data.simulation.id);",
+            ],
+        ),
+        _item(
+            "06 - Simulation goal bridge success (optional admin)",
+            _request(
+                method="POST",
+                raw_url="{{baseUrl}}/simulations/{{advancedSimulationId}}/goal",
+                headers=_headers(
+                    ("Content-Type", "application/json"),
+                    ("Authorization", "Bearer {{authToken}}"),
+                ),
+                body=_json_body(
+                    """
+                    {
+                      "title": "Notebook premium {{runSeed}}",
+                      "selected_option": "cash"
+                    }
+                    """
+                ),
+            ),
+            prerequest_lines=_skip_if_privileged_flows_disabled(),
+            test_lines=[
+                "pm.test('simulation goal bridge success returns 201', function () { pm.response.to.have.status(201); });",
+            ],
+        ),
+        _item(
+            "07 - Save fee simulation for planned expense bridge (optional admin)",
+            _request(
+                method="POST",
+                raw_url="{{baseUrl}}/simulations/installment-vs-cash/save",
+                headers=auth_json_headers,
+                body=_json_body(
+                    """
+                    {
+                      "cash_price": "900.00",
+                      "installment_count": 3,
+                      "installment_total": "990.00",
+                      "first_payment_delay_days": 30,
+                      "opportunity_rate_type": "manual",
+                      "opportunity_rate_annual": "12.00",
+                      "inflation_rate_annual": "4.50",
+                      "fees_enabled": true,
+                      "fees_upfront": "60.00",
+                      "scenario_label": "Fees {{runSeed}}"
+                    }
+                    """
+                ),
+            ),
+            prerequest_lines=_skip_if_privileged_flows_disabled(),
+            test_lines=[
+                "pm.test('fee simulation save returns 201', function () { pm.response.to.have.status(201); });",
+                "pm.collectionVariables.set('feeSimulationId', pm.response.json().data.simulation.id);",
+            ],
+        ),
+        _item(
+            "08 - Simulation planned expense bridge success (optional admin)",
+            _request(
+                method="POST",
+                raw_url="{{baseUrl}}/simulations/{{feeSimulationId}}/planned-expense",
+                headers=_headers(
+                    ("Content-Type", "application/json"),
+                    ("Authorization", "Bearer {{authToken}}"),
+                ),
+                body=_json_body(
+                    """
+                    {
+                      "title": "Notebook novo {{runSeed}}",
+                      "selected_option": "installment",
+                      "first_due_date": "{{runIn30Days}}"
+                    }
+                    """
+                ),
+            ),
+            prerequest_lines=_skip_if_privileged_flows_disabled(),
+            test_lines=[
+                "pm.test('simulation planned expense bridge success returns 201', function () { pm.response.to.have.status(201); });",
+                "var body = pm.response.json();",
+                "pm.test('simulation planned expense returns generated transactions', function () {",
+                "  pm.expect(body.transactions).to.be.an('array').and.not.empty;",
+                "});",
+            ],
+        ),
+        _item(
+            "09 - Revoke advanced simulations entitlement (optional admin)",
+            _request(
+                method="DELETE",
+                raw_url="{{baseUrl}}/entitlements/admin/{{entitlementId}}",
+                headers=_headers(
+                    ("Authorization", "Bearer {{adminToken}}"), ("X-API-Contract", "v2")
+                ),
+            ),
+            prerequest_lines=_skip_if_privileged_flows_disabled(),
+            test_lines=[
+                "pm.test('entitlement revoke returns 200', function () { pm.response.to.have.status(200); });",
+            ],
+        ),
+    ]
+
+    graphql_items = [
+        _item(
+            "01 - GraphQL empty query (validation error)",
+            _request(
+                method="POST",
+                raw_url="{{baseUrl}}/graphql",
+                headers=graphql_headers,
+                body=_json_body(
+                    """
+                    {
+                      "query": "   "
+                    }
+                    """
+                ),
+            ),
+            test_lines=[
+                "pm.test('graphql empty query returns 400', function () { pm.response.to.have.status(400); });",
+                "var body = pm.response.json();",
+                "var firstErr = body.errors && body.errors[0] ? body.errors[0] : {};",
+                "pm.test('graphql empty query uses VALIDATION_ERROR', function () { pm.expect(firstErr.extensions.code).to.eql('VALIDATION_ERROR'); });",
+            ],
+        ),
+        _item(
+            "02 - GraphQL login invalid credentials (safe error)",
+            _request(
+                method="POST",
+                raw_url="{{baseUrl}}/graphql",
+                headers=graphql_headers,
+                body=_json_body(
+                    """
+                    {
+                      "query": "mutation Login($email: String, $password: String!) { login(email: $email, password: $password) { token message } }",
+                      "variables": {
+                        "email": "{{runEmail}}",
+                        "password": "{{testPasswordWrong}}"
+                      }
+                    }
+                    """
+                ),
+            ),
+            test_lines=[
+                "pm.test('graphql invalid login transport status is 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "var firstErr = body.errors && body.errors[0] ? body.errors[0] : {};",
+                "pm.test('graphql invalid login exposes public UNAUTHORIZED code', function () { pm.expect(firstErr.extensions.code).to.eql('UNAUTHORIZED'); });",
+            ],
+        ),
+        _item(
+            "03 - GraphQL me query (auth required)",
+            _request(
+                method="POST",
+                raw_url="{{baseUrl}}/graphql",
+                headers=graphql_auth_headers,
+                body=_json_body(
+                    """
+                    {
+                      "query": "query Me { me { id email name } }"
+                    }
+                    """
+                ),
+            ),
+            test_lines=[
+                "pm.test('graphql me returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('graphql me returns authenticated user', function () {",
+                "  pm.expect(body.errors).to.eql(undefined);",
+                "  pm.expect(body.data.me.email).to.eql(pm.collectionVariables.get('runEmail'));",
+                "});",
+            ],
+        ),
+        _item(
+            "04 - GraphQL installment vs cash calculate (public)",
+            _request(
+                method="POST",
+                raw_url="{{baseUrl}}/graphql",
+                headers=graphql_headers,
+                body=_json_body(
+                    """
+                    {
+                      "query": "query InstallmentVsCashCalculate { installmentVsCashCalculate(cashPrice: \\"900.00\\", installmentCount: 3, installmentTotal: \\"990.00\\", firstPaymentDelayDays: 30, opportunityRateType: \\"manual\\", opportunityRateAnnual: \\"12.00\\", inflationRateAnnual: \\"4.50\\", feesEnabled: false, feesUpfront: \\"0.00\\") { toolId result { recommendedOption } } }"
+                    }
+                    """
+                ),
+            ),
+            test_lines=[
+                "pm.test('graphql installment calculate returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('graphql installment calculate returns tool id', function () { pm.expect(body.data.installmentVsCashCalculate.toolId).to.eql('installment_vs_cash'); });",
+            ],
+        ),
+        _item(
+            "05 - GraphQL installment vs cash save (auth required)",
+            _request(
+                method="POST",
+                raw_url="{{baseUrl}}/graphql",
+                headers=graphql_auth_headers,
+                body=_json_body(
+                    """
+                    {
+                      "query": "mutation SaveInstallmentVsCashSimulation { saveInstallmentVsCashSimulation(cashPrice: \\"900.00\\", installmentCount: 3, installmentTotal: \\"990.00\\", firstPaymentDelayDays: 30, opportunityRateType: \\"manual\\", opportunityRateAnnual: \\"12.00\\", inflationRateAnnual: \\"4.50\\", feesEnabled: true, feesUpfront: \\"60.00\\", scenarioLabel: \\"Notebook {{runSeed}}\\") { message simulation { id toolId saved } calculation { toolId } } }"
+                    }
+                    """
+                ),
+            ),
+            test_lines=[
+                "pm.test('graphql installment save returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('graphql installment save persists simulation', function () {",
+                "  pm.expect(body.errors).to.eql(undefined);",
+                "  pm.expect(body.data.saveInstallmentVsCashSimulation.simulation.saved).to.eql(true);",
+                "});",
+            ],
+        ),
+    ]
+
+    collection = {
+        "info": {
+            "_postman_id": "3fd49b04-3416-4cf2-9048-b58abf132a20",
+            "name": "Auraxis API - Canonical E2E and Smoke",
+            "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+            "description": (
+                "Canonical black-box suite for Auraxis API. Organized by domain, "
+                "validated by Newman in CI, and designed for direct Postman import. "
+                "Privileged flows are optional and gated by adminToken + enablePrivilegedFlows."
+            ),
+        },
+        "item": [
+            _folder("00 - Auth and User Bootstrap", auth_items),
+            _folder("01 - Transactions", transaction_items),
+            _folder("02 - Goals", goal_items),
+            _folder("03 - Wallet", wallet_items),
+            _folder("04 - Simulations", simulation_items),
+            _folder("05 - GraphQL", graphql_items),
+        ],
+        "variable": [
+            {"key": "runSeed", "value": ""},
+            {"key": "runEmail", "value": ""},
+            {"key": "runName", "value": ""},
+            {"key": "authToken", "value": ""},
+            {"key": "userId", "value": ""},
+            {"key": "transactionId", "value": ""},
+            {"key": "goalId", "value": ""},
+            {"key": "investmentId", "value": ""},
+            {"key": "operationId", "value": ""},
+            {"key": "simulationId", "value": ""},
+            {"key": "advancedSimulationId", "value": ""},
+            {"key": "feeSimulationId", "value": ""},
+            {"key": "entitlementId", "value": ""},
+        ],
+    }
+    return collection
+
+
+def main() -> None:
+    collection = build_collection()
+    COLLECTION_PATH.write_text(
+        json.dumps(collection, ensure_ascii=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    print(f"[postman] wrote {COLLECTION_PATH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_postman_suite.sh
+++ b/scripts/run_postman_suite.sh
@@ -7,6 +7,10 @@ ENV_FILE_DEFAULT="${ROOT_DIR}/api-tests/postman/environments/local.postman_envir
 ENV_FILE="${1:-$ENV_FILE_DEFAULT}"
 REPORT_DIR="${ROOT_DIR}/reports"
 REPORT_FILE="${REPORT_DIR}/newman-report.xml"
+TEST_PASSWORD="${POSTMAN_TEST_PASSWORD:-StrongPass@123}"
+TEST_PASSWORD_WRONG="${POSTMAN_TEST_PASSWORD_WRONG:-WrongPass@123}"
+ENABLE_PRIVILEGED_FLOWS="${POSTMAN_ENABLE_PRIVILEGED_FLOWS:-false}"
+ADMIN_TOKEN="${POSTMAN_ADMIN_TOKEN:-}"
 
 if ! command -v npx >/dev/null 2>&1; then
   echo "npx not found in PATH." >&2
@@ -35,11 +39,22 @@ mkdir -p "$REPORT_DIR"
 echo "[postman-suite] collection=$COLLECTION"
 echo "[postman-suite] environment=$ENV_FILE"
 
-npx --no-install newman run "$COLLECTION" \
-  -e "$ENV_FILE" \
-  --timeout-request 15000 \
-  --delay-request 150 \
-  --reporters cli,junit \
+NEWMAN_ARGS=(
+  run "$COLLECTION"
+  -e "$ENV_FILE"
+  --env-var "testPassword=${TEST_PASSWORD}"
+  --env-var "testPasswordWrong=${TEST_PASSWORD_WRONG}"
+  --env-var "enablePrivilegedFlows=${ENABLE_PRIVILEGED_FLOWS}"
+  --timeout-request 15000
+  --delay-request 150
+  --reporters cli,junit
   --reporter-junit-export "$REPORT_FILE"
+)
+
+if [[ -n "$ADMIN_TOKEN" ]]; then
+  NEWMAN_ARGS+=(--env-var "adminToken=${ADMIN_TOKEN}")
+fi
+
+npx --no-install newman "${NEWMAN_ARGS[@]}"
 
 echo "[postman-suite] report=$REPORT_FILE"

--- a/tests/test_postman_collection_contract.py
+++ b/tests/test_postman_collection_contract.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 
@@ -17,11 +18,116 @@ def _load_postman_items() -> list[dict[str, object]]:
     return items
 
 
+def _flatten_request_items(items: list[dict[str, object]]) -> list[dict[str, object]]:
+    flattened: list[dict[str, object]] = []
+    for item in items:
+        nested = item.get("item")
+        if isinstance(nested, list):
+            flattened.extend(_flatten_request_items(nested))
+            continue
+        flattened.append(item)
+    return flattened
+
+
+def _normalize_path(raw_url: str) -> str:
+    path = raw_url.split("{{baseUrl}}", 1)[1].split("?", 1)[0]
+    segments = []
+    for segment in path.split("/"):
+        if not segment:
+            continue
+        if segment.startswith("{{") and segment.endswith("}}"):
+            segments.append("{param}")
+            continue
+        if re.fullmatch(r"\{[^}]+\}", segment):
+            segments.append("{param}")
+            continue
+        segments.append(segment)
+    return "/" + "/".join(segments)
+
+
 def test_postman_collection_covers_installment_vs_cash_rest_and_graphql() -> None:
-    items = _load_postman_items()
+    items = _flatten_request_items(_load_postman_items())
     names = {str(item.get("name")) for item in items}
 
-    assert "12 - Installment vs Cash calculate (REST public)" in names
-    assert "13 - Installment vs Cash save (REST auth required)" in names
-    assert "14 - GraphQL installment vs cash calculate (public)" in names
-    assert "15 - GraphQL installment vs cash save (auth required)" in names
+    assert "01 - Installment vs cash calculate (REST public)" in names
+    assert "02 - Installment vs cash save (REST auth required)" in names
+    assert "04 - GraphQL installment vs cash calculate (public)" in names
+    assert "05 - GraphQL installment vs cash save (auth required)" in names
+
+
+def test_postman_collection_covers_critical_rest_routes() -> None:
+    items = _flatten_request_items(_load_postman_items())
+    covered = {
+        (
+            str(item["request"]["method"]).upper(),
+            _normalize_path(str(item["request"]["url"]["raw"])),
+        )
+        for item in items
+    }
+
+    expected = {
+        ("GET", "/healthz"),
+        ("POST", "/auth/register"),
+        ("POST", "/auth/login"),
+        ("POST", "/auth/logout"),
+        ("POST", "/auth/password/forgot"),
+        ("POST", "/auth/password/reset"),
+        ("GET", "/user/me"),
+        ("GET", "/user/profile"),
+        ("PUT", "/user/profile"),
+        ("GET", "/user/profile/questionnaire"),
+        ("POST", "/user/profile/questionnaire"),
+        ("POST", "/transactions"),
+        ("PUT", "/transactions/{param}"),
+        ("DELETE", "/transactions/{param}"),
+        ("GET", "/transactions/list"),
+        ("GET", "/transactions/summary"),
+        ("GET", "/transactions/dashboard"),
+        ("GET", "/transactions/expenses"),
+        ("GET", "/transactions/due-range"),
+        ("GET", "/transactions/deleted"),
+        ("PATCH", "/transactions/restore/{param}"),
+        ("DELETE", "/transactions/{param}/force"),
+        ("GET", "/goals"),
+        ("POST", "/goals"),
+        ("GET", "/goals/{param}"),
+        ("PUT", "/goals/{param}"),
+        ("DELETE", "/goals/{param}"),
+        ("GET", "/goals/{param}/plan"),
+        ("POST", "/goals/simulate"),
+        ("GET", "/wallet"),
+        ("POST", "/wallet"),
+        ("PUT", "/wallet/{param}"),
+        ("DELETE", "/wallet/{param}"),
+        ("GET", "/wallet/{param}/history"),
+        ("GET", "/wallet/valuation"),
+        ("GET", "/wallet/valuation/history"),
+        ("GET", "/wallet/{param}/valuation"),
+        ("GET", "/wallet/{param}/operations"),
+        ("POST", "/wallet/{param}/operations"),
+        ("PUT", "/wallet/{param}/operations/{param}"),
+        ("DELETE", "/wallet/{param}/operations/{param}"),
+        ("GET", "/wallet/{param}/operations/summary"),
+        ("GET", "/wallet/{param}/operations/position"),
+        ("GET", "/wallet/{param}/operations/invested-amount"),
+        ("POST", "/simulations/installment-vs-cash/calculate"),
+        ("POST", "/simulations/installment-vs-cash/save"),
+        ("POST", "/simulations/{param}/goal"),
+        ("POST", "/simulations/{param}/planned-expense"),
+    }
+
+    missing = sorted(expected - covered)
+    assert not missing, f"Postman collection missing critical REST coverage: {missing}"
+
+
+def test_postman_collection_uses_domain_folders() -> None:
+    top_level = _load_postman_items()
+    folder_names = [str(item.get("name")) for item in top_level]
+    assert folder_names == [
+        "00 - Auth and User Bootstrap",
+        "01 - Transactions",
+        "02 - Goals",
+        "03 - Wallet",
+        "04 - Simulations",
+        "05 - GraphQL",
+    ]


### PR DESCRIPTION
## Summary
- turn `api-tests/postman/auraxis.postman_collection.json` into the canonical domain-based Postman/Newman suite
- add a generator script and collection parity checks for critical REST coverage
- sanitize/version environments and document the official Postman/Newman workflow

## Validation
- `python3 scripts/build_postman_collection.py`
- `/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-api/.venv/bin/python -m pytest tests/test_postman_collection_contract.py -q`
- `/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-api/.venv/bin/python -m ruff check scripts/build_postman_collection.py tests/test_postman_collection_contract.py`
- `sh -n scripts/run_postman_suite.sh`
- local commit/push hooks with Python 3.13 on PATH
