### PR TITLE
feat(postman): expand canonical e2e parity coverage

### DIFF
--- a/api-tests/postman/auraxis.postman_collection.json
+++ b/api-tests/postman/auraxis.postman_collection.json
@@ -10,7 +10,7 @@
       "listen": "prerequest",
       "script": {
         "exec": [
-          "var smokeRequests = [\"01 - Healthz\", \"02 - Register user (REST v2)\", \"03 - Login user (REST v2)\", \"04 - Login invalid credentials returns safe error\", \"05 - Me (REST v2)\", \"01 - Create transaction (REST v2)\", \"04 - List active transactions (REST v2)\", \"05 - Transaction summary by month (REST v2)\", \"01 - Create goal (REST v2)\", \"02 - List goals (REST v2)\", \"05 - Goal simulate (REST v2)\", \"01 - Create wallet investment (REST v2)\", \"02 - List wallet investments (REST v2)\", \"08 - Create wallet operation (REST v2)\", \"10 - Wallet operation summary (REST v2)\", \"01 - Installment vs cash calculate (REST public)\", \"02 - Installment vs cash save (REST auth required)\", \"03 - Simulation goal bridge without entitlement returns 403\", \"02 - GraphQL login invalid credentials (safe error)\", \"03 - GraphQL me query (auth required)\", \"04 - GraphQL installment vs cash calculate (public)\"];",
+          "var smokeRequests = [\"01 - Healthz\", \"02 - Register user (REST v2)\", \"03 - Login user (REST v2)\", \"04 - Login invalid credentials returns safe error\", \"05 - Me (REST v2)\", \"01 - Create transaction (REST v2)\", \"04 - List active transactions (REST v2)\", \"05 - Transaction summary by month (REST v2)\", \"01 - Create goal (REST v2)\", \"02 - List goals (REST v2)\", \"05 - Goal simulate (REST v2)\", \"01 - Create wallet investment (REST v2)\", \"02 - List wallet investments (REST v2)\", \"08 - Create wallet operation (REST v2)\", \"10 - Wallet operation summary (REST v2)\", \"01 - Installment vs cash calculate (REST public)\", \"02 - Installment vs cash save (REST auth required)\", \"03 - Simulation goal bridge without entitlement returns 403\", \"02 - GraphQL login invalid credentials (safe error)\", \"03 - GraphQL me query (auth required)\", \"04 - GraphQL installment vs cash calculate (public)\", \"01 - List alert preferences (REST v2)\", \"01 - Get my subscription (REST v2)\", \"01 - List entitlements (REST v2)\", \"01 - List shared entries by me (REST v2)\", \"01 - CSV upload preview (REST v2)\"];",
           "var activeProfile = String(pm.environment.get('suiteProfile') || pm.collectionVariables.get('suiteProfile') || 'full').toLowerCase();",
           "if (!['smoke', 'full'].includes(activeProfile)) {",
           "  throw new Error('Unsupported suiteProfile: ' + activeProfile + '. Use smoke or full.');",
@@ -114,7 +114,9 @@
                   "pm.collectionVariables.set('runIn365Days', isoDate(365));",
                   "pm.collectionVariables.set('runMonthRef', isoMonth(0));",
                   "pm.collectionVariables.set('graphSimulationLabel', 'Notebook ' + seed);",
-                  "['authToken', 'userId', 'transactionId', 'goalId', 'investmentId', 'operationId', 'simulationId', 'advancedSimulationId', 'feeSimulationId', 'entitlementId'].forEach(function (key) { pm.collectionVariables.unset(key); });"
+                  "pm.collectionVariables.set('fakeUuid', '00000000-0000-4000-8000-000000000001');",
+                  "pm.collectionVariables.set('nonexistentInvitationToken', 'nonexistent-token-' + seed);",
+                  "['authToken', 'userId', 'transactionId', 'goalId', 'investmentId', 'operationId', 'simulationId', 'advancedSimulationId', 'feeSimulationId', 'entitlementId', 'receivableId', 'fiscalDocumentId', 'sharedEntryId', 'invitationId', 'subscriptionId'].forEach(function (key) { pm.collectionVariables.unset(key); });"
                 ],
                 "type": "text/javascript"
               }
