### PR TITLE
feat(postman): audit remaining route parity gaps

### DIFF
--- a/api-tests/postman/auraxis.postman_collection.json
+++ b/api-tests/postman/auraxis.postman_collection.json
@@ -125,8 +125,9 @@
                   "pm.collectionVariables.set('runMonthRef', isoMonth(0));",
                   "pm.collectionVariables.set('graphSimulationLabel', 'Notebook ' + seed);",
                   "pm.collectionVariables.set('fakeUuid', '00000000-0000-4000-8000-000000000001');",
+                  "pm.collectionVariables.set('alertCategory', 'system');",
                   "pm.collectionVariables.set('nonexistentInvitationToken', 'nonexistent-token-' + seed);",
-                  "['authToken', 'userId', 'transactionId', 'goalId', 'investmentId', 'operationId', 'simulationId', 'advancedSimulationId', 'feeSimulationId', 'entitlementId', 'receivableId', 'fiscalDocumentId', 'sharedEntryId', 'invitationId', 'subscriptionId'].forEach(function (key) { pm.collectionVariables.unset(key); });"
+                  "['authToken', 'userId', 'transactionId', 'goalId', 'investmentId', 'operationId', 'simulationId', 'genericSimulationId', 'advancedSimulationId', 'feeSimulationId', 'entitlementId', 'receivableId', 'fiscalDocumentId', 'sharedEntryId', 'invitationId', 'subscriptionId'].forEach(function (key) { pm.collectionVariables.unset(key); });"
                 ],
                 "type": "text/javascript"
               }
@@ -740,6 +741,57 @@
                   "pm.test('password reset invalid token is a validation error', function () {",
                   "  pm.expect(body.success).to.eql(false);",
                   "  pm.expect(body.error.code).to.eql('VALIDATION_ERROR');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "16 - Salary increase simulation (REST v2)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/user/simulate-salary-increase",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "user",
+                "simulate-salary-increase"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"base_salary\": \"5000.00\",\n                      \"base_date\": \"2024-01-01\",\n                      \"discounts\": \"500.00\",\n                      \"target_real_increase\": \"7.50\"\n                    }\n"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('salary increase simulation returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('salary increase simulation returns target payload', function () {",
+                  "  pm.expect(body.success).to.eql(true);",
+                  "  pm.expect(body.data.recomposition).to.be.a('string').and.not.empty;",
+                  "  pm.expect(body.data.target).to.be.a('string').and.not.empty;",
                   "});"
                 ],
                 "type": "text/javascript"
