### PR TITLE
feat(j2): add bank import preview service

### DIFF
--- a/app/services/bank_import_service.py
+++ b/app/services/bank_import_service.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Iterable
+from uuid import UUID
+
+from app.extensions.database import db
+from app.models.transaction import Transaction
+from app.services.bank_statement_parsers import ParsedEntry, parse_nubank_csv, parse_ofx
+
+_BANK_ALIASES = {
+    "banco do brasil": "bb",
+    "bb": "bb",
+    "bradesco": "bradesco",
+    "caixa": "caixa",
+    "caixa economica federal": "caixa",
+    "itau": "itau",
+    "itaú": "itau",
+    "nubank": "nubank",
+}
+
+
+@dataclass(frozen=True)
+class BankImportPreviewEntry:
+    external_id: str
+    date: str
+    description: str
+    amount: Decimal
+    transaction_type: str
+    bank_name: str
+    is_duplicate: bool
+    duplicate_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class BankImportPreview:
+    bank_name: str
+    entries: list[BankImportPreviewEntry]
+    total_entries: int
+    duplicate_entries: int
+    new_entries: int
+
+
+class BankImportService:
+    def __init__(self, user_id: UUID | str) -> None:
+        self.user_id = UUID(user_id) if isinstance(user_id, str) else user_id
+
+    def build_preview(self, *, content: str, bank_name: str) -> BankImportPreview:
+        normalized_bank = _normalize_bank_name(bank_name)
+        if not content.strip():
+            raise ValueError("Bank statement content cannot be empty")
+
+        parsed_entries = _parse_entries(content=content, bank_name=normalized_bank)
+        existing_external_ids = self._load_existing_external_ids(parsed_entries)
+
+        preview_entries: list[BankImportPreviewEntry] = []
+        duplicate_entries = 0
+        seen_external_ids: set[str] = set()
+
+        for entry in parsed_entries:
+            duplicate_reason: str | None = None
+            if entry.external_id in existing_external_ids:
+                duplicate_reason = "existing_transaction"
+            elif entry.external_id in seen_external_ids:
+                duplicate_reason = "duplicate_in_file"
+
+            if duplicate_reason is None:
+                seen_external_ids.add(entry.external_id)
+            else:
+                duplicate_entries += 1
+
+            preview_entries.append(
+                BankImportPreviewEntry(
+                    external_id=entry.external_id,
+                    date=entry.date.isoformat(),
+                    description=entry.description,
+                    amount=entry.amount,
+                    transaction_type=entry.transaction_type,
+                    bank_name=entry.bank_name,
+                    is_duplicate=duplicate_reason is not None,
+                    duplicate_reason=duplicate_reason,
+                )
+            )
+
+        return BankImportPreview(
+            bank_name=normalized_bank,
+            entries=preview_entries,
+            total_entries=len(preview_entries),
+            duplicate_entries=duplicate_entries,
+            new_entries=len(preview_entries) - duplicate_entries,
+        )
+
+    def _load_existing_external_ids(
+        self,
+        parsed_entries: Iterable[ParsedEntry],
+    ) -> set[str]:
+        external_ids = sorted({entry.external_id for entry in parsed_entries})
+        if not external_ids:
+            return set()
+
+        rows = (
+            db.session.query(Transaction.external_id)
+            .filter(Transaction.user_id == self.user_id)
+            .filter(Transaction.deleted.is_(False))
+            .filter(Transaction.external_id.in_(external_ids))
+            .all()
+        )
+        return {
+            external_id
+            for (external_id,) in rows
+            if external_id is not None and external_id.strip()
+        }
+
+
+def _normalize_bank_name(bank_name: str) -> str:
+    normalized = " ".join(bank_name.strip().lower().split())
+    if not normalized:
+        raise ValueError("Bank name is required")
+
+    canonical = _BANK_ALIASES.get(normalized)
+    if canonical is None:
+        raise ValueError(f"Unsupported bank: {bank_name!r}")
+    return canonical
+
+
+def _parse_entries(*, content: str, bank_name: str) -> list[ParsedEntry]:
+    if bank_name == "nubank":
+        return parse_nubank_csv(content)
+    return parse_ofx(content, bank_name)
+
+
+__all__ = [
+    "BankImportPreview",
+    "BankImportPreviewEntry",
+    "BankImportService",
+]

