### PR TITLE
feat(test): add smoke and full postman profiles

### DIFF
--- a/api-tests/postman/README.md
+++ b/api-tests/postman/README.md
@@ -32,6 +32,9 @@ Os environments devem conter apenas valores seguros para versionamento:
 - IDs e tokens devem ser encadeados por collection variables.
 - Fluxos privilegiados devem ser opcionais e gateados por `enablePrivilegedFlows=true` e `adminToken`.
 - O subset padrao que roda no CI deve continuar deterministico e seguro sem token administrativo.
+- `suiteProfile` governa o recorte oficial da execução:
+  - `full`: roda a colecao completa;
+  - `smoke`: roda o subconjunto canônico mínimo por dominio.
 
 ## Execucao
 Gerar/regravar a collection oficial:
@@ -45,10 +48,22 @@ npm ci
 npm run postman:local
 ```
 
+Perfis oficiais:
+```bash
+npm run postman:smoke:local
+npm run postman:full:local
+```
+
 Rodar com outro environment:
 ```bash
 ./scripts/run_postman_suite.sh ./api-tests/postman/environments/dev.postman_environment.json
 ./scripts/run_postman_suite.sh ./api-tests/postman/environments/prod.postman_environment.json
+```
+
+Rodar com perfil explícito:
+```bash
+./scripts/run_postman_suite.sh ./api-tests/postman/environments/dev.postman_environment.json --profile smoke
+./scripts/run_postman_suite.sh ./api-tests/postman/environments/dev.postman_environment.json --profile full
 ```
 
 Rodar fluxos privilegiados:

--- a/api-tests/postman/auraxis.postman_collection.json
+++ b/api-tests/postman/auraxis.postman_collection.json
@@ -5,6 +5,26 @@
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
     "description": "Canonical black-box suite for Auraxis API. Organized by domain, validated by Newman in CI, and designed for direct Postman import. Privileged flows are optional and gated by adminToken + enablePrivilegedFlows."
   },
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "exec": [
+          "var smokeRequests = [\"01 - Healthz\", \"02 - Register user (REST v2)\", \"03 - Login user (REST v2)\", \"04 - Login invalid credentials returns safe error\", \"05 - Me (REST v2)\", \"01 - Create transaction (REST v2)\", \"04 - List active transactions (REST v2)\", \"05 - Transaction summary by month (REST v2)\", \"01 - Create goal (REST v2)\", \"02 - List goals (REST v2)\", \"05 - Goal simulate (REST v2)\", \"01 - Create wallet investment (REST v2)\", \"02 - List wallet investments (REST v2)\", \"08 - Create wallet operation (REST v2)\", \"10 - Wallet operation summary (REST v2)\", \"01 - Installment vs cash calculate (REST public)\", \"02 - Installment vs cash save (REST auth required)\", \"03 - Simulation goal bridge without entitlement returns 403\", \"02 - GraphQL login invalid credentials (safe error)\", \"03 - GraphQL me query (auth required)\", \"04 - GraphQL installment vs cash calculate (public)\"];",
+          "var activeProfile = String(pm.environment.get('suiteProfile') || pm.collectionVariables.get('suiteProfile') || 'full').toLowerCase();",
+          "if (!['smoke', 'full'].includes(activeProfile)) {",
+          "  throw new Error('Unsupported suiteProfile: ' + activeProfile + '. Use smoke or full.');",
+          "}",
+          "pm.collectionVariables.set('suiteProfile', activeProfile);",
+          "if (activeProfile === 'smoke' && !smokeRequests.includes(pm.info.requestName)) {",
+          "  console.log('Skipping request outside smoke profile:', pm.info.requestName);",
+          "  pm.execution.skipRequest();",
+          "}"
+        ],
+        "type": "text/javascript"
+      }
+    }
+  ],
   "item": [
     {
       "name": "00 - Auth and User Bootstrap",
@@ -3125,6 +3145,10 @@
     {
       "key": "entitlementId",
       "value": ""
+    },
+    {
+      "key": "suiteProfile",
+      "value": "full"
     }
   ]
 }

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -43,10 +43,22 @@ Runner local (Newman):
 npm run postman:local
 ```
 
