### PR TITLE
feat(postman): isolate privileged integration profile

### DIFF
--- a/.github/workflows/postman-privileged.yml
+++ b/.github/workflows/postman-privileged.yml
@@ -1,0 +1,58 @@
+name: API Privileged Integration (Postman/Newman)
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Target Postman environment"
+        required: true
+        default: "dev"
+        type: choice
+        options:
+          - dev
+          - prod
+
+jobs:
+  postman-privileged:
+    name: Postman Privileged (${{ inputs.environment }})
+    runs-on: ubuntu-latest
+    env:
+      POSTMAN_ENABLE_PRIVILEGED_FLOWS: "true"
+      POSTMAN_ADMIN_TOKEN: ${{ secrets.POSTMAN_ADMIN_TOKEN }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Ensure privileged token is configured
+        run: |
+          if [[ -z "${POSTMAN_ADMIN_TOKEN}" ]]; then
+            echo "POSTMAN_ADMIN_TOKEN secret is required for the privileged Postman workflow." >&2
+            exit 1
+          fi
+
+      - name: Build canonical Postman collection
+        run: npm run postman:build
+
+      - name: Run privileged Newman suite
+        run: |
+          ENV_FILE="api-tests/postman/environments/${{ inputs.environment }}.postman_environment.json"
+          POSTMAN_REPORT_FILE="reports/newman-privileged-${{ inputs.environment }}-report.xml" \
+          bash scripts/run_postman_suite.sh "$ENV_FILE" --profile privileged
+
+      - name: Upload Newman privileged report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: newman-privileged-${{ inputs.environment }}-report
+          path: reports/newman-privileged-${{ inputs.environment }}-report.xml

--- a/api-tests/postman/README.md
+++ b/api-tests/postman/README.md
@@ -12,7 +12,11 @@ Ela cobre as superficies REST criticas por dominio e um smoke representativo de 
 - `02 - Goals`
 - `03 - Wallet`
 - `04 - Simulations`
-- `05 - GraphQL`
+- `05 - Alerts`
+- `06 - Subscriptions and Entitlements`
+- `07 - Shared Entries`
+- `08 - Fiscal`
+- `09 - GraphQL`
 
 ## Ambientes versionados
 - `environments/local.postman_environment.json`
@@ -33,7 +37,8 @@ Os environments devem conter apenas valores seguros para versionamento:
 - Fluxos privilegiados devem ser opcionais e gateados por `enablePrivilegedFlows=true` e `adminToken`.
 - O subset padrao que roda no CI deve continuar deterministico e seguro sem token administrativo.
 - `suiteProfile` governa o recorte oficial da execução:
-  - `full`: roda a colecao completa;
+  - `full`: roda a colecao completa nao-privilegiada;
+  - `privileged`: roda o subconjunto com bootstrap minimo + fluxos admin/privilegiados;
   - `smoke`: roda o subconjunto canônico mínimo por dominio.
 
 ## Execucao
@@ -52,6 +57,7 @@ Perfis oficiais:
 ```bash
 npm run postman:smoke:local
 npm run postman:full:local
+npm run postman:privileged:dev
 ```
 
 Perfis oficiais do CI:
@@ -70,16 +76,18 @@ Rodar com perfil explícito:
 ```bash
 ./scripts/run_postman_suite.sh ./api-tests/postman/environments/dev.postman_environment.json --profile smoke
 ./scripts/run_postman_suite.sh ./api-tests/postman/environments/dev.postman_environment.json --profile full
+./scripts/run_postman_suite.sh ./api-tests/postman/environments/dev.postman_environment.json --profile privileged
 ```
 
 Rodar fluxos privilegiados:
 ```bash
 POSTMAN_ENABLE_PRIVILEGED_FLOWS=true \
 POSTMAN_ADMIN_TOKEN=<token-admin> \
-./scripts/run_postman_suite.sh ./api-tests/postman/environments/dev.postman_environment.json
+./scripts/run_postman_suite.sh ./api-tests/postman/environments/dev.postman_environment.json --profile privileged
 ```
 
 ## Integracao CI
 - `smoke` continua sendo o gate rapido minimo para saude funcional cross-domain.
 - `full` roda em job dedicado de integracao, com report JUnit separado.
-- Ambos usam a mesma collection canonica; muda apenas o `suiteProfile`.
+- `privileged` fica em workflow manual separado, porque exige `adminToken` explicito.
+- Todos usam a mesma collection canonica; muda apenas o `suiteProfile`.

--- a/api-tests/postman/auraxis.postman_collection.json
+++ b/api-tests/postman/auraxis.postman_collection.json
@@ -3,7 +3,7 @@
     "_postman_id": "3fd49b04-3416-4cf2-9048-b58abf132a20",
     "name": "Auraxis API - Canonical E2E and Smoke",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "description": "Canonical black-box suite for Auraxis API. Organized by domain, validated by Newman in CI, and designed for direct Postman import. Privileged flows are optional and gated by adminToken + enablePrivilegedFlows."
+    "description": "Canonical black-box suite for Auraxis API. Organized by domain, validated by Newman in CI, and designed for direct Postman import. Privileged flows are optional and gated by adminToken + enablePrivilegedFlows. Use the dedicated privileged profile when executing admin-only coverage."
   },
   "event": [
     {
@@ -11,13 +11,23 @@
       "script": {
         "exec": [
           "var smokeRequests = [\"01 - Healthz\", \"02 - Register user (REST v2)\", \"03 - Login user (REST v2)\", \"04 - Login invalid credentials returns safe error\", \"05 - Me (REST v2)\", \"01 - Create transaction (REST v2)\", \"04 - List active transactions (REST v2)\", \"05 - Transaction summary by month (REST v2)\", \"01 - Create goal (REST v2)\", \"02 - List goals (REST v2)\", \"05 - Goal simulate (REST v2)\", \"01 - Create wallet investment (REST v2)\", \"02 - List wallet investments (REST v2)\", \"08 - Create wallet operation (REST v2)\", \"10 - Wallet operation summary (REST v2)\", \"01 - Installment vs cash calculate (REST public)\", \"02 - Installment vs cash save (REST auth required)\", \"03 - Simulation goal bridge without entitlement returns 403\", \"02 - GraphQL login invalid credentials (safe error)\", \"03 - GraphQL me query (auth required)\", \"04 - GraphQL installment vs cash calculate (public)\", \"01 - List alert preferences (REST v2)\", \"01 - Get my subscription (REST v2)\", \"01 - List entitlements (REST v2)\", \"01 - List shared entries by me (REST v2)\", \"01 - CSV upload preview (REST v2)\"];",
+          "var privilegedOnlyRequests = [\"04 - Grant advanced simulations entitlement (optional admin)\", \"05 - Save advanced simulation for success bridges (optional admin)\", \"06 - Simulation goal bridge success (optional admin)\", \"07 - Save fee simulation for planned expense bridge (optional admin)\", \"08 - Simulation planned expense bridge success (optional admin)\", \"09 - Revoke advanced simulations entitlement (optional admin)\"];",
+          "var privilegedProfileRequests = [\"01 - Healthz\", \"02 - Register user (REST v2)\", \"03 - Login user (REST v2)\", \"05 - Me (REST v2)\", \"01 - Installment vs cash calculate (REST public)\", \"02 - Installment vs cash save (REST auth required)\", \"03 - Simulation goal bridge without entitlement returns 403\", \"04 - Grant advanced simulations entitlement (optional admin)\", \"05 - Save advanced simulation for success bridges (optional admin)\", \"06 - Simulation goal bridge success (optional admin)\", \"07 - Save fee simulation for planned expense bridge (optional admin)\", \"08 - Simulation planned expense bridge success (optional admin)\", \"09 - Revoke advanced simulations entitlement (optional admin)\"];",
           "var activeProfile = String(pm.environment.get('suiteProfile') || pm.collectionVariables.get('suiteProfile') || 'full').toLowerCase();",
-          "if (!['smoke', 'full'].includes(activeProfile)) {",
-          "  throw new Error('Unsupported suiteProfile: ' + activeProfile + '. Use smoke or full.');",
+          "if (!['smoke', 'full', 'privileged'].includes(activeProfile)) {",
+          "  throw new Error('Unsupported suiteProfile: ' + activeProfile + '. Use smoke, full or privileged.');",
           "}",
           "pm.collectionVariables.set('suiteProfile', activeProfile);",
           "if (activeProfile === 'smoke' && !smokeRequests.includes(pm.info.requestName)) {",
           "  console.log('Skipping request outside smoke profile:', pm.info.requestName);",
+          "  pm.execution.skipRequest();",
+          "}",
+          "if (activeProfile === 'full' && privilegedOnlyRequests.includes(pm.info.requestName)) {",
+          "  console.log('Skipping privileged-only request outside privileged profile:', pm.info.requestName);",
+          "  pm.execution.skipRequest();",
+          "}",
+          "if (activeProfile === 'privileged' && !privilegedProfileRequests.includes(pm.info.requestName)) {",
+          "  console.log('Skipping request outside privileged profile:', pm.info.requestName);",
           "  pm.execution.skipRequest();",
           "}"
         ],
@@ -2568,11 +2578,14 @@
               "listen": "prerequest",
               "script": {
                 "exec": [
+                  "var activeProfile = String(pm.environment.get('suiteProfile') || pm.collectionVariables.get('suiteProfile') || 'full').toLowerCase();",
                   "var enabled = String(pm.environment.get('enablePrivilegedFlows') || pm.collectionVariables.get('enablePrivilegedFlows') || 'false').toLowerCase();",
                   "var adminToken = pm.environment.get('adminToken') || pm.collectionVariables.get('adminToken') || '';",
-                  "if (enabled !== 'true' || !adminToken) {",
-                  "  console.log('Skipping privileged request because enablePrivilegedFlows/adminToken is not configured.');",
+                  "if (activeProfile !== 'privileged') {",
                   "  pm.execution.skipRequest();",
+                  "}",
+                  "if (enabled !== 'true' || !adminToken) {",
+                  "  throw new Error('Privileged profile requires enablePrivilegedFlows=true and adminToken configured.');",
                   "}"
                 ],
                 "type": "text/javascript"
@@ -2630,11 +2643,14 @@
               "listen": "prerequest",
               "script": {
                 "exec": [
+                  "var activeProfile = String(pm.environment.get('suiteProfile') || pm.collectionVariables.get('suiteProfile') || 'full').toLowerCase();",
                   "var enabled = String(pm.environment.get('enablePrivilegedFlows') || pm.collectionVariables.get('enablePrivilegedFlows') || 'false').toLowerCase();",
                   "var adminToken = pm.environment.get('adminToken') || pm.collectionVariables.get('adminToken') || '';",
-                  "if (enabled !== 'true' || !adminToken) {",
-                  "  console.log('Skipping privileged request because enablePrivilegedFlows/adminToken is not configured.');",
+                  "if (activeProfile !== 'privileged') {",
                   "  pm.execution.skipRequest();",
+                  "}",
+                  "if (enabled !== 'true' || !adminToken) {",
+                  "  throw new Error('Privileged profile requires enablePrivilegedFlows=true and adminToken configured.');",
                   "}"
                 ],
                 "type": "text/javascript"
@@ -2687,11 +2703,14 @@
               "listen": "prerequest",
               "script": {
                 "exec": [
+                  "var activeProfile = String(pm.environment.get('suiteProfile') || pm.collectionVariables.get('suiteProfile') || 'full').toLowerCase();",
                   "var enabled = String(pm.environment.get('enablePrivilegedFlows') || pm.collectionVariables.get('enablePrivilegedFlows') || 'false').toLowerCase();",
                   "var adminToken = pm.environment.get('adminToken') || pm.collectionVariables.get('adminToken') || '';",
-                  "if (enabled !== 'true' || !adminToken) {",
-                  "  console.log('Skipping privileged request because enablePrivilegedFlows/adminToken is not configured.');",
+                  "if (activeProfile !== 'privileged') {",
                   "  pm.execution.skipRequest();",
+                  "}",
+                  "if (enabled !== 'true' || !adminToken) {",
+                  "  throw new Error('Privileged profile requires enablePrivilegedFlows=true and adminToken configured.');",
                   "}"
                 ],
                 "type": "text/javascript"
@@ -2747,11 +2766,14 @@
               "listen": "prerequest",
               "script": {
                 "exec": [
+                  "var activeProfile = String(pm.environment.get('suiteProfile') || pm.collectionVariables.get('suiteProfile') || 'full').toLowerCase();",
                   "var enabled = String(pm.environment.get('enablePrivilegedFlows') || pm.collectionVariables.get('enablePrivilegedFlows') || 'false').toLowerCase();",
                   "var adminToken = pm.environment.get('adminToken') || pm.collectionVariables.get('adminToken') || '';",
-                  "if (enabled !== 'true' || !adminToken) {",
-                  "  console.log('Skipping privileged request because enablePrivilegedFlows/adminToken is not configured.');",
+                  "if (activeProfile !== 'privileged') {",
                   "  pm.execution.skipRequest();",
+                  "}",
+                  "if (enabled !== 'true' || !adminToken) {",
+                  "  throw new Error('Privileged profile requires enablePrivilegedFlows=true and adminToken configured.');",
                   "}"
                 ],
                 "type": "text/javascript"
@@ -2804,11 +2826,14 @@
               "listen": "prerequest",
               "script": {
                 "exec": [
+                  "var activeProfile = String(pm.environment.get('suiteProfile') || pm.collectionVariables.get('suiteProfile') || 'full').toLowerCase();",
                   "var enabled = String(pm.environment.get('enablePrivilegedFlows') || pm.collectionVariables.get('enablePrivilegedFlows') || 'false').toLowerCase();",
                   "var adminToken = pm.environment.get('adminToken') || pm.collectionVariables.get('adminToken') || '';",
-                  "if (enabled !== 'true' || !adminToken) {",
-                  "  console.log('Skipping privileged request because enablePrivilegedFlows/adminToken is not configured.');",
+                  "if (activeProfile !== 'privileged') {",
                   "  pm.execution.skipRequest();",
+                  "}",
+                  "if (enabled !== 'true' || !adminToken) {",
+                  "  throw new Error('Privileged profile requires enablePrivilegedFlows=true and adminToken configured.');",
                   "}"
                 ],
                 "type": "text/javascript"
@@ -2860,11 +2885,14 @@
               "listen": "prerequest",
               "script": {
                 "exec": [
+                  "var activeProfile = String(pm.environment.get('suiteProfile') || pm.collectionVariables.get('suiteProfile') || 'full').toLowerCase();",
                   "var enabled = String(pm.environment.get('enablePrivilegedFlows') || pm.collectionVariables.get('enablePrivilegedFlows') || 'false').toLowerCase();",
                   "var adminToken = pm.environment.get('adminToken') || pm.collectionVariables.get('adminToken') || '';",
-                  "if (enabled !== 'true' || !adminToken) {",
-                  "  console.log('Skipping privileged request because enablePrivilegedFlows/adminToken is not configured.');",
+                  "if (activeProfile !== 'privileged') {",
                   "  pm.execution.skipRequest();",
+                  "}",
+                  "if (enabled !== 'true' || !adminToken) {",
+                  "  throw new Error('Privileged profile requires enablePrivilegedFlows=true and adminToken configured.');",
                   "}"
                 ],
                 "type": "text/javascript"
@@ -4378,6 +4406,14 @@
     {
       "key": "suiteProfile",
       "value": "full"
+    },
+    {
+      "key": "enablePrivilegedFlows",
+      "value": "false"
+    },
+    {
+      "key": "adminToken",
+      "value": ""
     }
   ]
 }

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -48,6 +48,7 @@ Perfis oficiais:
 ```bash
 npm run postman:smoke:local
 npm run postman:full:local
+npm run postman:privileged:dev
 ```
 
 Perfis oficiais no CI:
@@ -66,13 +67,14 @@ Runner com perfil explícito:
 ```bash
 ./scripts/run_postman_suite.sh ./api-tests/postman/environments/dev.postman_environment.json --profile smoke
 ./scripts/run_postman_suite.sh ./api-tests/postman/environments/dev.postman_environment.json --profile full
+./scripts/run_postman_suite.sh ./api-tests/postman/environments/dev.postman_environment.json --profile privileged
 ```
 
 Fluxos privilegiados opcionais:
 ```bash
 POSTMAN_ENABLE_PRIVILEGED_FLOWS=true \
 POSTMAN_ADMIN_TOKEN=<token-admin> \
-./scripts/run_postman_suite.sh ./api-tests/postman/environments/dev.postman_environment.json
+./scripts/run_postman_suite.sh ./api-tests/postman/environments/dev.postman_environment.json --profile privileged
 ```
 
 Cobertura canonica atual:
@@ -82,12 +84,18 @@ Cobertura canonica atual:
 - Goals: create, list, get, plan, simulate, update, delete
 - Wallet: create, list, update, history, valuation, operations CRUD, position, invested amount
 - Simulations: installment-vs-cash calculate/save e bridges com subset privilegiado opcional
+- Alerts: preferences, list, read/delete negative paths
+- Subscriptions/Entitlements: subscription me, checkout/cancel, webhook invalid signature, entitlements list/check, admin routes no perfil privilegiado
+- Shared entries: by-me, with-me, invitations list/create/accept/revoke negative paths
+- Fiscal: csv upload/confirm, receivables list/create/receive/delete negative path, summary, fiscal documents list/create
 - GraphQL: validation, auth-safe errors, me, installment-vs-cash calculate/save
 
 Perfis da suíte:
 - `smoke`: subconjunto mínimo canônico de saúde funcional cross-domain
-- `full`: coleção completa REST + GraphQL
+- `full`: coleção completa REST + GraphQL não-privilegiada
+- `privileged`: bootstrap mínimo + fluxos admin/privilegiados que exigem `POSTMAN_ENABLE_PRIVILEGED_FLOWS=true` e `POSTMAN_ADMIN_TOKEN`
 - O CI roda `smoke` como gate rápido e `full` em job dedicado de integração com artifact separado
+- O perfil `privileged` roda em workflow manual separado, para evitar acoplamento do CI comum a token administrativo
 
 ## Como a suíte está configurada
 - `pytest.ini` define padrão de descoberta dos testes.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "postman:full:ci": "POSTMAN_REPORT_FILE=reports/newman-full-report.xml bash scripts/run_postman_suite.sh api-tests/postman/environments/local.postman_environment.json --profile full",
     "postman:full:dev": "bash scripts/run_postman_suite.sh api-tests/postman/environments/dev.postman_environment.json --profile full",
     "postman:full:prod": "bash scripts/run_postman_suite.sh api-tests/postman/environments/prod.postman_environment.json --profile full",
+    "postman:privileged:local": "POSTMAN_ENABLE_PRIVILEGED_FLOWS=true bash scripts/run_postman_suite.sh --profile privileged",
+    "postman:privileged:dev": "POSTMAN_ENABLE_PRIVILEGED_FLOWS=true bash scripts/run_postman_suite.sh api-tests/postman/environments/dev.postman_environment.json --profile privileged",
+    "postman:privileged:prod": "POSTMAN_ENABLE_PRIVILEGED_FLOWS=true bash scripts/run_postman_suite.sh api-tests/postman/environments/prod.postman_environment.json --profile privileged",
     "smoke:local": "bash scripts/run_postman_suite.sh",
     "smoke:ci": "bash scripts/run_postman_suite.sh api-tests/postman/environments/local.postman_environment.json"
   },

--- a/scripts/build_postman_collection.py
+++ b/scripts/build_postman_collection.py
@@ -36,6 +36,24 @@ SMOKE_REQUESTS = [
     "01 - List shared entries by me (REST v2)",
     "01 - CSV upload preview (REST v2)",
 ]
+PRIVILEGED_ONLY_REQUESTS = [
+    "04 - Grant advanced simulations entitlement (optional admin)",
+    "05 - Save advanced simulation for success bridges (optional admin)",
+    "06 - Simulation goal bridge success (optional admin)",
+    "07 - Save fee simulation for planned expense bridge (optional admin)",
+    "08 - Simulation planned expense bridge success (optional admin)",
+    "09 - Revoke advanced simulations entitlement (optional admin)",
+]
+PRIVILEGED_PROFILE_REQUESTS = [
+    "01 - Healthz",
+    "02 - Register user (REST v2)",
+    "03 - Login user (REST v2)",
+    "05 - Me (REST v2)",
+    "01 - Installment vs cash calculate (REST public)",
+    "02 - Installment vs cash save (REST auth required)",
+    "03 - Simulation goal bridge without entitlement returns 403",
+    *PRIVILEGED_ONLY_REQUESTS,
+]
 
 
 def _js(lines: list[str]) -> dict[str, Any]:
@@ -112,15 +130,30 @@ def _folder(name: str, items: list[dict[str, Any]]) -> dict[str, Any]:
 
 def _suite_profile_prerequest() -> list[str]:
     smoke_json = json.dumps(SMOKE_REQUESTS, ensure_ascii=True)
+    privileged_only_json = json.dumps(PRIVILEGED_ONLY_REQUESTS, ensure_ascii=True)
+    privileged_profile_json = json.dumps(
+        PRIVILEGED_PROFILE_REQUESTS,
+        ensure_ascii=True,
+    )
     return [
         f"var smokeRequests = {smoke_json};",
+        f"var privilegedOnlyRequests = {privileged_only_json};",
+        f"var privilegedProfileRequests = {privileged_profile_json};",
         "var activeProfile = String(pm.environment.get('suiteProfile') || pm.collectionVariables.get('suiteProfile') || 'full').toLowerCase();",
-        "if (!['smoke', 'full'].includes(activeProfile)) {",
-        "  throw new Error('Unsupported suiteProfile: ' + activeProfile + '. Use smoke or full.');",
+        "if (!['smoke', 'full', 'privileged'].includes(activeProfile)) {",
+        "  throw new Error('Unsupported suiteProfile: ' + activeProfile + '. Use smoke, full or privileged.');",
         "}",
         "pm.collectionVariables.set('suiteProfile', activeProfile);",
         "if (activeProfile === 'smoke' && !smokeRequests.includes(pm.info.requestName)) {",
         "  console.log('Skipping request outside smoke profile:', pm.info.requestName);",
+        "  pm.execution.skipRequest();",
+        "}",
+        "if (activeProfile === 'full' && privilegedOnlyRequests.includes(pm.info.requestName)) {",
+        "  console.log('Skipping privileged-only request outside privileged profile:', pm.info.requestName);",
+        "  pm.execution.skipRequest();",
+        "}",
+        "if (activeProfile === 'privileged' && !privilegedProfileRequests.includes(pm.info.requestName)) {",
+        "  console.log('Skipping request outside privileged profile:', pm.info.requestName);",
         "  pm.execution.skipRequest();",
         "}",
     ]
@@ -128,11 +161,14 @@ def _suite_profile_prerequest() -> list[str]:
 
 def _skip_if_privileged_flows_disabled() -> list[str]:
     return [
+        "var activeProfile = String(pm.environment.get('suiteProfile') || pm.collectionVariables.get('suiteProfile') || 'full').toLowerCase();",
         "var enabled = String(pm.environment.get('enablePrivilegedFlows') || pm.collectionVariables.get('enablePrivilegedFlows') || 'false').toLowerCase();",
         "var adminToken = pm.environment.get('adminToken') || pm.collectionVariables.get('adminToken') || '';",
-        "if (enabled !== 'true' || !adminToken) {",
-        "  console.log('Skipping privileged request because enablePrivilegedFlows/adminToken is not configured.');",
+        "if (activeProfile !== 'privileged') {",
         "  pm.execution.skipRequest();",
+        "}",
+        "if (enabled !== 'true' || !adminToken) {",
+        "  throw new Error('Privileged profile requires enablePrivilegedFlows=true and adminToken configured.');",
         "}",
     ]
 
@@ -1971,6 +2007,7 @@ def build_collection() -> dict[str, Any]:
                 "Canonical black-box suite for Auraxis API. Organized by domain, "
                 "validated by Newman in CI, and designed for direct Postman import. "
                 "Privileged flows are optional and gated by adminToken + enablePrivilegedFlows."
+                " Use the dedicated privileged profile when executing admin-only coverage."
             ),
         },
         "event": [
@@ -2013,6 +2050,8 @@ def build_collection() -> dict[str, Any]:
             {"key": "fakeUuid", "value": "00000000-0000-4000-8000-000000000001"},
             {"key": "nonexistentInvitationToken", "value": ""},
             {"key": "suiteProfile", "value": "full"},
+            {"key": "enablePrivilegedFlows", "value": "false"},
+            {"key": "adminToken", "value": ""},
         ],
     }
     return collection

--- a/scripts/run_postman_suite.sh
+++ b/scripts/run_postman_suite.sh
@@ -16,7 +16,7 @@ SUITE_PROFILE="${POSTMAN_SUITE_PROFILE:-full}"
 usage() {
   cat <<'EOF'
 Usage:
-  bash scripts/run_postman_suite.sh [environment.json] [--profile smoke|full]
+  bash scripts/run_postman_suite.sh [environment.json] [--profile smoke|full|privileged]
 
 Examples:
   bash scripts/run_postman_suite.sh
@@ -29,7 +29,7 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --profile)
       if [[ $# -lt 2 ]]; then
-        echo "--profile requires a value (smoke|full)." >&2
+        echo "--profile requires a value (smoke|full|privileged)." >&2
         usage
         exit 4
       fi
@@ -48,10 +48,10 @@ while [[ $# -gt 0 ]]; do
 done
 
 case "${SUITE_PROFILE}" in
-  smoke|full)
+  smoke|full|privileged)
     ;;
   *)
-    echo "Unsupported profile: ${SUITE_PROFILE}. Use smoke or full." >&2
+    echo "Unsupported profile: ${SUITE_PROFILE}. Use smoke, full or privileged." >&2
     usage
     exit 5
     ;;
@@ -85,6 +85,13 @@ echo "[postman-suite] collection=$COLLECTION"
 echo "[postman-suite] environment=$ENV_FILE"
 echo "[postman-suite] profile=$SUITE_PROFILE"
 echo "[postman-suite] report=$REPORT_FILE"
+
+if [[ "$SUITE_PROFILE" == "privileged" ]]; then
+  if [[ "$ENABLE_PRIVILEGED_FLOWS" != "true" || -z "$ADMIN_TOKEN" ]]; then
+    echo "Privileged profile requires POSTMAN_ENABLE_PRIVILEGED_FLOWS=true and POSTMAN_ADMIN_TOKEN." >&2
+    exit 6
+  fi
+fi
 
 NEWMAN_ARGS=(
   run "$COLLECTION"

--- a/tests/test_postman_collection_contract.py
+++ b/tests/test_postman_collection_contract.py
@@ -32,6 +32,21 @@ SMOKE_REQUESTS = {
     "01 - List shared entries by me (REST v2)",
     "01 - CSV upload preview (REST v2)",
 }
+PRIVILEGED_REQUESTS = {
+    "01 - Healthz",
+    "02 - Register user (REST v2)",
+    "03 - Login user (REST v2)",
+    "05 - Me (REST v2)",
+    "01 - Installment vs cash calculate (REST public)",
+    "02 - Installment vs cash save (REST auth required)",
+    "03 - Simulation goal bridge without entitlement returns 403",
+    "04 - Grant advanced simulations entitlement (optional admin)",
+    "05 - Save advanced simulation for success bridges (optional admin)",
+    "06 - Simulation goal bridge success (optional admin)",
+    "07 - Save fee simulation for planned expense bridge (optional admin)",
+    "08 - Simulation planned expense bridge success (optional admin)",
+    "09 - Revoke advanced simulations entitlement (optional admin)",
+}
 
 
 def _load_postman_items() -> list[dict[str, object]]:
@@ -207,3 +222,23 @@ def test_postman_collection_smoke_profile_covers_known_requests() -> None:
     names = {str(item.get("name")) for item in items}
     missing = sorted(SMOKE_REQUESTS - names)
     assert not missing, f"Smoke profile references unknown requests: {missing}"
+
+
+def test_postman_collection_privileged_profile_covers_known_requests() -> None:
+    items = _flatten_request_items(_load_postman_items())
+    names = {str(item.get("name")) for item in items}
+    missing = sorted(PRIVILEGED_REQUESTS - names)
+    assert not missing, f"Privileged profile references unknown requests: {missing}"
+
+
+def test_postman_collection_smoke_profile_excludes_privileged_only_requests() -> None:
+    privileged_only = {
+        "04 - Grant advanced simulations entitlement (optional admin)",
+        "05 - Save advanced simulation for success bridges (optional admin)",
+        "06 - Simulation goal bridge success (optional admin)",
+        "07 - Save fee simulation for planned expense bridge (optional admin)",
+        "08 - Simulation planned expense bridge success (optional admin)",
+        "09 - Revoke advanced simulations entitlement (optional admin)",
+    }
+    overlap = sorted(SMOKE_REQUESTS & privileged_only)
+    assert not overlap, f"Smoke profile must not include privileged requests: {overlap}"


### PR DESCRIPTION
## Summary
- add an explicit `privileged` Postman/Newman profile so admin-only flows stop hiding behind implicit skips inside `full`
- make the runner fail fast when privileged execution is requested without `POSTMAN_ENABLE_PRIVILEGED_FLOWS=true` and `POSTMAN_ADMIN_TOKEN`
- add a manual GitHub Actions workflow dedicated to privileged Newman execution against versioned Postman environments

## Validation
- python3 scripts/build_postman_collection.py
- scripts/python_tool.sh pytest tests/test_postman_collection_contract.py -q
- bash scripts/run_postman_suite.sh api-tests/postman/environments/dev.postman_environment.json --profile privileged  # expected fail-fast without admin token
- scripts/python_tool.sh ruff check scripts/build_postman_collection.py tests/test_postman_collection_contract.py
- scripts/python_tool.sh mypy app
- .venv/bin/python - <<'PY' ... yaml.safe_load('.github/workflows/postman-privileged.yml') ...