@@ -1653,7 +1705,57 @@
           ]
         },
         {
-          "name": "07 - Delete goal by id (REST v2)",
+          "name": "07 - Goal PATCH by id (REST v2)",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/goals/{{goalId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "goals",
+                "{{goalId}}"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"status\": \"active\",\n                      \"current_amount\": \"6500.00\"\n                    }\n"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('goal patch returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('goal patch reflects updated amount', function () {",
+                  "  pm.expect(body.success).to.eql(true);",
+                  "  pm.expect(body.data.goal.current_amount).to.eql('6500.00');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "08 - Delete goal by id (REST v2)",
           "request": {
             "method": "DELETE",
             "header": [
@@ -2908,6 +3010,190 @@
               }
             }
           ]
+        },
+        {
+          "name": "10 - Save generic simulation (REST v2)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/simulations",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "simulations"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"tool_id\": \"salary_projection\",\n                      \"rule_version\": \"v1\",\n                      \"inputs\": {\n                        \"base_salary\": \"5000.00\",\n                        \"target_raise\": \"7.50\"\n                      },\n                      \"result\": {\n                        \"projected_salary\": \"5375.00\"\n                      }\n                    }\n"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('generic simulation create returns 201', function () { pm.response.to.have.status(201); });",
+                  "var body = pm.response.json();",
+                  "pm.collectionVariables.set('genericSimulationId', body.data.simulation.id);",
+                  "pm.test('generic simulation create captures id', function () {",
+                  "  pm.expect(body.success).to.eql(true);",
+                  "  pm.expect(body.data.simulation.id).to.be.a('string').and.not.empty;",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "11 - List saved simulations (REST v2)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/simulations?page=1&per_page=20",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "simulations"
+              ],
+              "query": [
+                {
+                  "key": "page",
+                  "value": "1"
+                },
+                {
+                  "key": "per_page",
+                  "value": "20"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('simulation list returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('simulation list includes pagination and items', function () {",
+                  "  pm.expect(body.success).to.eql(true);",
+                  "  pm.expect(body.data.items).to.be.an('array');",
+                  "  pm.expect(body.meta.pagination.total).to.be.at.least(1);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "12 - Get saved simulation by id (REST v2)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/simulations/{{genericSimulationId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "simulations",
+                "{{genericSimulationId}}"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('simulation get returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('simulation get returns requested id', function () {",
+                  "  pm.expect(body.success).to.eql(true);",
+                  "  pm.expect(body.data.simulation.id).to.eql(pm.collectionVariables.get('genericSimulationId'));",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "13 - Delete saved simulation by id (REST v2)",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/simulations/{{genericSimulationId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "simulations",
+                "{{genericSimulationId}}"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('simulation delete returns 200', function () { pm.response.to.have.status(200); });",
+                  "pm.test('simulation delete canonical success', function () {",
+                  "  pm.expect(pm.response.json().success).to.eql(true);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
         }
       ]
     },
@@ -2975,14 +3261,14 @@
               }
             ],
             "url": {
-              "raw": "{{baseUrl}}/alerts/preferences/system",
+              "raw": "{{baseUrl}}/alerts/preferences/{{alertCategory}}",
               "host": [
                 "{{baseUrl}}"
               ],
               "path": [
                 "alerts",
                 "preferences",
-                "system"
+                "{{alertCategory}}"
               ]
             },
             "body": {
@@ -2999,7 +3285,7 @@
                   "var body = pm.response.json();",
                   "pm.test('alert preference update returns preference payload', function () {",
                   "  pm.expect(body.success).to.eql(true);",
-                  "  pm.expect(body.data.preference.category).to.eql('system');",
+                  "  pm.expect(body.data.preference.category).to.eql(pm.collectionVariables.get('alertCategory'));",
                   "});"
                 ],
                 "type": "text/javascript"
@@ -4364,6 +4650,10 @@
       "value": ""
     },
     {
+      "key": "genericSimulationId",
+      "value": ""
+    },
+    {
       "key": "advancedSimulationId",
       "value": ""
     },
@@ -4398,6 +4688,10 @@
     {
       "key": "fakeUuid",
       "value": "00000000-0000-4000-8000-000000000001"
+    },
+    {
+      "key": "alertCategory",
+      "value": "system"
     },
     {
       "key": "nonexistentInvitationToken",

--- a/scripts/build_postman_collection.py
+++ b/scripts/build_postman_collection.py
@@ -200,8 +200,9 @@ def _bootstrap_prerequest() -> list[str]:
         "pm.collectionVariables.set('runMonthRef', isoMonth(0));",
         "pm.collectionVariables.set('graphSimulationLabel', 'Notebook ' + seed);",
         "pm.collectionVariables.set('fakeUuid', '00000000-0000-4000-8000-000000000001');",
+        "pm.collectionVariables.set('alertCategory', 'system');",
         "pm.collectionVariables.set('nonexistentInvitationToken', 'nonexistent-token-' + seed);",
-        "['authToken', 'userId', 'transactionId', 'goalId', 'investmentId', 'operationId', 'simulationId', 'advancedSimulationId', 'feeSimulationId', 'entitlementId', 'receivableId', 'fiscalDocumentId', 'sharedEntryId', 'invitationId', 'subscriptionId'].forEach(function (key) { pm.collectionVariables.unset(key); });",
+        "['authToken', 'userId', 'transactionId', 'goalId', 'investmentId', 'operationId', 'simulationId', 'genericSimulationId', 'advancedSimulationId', 'feeSimulationId', 'entitlementId', 'receivableId', 'fiscalDocumentId', 'sharedEntryId', 'invitationId', 'subscriptionId'].forEach(function (key) { pm.collectionVariables.unset(key); });",
     ]
 
 
@@ -530,6 +531,33 @@ def build_collection() -> dict[str, Any]:
                 "pm.test('password reset invalid token is a validation error', function () {",
                 "  pm.expect(body.success).to.eql(false);",
                 "  pm.expect(body.error.code).to.eql('VALIDATION_ERROR');",
+                "});",
+            ],
+        ),
+        _item(
+            "16 - Salary increase simulation (REST v2)",
+            _request(
+                method="POST",
+                raw_url="{{baseUrl}}/user/simulate-salary-increase",
+                headers=auth_json_headers,
+                body=_json_body(
+                    """
+                    {
+                      "base_salary": "5000.00",
+                      "base_date": "2024-01-01",
+                      "discounts": "500.00",
+                      "target_real_increase": "7.50"
+                    }
+                    """
+                ),
+            ),
+            test_lines=[
+                "pm.test('salary increase simulation returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('salary increase simulation returns target payload', function () {",
+                "  pm.expect(body.success).to.eql(true);",
+                "  pm.expect(body.data.recomposition).to.be.a('string').and.not.empty;",
+                "  pm.expect(body.data.target).to.be.a('string').and.not.empty;",
                 "});",
             ],
         ),
@@ -901,7 +929,31 @@ def build_collection() -> dict[str, Any]:
             ],
         ),
         _item(
-            "07 - Delete goal by id (REST v2)",
+            "07 - Goal PATCH by id (REST v2)",
+            _request(
+                method="PATCH",
+                raw_url="{{baseUrl}}/goals/{{goalId}}",
+                headers=auth_json_headers,
+                body=_json_body(
+                    """
+                    {
+                      "status": "active",
+                      "current_amount": "6500.00"
+                    }
+                    """
+                ),
+            ),
+            test_lines=[
+                "pm.test('goal patch returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('goal patch reflects updated amount', function () {",
+                "  pm.expect(body.success).to.eql(true);",
+                "  pm.expect(body.data.goal.current_amount).to.eql('6500.00');",
+                "});",
+            ],
+        ),
+        _item(
+            "08 - Delete goal by id (REST v2)",
             _request(
                 method="DELETE",
                 raw_url="{{baseUrl}}/goals/{{goalId}}",
@@ -1418,6 +1470,86 @@ def build_collection() -> dict[str, Any]:
                 "pm.test('entitlement revoke returns 200', function () { pm.response.to.have.status(200); });",
             ],
         ),
