### PR TITLE
ci(security): replace snyk with osv scanner

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -21,16 +21,11 @@ Definir pipelines de CI/CD e gates de qualidade, seguranca e deploy.
 
 ## Secrets relevantes
 - `TOKEN_GITHUB_ADMIN`: token com permissao de administracao do repositório para auditoria/sync de ruleset no `governance.yml`.
-- `SNYK_TOKEN`: token da Snyk (obrigatorio apenas quando `ENABLE_SNYK=true`).
-
-## Variaveis de controle
-- `ENABLE_SNYK`:
-  - `true`: habilita o job `Security Scan (Snyk)` no `ci.yml`.
-  - vazio/`false`: o job `snyk` e ignorado.
 
 ## Observabilidade de CI
 - O job `API Smoke (Postman/Newman)` aplica `flask db upgrade` antes da suite Postman para evitar falhas de schema em banco efemero.
 - O runner Newman do CI e local usa dependencias Node versionadas com `npm ci`, evitando dependencia de install global.
+- O job `Dependency Security (OSV-Scanner)` publica `osv-results.json` como artifact para auditoria de vulnerabilidades em lockfiles.
 
 ## Padroes obrigatorios
 - Toda mudanca de workflow deve manter reproducibilidade local quando aplicavel.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -391,45 +391,25 @@ jobs:
           severity: HIGH,CRITICAL
           exit-code: 1
 
-  snyk:
-    name: Security Scan (Snyk)
+  osv-scanner:
+    name: Dependency Security (OSV-Scanner)
     runs-on: ubuntu-latest
     needs: [tests, trivy]
-    if: ${{ vars.ENABLE_SNYK == 'true' }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Validate SNYK_TOKEN
+      - name: Run OSV-Scanner
         run: |
-          if [ -z "${SNYK_TOKEN:-}" ]; then
-            echo "Missing required secret: SNYK_TOKEN" >&2
-            exit 1
-          fi
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          bash scripts/run_osv_scanner.sh
 
-      - name: Snyk Python dependency scan
-        uses: snyk/actions/python@9adf32b1121593767fc3c057af55b55db032dc04
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+      - name: Upload OSV report artifact
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
         with:
-          command: test
-          args: --file=requirements.txt --package-manager=pip --severity-threshold=high --fail-on=all
-
-      - name: Build image for Snyk container scan
-        run: |
-          docker build -f Dockerfile.prod -t auraxis-ci:${{ github.sha }} .
-
-      - name: Snyk container scan
-        uses: snyk/actions/docker@9adf32b1121593767fc3c057af55b55db032dc04
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        with:
-          image: auraxis-ci:${{ github.sha }}
-          command: test
-          args: --severity-threshold=high --exclude-base-image-vulns
+          name: osv-results
+          path: reports/security/osv-results.json
 
   security-evidence:
     name: Security Evidence (S3)
@@ -453,7 +433,7 @@ jobs:
   sonar:
     name: SonarQube Cloud
     runs-on: ubuntu-latest
-    needs: [tests, schemathesis, mutation, trivy, security-evidence]
+    needs: [tests, schemathesis, mutation, trivy, osv-scanner, security-evidence]
 
     steps:
       - name: Check Sonar capability

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -56,9 +56,10 @@ Jobs relevantes:
 9. `trivy`
 - scan de filesystem + imagem Docker
 
-10. `snyk` (obrigatorio)
-- scan de dependencias Python
-- scan de container calibrado para reduzir ruido recorrente de base image
+10. `osv-scanner` (obrigatorio)
+- scan open source de lockfiles/dependencias versionadas
+- usa a base `OSV.dev` como complemento ao `pip-audit` e ao `dependency-review`
+- publica `reports/security/osv-results.json` como artifact
 
 11. `security-evidence`
 - executa `scripts/security_evidence_check.sh`
@@ -70,6 +71,7 @@ Notas:
 - `Cursor Bugbot` e camada complementar de review em PR.
 - Bugbot nao eh gate obrigatorio no ruleset (quota/ruido), mas continua util como sinal adicional.
 - O job `Review Signal (Cursor Bugbot)` publica resumo no `Step Summary` para triagem objetiva.
+- `Trivy` continua responsavel por filesystem + container; `OSV-Scanner` assume a trilha open source de SCA para lockfiles/dependencias.
 
 ### 2) Deploy
 Arquivo: `.github/workflows/deploy.yml`
@@ -195,7 +197,6 @@ Exemplos:
 
 Secrets:
 - `SONAR_TOKEN`
-- `SNYK_TOKEN`
 - `TOKEN_GITHUB_ADMIN`
 
 Vars:

--- a/scripts/run_ci_like_actions_local.sh
+++ b/scripts/run_ci_like_actions_local.sh
@@ -12,7 +12,8 @@ set -euo pipefail
 #   --help                show usage
 #
 # Notes:
-# - Trivy/Snyk jobs remain CI-native because they depend on runner secrets/tools.
+# - Trivy remains CI-native because image scanning depends on runner/container tooling.
+# - OSV-Scanner is reproducible locally through scripts/run_osv_scanner.sh.
 # - Use this script before push to reduce CI surprises.
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -143,6 +144,9 @@ run_core_pipeline() {
   else
     echo "[ci-like-local] step=security:gitleaks skipped (gitleaks not installed)"
   fi
+
+  echo "[ci-like-local] step=security:osv-scanner"
+  bash scripts/run_osv_scanner.sh
 
   echo "[ci-like-local] step=tests:pytest+coverage"
   "${PYTHON_BIN}" -m pytest -m "not schemathesis" \

--- a/scripts/run_osv_scanner.sh
+++ b/scripts/run_osv_scanner.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPORT_DIR="${ROOT_DIR}/reports/security"
+REPORT_FILE="${REPORT_DIR}/osv-results.json"
+OSV_SCANNER_VERSION="${OSV_SCANNER_VERSION:-2.3.3}"
+OSV_INCLUDE_NODE_LOCKFILE="${OSV_INCLUDE_NODE_LOCKFILE:-false}"
+
+mkdir -p "${REPORT_DIR}"
+
+resolve_platform() {
+  local os arch
+  os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  arch="$(uname -m)"
+
+  case "${os}" in
+    linux|darwin) ;;
+    *)
+      echo "[osv-scanner] unsupported OS: ${os}" >&2
+      return 1
+      ;;
+  esac
+
+  case "${arch}" in
+    x86_64|amd64)
+      arch="amd64"
+      ;;
+    arm64|aarch64)
+      arch="arm64"
+      ;;
+    *)
+      echo "[osv-scanner] unsupported architecture: ${arch}" >&2
+      return 1
+      ;;
+  esac
+
+  printf '%s_%s\n' "${os}" "${arch}"
+}
+
+ensure_osv_scanner() {
+  local platform cache_dir binary_path asset_url
+  platform="$(resolve_platform)"
+  cache_dir="${ROOT_DIR}/.cache/tools/osv-scanner/${OSV_SCANNER_VERSION}"
+  binary_path="${cache_dir}/osv-scanner"
+
+  if [[ -x "${binary_path}" ]]; then
+    printf '%s\n' "${binary_path}"
+    return 0
+  fi
+
+  mkdir -p "${cache_dir}"
+  asset_url="https://github.com/google/osv-scanner/releases/download/v${OSV_SCANNER_VERSION}/osv-scanner_${platform}"
+  curl -fsSL "${asset_url}" -o "${binary_path}"
+  chmod +x "${binary_path}"
+  printf '%s\n' "${binary_path}"
+}
+
+build_scan_args() {
+  local -a args
+  args=(scan source --recursive)
+
+  if [[ -f "${ROOT_DIR}/requirements.txt" ]]; then
+    args+=(--lockfile "${ROOT_DIR}/requirements.txt")
+  fi
+
+  if [[ "${OSV_INCLUDE_NODE_LOCKFILE}" == "true" && -f "${ROOT_DIR}/package-lock.json" ]]; then
+    args+=(--lockfile "${ROOT_DIR}/package-lock.json")
+  fi
+
+  args+=(--format json --output "${REPORT_FILE}")
+  printf '%s\n' "${args[@]}"
+}
+
+main() {
+  local scanner_path
+  mapfile -t scan_args < <(build_scan_args)
+  scanner_path="$(ensure_osv_scanner)"
+
+  echo "[osv-scanner] version=${OSV_SCANNER_VERSION}"
+  echo "[osv-scanner] report=${REPORT_FILE}"
+  "${scanner_path}" "${scan_args[@]}"
+}
+
+main "$@"