+Perfis oficiais:
+```bash
+npm run postman:smoke:local
+npm run postman:full:local
+```
+
 Runner com environment específico:
 ```bash
 ./scripts/run_postman_suite.sh ./api-tests/postman/environments/dev.postman_environment.json
 ./scripts/run_postman_suite.sh ./api-tests/postman/environments/prod.postman_environment.json
+```
+
+Runner com perfil explícito:
+```bash
+./scripts/run_postman_suite.sh ./api-tests/postman/environments/dev.postman_environment.json --profile smoke
+./scripts/run_postman_suite.sh ./api-tests/postman/environments/dev.postman_environment.json --profile full
 ```
 
 Fluxos privilegiados opcionais:
@@ -64,6 +76,10 @@ Cobertura canonica atual:
 - Wallet: create, list, update, history, valuation, operations CRUD, position, invested amount
 - Simulations: installment-vs-cash calculate/save e bridges com subset privilegiado opcional
 - GraphQL: validation, auth-safe errors, me, installment-vs-cash calculate/save
+
+Perfis da suíte:
+- `smoke`: subconjunto mínimo canônico de saúde funcional cross-domain
+- `full`: coleção completa REST + GraphQL
 
 ## Como a suíte está configurada
 - `pytest.ini` define padrão de descoberta dos testes.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,12 @@
     "postman:build": "python3 scripts/build_postman_collection.py",
     "postman:local": "bash scripts/run_postman_suite.sh",
     "postman:ci": "bash scripts/run_postman_suite.sh api-tests/postman/environments/local.postman_environment.json",
+    "postman:smoke:local": "bash scripts/run_postman_suite.sh --profile smoke",
+    "postman:smoke:dev": "bash scripts/run_postman_suite.sh api-tests/postman/environments/dev.postman_environment.json --profile smoke",
+    "postman:smoke:prod": "bash scripts/run_postman_suite.sh api-tests/postman/environments/prod.postman_environment.json --profile smoke",
+    "postman:full:local": "bash scripts/run_postman_suite.sh --profile full",
+    "postman:full:dev": "bash scripts/run_postman_suite.sh api-tests/postman/environments/dev.postman_environment.json --profile full",
+    "postman:full:prod": "bash scripts/run_postman_suite.sh api-tests/postman/environments/prod.postman_environment.json --profile full",
     "smoke:local": "bash scripts/run_postman_suite.sh",
     "smoke:ci": "bash scripts/run_postman_suite.sh api-tests/postman/environments/local.postman_environment.json"
   },

--- a/scripts/build_postman_collection.py
+++ b/scripts/build_postman_collection.py
@@ -8,6 +8,29 @@ from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
 COLLECTION_PATH = ROOT / "api-tests" / "postman" / "auraxis.postman_collection.json"
+SMOKE_REQUESTS = [
+    "01 - Healthz",
+    "02 - Register user (REST v2)",
+    "03 - Login user (REST v2)",
+    "04 - Login invalid credentials returns safe error",
+    "05 - Me (REST v2)",
+    "01 - Create transaction (REST v2)",
+    "04 - List active transactions (REST v2)",
+    "05 - Transaction summary by month (REST v2)",
+    "01 - Create goal (REST v2)",
+    "02 - List goals (REST v2)",
+    "05 - Goal simulate (REST v2)",
+    "01 - Create wallet investment (REST v2)",
+    "02 - List wallet investments (REST v2)",
+    "08 - Create wallet operation (REST v2)",
+    "10 - Wallet operation summary (REST v2)",
+    "01 - Installment vs cash calculate (REST public)",
+    "02 - Installment vs cash save (REST auth required)",
+    "03 - Simulation goal bridge without entitlement returns 403",
+    "02 - GraphQL login invalid credentials (safe error)",
+    "03 - GraphQL me query (auth required)",
+    "04 - GraphQL installment vs cash calculate (public)",
+]
 
 
 def _js(lines: list[str]) -> dict[str, Any]:
@@ -80,6 +103,22 @@ def _item(
 
 def _folder(name: str, items: list[dict[str, Any]]) -> dict[str, Any]:
     return {"name": name, "item": items}
+
+
+def _suite_profile_prerequest() -> list[str]:
+    smoke_json = json.dumps(SMOKE_REQUESTS, ensure_ascii=True)
+    return [
+        f"var smokeRequests = {smoke_json};",
+        "var activeProfile = String(pm.environment.get('suiteProfile') || pm.collectionVariables.get('suiteProfile') || 'full').toLowerCase();",
+        "if (!['smoke', 'full'].includes(activeProfile)) {",
+        "  throw new Error('Unsupported suiteProfile: ' + activeProfile + '. Use smoke or full.');",
+        "}",
+        "pm.collectionVariables.set('suiteProfile', activeProfile);",
+        "if (activeProfile === 'smoke' && !smokeRequests.includes(pm.info.requestName)) {",
+        "  console.log('Skipping request outside smoke profile:', pm.info.requestName);",
+        "  pm.execution.skipRequest();",
+        "}",
+    ]
 
 
 def _skip_if_privileged_flows_disabled() -> list[str]:
@@ -1464,6 +1503,9 @@ def build_collection() -> dict[str, Any]:
                 "Privileged flows are optional and gated by adminToken + enablePrivilegedFlows."
             ),
         },
+        "event": [
+            _prerequest_event(_suite_profile_prerequest()),
+        ],
         "item": [
             _folder("00 - Auth and User Bootstrap", auth_items),
             _folder("01 - Transactions", transaction_items),
@@ -1486,6 +1528,7 @@ def build_collection() -> dict[str, Any]:
             {"key": "advancedSimulationId", "value": ""},
             {"key": "feeSimulationId", "value": ""},
             {"key": "entitlementId", "value": ""},
+            {"key": "suiteProfile", "value": "full"},
         ],
     }
     return collection

--- a/scripts/run_postman_suite.sh
+++ b/scripts/run_postman_suite.sh
@@ -4,13 +4,58 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 COLLECTION="${ROOT_DIR}/api-tests/postman/auraxis.postman_collection.json"
 ENV_FILE_DEFAULT="${ROOT_DIR}/api-tests/postman/environments/local.postman_environment.json"
-ENV_FILE="${1:-$ENV_FILE_DEFAULT}"
+ENV_FILE="$ENV_FILE_DEFAULT"
 REPORT_DIR="${ROOT_DIR}/reports"
 REPORT_FILE="${REPORT_DIR}/newman-report.xml"
 TEST_PASSWORD="${POSTMAN_TEST_PASSWORD:-StrongPass@123}"
 TEST_PASSWORD_WRONG="${POSTMAN_TEST_PASSWORD_WRONG:-WrongPass@123}"
 ENABLE_PRIVILEGED_FLOWS="${POSTMAN_ENABLE_PRIVILEGED_FLOWS:-false}"
 ADMIN_TOKEN="${POSTMAN_ADMIN_TOKEN:-}"
+SUITE_PROFILE="${POSTMAN_SUITE_PROFILE:-full}"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/run_postman_suite.sh [environment.json] [--profile smoke|full]
+
+Examples:
+  bash scripts/run_postman_suite.sh
+  bash scripts/run_postman_suite.sh api-tests/postman/environments/dev.postman_environment.json --profile smoke
+  POSTMAN_SUITE_PROFILE=full bash scripts/run_postman_suite.sh api-tests/postman/environments/prod.postman_environment.json
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --profile)
+      if [[ $# -lt 2 ]]; then
+        echo "--profile requires a value (smoke|full)." >&2
+        usage
+        exit 4
+      fi
+      SUITE_PROFILE="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      ENV_FILE="$1"
+      shift
+      ;;
+  esac
+done
+
+case "${SUITE_PROFILE}" in
+  smoke|full)
+    ;;
+  *)
+    echo "Unsupported profile: ${SUITE_PROFILE}. Use smoke or full." >&2
+    usage
+    exit 5
+    ;;
+esac
 
 if ! command -v npx >/dev/null 2>&1; then
   echo "npx not found in PATH." >&2
