### PR TITLE
chore(api): govern security exception allowlists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,13 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt -r requirements-dev.txt
 
+      - name: Security exception governance
+        run: python3 scripts/security_exception_governance.py check
+
       - name: Dependency vulnerability scan
-        run: python -m pip_audit -r requirements.txt --ignore-vuln GHSA-5239-wwwm-4pmq
+        run: |
+          python -m pip_audit -r requirements.txt \
+            $(python3 scripts/security_exception_governance.py pip-audit-args)
 
       - name: Ruff format (check)
         run: python -m ruff format --check .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
     stages: [pre-push]
   - id: pip-audit
     name: pip-audit (dependencies)
-    entry: scripts/python_tool.sh pip_audit -r requirements.txt --ignore-vuln GHSA-5239-wwwm-4pmq
+    entry: bash -lc 'python3 scripts/security_exception_governance.py check && scripts/python_tool.sh pip_audit -r requirements.txt $(python3 scripts/security_exception_governance.py pip-audit-args)'
     language: system
     pass_filenames: false
     stages: [pre-push]

--- a/config/security_exception_allowlist.json
+++ b/config/security_exception_allowlist.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "exceptions": [
+    {
+      "id": "GHSA-5239-wwwm-4pmq",
+      "tools": ["pip-audit", "osv-scanner"],
+      "owner": "platform-security",
+      "reviewed_at": "2026-03-27",
+      "justification": "No upstream fix is published yet for this advisory, so the exception remains explicit and time-bounded while preserving scanner visibility."
+    }
+  ]
+}

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -66,6 +66,11 @@ Jobs relevantes:
 - usa a base `OSV.dev` como complemento ao `pip-audit` e ao `dependency-review`
 - publica `reports/security/osv-results.json` como artifact
 
+Governanca de excecoes de seguranca:
+- excecoes canonicas vivem em `config/security_exception_allowlist.json`
+- `pip-audit` e `OSV-Scanner` consomem a mesma fonte de verdade
+- `scripts/security_exception_governance.py check` roda antes dos scans para evitar drift, ignores sem justificativa e allowlists nao rastreaveis
+
 12. `security-evidence`
 - executa `scripts/security_evidence_check.sh`
 
@@ -188,6 +193,10 @@ Hooks:
 - `mypy`
 - `sonar-local-check` (opt-in local; `enforce` em CI ou com override)
 - pre-push: `security-evidence`, `pip-audit`
+
+Governanca de excecoes:
+- hooks locais usam a mesma allowlist canonica do CI
+- excecao nova so entra pelo inventario versionado com `owner`, `reviewed_at` e `justification`
 
 Política do `sonar-local-check`:
 - Local (default): `AURAXIS_ENABLE_LOCAL_SONAR=false` (skip não bloqueante para evitar latência alta no fluxo diário).

--- a/scripts/run_ci_like_actions_local.sh
+++ b/scripts/run_ci_like_actions_local.sh
@@ -123,8 +123,11 @@ run_core_pipeline() {
   echo "[ci-like-local] step=flags:hygiene"
   "${PYTHON_BIN}" scripts/check_feature_flags.py
 
+  echo "[ci-like-local] step=security:exception-governance"
+  python3 scripts/security_exception_governance.py check
+
   echo "[ci-like-local] step=quality:pip-audit"
-  "${PYTHON_BIN}" -m pip_audit -r requirements.txt --ignore-vuln GHSA-5239-wwwm-4pmq
+  "${PYTHON_BIN}" -m pip_audit -r requirements.txt $(python3 scripts/security_exception_governance.py pip-audit-args)
 
   echo "[ci-like-local] step=quality:ruff-format"
   "${PYTHON_BIN}" -m ruff format --check .

--- a/scripts/run_ci_quality_local.sh
+++ b/scripts/run_ci_quality_local.sh
@@ -24,7 +24,8 @@ if [[ "$MODE" == "docker" ]]; then
     python:3.13-slim \
     bash -lc "python -m pip install --upgrade pip && \
       python -m pip install -r requirements.txt -r requirements-dev.txt && \
-      python -m pip_audit -r requirements.txt --ignore-vuln GHSA-5239-wwwm-4pmq && \
+      python3 scripts/security_exception_governance.py check && \
+      python -m pip_audit -r requirements.txt \$(python3 scripts/security_exception_governance.py pip-audit-args) && \
       python -m ruff format --check . && \
       python -m ruff check app tests config run.py run_without_db.py && \
       python -m mypy --no-incremental app && \
@@ -36,7 +37,8 @@ fi
 PYTHON_BIN="$(resolve_repo_python "$ROOT_DIR")"
 
 echo "[quality-local] Running CI quality pipeline in local environment with ${PYTHON_BIN}..."
-"${PYTHON_BIN}" -m pip_audit -r requirements.txt --ignore-vuln GHSA-5239-wwwm-4pmq
+python3 scripts/security_exception_governance.py check
+"${PYTHON_BIN}" -m pip_audit -r requirements.txt $(python3 scripts/security_exception_governance.py pip-audit-args)
 "${PYTHON_BIN}" -m ruff format --check .
 "${PYTHON_BIN}" -m ruff check app tests config run.py run_without_db.py
 "${PYTHON_BIN}" -m mypy --no-incremental app

--- a/scripts/run_osv_scanner.sh
+++ b/scripts/run_osv_scanner.sh
@@ -6,7 +6,10 @@ REPORT_DIR="${ROOT_DIR}/reports/security"
 REPORT_FILE="${REPORT_DIR}/osv-results.json"
 OSV_SCANNER_VERSION="${OSV_SCANNER_VERSION:-2.3.3}"
 OSV_INCLUDE_NODE_LOCKFILE="${OSV_INCLUDE_NODE_LOCKFILE:-false}"
-OSV_ALLOWLIST_VULNS="${OSV_ALLOWLIST_VULNS:-GHSA-5239-wwwm-4pmq}"
+DEFAULT_OSV_ALLOWLIST_VULNS="$(
+  python3 "${ROOT_DIR}/scripts/security_exception_governance.py" osv-allowlist
+)"
+OSV_ALLOWLIST_VULNS="${OSV_ALLOWLIST_VULNS:-${DEFAULT_OSV_ALLOWLIST_VULNS}}"
 
 mkdir -p "${REPORT_DIR}"
 
