### PR TITLE
fix(ops): harden recurrence incidents and rate limit fallback

### DIFF
--- a/.github/workflows/recurrence-job.yml
+++ b/.github/workflows/recurrence-job.yml
@@ -5,6 +5,10 @@ on:
     - cron: "0 3 * * *"
   workflow_dispatch:
 
+concurrency:
+  group: recurrence-job-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   generate-recurring-transactions:
     name: Generate Recurring Transactions
@@ -46,25 +50,65 @@ jobs:
           script: |
             const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const now = new Date().toISOString();
+            const title = '🚨 [recurrence-job] Falha na geração de transações recorrentes';
+            const issueBody = [
+              '## Recurrence Job falhou',
+              '',
+              `**Última falha:** ${now}`,
+              `**Run:** ${runUrl}`,
+              '',
+              'O job agendado de geração de transações recorrentes falhou.',
+              'Verifique os logs do workflow e o estado do banco de dados de produção.',
+              '',
+              '### Ações sugeridas',
+              '- Revisar logs da execução no link acima',
+              '- Verificar conectividade com `RECURRENCE_DATABASE_URL`',
+              '- Executar `scripts/generate_recurring_transactions.py` manualmente se necessário',
+              '',
+              '_Issue criada automaticamente pelo GitHub Actions._',
+            ].join('\n');
+            const commentBody = [
+              'Nova falha detectada no recurrence job.',
+              '',
+              `- Data: ${now}`,
+              `- Run: ${runUrl}`,
+            ].join('\n');
+            const query = [
+              `repo:${context.repo.owner}/${context.repo.repo}`,
+              'is:issue',
+              'in:title',
+              `"${title}"`,
+            ].join(' ');
+            const search = await github.rest.search.issuesAndPullRequests({
+              q: query,
+              per_page: 10,
+            });
+            const matchingIssue = search.data.items.find(
+              (item) => item.title === title,
+            );
+
+            if (matchingIssue) {
+              if (matchingIssue.state === 'closed') {
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: matchingIssue.number,
+                  state: 'open',
+                });
+              }
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: matchingIssue.number,
+                body: commentBody,
+              });
+              return;
+            }
+
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: `🚨 [recurrence-job] Falha na geração de transações recorrentes — ${now.slice(0,10)}`,
-              body: [
-                '## Recurrence Job falhou',
-                '',
-                `**Data:** ${now}`,
-                `**Run:** ${runUrl}`,
-                '',
-                'O job agendado de geração de transações recorrentes falhou.',
-                'Verifique os logs do workflow e o estado do banco de dados de produção.',
-                '',
-                '### Ações sugeridas',
-                '- Revisar logs da execução no link acima',
-                '- Verificar conectividade com `RECURRENCE_DATABASE_URL`',
-                '- Executar `scripts/generate_recurring_transactions.py` manualmente se necessário',
-                '',
-                '_Issue criada automaticamente pelo GitHub Actions._',
-              ].join('\n'),
+              title,
+              body: issueBody,
               labels: ['bug', 'ops'],
             });

--- a/app/middleware/rate_limit.py
+++ b/app/middleware/rate_limit.py
@@ -12,6 +12,10 @@ from flask import Flask, Response, current_app, g, jsonify, request
 from flask_jwt_extended import decode_token
 
 from app.extensions.integration_metrics import increment_metric
+from app.middleware.rate_limit_settings import (
+    RateLimitSettings,
+    build_rate_limit_settings,
+)
 from app.utils.api_contract import is_v2_contract_request
 from app.utils.response_builder import error_payload
 
@@ -119,18 +123,20 @@ class RateLimiterService:
         *,
         rules: dict[str, RateLimitRule],
         storage: "RateLimitStorage",
+        settings: RateLimitSettings,
         backend_name: str,
         configured_backend: str,
         backend_ready: bool,
-        fail_closed: bool,
         backend_failure_reason: str | None = None,
     ) -> None:
         self._rules = rules
         self._storage = storage
+        self._enabled = settings.enabled
         self.backend_name = backend_name
         self.configured_backend = configured_backend
         self.backend_ready = backend_ready
