### PR TITLE
fix(ops): stabilize newman full runtime drift

### DIFF
--- a/app/controllers/subscription_controller.py
+++ b/app/controllers/subscription_controller.py
@@ -17,6 +17,7 @@ from typing import Any
 from uuid import UUID
 
 from flask import Blueprint, current_app, jsonify, request
+from flask.ctx import has_app_context
 from flask.typing import ResponseReturnValue
 
 from app.auth import get_active_auth_context
@@ -166,7 +167,27 @@ def _read_bool_env(name: str, default: bool = False) -> bool:
 
 def _allow_unsigned_webhooks() -> bool:
     """Unsigned webhook traffic must be explicitly enabled per environment."""
-    return _read_bool_env(_WEBHOOK_ALLOW_UNSIGNED_ENV, default=False)
+    if not _read_bool_env(_WEBHOOK_ALLOW_UNSIGNED_ENV, default=False):
+        return False
+    if not has_app_context():
+        return False
+    if current_app.testing:
+        return True
+
+    runtime_env = (
+        str(
+            current_app.config.get("ENV")
+            or current_app.config.get("FLASK_ENV")
+            or current_app.config.get("APP_ENV")
+            or os.getenv("FLASK_ENV")
+            or os.getenv("APP_ENV")
+            or os.getenv("AURAXIS_ENV")
+            or ""
+        )
+        .strip()
+        .lower()
+    )
+    return runtime_env in {"local", "test"}
 
 
 def _verify_webhook_signature(payload: bytes, signature: str) -> bool:

--- a/migrations/versions/3d6f4c2b1a9e_repair_ops20_runtime_drift.py
+++ b/migrations/versions/3d6f4c2b1a9e_repair_ops20_runtime_drift.py
@@ -1,0 +1,169 @@
+"""Repair OPS-20 runtime drift for billing, sharing and fiscal domains.
+
+Revision ID: 3d6f4c2b1a9e
+Revises: 7f9c2d1a4b6e
+Create Date: 2026-03-22 23:15:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "3d6f4c2b1a9e"
+down_revision = "7f9c2d1a4b6e"
+branch_labels = None
+depends_on = None
+
+
+def _rename_postgres_enum_value(type_name: str, old_value: str, new_value: str) -> None:
+    op.execute(
+        sa.text(
+            """
+            DO $$
+            BEGIN
+                IF EXISTS (
+                    SELECT 1
+                    FROM pg_type t
+                    JOIN pg_enum e ON e.enumtypid = t.oid
+                    WHERE t.typname = :type_name
+                      AND e.enumlabel = :old_value
+                ) AND NOT EXISTS (
+                    SELECT 1
+                    FROM pg_type t
+                    JOIN pg_enum e ON e.enumtypid = t.oid
+                    WHERE t.typname = :type_name
+                      AND e.enumlabel = :new_value
+                ) THEN
+                    EXECUTE format(
+                        'ALTER TYPE %I RENAME VALUE %L TO %L',
+                        :type_name,
+                        :old_value,
+                        :new_value
+                    );
+                END IF;
+            END
+            $$;
+            """
+        ).bindparams(
+            type_name=type_name,
+            old_value=old_value,
+            new_value=new_value,
+        )
+    )
+
+
+def _repair_invitation_columns() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    columns = {column["name"] for column in inspector.get_columns("invitations")}
+
+    if "token" not in columns:
+        op.add_column(
+            "invitations",
+            sa.Column("token", sa.String(length=64), nullable=True),
+        )
+    if "expires_at" not in columns:
+        op.add_column(
+            "invitations",
+            sa.Column("expires_at", sa.DateTime(), nullable=True),
+        )
+
+    if bind.dialect.name == "postgresql":
+        op.execute(
+            """
+            UPDATE invitations
+            SET
+                token = COALESCE(
+                    token,
+                    md5(id::text || clock_timestamp()::text || random()::text)
+                    || md5(random()::text || id::text)
+                ),
+                expires_at = COALESCE(expires_at, created_at + interval '48 hours')
+            WHERE status = 'pending'
+            """
+        )
+
+    indexes = {index["name"] for index in inspector.get_indexes("invitations")}
+    if "ix_invitations_token" not in indexes:
+        op.create_index("ix_invitations_token", "invitations", ["token"], unique=True)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        enum_renames = {
+            "subscriptionstatus": {
+                "FREE": "free",
+                "TRIALING": "trialing",
+                "ACTIVE": "active",
+                "PAST_DUE": "past_due",
+                "CANCELED": "canceled",
+                "EXPIRED": "expired",
+            },
+            "billingcycle": {
+                "MONTHLY": "monthly",
+                "SEMIANNUAL": "semiannual",
+                "ANNUAL": "annual",
+            },
+            "sharedentriesstatus": {
+                "PENDING": "pending",
+                "ACTIVE": "active",
+                "REVOKED": "revoked",
+            },
+            "splittype": {
+                "EQUAL": "equal",
+                "PERCENTAGE": "percentage",
+                "FIXED": "fixed",
+            },
+            "invitationstatus": {
+                "PENDING": "pending",
+                "ACCEPTED": "accepted",
+                "REJECTED": "rejected",
+                "REVOKED": "revoked",
+                "EXPIRED": "expired",
+            },
+            "fiscalimportstatus": {
+                "PROCESSING": "processing",
+                "PREVIEW_READY": "preview_ready",
+                "CONFIRMED": "confirmed",
+                "FAILED": "failed",
+            },
+            "fiscaldocumenttype": {
+                "SERVICE_INVOICE": "service_invoice",
+                "PRODUCT_INVOICE": "product_invoice",
+                "RECEIPT": "receipt",
+                "DEBIT_NOTE": "debit_note",
+                "CREDIT_NOTE": "credit_note",
+            },
+            "fiscaldocumentstatus": {
+                "ISSUED": "issued",
+                "CANCELED": "canceled",
+                "CORRECTED": "corrected",
+                "SETTLED": "settled",
+                "PARTIALLY_SETTLED": "partially_settled",
+            },
+            "reconciliationstatus": {
+                "PENDING": "pending",
+                "PARTIAL": "partial",
+                "RECONCILED": "reconciled",
+            },
+            "fiscaladjustmenttype": {
+                "TAX": "tax",
+                "FEE": "fee",
+                "WITHHOLDING": "withholding",
+                "DISCOUNT": "discount",
+                "REFUND": "refund",
+            },
+        }
+
+        for type_name, rename_map in enum_renames.items():
+            for old_value, new_value in rename_map.items():
+                _rename_postgres_enum_value(type_name, old_value, new_value)
+
+    _repair_invitation_columns()
+
+
+def downgrade() -> None:
+    # Repair migration only: keep runtime/schema compatible on rollback as well.
+    pass

--- a/tests/test_j9_billing_subscriptions.py
+++ b/tests/test_j9_billing_subscriptions.py
@@ -367,6 +367,30 @@ class TestWebhook:
         assert body["success"] is False
         assert body["error"]["code"] == "UNAUTHORIZED"
 
+    def test_webhook_rejects_unsigned_requests_outside_local_or_test_env(
+        self,
+        client,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.delenv("BILLING_WEBHOOK_SECRET", raising=False)
+        monkeypatch.setenv("BILLING_WEBHOOK_ALLOW_UNSIGNED", "true")
+        monkeypatch.setenv("APP_ENV", "dev")
+
+        original_testing = client.application.testing
+        client.application.testing = False
+        try:
+            resp = client.post(
+                "/subscriptions/webhook",
+                json={"event": "unknown.event", "subscription_id": "sub_xyz"},
+            )
+        finally:
+            client.application.testing = original_testing
+
+        assert resp.status_code == 401
+        body = resp.get_json()
+        assert body["success"] is False
+        assert body["error"]["code"] == "UNAUTHORIZED"
+
     def test_webhook_accepts_valid_signature_when_secret_is_configured(
         self,
         client,


### PR DESCRIPTION
## Summary
- harden billing webhook unsigned behavior so dev/prod no longer accept unsigned payloads just because the flag is enabled
- add an idempotent repair migration for invitation schema drift and legacy enum labels surfaced by the Newman full suite
- add regression coverage for the stricter webhook policy

## Validation
- scripts/python_tool.sh pytest tests/test_j9_billing_subscriptions.py -q
- scripts/python_tool.sh pytest tests/test_j13_shared_entries.py tests/test_j14_csv_ingestion.py -q
- scripts/python_tool.sh ruff check app/controllers/subscription_controller.py tests/test_j9_billing_subscriptions.py migrations/versions/3d6f4c2b1a9e_repair_ops20_runtime_drift.py
- scripts/python_tool.sh mypy app
- git diff --check
- npm ci
- POSTMAN_REPORT_FILE=reports/newman-full-local-ops20.xml bash scripts/run_postman_suite.sh /tmp/auraxis-api-ops20.local.postman_environment.json --profile full  # 92 requests / 164 assertions / 0 failed against local stack after flask db upgrade