### PR TITLE
test(user): freeze legacy user me contract

### DIFF
--- a/.context/feature_contracts/ARC-08-1.json
+++ b/.context/feature_contracts/ARC-08-1.json
@@ -1,0 +1,113 @@
+{
+  "task_id": "ARC-08-1",
+  "feature": "user_me_legacy_contract_freeze",
+  "rest_endpoint": {
+    "method": "GET",
+    "path": "/user/me",
+    "auth": true,
+    "query_params": {
+      "page": {
+        "type": "integer",
+        "default": 1,
+        "min": 1,
+        "max": 10000
+      },
+      "limit": {
+        "type": "integer",
+        "default": 10,
+        "min": 1,
+        "max": 100
+      },
+      "status": {
+        "type": "string",
+        "enum": ["paid", "pending", "cancelled", "postponed", "overdue"],
+        "required": false
+      },
+      "month": {
+        "type": "string",
+        "format": "YYYY-MM",
+        "required": false
+      }
+    }
+  },
+  "legacy_behavior": {
+    "responsibility": [
+      "user_profile",
+      "paginated_transactions",
+      "full_wallet_list"
+    ],
+    "known_oddities": [
+      "pagination applies only to transactions",
+      "wallet is returned as a full list even when page/limit are present",
+      "monthly_income mirrors monthly_income_net for backward compatibility"
+    ]
+  },
+  "contracts": {
+    "v1": {
+      "top_level_keys": ["user", "transactions", "wallet"]
+    },
+    "v2": {
+      "top_level_keys": ["success", "message", "data", "meta"],
+      "data_keys": ["user", "transactions", "wallet"],
+      "meta_keys": ["pagination"]
+    }
+  },
+  "user_fields": [
+    "id",
+    "name",
+    "email",
+    "gender",
+    "birth_date",
+    "monthly_income",
+    "monthly_income_net",
+    "net_worth",
+    "monthly_expenses",
+    "initial_investment",
+    "monthly_investment",
+    "investment_goal_date",
+    "state_uf",
+    "occupation",
+    "investor_profile",
+    "financial_objectives",
+    "investor_profile_suggested",
+    "profile_quiz_score",
+    "taxonomy_version"
+  ],
+  "transaction_item_fields": [
+    "id",
+    "title",
+    "amount",
+    "type",
+    "due_date",
+    "status",
+    "description",
+    "observation",
+    "is_recurring",
+    "is_installment",
+    "installment_count",
+    "tag_id",
+    "account_id",
+    "credit_card_id",
+    "currency",
+    "created_at",
+    "updated_at"
+  ],
+  "wallet_item_fields": [
+    "id",
+    "name",
+    "value",
+    "estimated_value_on_create_date",
+    "ticker",
+    "quantity",
+    "asset_class",
+    "annual_rate",
+    "target_withdraw_date",
+    "register_date",
+    "should_be_on_wallet"
+  ],
+  "graphql_baseline": {
+    "query": "me",
+    "responsibility": "authenticated_user_context_only",
+    "does_not_include": ["transactions", "wallet"]
+  }
+}

