### PR TITLE
fix: bootstrap recurrence operational scripts from repo root

### DIFF
--- a/scripts/generate_recurring_transactions.py
+++ b/scripts/generate_recurring_transactions.py
@@ -1,8 +1,14 @@
 import logging
+import sys
 from datetime import date
+from pathlib import Path
 
-from app import create_app
-from app.services.recurrence_service import RecurrenceService
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app import create_app  # noqa: E402
+from app.services.recurrence_service import RecurrenceService  # noqa: E402
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 logger = logging.getLogger(__name__)

--- a/scripts/manage_audit_events.py
+++ b/scripts/manage_audit_events.py
@@ -4,9 +4,14 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from pathlib import Path
 
-from app import create_app
-from app.services.audit_event_service import (
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app import create_app  # noqa: E402
+from app.services.audit_event_service import (  # noqa: E402
     purge_expired_audit_events,
     search_audit_events_by_request_id,
     serialize_audit_event,

--- a/tests/scripts/test_cli_script_bootstrap.py
+++ b/tests/scripts/test_cli_script_bootstrap.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _run_python_inline(code: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_generate_recurring_transactions_script_imports_app_from_repo_root() -> None:
+    result = _run_python_inline(
+        "import runpy; "
+        "runpy.run_path("
+        "'scripts/generate_recurring_transactions.py', "
+        "run_name='not_main'"
+        ")"
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_manage_audit_events_script_imports_app_from_repo_root() -> None:
+    result = _run_python_inline(
+        "import runpy; "
+        "runpy.run_path("
+        "'scripts/manage_audit_events.py', "
+        "run_name='not_main'"
+        ")"
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- bootstrap operational scripts from the repository root before importing `app`
- apply the same import-path guard to both recurrence and audit-event operational scripts
- add a regression test that executes those scripts from the repo root under the repo Python runtime

## Validation
- `scripts/python_tool.sh ruff check scripts/generate_recurring_transactions.py scripts/manage_audit_events.py tests/scripts/test_cli_script_bootstrap.py`
- `scripts/python_tool.sh pytest tests/scripts/test_cli_script_bootstrap.py tests/test_recurrence_service.py tests/test_audit_event_service.py -q`
- `git diff --check`

Fixes #701
Related to #663