@@ -152,6 +155,7 @@ PY
 
 main() {
   local scanner_path scan_exit scan_stderr
+  python3 "${ROOT_DIR}/scripts/security_exception_governance.py" check
   mapfile -t scan_args < <(build_scan_args)
   scanner_path="$(ensure_osv_scanner)"
   scan_stderr="$(mktemp)"

--- a/scripts/security_evidence_check.sh
+++ b/scripts/security_evidence_check.sh
@@ -91,8 +91,10 @@ check_contains "app/controllers/auth/dependencies.py" "generate_password_hash" "
 } >>"${REPORT_FILE}"
 
 check_exists ".gitleaks.toml" "Gitleaks config is versioned in repository"
+check_exists "config/security_exception_allowlist.json" "Canonical security exception allowlist is versioned"
 check_contains ".github/workflows/ci.yml" "name: Dependency Security \(OSV-Scanner\)" "OSV-Scanner dependency scan job configured"
 check_contains ".github/workflows/ci.yml" "bash scripts/run_osv_scanner\.sh" "OSV-Scanner is executed through the canonical script"
+check_contains ".github/workflows/ci.yml" "security_exception_governance\.py check" "CI validates security exception governance before dependency scanning"
 check_contains ".github/workflows/ci.yml" "name: Container Security \(Trivy\)" "Trivy container/filesystem scan job configured"
 
 if command -v rg >/dev/null 2>&1; then