+        _item(
+            "10 - Save generic simulation (REST v2)",
+            _request(
+                method="POST",
+                raw_url="{{baseUrl}}/simulations",
+                headers=auth_json_headers,
+                body=_json_body(
+                    """
+                    {
+                      "tool_id": "salary_projection",
+                      "rule_version": "v1",
+                      "inputs": {
+                        "base_salary": "5000.00",
+                        "target_raise": "7.50"
+                      },
+                      "result": {
+                        "projected_salary": "5375.00"
+                      }
+                    }
+                    """
+                ),
+            ),
+            test_lines=[
+                "pm.test('generic simulation create returns 201', function () { pm.response.to.have.status(201); });",
+                "var body = pm.response.json();",
+                "pm.collectionVariables.set('genericSimulationId', body.data.simulation.id);",
+                "pm.test('generic simulation create captures id', function () {",
+                "  pm.expect(body.success).to.eql(true);",
+                "  pm.expect(body.data.simulation.id).to.be.a('string').and.not.empty;",
+                "});",
+            ],
+        ),
+        _item(
+            "11 - List saved simulations (REST v2)",
+            _request(
+                method="GET",
+                raw_url="{{baseUrl}}/simulations?page=1&per_page=20",
+                headers=auth_contract_headers,
+                query=[("page", "1"), ("per_page", "20")],
+            ),
+            test_lines=[
+                "pm.test('simulation list returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('simulation list includes pagination and items', function () {",
+                "  pm.expect(body.success).to.eql(true);",
+                "  pm.expect(body.data.items).to.be.an('array');",
+                "  pm.expect(body.meta.pagination.total).to.be.at.least(1);",
+                "});",
+            ],
+        ),
+        _item(
+            "12 - Get saved simulation by id (REST v2)",
+            _request(
+                method="GET",
+                raw_url="{{baseUrl}}/simulations/{{genericSimulationId}}",
+                headers=auth_contract_headers,
+            ),
+            test_lines=[
+                "pm.test('simulation get returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('simulation get returns requested id', function () {",
+                "  pm.expect(body.success).to.eql(true);",
+                "  pm.expect(body.data.simulation.id).to.eql(pm.collectionVariables.get('genericSimulationId'));",
+                "});",
+            ],
+        ),
+        _item(
+            "13 - Delete saved simulation by id (REST v2)",
+            _request(
+                method="DELETE",
+                raw_url="{{baseUrl}}/simulations/{{genericSimulationId}}",
+                headers=auth_contract_headers,
+            ),
+            test_lines=[
+                "pm.test('simulation delete returns 200', function () { pm.response.to.have.status(200); });",
+                "pm.test('simulation delete canonical success', function () {",
+                "  pm.expect(pm.response.json().success).to.eql(true);",
+                "});",
+            ],
+        ),
     ]
 
     alert_items = [
@@ -1441,7 +1573,7 @@ def build_collection() -> dict[str, Any]:
             "02 - Update alert preference (REST v2)",
             _request(
                 method="PUT",
-                raw_url="{{baseUrl}}/alerts/preferences/system",
+                raw_url="{{baseUrl}}/alerts/preferences/{{alertCategory}}",
                 headers=auth_json_headers,
                 body=_json_body(
                     """
@@ -1458,7 +1590,7 @@ def build_collection() -> dict[str, Any]:
                 "var body = pm.response.json();",
                 "pm.test('alert preference update returns preference payload', function () {",
                 "  pm.expect(body.success).to.eql(true);",
-                "  pm.expect(body.data.preference.category).to.eql('system');",
+                "  pm.expect(body.data.preference.category).to.eql(pm.collectionVariables.get('alertCategory'));",
                 "});",
             ],
         ),
@@ -2039,6 +2171,7 @@ def build_collection() -> dict[str, Any]:
             {"key": "investmentId", "value": ""},
             {"key": "operationId", "value": ""},
             {"key": "simulationId", "value": ""},
+            {"key": "genericSimulationId", "value": ""},
             {"key": "advancedSimulationId", "value": ""},
             {"key": "feeSimulationId", "value": ""},
             {"key": "entitlementId", "value": ""},
@@ -2048,6 +2181,7 @@ def build_collection() -> dict[str, Any]:
             {"key": "invitationId", "value": ""},
             {"key": "subscriptionId", "value": ""},
             {"key": "fakeUuid", "value": "00000000-0000-4000-8000-000000000001"},
+            {"key": "alertCategory", "value": "system"},
             {"key": "nonexistentInvitationToken", "value": ""},
             {"key": "suiteProfile", "value": "full"},
             {"key": "enablePrivilegedFlows", "value": "false"},

--- a/tests/test_postman_collection_contract.py
+++ b/tests/test_postman_collection_contract.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import re
 from pathlib import Path
+from typing import Any
 
 SMOKE_REQUESTS = {
     "01 - Healthz",
@@ -121,6 +122,7 @@ def test_postman_collection_covers_critical_rest_routes() -> None:
         ("PUT", "/user/profile"),
         ("GET", "/user/profile/questionnaire"),
         ("POST", "/user/profile/questionnaire"),
+        ("POST", "/user/simulate-salary-increase"),
         ("POST", "/transactions"),
         ("PUT", "/transactions/{param}"),
         ("DELETE", "/transactions/{param}"),
@@ -136,6 +138,7 @@ def test_postman_collection_covers_critical_rest_routes() -> None:
         ("POST", "/goals"),
         ("GET", "/goals/{param}"),
         ("PUT", "/goals/{param}"),
+        ("PATCH", "/goals/{param}"),
         ("DELETE", "/goals/{param}"),
         ("GET", "/goals/{param}/plan"),
         ("POST", "/goals/simulate"),
@@ -156,10 +159,14 @@ def test_postman_collection_covers_critical_rest_routes() -> None:
         ("GET", "/wallet/{param}/operations/invested-amount"),
         ("POST", "/simulations/installment-vs-cash/calculate"),
         ("POST", "/simulations/installment-vs-cash/save"),
+        ("GET", "/simulations"),
+        ("POST", "/simulations"),
+        ("GET", "/simulations/{param}"),
+        ("DELETE", "/simulations/{param}"),
         ("POST", "/simulations/{param}/goal"),
         ("POST", "/simulations/{param}/planned-expense"),
         ("GET", "/alerts/preferences"),
-        ("PUT", "/alerts/preferences/system"),
+        ("PUT", "/alerts/preferences/{param}"),
         ("GET", "/alerts"),
         ("POST", "/alerts/{param}/read"),
         ("DELETE", "/alerts/{param}"),
@@ -242,3 +249,39 @@ def test_postman_collection_smoke_profile_excludes_privileged_only_requests() ->
     }
     overlap = sorted(SMOKE_REQUESTS & privileged_only)
     assert not overlap, f"Smoke profile must not include privileged requests: {overlap}"
+
+
+def test_postman_collection_covers_registered_rest_routes(app: Any) -> None:
+    covered = {
+        (
+            str(item["request"]["method"]).upper(),
+            _normalize_path(str(item["request"]["url"]["raw"])),
+        )
+        for item in _flatten_request_items(_load_postman_items())
+    }
+    allowed_gaps = {
+        ("PUT", "/transactions"),
+        ("DELETE", "/transactions"),
+    }
+    missing: list[tuple[str, str, str]] = []
+
+    with app.app_context():
+        for rule in sorted(
+            app.url_map.iter_rules(),
+            key=lambda r: (r.rule, sorted(r.methods)),
+        ):
+            if rule.endpoint == "static" or rule.endpoint.startswith("flask-apispec."):
+                continue
+            if rule.rule.startswith("/docs") or rule.rule.startswith("/swagger"):
+                continue
+            normalized_rule = re.sub(r"<(?:[^:>]+:)?[^>]+>", "{param}", rule.rule)
+            for method in sorted(
+                m for m in rule.methods if m not in {"HEAD", "OPTIONS"}
+            ):
+                route_key = (method, normalized_rule)
+                if route_key in allowed_gaps:
+                    continue
+                if route_key not in covered:
+                    missing.append((method, normalized_rule, rule.endpoint))
+
+    assert not missing, f"Postman collection missing registered REST routes: {missing}"


### PR DESCRIPTION
## Summary
- audit the canonical Postman collection against Flask's registered REST routes
- add the remaining route coverage gaps for goals, generic simulations and salary increase simulation
- harden the contract test so route parity regressions fail fast

## Validation
- `python3 scripts/build_postman_collection.py`
- `scripts/python_tool.sh pytest tests/test_postman_collection_contract.py -q`
- `scripts/python_tool.sh pytest tests/test_postman_collection_contract.py tests/test_installment_vs_cash_contract.py tests/test_graphql_installment_vs_cash_api.py tests/test_j9_billing_subscriptions.py tests/test_j13_shared_entries.py tests/test_j_task_models.py -q`
- `scripts/python_tool.sh ruff check scripts/build_postman_collection.py tests/test_postman_collection_contract.py`
- `scripts/python_tool.sh mypy app`
- `git diff --check`
- `npm ci`
- `npm run postman:full:dev`

## Notes
- The Newman `full` run on `dev` exposed existing backend/runtime failures outside this PR's route-parity scope:
  - subscriptions: `/subscriptions/me`, `/subscriptions/cancel`, invalid-signature webhook handling
  - shared-entries: `/with-me`, `/invitations`, invitation accept/delete error paths
  - fiscal: confirm import, receivable create/receive/delete, fiscal document create
- Those failures were not masked here; they are now explicit evidence for follow-up hardening.