-        self.fail_closed = fail_closed
+        self.degraded_mode = settings.degraded_mode
+        self.fail_closed = settings.fail_closed
         self.backend_failure_reason = backend_failure_reason
         self._route_rule_order: tuple[tuple[str, str], ...] = (
             ("/auth/login", "auth"),
@@ -191,21 +197,22 @@ class RateLimiterService:
             configured_backend,
             backend_failure_reason,
         ) = _build_storage_from_env()
-        default_fail_closed = (
-            configured_backend == "redis"
-            and not _read_bool_env("FLASK_DEBUG", False)
-            and not _read_bool_env("FLASK_TESTING", False)
+        settings = build_rate_limit_settings(
+            configured_backend=configured_backend,
         )
-        fail_closed = _read_bool_env("RATE_LIMIT_FAIL_CLOSED", default_fail_closed)
         return cls(
             rules=rules,
             storage=storage,
+            settings=settings,
             backend_name=backend_name,
             configured_backend=configured_backend,
             backend_ready=backend_ready,
-            fail_closed=fail_closed,
             backend_failure_reason=backend_failure_reason,
         )
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
 
     def set_rule(
         self,
@@ -513,11 +520,12 @@ def _log_rate_limit_backend_configuration(
     app.logger.info(
         (
             "rate_limit_backend_config configured_backend=%s "
-            "backend_name=%s ready=%s fail_closed=%s reason=%s"
+            "backend_name=%s ready=%s degraded_mode=%s fail_closed=%s reason=%s"
         ),
         limiter.configured_backend,
         limiter.backend_name,
         limiter.backend_ready,
+        limiter.degraded_mode,
         limiter.fail_closed,
         limiter.backend_failure_reason or "none",
     )
@@ -536,10 +544,9 @@ def _record_allowed_decision_metrics(decision: RateLimitDecision) -> None:
 
 
 def register_rate_limit_guard(app: Flask) -> None:
-    if not _read_bool_env("RATE_LIMIT_ENABLED", True):
-        return
-
     limiter = RateLimiterService.from_env()
+    if not limiter.enabled:
+        return
     app.extensions["rate_limiter"] = limiter
     _log_rate_limit_backend_configuration(app, limiter)
 

--- a/app/middleware/rate_limit_settings.py
+++ b/app/middleware/rate_limit_settings.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Literal
+
+RateLimitDegradedMode = Literal["memory_fallback", "fail_closed"]
+
+
+@dataclass(frozen=True)
+class RateLimitSettings:
+    enabled: bool
+    degraded_mode: RateLimitDegradedMode
+
+    @property
+    def fail_closed(self) -> bool:
+        return self.degraded_mode == "fail_closed"
+
+
+def read_bool_env(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _is_secure_runtime() -> bool:
+    return not read_bool_env("FLASK_DEBUG", False) and not read_bool_env(
+        "FLASK_TESTING", False
+    )
+
+
+def _read_explicit_bool_env(name: str) -> tuple[bool, bool]:
+    raw = os.getenv(name)
+    if raw is None:
+        return False, False
+    return raw.strip().lower() in {"1", "true", "yes", "on"}, True
+
+
+def _resolve_degraded_mode() -> RateLimitDegradedMode:
+    explicit_mode = str(os.getenv("RATE_LIMIT_DEGRADED_MODE", "")).strip().lower()
+    if explicit_mode:
+        if explicit_mode not in {"memory_fallback", "fail_closed"}:
+            raise RuntimeError(
+                "Invalid RATE_LIMIT_DEGRADED_MODE. Expected memory_fallback or "
+                "fail_closed."
+            )
+        return explicit_mode  # type: ignore[return-value]
+
+    explicit_fail_closed, has_explicit_fail_closed = _read_explicit_bool_env(
+        "RATE_LIMIT_FAIL_CLOSED"
+    )
+    if has_explicit_fail_closed:
+        return "fail_closed" if explicit_fail_closed else "memory_fallback"
+
+    return "memory_fallback"
+
+
+def build_rate_limit_settings(*, configured_backend: str) -> RateLimitSettings:
+    secure_runtime = _is_secure_runtime()
+    if (
+        configured_backend == "redis"
+        and secure_runtime
+        and os.getenv("RATE_LIMIT_DEGRADED_MODE") is None
+        and os.getenv("RATE_LIMIT_FAIL_CLOSED") is None
+    ):
+        raise RuntimeError(
+            "Missing RATE_LIMIT_DEGRADED_MODE. Configure explicit degraded mode "
+            "for RATE_LIMIT_BACKEND=redis in secure runtime."
+        )
+
+    return RateLimitSettings(
+        enabled=read_bool_env("RATE_LIMIT_ENABLED", True),
+        degraded_mode=_resolve_degraded_mode(),
+    )
+
+
+__all__ = [
+    "RateLimitDegradedMode",
+    "RateLimitSettings",
+    "build_rate_limit_settings",
+    "read_bool_env",
+]

--- a/tests/test_rate_limit_backend.py
+++ b/tests/test_rate_limit_backend.py
@@ -25,7 +25,7 @@ def test_rate_limit_falls_back_to_memory_when_redis_url_missing(monkeypatch) -> 
 def test_rate_limit_falls_back_to_memory_on_unreachable_redis(monkeypatch) -> None:
     monkeypatch.setenv("RATE_LIMIT_BACKEND", "redis")
     monkeypatch.setenv("RATE_LIMIT_REDIS_URL", "redis://127.0.0.1:6399/0")
-    monkeypatch.setenv("RATE_LIMIT_FAIL_CLOSED", "false")
+    monkeypatch.setenv("RATE_LIMIT_DEGRADED_MODE", "memory_fallback")
 
     limiter = RateLimiterService.from_env()
 
@@ -36,7 +36,7 @@ def test_rate_limit_fail_closed_on_unavailable_redis(monkeypatch) -> None:
     monkeypatch.setenv("RATE_LIMIT_BACKEND", "redis")
     monkeypatch.delenv("RATE_LIMIT_REDIS_URL", raising=False)
     monkeypatch.delenv("REDIS_URL", raising=False)
-    monkeypatch.setenv("RATE_LIMIT_FAIL_CLOSED", "true")
+    monkeypatch.setenv("RATE_LIMIT_DEGRADED_MODE", "fail_closed")
 
     limiter = RateLimiterService.from_env()
 
@@ -50,7 +50,7 @@ def test_rate_limit_guard_returns_503_when_fail_closed(monkeypatch) -> None:
     monkeypatch.setenv("RATE_LIMIT_BACKEND", "redis")
     monkeypatch.delenv("RATE_LIMIT_REDIS_URL", raising=False)
     monkeypatch.delenv("REDIS_URL", raising=False)
-    monkeypatch.setenv("RATE_LIMIT_FAIL_CLOSED", "true")
+    monkeypatch.setenv("RATE_LIMIT_DEGRADED_MODE", "fail_closed")
 
     app = Flask(__name__)
     app.config["TESTING"] = True
@@ -67,3 +67,27 @@ def test_rate_limit_guard_returns_503_when_fail_closed(monkeypatch) -> None:
     assert response.status_code == 503
     body = response.get_json()
     assert body["error"] == "RATE_LIMIT_BACKEND_UNAVAILABLE"
+
+
+def test_rate_limit_guard_uses_memory_fallback_when_degraded_mode_is_memory_fallback(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("RATE_LIMIT_ENABLED", "true")
+    monkeypatch.setenv("RATE_LIMIT_BACKEND", "redis")
+    monkeypatch.delenv("RATE_LIMIT_REDIS_URL", raising=False)
+    monkeypatch.delenv("REDIS_URL", raising=False)
+    monkeypatch.setenv("RATE_LIMIT_DEGRADED_MODE", "memory_fallback")
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+
+    @app.get("/probe")
+    def _probe() -> tuple[str, int]:
+        return "ok", 200
+
+    register_rate_limit_guard(app)
+
+    client = app.test_client()
+    response = client.get("/probe")
+
+    assert response.status_code == 200

--- a/tests/test_rate_limit_observability.py
+++ b/tests/test_rate_limit_observability.py
@@ -39,7 +39,7 @@ def test_rate_limit_metrics_increment_when_redis_backend_unavailable(
 ) -> None:
     monkeypatch.setenv("RATE_LIMIT_ENABLED", "true")
     monkeypatch.setenv("RATE_LIMIT_BACKEND", "redis")
-    monkeypatch.setenv("RATE_LIMIT_FAIL_CLOSED", "true")
+    monkeypatch.setenv("RATE_LIMIT_DEGRADED_MODE", "fail_closed")
     monkeypatch.delenv("RATE_LIMIT_REDIS_URL", raising=False)
     monkeypatch.delenv("REDIS_URL", raising=False)
 

--- a/tests/test_rate_limit_settings.py
+++ b/tests/test_rate_limit_settings.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.middleware.rate_limit_settings import build_rate_limit_settings
+
+
+def test_rate_limit_requires_explicit_degraded_mode_for_redis_in_secure_runtime(
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setenv("FLASK_DEBUG", "false")
+    monkeypatch.setenv("FLASK_TESTING", "false")
+    monkeypatch.delenv("RATE_LIMIT_DEGRADED_MODE", raising=False)
+    monkeypatch.delenv("RATE_LIMIT_FAIL_CLOSED", raising=False)
+
+    with pytest.raises(
+        RuntimeError,
+        match="Missing RATE_LIMIT_DEGRADED_MODE",
+    ):
+        build_rate_limit_settings(configured_backend="redis")
+
+
+def test_rate_limit_accepts_explicit_memory_fallback_mode(monkeypatch: Any) -> None:
+    monkeypatch.setenv("FLASK_DEBUG", "false")
+    monkeypatch.setenv("FLASK_TESTING", "false")
+    monkeypatch.setenv("RATE_LIMIT_DEGRADED_MODE", "memory_fallback")
+
+    settings = build_rate_limit_settings(configured_backend="redis")
+
+    assert settings.degraded_mode == "memory_fallback"
+    assert settings.fail_closed is False
+
+
+def test_rate_limit_accepts_explicit_fail_closed_mode(monkeypatch: Any) -> None:
+    monkeypatch.setenv("FLASK_DEBUG", "false")
+    monkeypatch.setenv("FLASK_TESTING", "false")
+    monkeypatch.setenv("RATE_LIMIT_DEGRADED_MODE", "fail_closed")
+
+    settings = build_rate_limit_settings(configured_backend="redis")
+
+    assert settings.degraded_mode == "fail_closed"
+    assert settings.fail_closed is True
+
+
+def test_rate_limit_supports_legacy_fail_closed_flag(monkeypatch: Any) -> None:
+    monkeypatch.setenv("FLASK_DEBUG", "false")
+    monkeypatch.setenv("FLASK_TESTING", "false")
+    monkeypatch.delenv("RATE_LIMIT_DEGRADED_MODE", raising=False)
+    monkeypatch.setenv("RATE_LIMIT_FAIL_CLOSED", "false")
+
+    settings = build_rate_limit_settings(configured_backend="redis")
+
+    assert settings.degraded_mode == "memory_fallback"
+    assert settings.fail_closed is False
+
+
+def test_rate_limit_keeps_relaxed_default_outside_secure_runtime(
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setenv("FLASK_DEBUG", "true")
+    monkeypatch.setenv("FLASK_TESTING", "false")
+    monkeypatch.delenv("RATE_LIMIT_DEGRADED_MODE", raising=False)
+    monkeypatch.delenv("RATE_LIMIT_FAIL_CLOSED", raising=False)
+
+    settings = build_rate_limit_settings(configured_backend="redis")
+
+    assert settings.degraded_mode == "memory_fallback"
+    assert settings.fail_closed is False


### PR DESCRIPTION
## Summary
- deduplicate recurrence-job incidents and serialize executions with workflow concurrency
- introduce explicit degraded-mode settings for Redis-backed rate limiting
- cover the new rate-limit policy with regression tests for secure-runtime and fallback behavior

## Linked work
- closes #672
- closes #673

## Validation
- scripts/python_tool.sh pytest tests/test_rate_limit_backend.py tests/test_rate_limit_observability.py tests/test_rate_limit_settings.py -q
- scripts/python_tool.sh ruff check app/middleware/rate_limit.py app/middleware/rate_limit_settings.py tests/test_rate_limit_backend.py tests/test_rate_limit_observability.py tests/test_rate_limit_settings.py
- scripts/python_tool.sh mypy app
- .venv/bin/python -c "import yaml; from pathlib import Path; yaml.safe_load(Path('.github/workflows/recurrence-job.yml').read_text())"
- git diff --check