--- a/.context/feature_contracts/ARC-08-1.md
+++ b/.context/feature_contracts/ARC-08-1.md
@@ -1,0 +1,121 @@
+# Feature Contract Pack — ARC-08-1
+
+## Feature
+
+- Congelamento do contrato legado atual de `GET /user/me`
+
+## Objetivo
+
+- preservar um baseline explícito do payload atual antes do refactor estrutural de `/user/me`
+- dar previsibilidade para `web` e `app` durante a transição
+- registrar as estranhezas legadas que serão removidas no refactor posterior
+
+## REST atual
+
+- endpoint: `GET /user/me`
+- autenticação: obrigatória
+- query params legados:
+  - `page`
+  - `limit`
+  - `status`
+  - `month`
+
+## Shape legado v1
+
+Top-level:
+- `user`
+- `transactions`
+- `wallet`
+
+## Shape legado v2
+
+Top-level:
+- `success`
+- `message`
+- `data`
+- `meta`
+
+`data`:
+- `user`
+- `transactions`
+- `wallet`
+
+`meta`:
+- `pagination`
+
+## User fields congelados
+
+- `id`
+- `name`
+- `email`
+- `gender`
+- `birth_date`
+- `monthly_income`
+- `monthly_income_net`
+- `net_worth`
+- `monthly_expenses`
+- `initial_investment`
+- `monthly_investment`
+- `investment_goal_date`
+- `state_uf`
+- `occupation`
+- `investor_profile`
+- `financial_objectives`
+- `investor_profile_suggested`
+- `profile_quiz_score`
+- `taxonomy_version`
+
+## Transaction item fields congelados
+
+- `id`
+- `title`
+- `amount`
+- `type`
+- `due_date`
+- `status`
+- `description`
+- `observation`
+- `is_recurring`
+- `is_installment`
+- `installment_count`
+- `tag_id`
+- `account_id`
+- `credit_card_id`
+- `currency`
+- `created_at`
+- `updated_at`
+
+## Wallet item fields congelados
+
+- `id`
+- `name`
+- `value`
+- `estimated_value_on_create_date`
+- `ticker`
+- `quantity`
+- `asset_class`
+- `annual_rate`
+- `target_withdraw_date`
+- `register_date`
+- `should_be_on_wallet`
+
+## Legacy oddities explicitadas
+
+1. `page` e `limit` afetam apenas `transactions`
+2. `wallet` continua vindo como lista completa
+3. `monthly_income` espelha `monthly_income_net` por compatibilidade
+
+## Baseline GraphQL
+
+`me` em GraphQL continua representando apenas contexto autenticado do usuário.
+
+Não faz parte do baseline GraphQL:
+- `transactions`
+- `wallet`
+
+## Uso operacional deste pack
+
+Este pack existe para:
+- proteger os frontends durante o refactor;
+- diferenciar legado congelado de contrato canônico futuro;
+- permitir que o próximo slice mude arquitetura sem ambiguidade semântica.

--- a/tests/test_graphql_api.py
+++ b/tests/test_graphql_api.py
@@ -7,6 +7,7 @@ from app.application.services.password_reset_service import (
     PASSWORD_RESET_NEUTRAL_MESSAGE,
     PASSWORD_RESET_SUCCESS_MESSAGE,
 )