--- a/scripts/security_evidence_check.sh
+++ b/scripts/security_evidence_check.sh
@@ -91,8 +91,9 @@ check_contains "app/controllers/auth/dependencies.py" "generate_password_hash" "
 } >>"${REPORT_FILE}"
 
 check_exists ".gitleaks.toml" "Gitleaks config is versioned in repository"
-check_contains ".github/workflows/ci.yml" "name: Security Scan \(Snyk\)" "Snyk security scan job configured"
-check_contains ".github/workflows/ci.yml" "vars\.ENABLE_SNYK == 'true'" "Snyk security scan uses explicit opt-in gate (ENABLE_SNYK)"
+check_contains ".github/workflows/ci.yml" "name: Dependency Security \(OSV-Scanner\)" "OSV-Scanner dependency scan job configured"
+check_contains ".github/workflows/ci.yml" "bash scripts/run_osv_scanner\.sh" "OSV-Scanner is executed through the canonical script"
+check_contains ".github/workflows/ci.yml" "name: Container Security \(Trivy\)" "Trivy container/filesystem scan job configured"
 
 if command -v rg >/dev/null 2>&1; then
   jwt_count=$(rg -n "@jwt_required\(" app/controllers | wc -l | tr -d ' ')

--- a/steering.md
+++ b/steering.md
@@ -133,7 +133,7 @@ push/PR
  │    ├── api-smoke (Newman — smoke black-box oficial pré-merge)
  │    ├── mutation (Cosmic Ray — 0% survival)
  │    └── trivy (FS + image scan)
- │         └── snyk [se ENABLE_SNYK=true]
+ │    └── osv-scanner (lockfiles/dependency SCA open source)
  │
  ├── schemathesis (contract reliability)
  └── security-evidence


### PR DESCRIPTION
## Summary
- replace the legacy Snyk job with a pinned OSV-Scanner flow for dependency SCA
- keep Trivy as the filesystem/container scanner and update the security evidence checks
- document the new open source security stack and make the OSV scan reproducible locally

## Validation
- bash scripts/run_osv_scanner.sh
- bash -n scripts/run_osv_scanner.sh scripts/run_ci_like_actions_local.sh scripts/security_evidence_check.sh
- git diff --check
- bash scripts/security_evidence_check.sh
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "yaml-ok"'\n\nCloses #695