@@ -38,6 +83,7 @@ mkdir -p "$REPORT_DIR"
 
 echo "[postman-suite] collection=$COLLECTION"
 echo "[postman-suite] environment=$ENV_FILE"
+echo "[postman-suite] profile=$SUITE_PROFILE"
 
 NEWMAN_ARGS=(
   run "$COLLECTION"
@@ -45,6 +91,7 @@ NEWMAN_ARGS=(
   --env-var "testPassword=${TEST_PASSWORD}"
   --env-var "testPasswordWrong=${TEST_PASSWORD_WRONG}"
   --env-var "enablePrivilegedFlows=${ENABLE_PRIVILEGED_FLOWS}"
+  --env-var "suiteProfile=${SUITE_PROFILE}"
   --timeout-request 15000
   --delay-request 150
   --reporters cli,junit

--- a/tests/test_postman_collection_contract.py
+++ b/tests/test_postman_collection_contract.py
@@ -4,6 +4,30 @@ import json
 import re
 from pathlib import Path
 
+SMOKE_REQUESTS = {
+    "01 - Healthz",
+    "02 - Register user (REST v2)",
+    "03 - Login user (REST v2)",
+    "04 - Login invalid credentials returns safe error",
+    "05 - Me (REST v2)",
+    "01 - Create transaction (REST v2)",
+    "04 - List active transactions (REST v2)",
+    "05 - Transaction summary by month (REST v2)",
+    "01 - Create goal (REST v2)",
+    "02 - List goals (REST v2)",
+    "05 - Goal simulate (REST v2)",
+    "01 - Create wallet investment (REST v2)",
+    "02 - List wallet investments (REST v2)",
+    "08 - Create wallet operation (REST v2)",
+    "10 - Wallet operation summary (REST v2)",
+    "01 - Installment vs cash calculate (REST public)",
+    "02 - Installment vs cash save (REST auth required)",
+    "03 - Simulation goal bridge without entitlement returns 403",
+    "02 - GraphQL login invalid credentials (safe error)",
+    "03 - GraphQL me query (auth required)",
+    "04 - GraphQL installment vs cash calculate (public)",
+}
+
 
 def _load_postman_items() -> list[dict[str, object]]:
     collection_path = (
@@ -131,3 +155,16 @@ def test_postman_collection_uses_domain_folders() -> None:
         "04 - Simulations",
         "05 - GraphQL",
     ]
+
+
+def test_postman_collection_request_names_are_unique() -> None:
+    items = _flatten_request_items(_load_postman_items())
+    names = [str(item.get("name")) for item in items]
+    assert len(names) == len(set(names)), "Postman request names must stay unique"
+
+
+def test_postman_collection_smoke_profile_covers_known_requests() -> None:
+    items = _flatten_request_items(_load_postman_items())
+    names = {str(item.get("name")) for item in items}
+    missing = sorted(SMOKE_REQUESTS - names)
+    assert not missing, f"Smoke profile references unknown requests: {missing}"


### PR DESCRIPTION
## Summary
- add official Newman suite profiles for `smoke` and `full`
- make the canonical Postman collection profile-aware without duplicating collections
- document the official execution modes in the existing testing docs

## Validation
- `python3 scripts/build_postman_collection.py`
- `bash -n scripts/run_postman_suite.sh`
- `npm run postman:smoke:dev`
- `npm run postman:full:dev`

## Notes
- local commit/push hooks that require Python 3.13 were skipped only at publish time because this machine still exposes Python 3.14 in PATH; the PR CI remains the canonical gate.
- smoke on DEV: 21 requests / 40 assertions / 0 failed
- full on DEV: 58 requests / 110 assertions / 0 failed