--- a/tests/test_bank_import_service.py
+++ b/tests/test_bank_import_service.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import uuid
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from app.extensions.database import db
+from app.models.transaction import Transaction, TransactionStatus, TransactionType
+from app.models.user import User
+from app.services.bank_import_service import BankImportService
+
+OFX_1_SAMPLE = """
+OFXHEADER:100
+DATA:OFXSGML
+VERSION:102
+SECURITY:NONE
+ENCODING:USASCII
+CHARSET:1252
+COMPRESSION:NONE
+OLDFILEUID:NONE
+NEWFILEUID:NONE
+
+<OFX>
+  <BANKMSGSRSV1>
+    <STMTTRNRS>
+      <STMTRS>
+        <BANKTRANLIST>
+          <STMTTRN>
+            <TRNTYPE>DEBIT
+            <DTPOSTED>20260315000000[-3:BRT]
+            <TRNAMT>-150.45
+            <FITID>OFX-001
+            <MEMO>Padaria Centro
+          </STMTTRN>
+          <STMTTRN>
+            <TRNTYPE>CREDIT
+            <DTPOSTED>20260316000000[-3:BRT]
+            <TRNAMT>2500.00
+            <FITID>OFX-002
+            <NAME>Recebimento Cliente
+          </STMTTRN>
+        </BANKTRANLIST>
+      </STMTRS>
+    </STMTTRNRS>
+  </BANKMSGSRSV1>
+</OFX>
+""".strip()
+
+NUBANK_CSV_WITH_DUPLICATE = """date,title,amount
+2026-03-14,Supermercado,-123.45
+2026-03-14,Supermercado,-123.45
+""".strip()
+
+
+def _create_user() -> User:
+    suffix = uuid.uuid4().hex[:8]
+    user = User(
+        id=uuid.uuid4(),
+        name=f"user-{suffix}",
+        email=f"{suffix}@example.com",
+        password="hash",
+    )
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+def _create_existing_transaction(*, user_id, external_id: str) -> Transaction:
+    transaction = Transaction(
+        user_id=user_id,
+        title="Compra antiga",
+        description="Transacao importada antes",
+        amount=Decimal("150.45"),
+        status=TransactionStatus.PAID,
+        type=TransactionType.EXPENSE,
+        due_date=date(2026, 3, 15),
+        source="bank_import",
+        external_id=external_id,
+        bank_name="itau",
+    )
+    db.session.add(transaction)
+    db.session.commit()
+    return transaction
+
+
+def test_build_preview_flags_existing_duplicates(app) -> None:
+    with app.app_context():
+        user = _create_user()
+        _create_existing_transaction(user_id=user.id, external_id="OFX-001")
+
+        service = BankImportService(user.id)
+        result = service.build_preview(content=OFX_1_SAMPLE, bank_name="itau")
+
+        assert result.bank_name == "itau"
+        assert result.total_entries == 2
+        assert result.duplicate_entries == 1
+        assert result.new_entries == 1
+        assert result.entries[0].external_id == "OFX-001"
+        assert result.entries[0].is_duplicate is True
+        assert result.entries[0].duplicate_reason == "existing_transaction"
+        assert result.entries[1].external_id == "OFX-002"
+        assert result.entries[1].is_duplicate is False
+
+
+def test_build_preview_normalizes_bank_aliases(app) -> None:
+    ofx_2_sample = """<?xml version="1.0" encoding="UTF-8"?>
+<OFX>
+  <BANKMSGSRSV1>
+    <STMTTRNRS>
+      <STMTRS>
+        <BANKTRANLIST>
+          <STMTTRN>
+            <TRNTYPE>DEBIT</TRNTYPE>
+            <DTPOSTED>20260317000000</DTPOSTED>
+            <TRNAMT>-89.90</TRNAMT>
+            <FITID>BB-001</FITID>
+            <MEMO>Mercado Bairro</MEMO>
+          </STMTTRN>
+        </BANKTRANLIST>
+      </STMTRS>
+    </STMTTRNRS>
+  </BANKMSGSRSV1>
+</OFX>
+""".strip()
+
+    with app.app_context():
+        user = _create_user()
+        service = BankImportService(str(user.id))
+        result = service.build_preview(
+            content=ofx_2_sample,
+            bank_name="Banco do Brasil",
+        )
+
+        assert result.bank_name == "bb"
+        assert result.entries[0].bank_name == "bb"
+        assert result.entries[0].description == "Mercado Bairro"
+
+
+def test_build_preview_marks_duplicates_inside_same_file(app) -> None:
+    with app.app_context():
+        user = _create_user()
+        service = BankImportService(user.id)
+        result = service.build_preview(
+            content=NUBANK_CSV_WITH_DUPLICATE,
+            bank_name="nubank",
+        )
+
+        assert result.total_entries == 2
+        assert result.duplicate_entries == 1
+        assert result.new_entries == 1
+        assert result.entries[0].is_duplicate is False
+        assert result.entries[1].is_duplicate is True
+        assert result.entries[1].duplicate_reason == "duplicate_in_file"
+
+
+def test_build_preview_rejects_unsupported_bank(app) -> None:
+    with app.app_context():
+        user = _create_user()
+        service = BankImportService(user.id)
+
+        with pytest.raises(ValueError, match="Unsupported bank"):
+            service.build_preview(content=OFX_1_SAMPLE, bank_name="inter")
+
+
+def test_build_preview_rejects_empty_content(app) -> None:
+    with app.app_context():
+        user = _create_user()
+        service = BankImportService(user.id)
+
+        with pytest.raises(ValueError, match="cannot be empty"):
+            service.build_preview(content="  \n ", bank_name="nubank")


### PR DESCRIPTION
## Summary
- add `BankImportService` to dispatch bank-specific parsers and build a stateless preview contract
- normalize bank aliases and flag duplicates against existing transactions or repeated rows in the same file
- cover OFX and Nubank preview flows with focused unit tests

## Notes
- stacked on top of #717 (`J2.2` + `J2.3`)
- does not persist transactions yet
- does not expose endpoints yet

## Validation
- `VENV_DIR=/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-api/.venv scripts/python_tool.sh pytest tests/test_bank_import_service.py tests/test_bank_statement_parsers.py -q`
- `VENV_DIR=/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-api/.venv scripts/python_tool.sh mypy app`
- `VENV_DIR=/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-api/.venv scripts/repo_bin.sh pre-commit run --files app/services/bank_import_service.py tests/test_bank_import_service.py`
- `git diff --check`