+from app.graphql.types import UserType
 
 
 def _graphql(
@@ -90,6 +91,20 @@ def test_graphql_register_login_and_me(client) -> None:
     body = response.get_json()
     assert "errors" not in body
     assert body["data"]["me"]["email"] == "graphql-user@email.com"
+
+
+def test_graphql_me_remains_user_context_only(client) -> None:
+    token = _register_and_login_graphql(client)
+
+    response = _graphql(
+        client, "query Me { me { id name email monthlyIncome } }", token=token
+    )
+    assert response.status_code == 200
+    body = response.get_json()
+    assert "errors" not in body
+    assert body["data"]["me"]["email"] == "graphql-user@email.com"
+    assert "wallet" not in UserType._meta.fields
+    assert "transactions" not in UserType._meta.fields
 
 
 def test_graphql_forgot_password_is_neutral(client) -> None:

--- a/tests/test_user_contract.py
+++ b/tests/test_user_contract.py
@@ -1,6 +1,12 @@
 import uuid
 from datetime import date, timedelta
+from decimal import Decimal
 from typing import Dict
+
+from app.extensions.database import db
+from app.models.transaction import Transaction, TransactionStatus, TransactionType
+from app.models.user import User
+from app.models.wallet import Wallet
 
 
 def _register_and_login(client) -> str:
@@ -31,6 +37,120 @@ def _auth_headers(token: str, contract: str | None = None) -> Dict[str, str]:
     if contract:
         headers["X-API-Contract"] = contract
     return headers
+
+
+USER_FIELDS = {
+    "id",
+    "name",
+    "email",
+    "gender",
+    "birth_date",
+    "monthly_income",
+    "monthly_income_net",
+    "net_worth",
+    "monthly_expenses",
+    "initial_investment",
+    "monthly_investment",
+    "investment_goal_date",
+    "state_uf",
+    "occupation",
+    "investor_profile",
+    "financial_objectives",
+    "investor_profile_suggested",
+    "profile_quiz_score",
+    "taxonomy_version",
+}
+
+TRANSACTION_ITEM_FIELDS = {
+    "id",
+    "title",
+    "amount",
+    "type",
+    "due_date",
+    "status",
+    "description",
+    "observation",
+    "is_recurring",
+    "is_installment",
+    "installment_count",
+    "tag_id",
+    "account_id",
+    "credit_card_id",
+    "currency",
+    "created_at",
+    "updated_at",
+}
+
+WALLET_ITEM_FIELDS = {
+    "id",
+    "name",
+    "value",
+    "estimated_value_on_create_date",
+    "ticker",
+    "quantity",
+    "asset_class",
+    "annual_rate",
+    "target_withdraw_date",
+    "register_date",
+    "should_be_on_wallet",
+}
+
+
+def _seed_me_contract_entities(client, app) -> str:
+    token = _register_and_login(client)
+    auth_context = client.get(
+        "/user/me",
+        headers=_auth_headers(token),
+    )
+    assert auth_context.status_code == 200
+    email = auth_context.get_json()["user"]["email"]
+
+    with app.app_context():
+        user = User.query.filter_by(email=email).first()
+        assert user is not None
+
+        transaction_one = Transaction(
+            user_id=user.id,
+            title="Receita recorrente",
+            amount=Decimal("100.00"),
+            type=TransactionType.INCOME,
+            due_date=date.today(),
+            status=TransactionStatus.PAID,
+            currency="BRL",
+            deleted=False,
+        )
+        transaction_two = Transaction(
+            user_id=user.id,
+            title="Despesa mensal",
+            amount=Decimal("45.50"),
+            type=TransactionType.EXPENSE,
+            due_date=date.today() + timedelta(days=1),
+            status=TransactionStatus.PENDING,
+            currency="BRL",
+            deleted=False,
+        )
+        wallet_one = Wallet(
+            user_id=user.id,
+            name="Caixa",
+            value=Decimal("1000.00"),
+            estimated_value_on_create_date=Decimal("1000.00"),
+            quantity=1,
+            should_be_on_wallet=True,
+            register_date=date.today(),
+        )
+        wallet_two = Wallet(
+            user_id=user.id,
+            name="Reserva",
+            value=Decimal("2000.00"),
+            estimated_value_on_create_date=Decimal("2000.00"),
+            quantity=1,
+            should_be_on_wallet=True,
+            register_date=date.today(),
+        )
+        db.session.add_all([transaction_one, transaction_two, wallet_one, wallet_two])
+        db.session.commit()
+
+    return token
 
 
 def test_user_profile_v1_legacy_contract(client) -> None:
@@ -109,6 +229,42 @@ def test_user_me_v2_contract_has_meta_pagination(client) -> None:
     assert "transactions" in body["data"]
     assert "wallet" in body["data"]
     assert "pagination" in body["meta"]
+
+
+def test_user_me_v2_contract_freezes_current_field_sets(client, app) -> None:
+    token = _seed_me_contract_entities(client, app)
+
+    response = client.get(
+        "/user/me?page=1&limit=10",
+        headers=_auth_headers(token, "v2"),
+    )
+
+    assert response.status_code == 200
+    body = response.get_json()
+
+    assert set(body["data"]["user"].keys()) == USER_FIELDS
+    assert body["data"]["transactions"]["items"]
+    assert body["data"]["wallet"]
+    assert (
+        set(body["data"]["transactions"]["items"][0].keys()) == TRANSACTION_ITEM_FIELDS
+    )
+    assert set(body["data"]["wallet"][0].keys()) == WALLET_ITEM_FIELDS
+
+
+def test_user_me_legacy_pagination_only_applies_to_transactions(client, app) -> None:
+    token = _seed_me_contract_entities(client, app)
+
+    response = client.get(
+        "/user/me?page=1&limit=1",
+        headers=_auth_headers(token, "v2"),
+    )
+
+    assert response.status_code == 200
+    body = response.get_json()
+
+    assert len(body["data"]["transactions"]["items"]) == 1
+    assert body["data"]["transactions"]["total"] >= 2
+    assert len(body["data"]["wallet"]) == 2
 
 
 def test_user_me_invalid_status_v2_contract(client) -> None:


### PR DESCRIPTION
## Summary
- freeze the current REST /user/me contract with explicit regression coverage
- document the legacy contract pack for ARC-08.1 before structural refactor
- assert GraphQL me remains authenticated-user-context only

## Validation
- VENV_DIR=/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-api/.venv scripts/repo_bin.sh pytest tests/test_user_contract.py tests/test_graphql_api.py tests/test_auth_contract.py -q
- VENV_DIR=/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-api/.venv scripts/repo_bin.sh mypy app
- scripts/repo_bin.sh pre-commit run --files tests/test_user_contract.py tests/test_graphql_api.py .context/feature_contracts/ARC-08-1.json .context/feature_contracts/ARC-08-1.md
- git diff --check

## Linked issue
- closes #729