--- a/scripts/security_exception_governance.py
+++ b/scripts/security_exception_governance.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Canonical governance for security exceptions used in local and CI checks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+DEFAULT_CONFIG_PATH = ROOT_DIR / "config" / "security_exception_allowlist.json"
+SUPPORTED_TOOLS = frozenset({"pip-audit", "osv-scanner"})
+
+
+class SecurityExceptionGovernanceError(Exception):
+    """Raised when the canonical exception inventory is invalid."""
+
+
+@dataclass(frozen=True)
+class SecurityException:
+    id: str
+    tools: tuple[str, ...]
+    owner: str
+    reviewed_at: str
+    justification: str
+
+
+def _load_raw_config(path: Path) -> dict[str, Any]:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise SecurityExceptionGovernanceError(
+            f"Missing security exception config: {path}"
+        ) from exc
+    except json.JSONDecodeError as exc:
+        raise SecurityExceptionGovernanceError(
+            f"Invalid JSON in security exception config: {path}"
+        ) from exc
+
+    if not isinstance(raw, dict):
+        raise SecurityExceptionGovernanceError(
+            "Security exception config must be a JSON object"
+        )
+    return raw
+
+
+def _require_string(
+    item: dict[str, Any],
+    *,
+    field_name: str,
+    exception_id: str,
+) -> str:
+    value = str(item.get(field_name) or "").strip()
+    if not value:
+        raise SecurityExceptionGovernanceError(
+            f"Exception {exception_id} must define {field_name}"
+        )
+    return value
+
+
+def _parse_tools(item: dict[str, Any], *, exception_id: str) -> tuple[str, ...]:
+    tools_raw = item.get("tools")
+    if not isinstance(tools_raw, list) or not tools_raw:
+        raise SecurityExceptionGovernanceError(
+            f"Exception {exception_id} must define a non-empty tools list"
+        )
+    tools = tuple(str(tool).strip() for tool in tools_raw if str(tool).strip())
+    if not tools:
+        raise SecurityExceptionGovernanceError(
+            f"Exception {exception_id} must define at least one valid tool"
+        )
+    unknown_tools = sorted(set(tools) - SUPPORTED_TOOLS)
+    if unknown_tools:
+        unknown_label = ", ".join(unknown_tools)
+        raise SecurityExceptionGovernanceError(
+            f"Exception {exception_id} uses unsupported tools: {unknown_label}"
+        )
+    return tools
+
+
+def _parse_exception_item(
+    item: dict[str, Any],
+    *,
+    index: int,
+    seen_ids: set[str],
+) -> SecurityException:
+    exception_id = str(item.get("id") or "").strip()
+    if not exception_id:
+        raise SecurityExceptionGovernanceError(
+            f"Exception entry #{index} must define a non-empty id"
+        )
+    if exception_id in seen_ids:
+        raise SecurityExceptionGovernanceError(
+            f"Duplicate security exception id: {exception_id}"
+        )
+    seen_ids.add(exception_id)
+
+    tools = _parse_tools(item, exception_id=exception_id)
+    owner = _require_string(item, field_name="owner", exception_id=exception_id)
+    reviewed_at = _require_string(
+        item,
+        field_name="reviewed_at",
+        exception_id=exception_id,
+    )
+    try:
+        date.fromisoformat(reviewed_at)
+    except ValueError as exc:
+        raise SecurityExceptionGovernanceError(
+            f"Exception {exception_id} has invalid reviewed_at: {reviewed_at}"
+        ) from exc
+
+    justification = _require_string(
+        item,
+        field_name="justification",
+        exception_id=exception_id,
+    )
+    return SecurityException(
+        id=exception_id,
+        tools=tools,
+        owner=owner,
+        reviewed_at=reviewed_at,
+        justification=justification,
+    )
+
+
+def load_security_exceptions(
+    path: Path = DEFAULT_CONFIG_PATH,
+) -> list[SecurityException]:
+    raw = _load_raw_config(path)
+    exceptions_raw = raw.get("exceptions")
+    if not isinstance(exceptions_raw, list):
+        raise SecurityExceptionGovernanceError(
+            "Security exception config must define an 'exceptions' list"
+        )
+
+    seen_ids: set[str] = set()
+    exceptions: list[SecurityException] = []
+
+    for index, item in enumerate(exceptions_raw, start=1):
+        if not isinstance(item, dict):
+            raise SecurityExceptionGovernanceError(
+                f"Exception entry #{index} must be an object"
+            )
+        exceptions.append(_parse_exception_item(item, index=index, seen_ids=seen_ids))
+
+    return exceptions
+
+
+def _ids_for_tool(exceptions: list[SecurityException], tool: str) -> list[str]:
+    if tool not in SUPPORTED_TOOLS:
+        raise SecurityExceptionGovernanceError(f"Unsupported tool: {tool}")
+    return sorted(
+        exception.id for exception in exceptions if tool in set(exception.tools)
+    )
+
+
+def build_pip_audit_args(exceptions: list[SecurityException]) -> list[str]:
+    args: list[str] = []
+    for exception_id in _ids_for_tool(exceptions, "pip-audit"):
+        args.extend(["--ignore-vuln", exception_id])
+    return args
+
+
+def build_osv_allowlist(exceptions: list[SecurityException]) -> str:
+    return ",".join(_ids_for_tool(exceptions, "osv-scanner"))
+
+
+def _build_summary(exceptions: list[SecurityException]) -> str:
+    lines = ["# Security Exception Governance", ""]
+    if not exceptions:
+        lines.append("- No active exceptions.")
+        return "\n".join(lines)
+
+    for exception in exceptions:
+        lines.append(
+            f"- `{exception.id}` via {', '.join(exception.tools)} "
+            f"(owner={exception.owner}, reviewed_at={exception.reviewed_at})"
+        )
+    return "\n".join(lines)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Govern canonical security exceptions for CI and local checks."
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=DEFAULT_CONFIG_PATH,
+        help="Path to the canonical security exception allowlist JSON.",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("check", help="Validate the canonical exception inventory.")
+    subparsers.add_parser(
+        "pip-audit-args",
+        help="Emit canonical --ignore-vuln flags for pip-audit.",
+    )
+    subparsers.add_parser(
+        "osv-allowlist",
+        help="Emit the canonical comma-separated allowlist for OSV-Scanner.",
+    )
+    subparsers.add_parser(
+        "summary",
+        help="Print a human-readable summary of active security exceptions.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    exceptions = load_security_exceptions(args.config)
+
+    if args.command == "check":
+        print(
+            f"[security-exception-governance] ok: {len(exceptions)} active exception(s)"
+        )
+        return 0
+    if args.command == "pip-audit-args":
+        print(" ".join(build_pip_audit_args(exceptions)))
+        return 0
+    if args.command == "osv-allowlist":
+        print(build_osv_allowlist(exceptions))
+        return 0
+    if args.command == "summary":
+        print(_build_summary(exceptions))
+        return 0
+
+    raise SecurityExceptionGovernanceError(f"Unsupported command: {args.command}")
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except SecurityExceptionGovernanceError as exc:
+        print(f"[security-exception-governance] {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc

--- a/tests/scripts/test_security_exception_governance.py
+++ b/tests/scripts/test_security_exception_governance.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _load_module():
+    module_path = (
+        Path(__file__).resolve().parents[2]
+        / "scripts"
+        / "security_exception_governance.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "security_exception_governance", module_path
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_load_security_exceptions_requires_metadata(tmp_path: Path) -> None:
+    module = _load_module()
+    config_path = tmp_path / "exceptions.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "exceptions": [
+                    {
+                        "id": "GHSA-example",
+                        "tools": ["pip-audit"],
+                        "owner": "platform-security",
+                        "reviewed_at": "2026-03-27",
+                        "justification": "Awaiting upstream fix.",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    exceptions = module.load_security_exceptions(config_path)
+
+    assert [item.id for item in exceptions] == ["GHSA-example"]
+    assert exceptions[0].tools == ("pip-audit",)
+
+
+def test_build_pip_audit_args_emits_ignore_flags(tmp_path: Path) -> None:
+    module = _load_module()
+    config_path = tmp_path / "exceptions.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "exceptions": [
+                    {
+                        "id": "GHSA-a",
+                        "tools": ["pip-audit", "osv-scanner"],
+                        "owner": "platform-security",
+                        "reviewed_at": "2026-03-27",
+                        "justification": "Awaiting upstream fix.",
+                    },
+                    {
+                        "id": "GHSA-b",
+                        "tools": ["osv-scanner"],
+                        "owner": "platform-security",
+                        "reviewed_at": "2026-03-27",
+                        "justification": "Awaiting upstream fix.",
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    exceptions = module.load_security_exceptions(config_path)
+
+    assert module.build_pip_audit_args(exceptions) == ["--ignore-vuln", "GHSA-a"]
+    assert module.build_osv_allowlist(exceptions) == "GHSA-a,GHSA-b"
+
+
+def test_load_security_exceptions_rejects_duplicate_ids(tmp_path: Path) -> None:
+    module = _load_module()
+    config_path = tmp_path / "exceptions.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "exceptions": [
+                    {
+                        "id": "GHSA-a",
+                        "tools": ["pip-audit"],
+                        "owner": "platform-security",
+                        "reviewed_at": "2026-03-27",
+                        "justification": "Awaiting upstream fix.",
+                    },
+                    {
+                        "id": "GHSA-a",
+                        "tools": ["osv-scanner"],
+                        "owner": "platform-security",
+                        "reviewed_at": "2026-03-27",
+                        "justification": "Awaiting upstream fix.",
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(module.SecurityExceptionGovernanceError):
+        module.load_security_exceptions(config_path)


### PR DESCRIPTION
## Summary
- add a canonical security exception allowlist with owner, review date and justification
- make pip-audit, OSV-Scanner and local CI-like scripts consume that single source of truth
- add a lightweight governance checker plus regression tests and security evidence coverage

## Validation
- scripts/repo_bin.sh pytest --noconftest tests/scripts/test_security_exception_governance.py -q
- scripts/repo_bin.sh pre-commit run --files .pre-commit-config.yaml .github/workflows/ci.yml scripts/run_osv_scanner.sh scripts/run_ci_quality_local.sh scripts/run_ci_like_actions_local.sh scripts/security_evidence_check.sh scripts/security_exception_governance.py config/security_exception_allowlist.json tests/scripts/test_security_exception_governance.py docs/CI_CD.md
- scripts/python_tool.sh mypy app
- bash scripts/security_evidence_check.sh
- scripts/python_tool.sh pip_audit -r requirements.txt $(python3 scripts/security_exception_governance.py pip-audit-args)
- bash scripts/run_osv_scanner.sh

Closes #727