@@ -2882,7 +2884,1206 @@
       ]
     },
     {
-      "name": "05 - GraphQL",
+      "name": "05 - Alerts",
+      "item": [
+        {
+          "name": "01 - List alert preferences (REST v2)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/alerts/preferences",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "alerts",
+                "preferences"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('alert preferences returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('alert preferences returns list payload', function () {",
+                  "  pm.expect(body.success).to.eql(true);",
+                  "  pm.expect(body.data.preferences).to.be.an('array');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "02 - Update alert preference (REST v2)",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/alerts/preferences/system",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "alerts",
+                "preferences",
+                "system"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"enabled\": true,\n                      \"channels\": [\"in_app\"],\n                      \"global_opt_out\": false\n                    }\n"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('alert preference update returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('alert preference update returns preference payload', function () {",
+                  "  pm.expect(body.success).to.eql(true);",
+                  "  pm.expect(body.data.preference.category).to.eql('system');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "03 - List alerts (REST v2)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/alerts?unread_only=false",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "alerts"
+              ],
+              "query": [
+                {
+                  "key": "unread_only",
+                  "value": "false"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('alerts list returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('alerts list returns alerts array', function () {",
+                  "  pm.expect(body.success).to.eql(true);",
+                  "  pm.expect(body.data.alerts).to.be.an('array');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "04 - Mark alert as read for nonexistent id returns 404",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/alerts/{{fakeUuid}}/read",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "alerts",
+                "{{fakeUuid}}",
+                "read"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('alert read missing id returns 404', function () { pm.response.to.have.status(404); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "05 - Delete alert for nonexistent id returns 404",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/alerts/{{fakeUuid}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "alerts",
+                "{{fakeUuid}}"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('alert delete missing id returns 404', function () { pm.response.to.have.status(404); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "06 - Subscriptions and Entitlements",
+      "item": [
+        {
+          "name": "01 - Get my subscription (REST v2)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/subscriptions/me",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "subscriptions",
+                "me"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('subscription me returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('subscription me returns subscription payload', function () {",
+                  "  pm.expect(body.success).to.eql(true);",
+                  "  pm.expect(body.data.subscription.id).to.be.a('string').and.not.empty;",
+                  "});",
+                  "pm.collectionVariables.set('subscriptionId', pm.response.json().data.subscription.id);"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "02 - Create checkout session (REST v2)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/subscriptions/checkout",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "subscriptions",
+                "checkout"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"plan_slug\": \"pro_monthly\"\n                    }\n"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('subscription checkout returns 201', function () { pm.response.to.have.status(201); });",
+                  "var body = pm.response.json();",
+                  "pm.test('subscription checkout returns checkout url', function () {",
+                  "  pm.expect(body.success).to.eql(true);",
+                  "  pm.expect(body.data.checkout_url).to.be.a('string').and.not.empty;",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "03 - Cancel subscription (REST v2)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/subscriptions/cancel",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "subscriptions",
+                "cancel"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('subscription cancel returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('subscription cancel returns canceled status', function () {",
+                  "  pm.expect(body.success).to.eql(true);",
+                  "  pm.expect(body.data.subscription.status).to.eql('canceled');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "04 - Webhook invalid signature returns 401",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-Billing-Signature",
+                "value": "invalid-signature"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/subscriptions/webhook",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "subscriptions",
+                "webhook"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"event\": \"subscription.activated\",\n                      \"subscription_id\": \"sub_fake\"\n                    }\n"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('subscription webhook invalid signature returns 401', function () { pm.response.to.have.status(401); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "01 - List entitlements (REST v2)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/entitlements",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "entitlements"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('entitlements list returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('entitlements list returns items array', function () {",
+                  "  pm.expect(body.success).to.eql(true);",
+                  "  pm.expect(body.data.items).to.be.an('array');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "02 - Check entitlement missing feature key returns 400",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/entitlements/check",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "entitlements",
+                "check"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('entitlement check missing feature key returns 400', function () { pm.response.to.have.status(400); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "07 - Shared Entries",
+      "item": [
+        {
+          "name": "01 - List shared entries by me (REST v2)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/shared-entries/by-me",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "shared-entries",
+                "by-me"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('shared entries by me returns 200', function () { pm.response.to.have.status(200); });",
+                  "pm.test('shared entries by me returns array', function () { pm.expect(pm.response.json().shared_entries).to.be.an('array'); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "02 - List shared entries with me (REST v2)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/shared-entries/with-me",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "shared-entries",
+                "with-me"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('shared entries with me returns 200', function () { pm.response.to.have.status(200); });",
+                  "pm.test('shared entries with me returns array', function () { pm.expect(pm.response.json().shared_entries).to.be.an('array'); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "03 - Create shared entry missing fields returns 400",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/shared-entries",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "shared-entries"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}\n"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('shared entry missing fields returns 400', function () { pm.response.to.have.status(400); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "04 - List invitations (REST v2)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/shared-entries/invitations",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "shared-entries",
+                "invitations"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('shared invitations list returns 200', function () { pm.response.to.have.status(200); });",
+                  "pm.test('shared invitations list returns array', function () { pm.expect(pm.response.json().invitations).to.be.an('array'); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "05 - Create invitation missing fields returns 400",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/shared-entries/invitations",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "shared-entries",
+                "invitations"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}\n"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('shared invitation missing fields returns 400', function () { pm.response.to.have.status(400); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "06 - Accept nonexistent invitation returns 404",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/shared-entries/invitations/{{nonexistentInvitationToken}}/accept",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "shared-entries",
+                "invitations",
+                "{{nonexistentInvitationToken}}",
+                "accept"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('shared invitation accept missing token returns 404', function () { pm.response.to.have.status(404); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "07 - Delete nonexistent shared entry returns 404",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/shared-entries/{{fakeUuid}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "shared-entries",
+                "{{fakeUuid}}"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('shared entry delete missing id returns 404', function () { pm.response.to.have.status(404); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "08 - Delete nonexistent invitation returns 404",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/shared-entries/invitations/{{fakeUuid}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "shared-entries",
+                "invitations",
+                "{{fakeUuid}}"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('shared invitation delete missing id returns 404', function () { pm.response.to.have.status(404); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "08 - Fiscal",
+      "item": [
+        {
+          "name": "01 - CSV upload preview (REST v2)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/fiscal/csv/upload",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "fiscal",
+                "csv",
+                "upload"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"content\": \"description,amount,date,category,external_id\\nConsultoria,1500.00,2026-03-22,consulting,ext-{{runSeed}}\\nLicenca,900.00,2026-03-23,software,ext2-{{runSeed}}\",\n                      \"column_map\": {\n                        \"description\": \"description\",\n                        \"amount\": \"amount\",\n                        \"date\": \"date\",\n                        \"category\": \"category\",\n                        \"external_id\": \"external_id\"\n                      }\n                    }\n"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('fiscal csv upload returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('fiscal csv upload returns preview rows', function () { pm.expect(body.data.preview || body.preview).to.be.an('array'); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "02 - CSV confirm import (REST v2)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/fiscal/csv/confirm",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "fiscal",
+                "csv",
+                "confirm"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"content\": \"description,amount,date,category,external_id\\nConsultoria,1500.00,2026-03-22,consulting,ext-{{runSeed}}\\nLicenca,900.00,2026-03-23,software,ext2-{{runSeed}}\",\n                      \"column_map\": {\n                        \"description\": \"description\",\n                        \"amount\": \"amount\",\n                        \"date\": \"date\",\n                        \"category\": \"category\",\n                        \"external_id\": \"external_id\"\n                      }\n                    }\n"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('fiscal csv confirm returns 201', function () { pm.response.to.have.status(201); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "03 - List receivables (REST v2)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/fiscal/receivables",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "fiscal",
+                "receivables"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('fiscal receivables list returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "var items = body.data ? body.data.receivables : body.receivables;",
+                  "pm.test('fiscal receivables list returns items array', function () { pm.expect(items).to.be.an('array'); });",
+                  "if (items.length > 0) { pm.collectionVariables.set('receivableId', items[0].id); }"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "04 - Create manual receivable (REST v2)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/fiscal/receivables",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "fiscal",
+                "receivables"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"description\": \"Servico extra {{runSeed}}\",\n                      \"amount\": \"2500.00\",\n                      \"expected_date\": \"{{runTomorrow}}\",\n                      \"category\": \"consulting\"\n                    }\n"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('fiscal receivable create returns 201', function () { pm.response.to.have.status(201); });",
+                  "var body = pm.response.json();",
+                  "var receivable = body.data ? body.data.receivable : body.receivable;",
+                  "pm.collectionVariables.set('receivableId', receivable.id);",
+                  "pm.test('fiscal receivable create returns id', function () { pm.expect(receivable.id).to.be.a('string').and.not.empty; });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "05 - Mark receivable as received (REST v2)",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/fiscal/receivables/{{receivableId}}/receive",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "fiscal",
+                "receivables",
+                "{{receivableId}}",
+                "receive"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"received_date\": \"{{runToday}}\",\n                      \"received_amount\": \"2500.00\"\n                    }\n"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('fiscal receivable receive returns 200', function () { pm.response.to.have.status(200); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "06 - Receivables summary (REST v2)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/fiscal/receivables/summary",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "fiscal",
+                "receivables",
+                "summary"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('fiscal receivables summary returns 200', function () { pm.response.to.have.status(200); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "07 - Delete settled receivable returns 409",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/fiscal/receivables/{{receivableId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "fiscal",
+                "receivables",
+                "{{receivableId}}"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('fiscal receivable delete settled returns 409', function () { pm.response.to.have.status(409); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "08 - List fiscal documents (REST v2)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/fiscal/fiscal-documents",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "fiscal",
+                "fiscal-documents"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('fiscal documents list returns 200', function () { pm.response.to.have.status(200); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "09 - Create fiscal document (REST v2)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/fiscal/fiscal-documents",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "fiscal",
+                "fiscal-documents"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"type\": \"service_invoice\",\n                      \"amount\": \"1999.90\",\n                      \"issued_at\": \"{{runToday}}\",\n                      \"counterpart_name\": \"Cliente {{runSeed}}\",\n                      \"external_id\": \"invoice-{{runSeed}}\"\n                    }\n"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('fiscal document create returns 201', function () { pm.response.to.have.status(201); });",
+                  "var body = pm.response.json();",
+                  "var doc = body.data ? body.data.fiscal_document : body.fiscal_document;",
+                  "pm.collectionVariables.set('fiscalDocumentId', doc.id);",
+                  "pm.test('fiscal document create returns id', function () { pm.expect(doc.id).to.be.a('string').and.not.empty; });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "09 - GraphQL",
       "item": [
         {
           "name": "01 - GraphQL empty query (validation error)",
@@ -3144,6 +4345,34 @@
     },
     {
       "key": "entitlementId",
+      "value": ""
+    },
+    {
+      "key": "receivableId",
+      "value": ""
+    },
+    {
+      "key": "fiscalDocumentId",
+      "value": ""
+    },
+    {
+      "key": "sharedEntryId",
+      "value": ""
+    },
+    {
+      "key": "invitationId",
+      "value": ""
+    },
+    {
+      "key": "subscriptionId",
+      "value": ""
+    },
+    {
+      "key": "fakeUuid",
+      "value": "00000000-0000-4000-8000-000000000001"
+    },
+    {
+      "key": "nonexistentInvitationToken",
       "value": ""
     },
     {

--- a/app/models/fiscal.py
+++ b/app/models/fiscal.py
@@ -23,6 +23,10 @@ from app.extensions.database import db
 from app.utils.datetime_utils import utc_now_naive
 
 
+def _enum_values(enum_cls: type[enum.Enum]) -> list[str]:
+    return [str(item.value) for item in enum_cls]
+
+
 class FiscalImportStatus(enum.Enum):
     PROCESSING = "processing"
     PREVIEW_READY = "preview_ready"
@@ -72,7 +76,7 @@ class FiscalImport(db.Model):
         UUID(as_uuid=True), db.ForeignKey("users.id"), nullable=False, index=True
     )
     status = db.Column(
-        db.Enum(FiscalImportStatus),
+        db.Enum(FiscalImportStatus, values_callable=_enum_values),
         nullable=False,
         default=FiscalImportStatus.PROCESSING,
     )
@@ -107,9 +111,11 @@ class FiscalDocument(db.Model):
         UUID(as_uuid=True), db.ForeignKey("fiscal_imports.id"), nullable=True
     )
     external_id = db.Column(db.String(120), nullable=False)
-    type = db.Column(db.Enum(FiscalDocumentType), nullable=False)
+    type = db.Column(
+        db.Enum(FiscalDocumentType, values_callable=_enum_values), nullable=False
+    )
     status = db.Column(
-        db.Enum(FiscalDocumentStatus),
+        db.Enum(FiscalDocumentStatus, values_callable=_enum_values),
         nullable=False,
         default=FiscalDocumentStatus.ISSUED,
     )
@@ -173,7 +179,7 @@ class ReceivableEntry(db.Model):
     # outstanding_amount = expected_net_amount - received_amount (calculated in app)
     outstanding_amount = db.Column(db.Numeric(14, 2), nullable=True)
     reconciliation_status = db.Column(
-        db.Enum(ReconciliationStatus),
+        db.Enum(ReconciliationStatus, values_callable=_enum_values),
         nullable=False,
         default=ReconciliationStatus.PENDING,
     )
@@ -212,7 +218,9 @@ class FiscalAdjustment(db.Model):
         index=True,
     )
     user_id = db.Column(UUID(as_uuid=True), db.ForeignKey("users.id"), nullable=False)
-    type = db.Column(db.Enum(FiscalAdjustmentType), nullable=False)
+    type = db.Column(
+        db.Enum(FiscalAdjustmentType, values_callable=_enum_values), nullable=False
+    )
     description = db.Column(db.String(300), nullable=False)
     amount = db.Column(db.Numeric(14, 2), nullable=False)
     # "gross" | "net"

--- a/app/models/shared_entry.py
+++ b/app/models/shared_entry.py
@@ -12,6 +12,10 @@ from app.extensions.database import db
 from app.utils.datetime_utils import utc_now_naive
 
 
+def _enum_values(enum_cls: type[enum.Enum]) -> list[str]:
+    return [str(item.value) for item in enum_cls]
+
+
 class SharedEntryStatus(enum.Enum):
     PENDING = "pending"
     ACTIVE = "active"
@@ -53,11 +57,13 @@ class SharedEntry(db.Model):
         index=True,
     )
     status = db.Column(
-        db.Enum(SharedEntryStatus),
+        db.Enum(SharedEntryStatus, values_callable=_enum_values),
         nullable=False,
         default=SharedEntryStatus.PENDING,
     )
-    split_type = db.Column(db.Enum(SplitType), nullable=False)
+    split_type = db.Column(
+        db.Enum(SplitType, values_callable=_enum_values), nullable=False
+    )
     created_at = db.Column(db.DateTime, nullable=False, default=utc_now_naive)
     updated_at = db.Column(
         db.DateTime, nullable=False, default=utc_now_naive, onupdate=utc_now_naive
@@ -94,7 +100,7 @@ class Invitation(db.Model):
     share_amount = db.Column(db.Numeric(12, 2), nullable=True)
     message = db.Column(db.String(300), nullable=True)
     status = db.Column(
-        db.Enum(InvitationStatus),
+        db.Enum(InvitationStatus, values_callable=_enum_values),
         nullable=False,
         default=InvitationStatus.PENDING,
     )

--- a/app/models/subscription.py
+++ b/app/models/subscription.py
@@ -12,6 +12,10 @@ from app.extensions.database import db
 from app.utils.datetime_utils import utc_now_naive
 
 
+def _enum_values(enum_cls: type[enum.Enum]) -> list[str]:
+    return [str(item.value) for item in enum_cls]
+
+
 class SubscriptionStatus(enum.Enum):
     FREE = "free"
     TRIALING = "trialing"
@@ -44,11 +48,13 @@ class Subscription(db.Model):
     )
     plan_code = db.Column(db.String(40), nullable=False)
     status = db.Column(
-        db.Enum(SubscriptionStatus),
+        db.Enum(SubscriptionStatus, values_callable=_enum_values),
         nullable=False,
         default=SubscriptionStatus.FREE,
     )
-    billing_cycle = db.Column(db.Enum(BillingCycle), nullable=True)
+    billing_cycle = db.Column(
+        db.Enum(BillingCycle, values_callable=_enum_values), nullable=True
+    )
 
     # Billing provider fields (Asaas)
     provider = db.Column(db.String(40), nullable=True)

--- a/migrations/versions/7f9c2d1a4b6e_add_invitation_token_and_expiry.py
+++ b/migrations/versions/7f9c2d1a4b6e_add_invitation_token_and_expiry.py
@@ -1,0 +1,41 @@
+"""Add invitation token and expiry columns.
+
+Revision ID: 7f9c2d1a4b6e
+Revises: j618_foundation
+Create Date: 2026-03-22 19:05:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "7f9c2d1a4b6e"
+down_revision = "j618_foundation"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "invitations",
+        sa.Column("token", sa.String(length=64), nullable=True),
+    )
+    op.add_column("invitations", sa.Column("expires_at", sa.DateTime(), nullable=True))
+    op.execute(
+        """
+        UPDATE invitations
+        SET
+            token = md5(id::text || clock_timestamp()::text || random()::text)
+                || md5(random()::text || id::text),
+            expires_at = COALESCE(expires_at, created_at + interval '48 hours')
+        WHERE status = 'pending'
+        """
+    )
+    op.create_index("ix_invitations_token", "invitations", ["token"], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_invitations_token", table_name="invitations")
+    op.drop_column("invitations", "expires_at")
+    op.drop_column("invitations", "token")

--- a/scripts/build_postman_collection.py
+++ b/scripts/build_postman_collection.py
@@ -30,6 +30,11 @@ SMOKE_REQUESTS = [
     "02 - GraphQL login invalid credentials (safe error)",
     "03 - GraphQL me query (auth required)",
     "04 - GraphQL installment vs cash calculate (public)",
+    "01 - List alert preferences (REST v2)",
+    "01 - Get my subscription (REST v2)",
+    "01 - List entitlements (REST v2)",
+    "01 - List shared entries by me (REST v2)",
+    "01 - CSV upload preview (REST v2)",
 ]
 
 
@@ -158,7 +163,9 @@ def _bootstrap_prerequest() -> list[str]:
         "pm.collectionVariables.set('runIn365Days', isoDate(365));",
         "pm.collectionVariables.set('runMonthRef', isoMonth(0));",
         "pm.collectionVariables.set('graphSimulationLabel', 'Notebook ' + seed);",
-        "['authToken', 'userId', 'transactionId', 'goalId', 'investmentId', 'operationId', 'simulationId', 'advancedSimulationId', 'feeSimulationId', 'entitlementId'].forEach(function (key) { pm.collectionVariables.unset(key); });",
+        "pm.collectionVariables.set('fakeUuid', '00000000-0000-4000-8000-000000000001');",
+        "pm.collectionVariables.set('nonexistentInvitationToken', 'nonexistent-token-' + seed);",
+        "['authToken', 'userId', 'transactionId', 'goalId', 'investmentId', 'operationId', 'simulationId', 'advancedSimulationId', 'feeSimulationId', 'entitlementId', 'receivableId', 'fiscalDocumentId', 'sharedEntryId', 'invitationId', 'subscriptionId'].forEach(function (key) { pm.collectionVariables.unset(key); });",
     ]
 
 
@@ -1377,6 +1384,469 @@ def build_collection() -> dict[str, Any]:
         ),
     ]
 
+    alert_items = [
+        _item(
+            "01 - List alert preferences (REST v2)",
+            _request(
+                method="GET",
+                raw_url="{{baseUrl}}/alerts/preferences",
+                headers=auth_contract_headers,
+            ),
+            test_lines=[
+                "pm.test('alert preferences returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('alert preferences returns list payload', function () {",
+                "  pm.expect(body.success).to.eql(true);",
+                "  pm.expect(body.data.preferences).to.be.an('array');",
+                "});",
+            ],
+        ),
+        _item(
+            "02 - Update alert preference (REST v2)",
+            _request(
+                method="PUT",
+                raw_url="{{baseUrl}}/alerts/preferences/system",
+                headers=auth_json_headers,
+                body=_json_body(
+                    """
+                    {
+                      "enabled": true,
+                      "channels": ["in_app"],
+                      "global_opt_out": false
+                    }
+                    """
+                ),
+            ),
+            test_lines=[
+                "pm.test('alert preference update returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('alert preference update returns preference payload', function () {",
+                "  pm.expect(body.success).to.eql(true);",
+                "  pm.expect(body.data.preference.category).to.eql('system');",
+                "});",
+            ],
+        ),
+        _item(
+            "03 - List alerts (REST v2)",
+            _request(
+                method="GET",
+                raw_url="{{baseUrl}}/alerts?unread_only=false",
+                headers=auth_contract_headers,
+                query=[("unread_only", "false")],
+            ),
+            test_lines=[
+                "pm.test('alerts list returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('alerts list returns alerts array', function () {",
+                "  pm.expect(body.success).to.eql(true);",
+                "  pm.expect(body.data.alerts).to.be.an('array');",
+                "});",
+            ],
+        ),
+        _item(
+            "04 - Mark alert as read for nonexistent id returns 404",
+            _request(
+                method="POST",
+                raw_url="{{baseUrl}}/alerts/{{fakeUuid}}/read",
+                headers=auth_contract_headers,
+            ),
+            test_lines=[
+                "pm.test('alert read missing id returns 404', function () { pm.response.to.have.status(404); });",
+            ],
+        ),
+        _item(
+            "05 - Delete alert for nonexistent id returns 404",
+            _request(
+                method="DELETE",
+                raw_url="{{baseUrl}}/alerts/{{fakeUuid}}",
+                headers=auth_contract_headers,
+            ),
+            test_lines=[
+                "pm.test('alert delete missing id returns 404', function () { pm.response.to.have.status(404); });",
+            ],
+        ),
+    ]
+
+    subscription_items = [
+        _item(
+            "01 - Get my subscription (REST v2)",
+            _request(
+                method="GET",
+                raw_url="{{baseUrl}}/subscriptions/me",
+                headers=auth_contract_headers,
+            ),
+            test_lines=[
+                "pm.test('subscription me returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('subscription me returns subscription payload', function () {",
+                "  pm.expect(body.success).to.eql(true);",
+                "  pm.expect(body.data.subscription.id).to.be.a('string').and.not.empty;",
+                "});",
+                "pm.collectionVariables.set('subscriptionId', pm.response.json().data.subscription.id);",
+            ],
+        ),
+        _item(
+            "02 - Create checkout session (REST v2)",
+            _request(
+                method="POST",
+                raw_url="{{baseUrl}}/subscriptions/checkout",
+                headers=auth_json_headers,
+                body=_json_body(
+                    """
+                    {
+                      "plan_slug": "pro_monthly"
+                    }
+                    """
+                ),
+            ),
+            test_lines=[
+                "pm.test('subscription checkout returns 201', function () { pm.response.to.have.status(201); });",
+                "var body = pm.response.json();",
+                "pm.test('subscription checkout returns checkout url', function () {",
+                "  pm.expect(body.success).to.eql(true);",
+                "  pm.expect(body.data.checkout_url).to.be.a('string').and.not.empty;",
+                "});",
+            ],
+        ),
+        _item(
+            "03 - Cancel subscription (REST v2)",
+            _request(
+                method="POST",
+                raw_url="{{baseUrl}}/subscriptions/cancel",
+                headers=auth_contract_headers,
+            ),
+            test_lines=[
+                "pm.test('subscription cancel returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('subscription cancel returns canceled status', function () {",
+                "  pm.expect(body.success).to.eql(true);",
+                "  pm.expect(body.data.subscription.status).to.eql('canceled');",
+                "});",
+            ],
+        ),
+        _item(
+            "04 - Webhook invalid signature returns 401",
+            _request(
+                method="POST",
+                raw_url="{{baseUrl}}/subscriptions/webhook",
+                headers=_headers(
+                    ("Content-Type", "application/json"),
+                    ("X-Billing-Signature", "invalid-signature"),
+                ),
+                body=_json_body(
+                    """
+                    {
+                      "event": "subscription.activated",
+                      "subscription_id": "sub_fake"
+                    }
+                    """
+                ),
+            ),
+            test_lines=[
+                "pm.test('subscription webhook invalid signature returns 401', function () { pm.response.to.have.status(401); });",
+            ],
+        ),
+    ]
+
+    entitlement_items = [
+        _item(
+            "01 - List entitlements (REST v2)",
+            _request(
+                method="GET",
+                raw_url="{{baseUrl}}/entitlements",
+                headers=auth_contract_headers,
+            ),
+            test_lines=[
+                "pm.test('entitlements list returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('entitlements list returns items array', function () {",
+                "  pm.expect(body.success).to.eql(true);",
+                "  pm.expect(body.data.items).to.be.an('array');",
+                "});",
+            ],
+        ),
+        _item(
+            "02 - Check entitlement missing feature key returns 400",
+            _request(
+                method="GET",
+                raw_url="{{baseUrl}}/entitlements/check",
+                headers=auth_contract_headers,
+            ),
+            test_lines=[
+                "pm.test('entitlement check missing feature key returns 400', function () { pm.response.to.have.status(400); });",
+            ],
+        ),
+    ]
+
+    shared_entries_items = [
+        _item(
+            "01 - List shared entries by me (REST v2)",
+            _request(
+                method="GET",
+                raw_url="{{baseUrl}}/shared-entries/by-me",
+                headers=auth_contract_headers,
+            ),
+            test_lines=[
+                "pm.test('shared entries by me returns 200', function () { pm.response.to.have.status(200); });",
+                "pm.test('shared entries by me returns array', function () { pm.expect(pm.response.json().shared_entries).to.be.an('array'); });",
+            ],
+        ),
+        _item(
+            "02 - List shared entries with me (REST v2)",
+            _request(
+                method="GET",
+                raw_url="{{baseUrl}}/shared-entries/with-me",
+                headers=auth_contract_headers,
+            ),
+            test_lines=[
+                "pm.test('shared entries with me returns 200', function () { pm.response.to.have.status(200); });",
+                "pm.test('shared entries with me returns array', function () { pm.expect(pm.response.json().shared_entries).to.be.an('array'); });",
+            ],
+        ),
+        _item(
+            "03 - Create shared entry missing fields returns 400",
+            _request(
+                method="POST",
+                raw_url="{{baseUrl}}/shared-entries",
+                headers=auth_json_headers,
+                body=_json_body("{}"),
+            ),
+            test_lines=[
+                "pm.test('shared entry missing fields returns 400', function () { pm.response.to.have.status(400); });",
+            ],
+        ),
+        _item(
+            "04 - List invitations (REST v2)",
+            _request(
+                method="GET",
+                raw_url="{{baseUrl}}/shared-entries/invitations",
+                headers=auth_contract_headers,
+            ),
+            test_lines=[
+                "pm.test('shared invitations list returns 200', function () { pm.response.to.have.status(200); });",
+                "pm.test('shared invitations list returns array', function () { pm.expect(pm.response.json().invitations).to.be.an('array'); });",
+            ],
+        ),
+        _item(
+            "05 - Create invitation missing fields returns 400",
+            _request(
+                method="POST",
+                raw_url="{{baseUrl}}/shared-entries/invitations",
+                headers=auth_json_headers,
+                body=_json_body("{}"),
+            ),
+            test_lines=[
+                "pm.test('shared invitation missing fields returns 400', function () { pm.response.to.have.status(400); });",
+            ],
+        ),
+        _item(
+            "06 - Accept nonexistent invitation returns 404",
+            _request(
+                method="POST",
+                raw_url="{{baseUrl}}/shared-entries/invitations/{{nonexistentInvitationToken}}/accept",
+                headers=auth_contract_headers,
+            ),
+            test_lines=[
+                "pm.test('shared invitation accept missing token returns 404', function () { pm.response.to.have.status(404); });",
+            ],
+        ),
+        _item(
+            "07 - Delete nonexistent shared entry returns 404",
+            _request(
+                method="DELETE",
+                raw_url="{{baseUrl}}/shared-entries/{{fakeUuid}}",
+                headers=auth_contract_headers,
+            ),
+            test_lines=[
+                "pm.test('shared entry delete missing id returns 404', function () { pm.response.to.have.status(404); });",
+            ],
+        ),
+        _item(
+            "08 - Delete nonexistent invitation returns 404",
+            _request(
+                method="DELETE",
+                raw_url="{{baseUrl}}/shared-entries/invitations/{{fakeUuid}}",
+                headers=auth_contract_headers,
+            ),
+            test_lines=[
+                "pm.test('shared invitation delete missing id returns 404', function () { pm.response.to.have.status(404); });",
+            ],
+        ),
+    ]
+
+    fiscal_items = [
+        _item(
+            "01 - CSV upload preview (REST v2)",
+            _request(
+                method="POST",
+                raw_url="{{baseUrl}}/fiscal/csv/upload",
+                headers=auth_json_headers,
+                body=_json_body(
+                    """
+                    {
+                      "content": "description,amount,date,category,external_id\\nConsultoria,1500.00,2026-03-22,consulting,ext-{{runSeed}}\\nLicenca,900.00,2026-03-23,software,ext2-{{runSeed}}",
+                      "column_map": {
+                        "description": "description",
+                        "amount": "amount",
+                        "date": "date",
+                        "category": "category",
+                        "external_id": "external_id"
+                      }
+                    }
+                    """
+                ),
+            ),
+            test_lines=[
+                "pm.test('fiscal csv upload returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('fiscal csv upload returns preview rows', function () { pm.expect(body.data.preview || body.preview).to.be.an('array'); });",
+            ],
+        ),
+        _item(
+            "02 - CSV confirm import (REST v2)",
+            _request(
+                method="POST",
+                raw_url="{{baseUrl}}/fiscal/csv/confirm",
+                headers=auth_json_headers,
+                body=_json_body(
+                    """
+                    {
+                      "content": "description,amount,date,category,external_id\\nConsultoria,1500.00,2026-03-22,consulting,ext-{{runSeed}}\\nLicenca,900.00,2026-03-23,software,ext2-{{runSeed}}",
+                      "column_map": {
+                        "description": "description",
+                        "amount": "amount",
+                        "date": "date",
+                        "category": "category",
+                        "external_id": "external_id"
+                      }
+                    }
+                    """
+                ),
+            ),
+            test_lines=[
+                "pm.test('fiscal csv confirm returns 201', function () { pm.response.to.have.status(201); });",
+            ],
+        ),
+        _item(
+            "03 - List receivables (REST v2)",
+            _request(
+                method="GET",
+                raw_url="{{baseUrl}}/fiscal/receivables",
+                headers=auth_contract_headers,
+            ),
+            test_lines=[
+                "pm.test('fiscal receivables list returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "var items = body.data ? body.data.receivables : body.receivables;",
+                "pm.test('fiscal receivables list returns items array', function () { pm.expect(items).to.be.an('array'); });",
+                "if (items.length > 0) { pm.collectionVariables.set('receivableId', items[0].id); }",
+            ],
+        ),
+        _item(
+            "04 - Create manual receivable (REST v2)",
+            _request(
+                method="POST",
+                raw_url="{{baseUrl}}/fiscal/receivables",
+                headers=auth_json_headers,
+                body=_json_body(
+                    """
+                    {
+                      "description": "Servico extra {{runSeed}}",
+                      "amount": "2500.00",
+                      "expected_date": "{{runTomorrow}}",
+                      "category": "consulting"
+                    }
+                    """
+                ),
+            ),
+            test_lines=[
+                "pm.test('fiscal receivable create returns 201', function () { pm.response.to.have.status(201); });",
+                "var body = pm.response.json();",
+                "var receivable = body.data ? body.data.receivable : body.receivable;",
+                "pm.collectionVariables.set('receivableId', receivable.id);",
+                "pm.test('fiscal receivable create returns id', function () { pm.expect(receivable.id).to.be.a('string').and.not.empty; });",
+            ],
+        ),
+        _item(
+            "05 - Mark receivable as received (REST v2)",
+            _request(
+                method="PATCH",
+                raw_url="{{baseUrl}}/fiscal/receivables/{{receivableId}}/receive",
+                headers=auth_json_headers,
+                body=_json_body(
+                    """
+                    {
+                      "received_date": "{{runToday}}",
+                      "received_amount": "2500.00"
+                    }
+                    """
+                ),
+            ),
+            test_lines=[
+                "pm.test('fiscal receivable receive returns 200', function () { pm.response.to.have.status(200); });",
+            ],
+        ),
+        _item(
+            "06 - Receivables summary (REST v2)",
+            _request(
+                method="GET",
+                raw_url="{{baseUrl}}/fiscal/receivables/summary",
+                headers=auth_contract_headers,
+            ),
+            test_lines=[
+                "pm.test('fiscal receivables summary returns 200', function () { pm.response.to.have.status(200); });",
+            ],
+        ),
+        _item(
+            "07 - Delete settled receivable returns 409",
+            _request(
+                method="DELETE",
+                raw_url="{{baseUrl}}/fiscal/receivables/{{receivableId}}",
+                headers=auth_contract_headers,
+            ),
+            test_lines=[
+                "pm.test('fiscal receivable delete settled returns 409', function () { pm.response.to.have.status(409); });",
+            ],
+        ),
+        _item(
+            "08 - List fiscal documents (REST v2)",
+            _request(
+                method="GET",
+                raw_url="{{baseUrl}}/fiscal/fiscal-documents",
+                headers=auth_contract_headers,
+            ),
+            test_lines=[
+                "pm.test('fiscal documents list returns 200', function () { pm.response.to.have.status(200); });",
+            ],
+        ),
+        _item(
+            "09 - Create fiscal document (REST v2)",
+            _request(
+                method="POST",
+                raw_url="{{baseUrl}}/fiscal/fiscal-documents",
+                headers=auth_json_headers,
+                body=_json_body(
+                    """
+                    {
+                      "type": "service_invoice",
+                      "amount": "1999.90",
+                      "issued_at": "{{runToday}}",
+                      "counterpart_name": "Cliente {{runSeed}}",
+                      "external_id": "invoice-{{runSeed}}"
+                    }
+                    """
+                ),
+            ),
+            test_lines=[
+                "pm.test('fiscal document create returns 201', function () { pm.response.to.have.status(201); });",
+                "var body = pm.response.json();",
+                "var doc = body.data ? body.data.fiscal_document : body.fiscal_document;",
+                "pm.collectionVariables.set('fiscalDocumentId', doc.id);",
+                "pm.test('fiscal document create returns id', function () { pm.expect(doc.id).to.be.a('string').and.not.empty; });",
+            ],
+        ),
+    ]
+
     graphql_items = [
         _item(
             "01 - GraphQL empty query (validation error)",
@@ -1512,7 +1982,14 @@ def build_collection() -> dict[str, Any]:
             _folder("02 - Goals", goal_items),
             _folder("03 - Wallet", wallet_items),
             _folder("04 - Simulations", simulation_items),
-            _folder("05 - GraphQL", graphql_items),
+            _folder("05 - Alerts", alert_items),
+            _folder(
+                "06 - Subscriptions and Entitlements",
+                subscription_items + entitlement_items,
+            ),
+            _folder("07 - Shared Entries", shared_entries_items),
+            _folder("08 - Fiscal", fiscal_items),
+            _folder("09 - GraphQL", graphql_items),
         ],
         "variable": [
             {"key": "runSeed", "value": ""},
@@ -1528,6 +2005,13 @@ def build_collection() -> dict[str, Any]:
             {"key": "advancedSimulationId", "value": ""},
             {"key": "feeSimulationId", "value": ""},
             {"key": "entitlementId", "value": ""},
+            {"key": "receivableId", "value": ""},
+            {"key": "fiscalDocumentId", "value": ""},
+            {"key": "sharedEntryId", "value": ""},
+            {"key": "invitationId", "value": ""},
+            {"key": "subscriptionId", "value": ""},
+            {"key": "fakeUuid", "value": "00000000-0000-4000-8000-000000000001"},
+            {"key": "nonexistentInvitationToken", "value": ""},
             {"key": "suiteProfile", "value": "full"},
         ],
     }

--- a/tests/test_postman_collection_contract.py
+++ b/tests/test_postman_collection_contract.py
@@ -26,6 +26,11 @@ SMOKE_REQUESTS = {
     "02 - GraphQL login invalid credentials (safe error)",
     "03 - GraphQL me query (auth required)",
     "04 - GraphQL installment vs cash calculate (public)",
+    "01 - List alert preferences (REST v2)",
+    "01 - Get my subscription (REST v2)",
+    "01 - List entitlements (REST v2)",
+    "01 - List shared entries by me (REST v2)",
+    "01 - CSV upload preview (REST v2)",
 }
 
 
@@ -138,6 +143,36 @@ def test_postman_collection_covers_critical_rest_routes() -> None:
         ("POST", "/simulations/installment-vs-cash/save"),
         ("POST", "/simulations/{param}/goal"),
         ("POST", "/simulations/{param}/planned-expense"),
+        ("GET", "/alerts/preferences"),
+        ("PUT", "/alerts/preferences/system"),
+        ("GET", "/alerts"),
+        ("POST", "/alerts/{param}/read"),
+        ("DELETE", "/alerts/{param}"),
+        ("GET", "/subscriptions/me"),
+        ("POST", "/subscriptions/checkout"),
+        ("POST", "/subscriptions/cancel"),
+        ("POST", "/subscriptions/webhook"),
+        ("GET", "/entitlements"),
+        ("GET", "/entitlements/check"),
+        ("POST", "/entitlements/admin"),
+        ("DELETE", "/entitlements/admin/{param}"),
+        ("POST", "/shared-entries"),
+        ("GET", "/shared-entries/by-me"),
+        ("GET", "/shared-entries/with-me"),
+        ("DELETE", "/shared-entries/{param}"),
+        ("GET", "/shared-entries/invitations"),
+        ("POST", "/shared-entries/invitations"),
+        ("POST", "/shared-entries/invitations/{param}/accept"),
+        ("DELETE", "/shared-entries/invitations/{param}"),
+        ("POST", "/fiscal/csv/upload"),
+        ("POST", "/fiscal/csv/confirm"),
+        ("GET", "/fiscal/receivables"),
+        ("POST", "/fiscal/receivables"),
+        ("PATCH", "/fiscal/receivables/{param}/receive"),
+        ("DELETE", "/fiscal/receivables/{param}"),
+        ("GET", "/fiscal/receivables/summary"),
+        ("GET", "/fiscal/fiscal-documents"),
+        ("POST", "/fiscal/fiscal-documents"),
     }
 
     missing = sorted(expected - covered)
@@ -153,7 +188,11 @@ def test_postman_collection_uses_domain_folders() -> None:
         "02 - Goals",
         "03 - Wallet",
         "04 - Simulations",
-        "05 - GraphQL",
+        "05 - Alerts",
+        "06 - Subscriptions and Entitlements",
+        "07 - Shared Entries",
+        "08 - Fiscal",
+        "09 - GraphQL",
     ]
 
 


### PR DESCRIPTION
## Summary
- expand the canonical Postman/Newman collection to cover alerts, subscriptions, entitlements, shared entries, fiscal and GraphQL flows with smoke/full profiles
- fix enum persistence to use database enum values and add the missing invitation token/expiry migration required by shared-entry invitation routes
- strengthen the contract test so critical REST coverage and folder taxonomy stay aligned during the Flask -> FastAPI coexistence period

## Validation
- python3 scripts/build_postman_collection.py
- scripts/python_tool.sh pytest tests/test_postman_collection_contract.py tests/test_j13_shared_entries.py tests/test_j_task_models.py -q
- scripts/python_tool.sh ruff check app/models/subscription.py app/models/shared_entry.py app/models/fiscal.py scripts/build_postman_collection.py tests/test_postman_collection_contract.py migrations/versions/7f9c2d1a4b6e_add_invitation_token_and_expiry.py
- scripts/python_tool.sh mypy app
- docker compose down -v --remove-orphans && cp .env.dev.example .env && docker compose up -d --build db redis web && ... && npm run postman:full:ci
- Newman full local run: 86 requests, 152 assertions, 0 failed
