### PR TITLE
test(ops): expand graphql postman coverage

### DIFF
--- a/api-tests/postman/auraxis.postman_collection.json
+++ b/api-tests/postman/auraxis.postman_collection.json
@@ -4523,7 +4523,87 @@
           ]
         },
         {
-          "name": "04 - GraphQL installment vs cash calculate (public)",
+          "name": "04 - GraphQL forgot password stays neutral",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/graphql",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "graphql"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"query\": \"mutation ForgotPassword($email: String!) { forgotPassword(email: $email) { message } }\",\n                      \"variables\": {\n                        \"email\": \"unknown-user@email.com\"\n                      }\n                    }\n"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('graphql forgot password returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('graphql forgot password stays neutral', function () {",
+                  "  pm.expect(body.errors).to.eql(undefined);",
+                  "  pm.expect(body.data.forgotPassword.message).to.be.a('string').and.not.empty;",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "05 - GraphQL reset password invalid token is public validation error",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/graphql",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "graphql"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"query\": \"mutation ResetPassword($token: String!, $newPassword: String!) { resetPassword(token: $token, newPassword: $newPassword) { message } }\",\n                      \"variables\": {\n                        \"token\": \"invalid-token-value-with-sufficient-length-123456\",\n                        \"newPassword\": \"NovaSenha@123\"\n                      }\n                    }\n"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('graphql reset invalid token returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "var firstErr = body.errors && body.errors[0] ? body.errors[0] : {};",
+                  "pm.test('graphql reset invalid token returns VALIDATION_ERROR', function () { pm.expect(firstErr.extensions.code).to.eql('VALIDATION_ERROR'); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "06 - GraphQL installment vs cash calculate (public)",
           "request": {
             "method": "POST",
             "header": [
@@ -4561,7 +4641,7 @@
           ]
         },
         {
-          "name": "05 - GraphQL installment vs cash save (auth required)",
+          "name": "07 - GraphQL installment vs cash save (auth required)",
           "request": {
             "method": "POST",
             "header": [
@@ -4598,6 +4678,237 @@
                   "pm.test('graphql installment save persists simulation', function () {",
                   "  pm.expect(body.errors).to.eql(undefined);",
                   "  pm.expect(body.data.saveInstallmentVsCashSimulation.simulation.saved).to.eql(true);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "08 - GraphQL transaction dashboard seed (auth required)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/graphql",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "graphql"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"query\": \"mutation SeedExpense($title: String!, $amount: String!, $dueDate: String!) { createTransaction(title: $title, amount: $amount, type: \\\"expense\\\", dueDate: $dueDate) { items { id title } } }\",\n                      \"variables\": {\n                        \"title\": \"Conta luz {{runSeed}}\",\n                        \"amount\": \"150.00\",\n                        \"dueDate\": \"{{runToday}}\"\n                      }\n                    }\n"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('graphql transaction seed returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('graphql transaction seed creates an item', function () {",
+                  "  pm.expect(body.errors).to.eql(undefined);",
+                  "  pm.expect(body.data.createTransaction.items[0].id).to.be.a('string').and.not.empty;",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "09 - GraphQL transaction summary and dashboard (auth required)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/graphql",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "graphql"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"query\": \"query GraphqlDashboard($month: String!, $initialDate: String!, $finalDate: String!) { transactionSummary(month: $month, page: 1, pageSize: 10) { month pagination { total } } transactionDashboard(month: $month) { month counts { totalTransactions } } transactionDueRange(initialDate: $initialDate, finalDate: $finalDate, page: 1, perPage: 10, orderBy: \\\"overdue_first\\\") { counts { totalTransactions } pagination { total } } }\",\n                      \"variables\": {\n                        \"month\": \"{{runMonthRef}}\",\n                        \"initialDate\": \"{{runYesterday}}\",\n                        \"finalDate\": \"{{runToday}}\"\n                      }\n                    }\n"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('graphql dashboard returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('graphql dashboard aggregates transaction data', function () {",
+                  "  pm.expect(body.errors).to.eql(undefined);",
+                  "  pm.expect(body.data.transactionSummary.month).to.eql(pm.collectionVariables.get('runMonthRef'));",
+                  "  pm.expect(body.data.transactionDashboard.month).to.eql(pm.collectionVariables.get('runMonthRef'));",
+                  "  pm.expect(body.data.transactionDueRange.counts.totalTransactions).to.be.at.least(1);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "10 - GraphQL wallet create (auth required)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/graphql",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "graphql"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"query\": \"mutation AddWalletEntry { addWalletEntry(name: \\\"Reserva {{runSeed}}\\\", value: 1000, registerDate: \\\"{{runToday}}\\\", shouldBeOnWallet: true) { item { id name assetClass } } }\"\n                    }\n"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('graphql wallet create returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "var item = body.data.addWalletEntry.item;",
+                  "pm.collectionVariables.set('graphqlWalletId', item.id);",
+                  "pm.test('graphql wallet create stores investment id', function () {",
+                  "  pm.expect(body.errors).to.eql(undefined);",
+                  "  pm.expect(item.id).to.be.a('string').and.not.empty;",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "11 - GraphQL wallet list and valuation (auth required)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/graphql",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "graphql"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"query\": \"query WalletCoverage($investmentId: UUID!) { walletEntries(page: 1, perPage: 10) { pagination { total } items { id name shouldBeOnWallet } } investmentValuation(investmentId: $investmentId) { investmentId assetClass valuationSource } portfolioValuation { summary { totalInvestments } } }\",\n                      \"variables\": {\n                        \"investmentId\": \"{{graphqlWalletId}}\"\n                      }\n                    }\n"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('graphql wallet coverage returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('graphql wallet coverage returns canonical portfolio payload', function () {",
+                  "  pm.expect(body.errors).to.eql(undefined);",
+                  "  pm.expect(body.data.walletEntries.pagination.total).to.be.at.least(1);",
+                  "  pm.expect(body.data.investmentValuation.investmentId).to.eql(pm.collectionVariables.get('graphqlWalletId'));",
+                  "  pm.expect(body.data.portfolioValuation.summary.totalInvestments).to.be.at.least(1);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "12 - GraphQL logout mutation (auth required)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/graphql",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "graphql"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n                      \"query\": \"mutation Logout { logout { ok message } }\"\n                    }\n"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('graphql logout returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('graphql logout confirms success', function () {",
+                  "  pm.expect(body.errors).to.eql(undefined);",
+                  "  pm.expect(body.data.logout.ok).to.eql(true);",
                   "});"
                 ],
                 "type": "text/javascript"
@@ -4683,6 +4994,10 @@
     },
     {
       "key": "subscriptionId",
+      "value": ""
+    },
+    {
+      "key": "graphqlWalletId",
       "value": ""
     },
     {

--- a/scripts/build_postman_collection.py
+++ b/scripts/build_postman_collection.py
@@ -2086,7 +2086,58 @@ def build_collection() -> dict[str, Any]:
             ],
         ),
         _item(
-            "04 - GraphQL installment vs cash calculate (public)",
+            "04 - GraphQL forgot password stays neutral",
+            _request(
+                method="POST",
+                raw_url="{{baseUrl}}/graphql",
+                headers=graphql_headers,
+                body=_json_body(
+                    """
+                    {
+                      "query": "mutation ForgotPassword($email: String!) { forgotPassword(email: $email) { message } }",
+                      "variables": {
+                        "email": "unknown-user@email.com"
+                      }
+                    }
+                    """
+                ),
+            ),
+            test_lines=[
+                "pm.test('graphql forgot password returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('graphql forgot password stays neutral', function () {",
+                "  pm.expect(body.errors).to.eql(undefined);",
+                "  pm.expect(body.data.forgotPassword.message).to.be.a('string').and.not.empty;",
+                "});",
+            ],
+        ),
+        _item(
+            "05 - GraphQL reset password invalid token is public validation error",
+            _request(
+                method="POST",
+                raw_url="{{baseUrl}}/graphql",
+                headers=graphql_headers,
+                body=_json_body(
+                    """
+                    {
+                      "query": "mutation ResetPassword($token: String!, $newPassword: String!) { resetPassword(token: $token, newPassword: $newPassword) { message } }",
+                      "variables": {
+                        "token": "invalid-token-value-with-sufficient-length-123456",
+                        "newPassword": "NovaSenha@123"
+                      }
+                    }
+                    """
+                ),
+            ),
+            test_lines=[
+                "pm.test('graphql reset invalid token returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "var firstErr = body.errors && body.errors[0] ? body.errors[0] : {};",
+                "pm.test('graphql reset invalid token returns VALIDATION_ERROR', function () { pm.expect(firstErr.extensions.code).to.eql('VALIDATION_ERROR'); });",
+            ],
+        ),
+        _item(
+            "06 - GraphQL installment vs cash calculate (public)",
             _request(
                 method="POST",
                 raw_url="{{baseUrl}}/graphql",
@@ -2106,7 +2157,7 @@ def build_collection() -> dict[str, Any]:
             ],
         ),
         _item(
-            "05 - GraphQL installment vs cash save (auth required)",
+            "07 - GraphQL installment vs cash save (auth required)",
             _request(
                 method="POST",
                 raw_url="{{baseUrl}}/graphql",
@@ -2125,6 +2176,140 @@ def build_collection() -> dict[str, Any]:
                 "pm.test('graphql installment save persists simulation', function () {",
                 "  pm.expect(body.errors).to.eql(undefined);",
                 "  pm.expect(body.data.saveInstallmentVsCashSimulation.simulation.saved).to.eql(true);",
+                "});",
+            ],
+        ),
+        _item(
+            "08 - GraphQL transaction dashboard seed (auth required)",
+            _request(
+                method="POST",
+                raw_url="{{baseUrl}}/graphql",
+                headers=graphql_auth_headers,
+                body=_json_body(
+                    """
+                    {
+                      "query": "mutation SeedExpense($title: String!, $amount: String!, $dueDate: String!) { createTransaction(title: $title, amount: $amount, type: \\"expense\\", dueDate: $dueDate) { items { id title } } }",
+                      "variables": {
+                        "title": "Conta luz {{runSeed}}",
+                        "amount": "150.00",
+                        "dueDate": "{{runToday}}"
+                      }
+                    }
+                    """
+                ),
+            ),
+            test_lines=[
+                "pm.test('graphql transaction seed returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('graphql transaction seed creates an item', function () {",
+                "  pm.expect(body.errors).to.eql(undefined);",
+                "  pm.expect(body.data.createTransaction.items[0].id).to.be.a('string').and.not.empty;",
+                "});",
+            ],
+        ),
+        _item(
+            "09 - GraphQL transaction summary and dashboard (auth required)",
+            _request(
+                method="POST",
+                raw_url="{{baseUrl}}/graphql",
+                headers=graphql_auth_headers,
+                body=_json_body(
+                    """
+                    {
+                      "query": "query GraphqlDashboard($month: String!, $initialDate: String!, $finalDate: String!) { transactionSummary(month: $month, page: 1, pageSize: 10) { month pagination { total } } transactionDashboard(month: $month) { month counts { totalTransactions } } transactionDueRange(initialDate: $initialDate, finalDate: $finalDate, page: 1, perPage: 10, orderBy: \\"overdue_first\\") { counts { totalTransactions } pagination { total } } }",
+                      "variables": {
+                        "month": "{{runMonthRef}}",
+                        "initialDate": "{{runYesterday}}",
+                        "finalDate": "{{runToday}}"
+                      }
+                    }
+                    """
+                ),
+            ),
+            test_lines=[
+                "pm.test('graphql dashboard returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('graphql dashboard aggregates transaction data', function () {",
+                "  pm.expect(body.errors).to.eql(undefined);",
+                "  pm.expect(body.data.transactionSummary.month).to.eql(pm.collectionVariables.get('runMonthRef'));",
+                "  pm.expect(body.data.transactionDashboard.month).to.eql(pm.collectionVariables.get('runMonthRef'));",
+                "  pm.expect(body.data.transactionDueRange.counts.totalTransactions).to.be.at.least(1);",
+                "});",
+            ],
+        ),
+        _item(
+            "10 - GraphQL wallet create (auth required)",
+            _request(
+                method="POST",
+                raw_url="{{baseUrl}}/graphql",
+                headers=graphql_auth_headers,
+                body=_json_body(
+                    """
+                    {
+                      "query": "mutation AddWalletEntry { addWalletEntry(name: \\"Reserva {{runSeed}}\\", value: 1000, registerDate: \\"{{runToday}}\\", shouldBeOnWallet: true) { item { id name assetClass } } }"
+                    }
+                    """
+                ),
+            ),
+            test_lines=[
+                "pm.test('graphql wallet create returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "var item = body.data.addWalletEntry.item;",
+                "pm.collectionVariables.set('graphqlWalletId', item.id);",
+                "pm.test('graphql wallet create stores investment id', function () {",
+                "  pm.expect(body.errors).to.eql(undefined);",
+                "  pm.expect(item.id).to.be.a('string').and.not.empty;",
+                "});",
+            ],
+        ),
+        _item(
+            "11 - GraphQL wallet list and valuation (auth required)",
+            _request(
+                method="POST",
+                raw_url="{{baseUrl}}/graphql",
+                headers=graphql_auth_headers,
+                body=_json_body(
+                    """
+                    {
+                      "query": "query WalletCoverage($investmentId: UUID!) { walletEntries(page: 1, perPage: 10) { pagination { total } items { id name shouldBeOnWallet } } investmentValuation(investmentId: $investmentId) { investmentId assetClass valuationSource } portfolioValuation { summary { totalInvestments } } }",
+                      "variables": {
+                        "investmentId": "{{graphqlWalletId}}"
+                      }
+                    }
+                    """
+                ),
+            ),
+            test_lines=[
+                "pm.test('graphql wallet coverage returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('graphql wallet coverage returns canonical portfolio payload', function () {",
+                "  pm.expect(body.errors).to.eql(undefined);",
+                "  pm.expect(body.data.walletEntries.pagination.total).to.be.at.least(1);",
+                "  pm.expect(body.data.investmentValuation.investmentId).to.eql(pm.collectionVariables.get('graphqlWalletId'));",
+                "  pm.expect(body.data.portfolioValuation.summary.totalInvestments).to.be.at.least(1);",
+                "});",
+            ],
+        ),
+        _item(
+            "12 - GraphQL logout mutation (auth required)",
+            _request(
+                method="POST",
+                raw_url="{{baseUrl}}/graphql",
+                headers=graphql_auth_headers,
+                body=_json_body(
+                    """
+                    {
+                      "query": "mutation Logout { logout { ok message } }"
+                    }
+                    """
+                ),
+            ),
+            test_lines=[
+                "pm.test('graphql logout returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('graphql logout confirms success', function () {",
+                "  pm.expect(body.errors).to.eql(undefined);",
+                "  pm.expect(body.data.logout.ok).to.eql(true);",
                 "});",
             ],
         ),
@@ -2180,6 +2365,7 @@ def build_collection() -> dict[str, Any]:
             {"key": "sharedEntryId", "value": ""},
             {"key": "invitationId", "value": ""},
             {"key": "subscriptionId", "value": ""},
+            {"key": "graphqlWalletId", "value": ""},
             {"key": "fakeUuid", "value": "00000000-0000-4000-8000-000000000001"},
             {"key": "alertCategory", "value": "system"},
             {"key": "nonexistentInvitationToken", "value": ""},

--- a/tests/test_postman_collection_contract.py
+++ b/tests/test_postman_collection_contract.py
@@ -26,7 +26,7 @@ SMOKE_REQUESTS = {
     "03 - Simulation goal bridge without entitlement returns 403",
     "02 - GraphQL login invalid credentials (safe error)",
     "03 - GraphQL me query (auth required)",
-    "04 - GraphQL installment vs cash calculate (public)",
+    "06 - GraphQL installment vs cash calculate (public)",
     "01 - List alert preferences (REST v2)",
     "01 - Get my subscription (REST v2)",
     "01 - List entitlements (REST v2)",
@@ -96,8 +96,33 @@ def test_postman_collection_covers_installment_vs_cash_rest_and_graphql() -> Non
 
     assert "01 - Installment vs cash calculate (REST public)" in names
     assert "02 - Installment vs cash save (REST auth required)" in names
-    assert "04 - GraphQL installment vs cash calculate (public)" in names
-    assert "05 - GraphQL installment vs cash save (auth required)" in names
+    assert "06 - GraphQL installment vs cash calculate (public)" in names
+    assert "07 - GraphQL installment vs cash save (auth required)" in names
+
+
+def test_postman_collection_covers_canonical_graphql_operations() -> None:
+    items = _flatten_request_items(_load_postman_items())
+    names = {str(item.get("name")) for item in items}
+
+    expected = {
+        "01 - GraphQL empty query (validation error)",
+        "02 - GraphQL login invalid credentials (safe error)",
+        "03 - GraphQL me query (auth required)",
+        "04 - GraphQL forgot password stays neutral",
+        "05 - GraphQL reset password invalid token is public validation error",
+        "06 - GraphQL installment vs cash calculate (public)",
+        "07 - GraphQL installment vs cash save (auth required)",
+        "08 - GraphQL transaction dashboard seed (auth required)",
+        "09 - GraphQL transaction summary and dashboard (auth required)",
+        "10 - GraphQL wallet create (auth required)",
+        "11 - GraphQL wallet list and valuation (auth required)",
+        "12 - GraphQL logout mutation (auth required)",
+    }
+
+    missing = sorted(expected - names)
+    assert not missing, (
+        f"Postman collection missing canonical GraphQL coverage: {missing}"
+    )
 
 
 def test_postman_collection_covers_critical_rest_routes() -> None:


### PR DESCRIPTION
## Summary
- expand the canonical Postman/Newman suite with deeper GraphQL functional coverage for auth recovery, dashboard, wallet valuation and logout
- strengthen the collection contract tests so these GraphQL operations stay part of the official suite
- regenerate the canonical collection after the new coverage

## Validation
- scripts/python_tool.sh pytest tests/test_postman_collection_contract.py tests/test_graphql_api.py -q
- scripts/python_tool.sh ruff check scripts/build_postman_collection.py tests/test_postman_collection_contract.py
- scripts/python_tool.sh mypy app
- git diff --check
- npm ci
- POSTMAN_REPORT_FILE=reports/newman-full-local-ops21.xml bash scripts/run_postman_suite.sh /tmp/auraxis-api-ops21.local.postman_environment.json --profile full  # 99 requests / 178 assertions / 0 failed against isolated local stack