### PR TITLE
feat(user): publish canonical me contract

### DIFF
--- a/.context/feature_contracts/ARC-08-3.json
+++ b/.context/feature_contracts/ARC-08-3.json
@@ -1,0 +1,75 @@
+{
+  "task_id": "ARC-08-3",
+  "feature": "user_me_canonical_contract",
+  "rest_endpoint": {
+    "method": "GET",
+    "path": "/user/me",
+    "auth": true,
+    "contract_header": {
+      "name": "X-API-Contract",
+      "legacy_versions": ["v1", "v2"],
+      "canonical_version": "v3"
+    }
+  },
+  "v3_behavior": {
+    "responsibility": [
+      "authenticated_user_identity",
+      "authenticated_user_profile",
+      "authenticated_user_financial_profile",
+      "authenticated_user_investor_profile",
+      "authenticated_user_product_context"
+    ],
+    "does_not_include": ["transactions", "wallet", "pagination", "filters"],
+    "rejects_query_params": ["page", "limit", "status", "month"],
+    "canonical_income_field": "monthly_income_net"
+  },
+  "contracts": {
+    "v1": {
+      "top_level_keys": ["user", "transactions", "wallet"]
+    },
+    "v2": {
+      "top_level_keys": ["success", "message", "data", "meta"],
+      "data_keys": ["user", "transactions", "wallet"],
+      "meta_keys": ["pagination"]
+    },
+    "v3": {
+      "top_level_keys": ["success", "message", "data"],
+      "data_keys": ["user"],
+      "user_keys": [
+        "identity",
+        "profile",
+        "financial_profile",
+        "investor_profile",
+        "product_context"
+      ]
+    }
+  },
+  "v3_payload": {
+    "identity": ["id", "name", "email"],
+    "profile": ["gender", "birth_date", "state_uf", "occupation"],
+    "financial_profile": [
+      "monthly_income_net",
+      "monthly_expenses",
+      "net_worth",
+      "initial_investment",
+      "monthly_investment",
+      "investment_goal_date"
+    ],
+    "investor_profile": [
+      "declared",
+      "suggested",
+      "quiz_score",
+      "taxonomy_version",
+      "financial_objectives"
+    ],
+    "product_context": ["entitlements_version"]
+  },
+  "graphql_alignment": {
+    "query": "me",
+    "status": "aligned_on_shared_core",
+    "notes": [
+      "GraphQL remains authenticated-context-only",
+      "GraphQL does not expose transactions or wallet on me"
+    ]
+  }
+}

--- a/.context/feature_contracts/ARC-08-3.md
+++ b/.context/feature_contracts/ARC-08-3.md
@@ -1,0 +1,108 @@
+# Feature Contract Pack — ARC-08-3
+
+## Feature
+
+- Publicação do contrato canônico de `GET /user/me`
+
+## Objetivo
+
+- fornecer um contrato limpo para os frontends consumirem contexto autenticado
+- remover semântica de coleção do shape canônico
+- preservar `v1` e `v2` durante a migração
+
+## Versionamento
+
+- `v1`: legado sem envelope padronizado
+- `v2`: legado padronizado com `success/message/data/meta`
+- `v3`: contrato canônico
+
+Header:
+
+- `X-API-Contract: v3`
+
+## Shape canônico (`v3`)
+
+Top-level:
+
+- `success`
+- `message`
+- `data`
+
+`data`:
+
+- `user`
+
+`user`:
+
+- `identity`
+- `profile`
+- `financial_profile`
+- `investor_profile`
+- `product_context`
+
+## Identity
+
+- `id`
+- `name`
+- `email`
+
+## Profile
+
+- `gender`
+- `birth_date`
+- `state_uf`
+- `occupation`
+
+## Financial profile
+
+- `monthly_income_net`
+- `monthly_expenses`
+- `net_worth`
+- `initial_investment`
+- `monthly_investment`
+- `investment_goal_date`
+
+Regra canônica:
+
+- `monthly_income_net` é o campo de renda mensal canônico
+- `monthly_income` permanece apenas no legado por compatibilidade
+
+## Investor profile
+
+- `declared`
+- `suggested`
+- `quiz_score`
+- `taxonomy_version`
+- `financial_objectives`
+
+## Product context
+
+- `entitlements_version`
+
+## O que não faz parte do `v3`
+
+- `transactions`
+- `wallet`
+- `pagination`
+- `page`
+- `limit`
+- `status`
+- `month`
+
+## Regra de erro
+
+Se o cliente enviar semântica de coleção em `v3`, a API responde:
+
+- `400`
+- `success = false`
+- `error.code = VALIDATION_ERROR`
+
+## Alinhamento com GraphQL
+
+`me` em GraphQL continua alinhado ao mesmo core autenticado compartilhado.
+
+Não faz parte de `me` em GraphQL:
+
+- `transactions`
+- `wallet`
+

--- a/app/controllers/response_contract.py
+++ b/app/controllers/response_contract.py
@@ -11,7 +11,13 @@ from app.http import (
     runtime_debug_or_testing,
     serialize_error_contract,
 )
-from app.utils.api_contract import CONTRACT_HEADER, CONTRACT_V2, is_v2_contract_request
+from app.utils.api_contract import (
+    CONTRACT_HEADER,
+    CONTRACT_V2,
+    CONTRACT_V3,
+    is_v2_contract_request,
+    is_v3_contract_request,
+)
 from app.utils.response_builder import (
     SENSITIVE_DATA_FIELDS,
     json_response,
@@ -48,6 +54,14 @@ def is_v2_contract() -> bool:
     return is_v2_contract_request()
 
 
+def is_v3_contract() -> bool:
+    return is_v3_contract_request()
+
+
+def is_standard_contract() -> bool:
+    return is_v2_contract() or is_v3_contract()
+
+
 def compat_success_response(
     *,
     legacy_payload: dict[str, Any],
@@ -57,7 +71,7 @@ def compat_success_response(
     meta: dict[str, Any] | None = None,
 ) -> Response:
     payload = legacy_payload
-    if is_v2_contract():
+    if is_standard_contract():
         payload = success_payload(message=message, data=data, meta=meta)
     return json_response(payload, status_code=status_code)
 
@@ -71,7 +85,7 @@ def compat_error_response(
     details: dict[str, Any] | None = None,
 ) -> Response:
     payload = legacy_payload
-    if is_v2_contract():
+    if is_standard_contract():
         return flask_error_response(
             ErrorContract(
                 message=message,
@@ -95,7 +109,7 @@ def compat_success_tuple(
     meta: dict[str, Any] | None = None,
 ) -> tuple[dict[str, Any], int]:
     payload = legacy_payload
-    if is_v2_contract():
+    if is_standard_contract():
         payload = success_payload(message=message, data=data, meta=meta)
     return payload, status_code
 
@@ -109,7 +123,7 @@ def compat_error_tuple(
     details: dict[str, Any] | None = None,
 ) -> tuple[dict[str, Any], int]:
     payload = legacy_payload
-    if is_v2_contract():
+    if is_standard_contract():
         payload = serialize_error_contract(
             ErrorContract(
                 message=message,
@@ -150,8 +164,11 @@ def response_from_contract_error(error: ResponseContractError) -> Response:
 __all__ = [
     "CONTRACT_HEADER",
     "CONTRACT_V2",
+    "CONTRACT_V3",
     "ResponseContractError",
+    "is_standard_contract",
     "is_v2_contract",
+    "is_v3_contract",
     "compat_success_response",
     "compat_error_response",
     "compat_success_tuple",

--- a/app/controllers/user/contracts.py
+++ b/app/controllers/user/contracts.py
@@ -9,6 +9,7 @@ from app.controllers.response_contract import (
     compat_success_response,
     is_v2_contract,
 )
+from app.utils.api_contract import is_v3_contract_request
 
 
 def compat_success(
@@ -47,6 +48,7 @@ def compat_error(
 
 __all__ = [
     "is_v2_contract",
+    "is_v3_contract_request",
     "compat_success",
     "compat_error",
 ]

--- a/app/controllers/user/me_resource.py
+++ b/app/controllers/user/me_resource.py
@@ -10,17 +10,27 @@ from app.application.services.authenticated_user_context_service import (
 )
 from app.auth import get_active_auth_context
 from app.models.transaction import Transaction
+from app.services.authenticated_user_payloads import (
+    to_authenticated_user_canonical_payload,
+)
 from app.utils.pagination import PaginatedResponse
+from app.utils.response_builder import json_response, success_payload
 from app.utils.typed_decorators import typed_doc as doc
 from app.utils.typed_decorators import typed_jwt_required as jwt_required
 
-from .contracts import compat_success
+from .contracts import compat_success, is_v3_contract_request
 from .helpers import (
     _validation_error_response,
     filter_transactions,
     validate_user_token,
 )
 from .presenters import to_user_profile_payload, to_wallet_payload
+
+COLLECTION_QUERY_PARAMS = ("page", "limit", "status", "month")
+
+
+def _has_collection_semantics() -> bool:
+    return any(request.args.get(field) is not None for field in COLLECTION_QUERY_PARAMS)
 
 
 def _parse_positive_int_compat(
@@ -45,7 +55,11 @@ def _parse_positive_int_compat(
 class UserMeResource(MethodResource):
     @doc(
         description=(
-            "Retorna os dados do usuário autenticado e suas transações paginadas.\n\n"
+            "Retorna o contexto do usuário autenticado.\n\n"
+            "Contrato canônico (`X-API-Contract: v3`): retorna apenas identidade, "
+            "perfil, perfil financeiro, perfil investidor e contexto de produto.\n\n"
+            "Contratos legados (`v1`/`v2`): mantêm transações paginadas e carteira.\n\n"
+            "Filtros legados disponíveis apenas em `v1`/`v2`:\n"
             "Filtros disponíveis:\n"
             "- page: número da página\n"
             "- limit: itens por página\n"
@@ -64,7 +78,10 @@ class UserMeResource(MethodResource):
             "month": {"description": "Mês no formato YYYY-MM", "type": "string"},
             "X-API-Contract": {
                 "in": "header",
-                "description": "Opcional. Envie 'v2' para o contrato padronizado.",
+                "description": (
+                    "Opcional. `v2` mantém shape legado padronizado; `v3` "
+                    "publica o contrato canônico sem coleções."
+                ),
                 "type": "string",
                 "required": False,
             },
@@ -81,6 +98,31 @@ class UserMeResource(MethodResource):
         if isinstance(user_or_response, Response):
             return user_or_response
         user = user_or_response
+
+        context_service = AuthenticatedUserContextService.with_defaults()
+        authenticated_user_context = context_service.build_context(user)
+
+        if is_v3_contract_request():
+            if _has_collection_semantics():
+                return _validation_error_response(
+                    exc=ValueError("collection semantics not supported"),
+                    fallback_message=(
+                        "O contrato canônico de '/user/me' não aceita paginação "
+                        "nem filtros de coleção. Use '/transactions' ou o "
+                        "bootstrap dedicado."
+                    ),
+                )
+            return json_response(
+                success_payload(
+                    message="Contexto autenticado retornado com sucesso",
+                    data={
+                        "user": to_authenticated_user_canonical_payload(
+                            authenticated_user_context.profile
+                        )
+                    },
+                ),
+                status_code=200,
+            )
 
         try:
             page = _parse_positive_int_compat(
@@ -137,8 +179,6 @@ class UserMeResource(MethodResource):
             transactions, pagination.total, pagination.page, pagination.per_page
         )
 
-        context_service = AuthenticatedUserContextService.with_defaults()
-        authenticated_user_context = context_service.build_context(user)
         user_data = to_user_profile_payload(authenticated_user_context.profile)
         wallet_data = to_wallet_payload(authenticated_user_context.wallet_entries)
         legacy_payload = {

--- a/app/services/authenticated_user_payloads.py
+++ b/app/services/authenticated_user_payloads.py
@@ -31,6 +31,48 @@ class UserProfilePayload(TypedDict):
     taxonomy_version: str | None
 
 
+class AuthenticatedUserIdentityPayload(TypedDict):
+    id: str
+    name: str
+    email: str
+
+
+class AuthenticatedUserProfileDetailsPayload(TypedDict):
+    gender: str | None
+    birth_date: str | None
+    state_uf: str | None
+    occupation: str | None
+
+
+class AuthenticatedUserFinancialProfilePayload(TypedDict):
+    monthly_income_net: float | None
+    monthly_expenses: float | None
+    net_worth: float | None
+    initial_investment: float | None
+    monthly_investment: float | None
+    investment_goal_date: str | None
+
+
+class AuthenticatedUserInvestorProfilePayload(TypedDict):
+    declared: str | None
+    suggested: str | None
+    quiz_score: int | None
+    taxonomy_version: str | None
+    financial_objectives: str | None
+
+
+class AuthenticatedUserProductContextPayload(TypedDict):
+    entitlements_version: int
+
+
+class AuthenticatedUserCanonicalPayload(TypedDict):
+    identity: AuthenticatedUserIdentityPayload
+    profile: AuthenticatedUserProfileDetailsPayload
+    financial_profile: AuthenticatedUserFinancialProfilePayload
+    investor_profile: AuthenticatedUserInvestorProfilePayload
+    product_context: AuthenticatedUserProductContextPayload
+
+
 class WalletEntryPayload(TypedDict):
     id: str
     name: str
@@ -51,6 +93,42 @@ def to_user_profile_payload(profile: AuthenticatedUserProfile) -> UserProfilePay
     return cast(UserProfilePayload, payload)
 
 
+def to_authenticated_user_canonical_payload(
+    profile: AuthenticatedUserProfile,
+) -> AuthenticatedUserCanonicalPayload:
+    return {
+        "identity": {
+            "id": profile.id,
+            "name": profile.name,
+            "email": profile.email,
+        },
+        "profile": {
+            "gender": profile.gender,
+            "birth_date": profile.birth_date,
+            "state_uf": profile.state_uf,
+            "occupation": profile.occupation,
+        },
+        "financial_profile": {
+            "monthly_income_net": profile.monthly_income_net,
+            "monthly_expenses": profile.monthly_expenses,
+            "net_worth": profile.net_worth,
+            "initial_investment": profile.initial_investment,
+            "monthly_investment": profile.monthly_investment,
+            "investment_goal_date": profile.investment_goal_date,
+        },
+        "investor_profile": {
+            "declared": profile.investor_profile,
+            "suggested": profile.investor_profile_suggested,
+            "quiz_score": profile.profile_quiz_score,
+            "taxonomy_version": profile.taxonomy_version,
+            "financial_objectives": profile.financial_objectives,
+        },
+        "product_context": {
+            "entitlements_version": profile.entitlements_version,
+        },
+    }
+
+
 def to_wallet_entry_payload(
     wallet_entry: AuthenticatedWalletEntry,
 ) -> WalletEntryPayload:
@@ -64,8 +142,15 @@ def to_wallet_payload(
 
 
 __all__ = [
+    "AuthenticatedUserCanonicalPayload",
+    "AuthenticatedUserFinancialProfilePayload",
+    "AuthenticatedUserIdentityPayload",
+    "AuthenticatedUserInvestorProfilePayload",
+    "AuthenticatedUserProductContextPayload",
+    "AuthenticatedUserProfileDetailsPayload",
     "UserProfilePayload",
     "WalletEntryPayload",
+    "to_authenticated_user_canonical_payload",
     "to_user_profile_payload",
     "to_wallet_entry_payload",
     "to_wallet_payload",

--- a/app/utils/api_contract.py
+++ b/app/utils/api_contract.py
@@ -6,6 +6,7 @@ from flask import has_request_context, request
 
 CONTRACT_HEADER = "X-API-Contract"
 CONTRACT_V2 = "v2"
+CONTRACT_V3 = "v3"
 
 
 def is_v2_contract_request() -> bool:
@@ -13,3 +14,10 @@ def is_v2_contract_request() -> bool:
         return False
     header_value = str(request.headers.get(CONTRACT_HEADER, "")).strip().lower()
     return header_value == CONTRACT_V2
+
+
+def is_v3_contract_request() -> bool:
+    if not has_request_context():
+        return False
+    header_value = str(request.headers.get(CONTRACT_HEADER, "")).strip().lower()
+    return header_value == CONTRACT_V3

--- a/tests/test_controller_response_contract.py
+++ b/tests/test_controller_response_contract.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 from app.controllers.response_contract import (
+    CONTRACT_V3,
     ResponseContractError,
     compat_error_response,
     compat_error_tuple,
     compat_success_response,
     compat_success_tuple,
+    is_standard_contract,
     is_v2_contract,
+    is_v3_contract,
     response_from_contract_error,
 )
 
@@ -34,6 +37,8 @@ def test_contract_detection_and_response_compatibility(app) -> None:
 
     with app.test_request_context("/health", headers={"X-API-Contract": "v2"}):
         assert is_v2_contract() is True
+        assert is_v3_contract() is False
+        assert is_standard_contract() is True
         v2_success = compat_success_response(
             legacy_payload={"message": "legacy"},
             status_code=200,
@@ -52,6 +57,28 @@ def test_contract_detection_and_response_compatibility(app) -> None:
     assert v2_success.get_json()["data"] == {"id": 1}
     assert v2_error.get_json()["success"] is False
     assert v2_error.get_json()["error"]["details"] == {"field": "name"}
+
+    with app.test_request_context("/health", headers={"X-API-Contract": CONTRACT_V3}):
+        assert is_v2_contract() is False
+        assert is_v3_contract() is True
+        assert is_standard_contract() is True
+        v3_success = compat_success_response(
+            legacy_payload={"message": "legacy"},
+            status_code=200,
+            message="ok",
+            data={"id": 2},
+        )
+        v3_error = compat_error_response(
+            legacy_payload={"error": "legacy"},
+            status_code=400,
+            message="boom",
+            error_code="VALIDATION_ERROR",
+        )
+
+    assert v3_success.get_json()["success"] is True
+    assert v3_success.get_json()["data"] == {"id": 2}
+    assert v3_error.get_json()["success"] is False
+    assert v3_error.get_json()["error"]["code"] == "VALIDATION_ERROR"
 
 
 def test_contract_tuple_and_error_class(app) -> None:

--- a/tests/test_user_contract.py
+++ b/tests/test_user_contract.py
@@ -61,6 +61,33 @@ USER_FIELDS = {
     "taxonomy_version",
 }
 
+CANONICAL_USER_KEYS = {
+    "identity",
+    "profile",
+    "financial_profile",
+    "investor_profile",
+    "product_context",
+}
+
+IDENTITY_FIELDS = {"id", "name", "email"}
+PROFILE_FIELDS = {"gender", "birth_date", "state_uf", "occupation"}
+FINANCIAL_PROFILE_FIELDS = {
+    "monthly_income_net",
+    "monthly_expenses",
+    "net_worth",
+    "initial_investment",
+    "monthly_investment",
+    "investment_goal_date",
+}
+INVESTOR_PROFILE_FIELDS = {
+    "declared",
+    "suggested",
+    "quiz_score",
+    "taxonomy_version",
+    "financial_objectives",
+}
+PRODUCT_CONTEXT_FIELDS = {"entitlements_version"}
+
 TRANSACTION_ITEM_FIELDS = {
     "id",
     "title",
@@ -278,6 +305,52 @@ def test_user_me_invalid_status_v2_contract(client) -> None:
     body = response.get_json()
     assert body["success"] is False
     assert body["error"]["code"] == "VALIDATION_ERROR"
+
+
+def test_user_me_v3_contract_returns_canonical_context_only(client) -> None:
+    token = _register_and_login(client)
+    response = client.get(
+        "/user/me",
+        headers=_auth_headers(token, "v3"),
+    )
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["success"] is True
+    assert body["message"] == "Contexto autenticado retornado com sucesso"
+    assert "meta" not in body
+    assert set(body["data"].keys()) == {"user"}
+    assert set(body["data"]["user"].keys()) == CANONICAL_USER_KEYS
+    assert set(body["data"]["user"]["identity"].keys()) == IDENTITY_FIELDS
+    assert set(body["data"]["user"]["profile"].keys()) == PROFILE_FIELDS
+    assert (
+        set(body["data"]["user"]["financial_profile"].keys())
+        == FINANCIAL_PROFILE_FIELDS
+    )
+    assert (
+        set(body["data"]["user"]["investor_profile"].keys()) == INVESTOR_PROFILE_FIELDS
+    )
+    assert set(body["data"]["user"]["product_context"].keys()) == PRODUCT_CONTEXT_FIELDS
+    assert "monthly_income" not in body["data"]["user"]["financial_profile"]
+    assert "transactions" not in body["data"]["user"]
+    assert "wallet" not in body["data"]["user"]
+
+
+def test_user_me_v3_contract_rejects_collection_semantics(client) -> None:
+    token = _register_and_login(client)
+    response = client.get(
+        "/user/me?page=1&limit=10",
+        headers=_auth_headers(token, "v3"),
+    )
+
+    assert response.status_code == 400
+    body = response.get_json()
+    assert body["success"] is False
+    assert body["error"]["code"] == "VALIDATION_ERROR"
+    assert body["message"] == (
+        "O contrato canônico de '/user/me' não aceita paginação nem filtros de "
+        "coleção. Use '/transactions' ou o bootstrap dedicado."
+    )
 
 
 def test_user_me_masks_unexpected_value_error(client, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- publish `X-API-Contract: v3` for `GET /user/me` with canonical authenticated-context shape
- keep legacy `v1`/`v2` behavior intact during migration
- add contract tests and feature contract pack for frontend consumers

## Validation
- `VENV_DIR=/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-api/.venv scripts/repo_bin.sh pytest tests/test_user_contract.py tests/test_controller_response_contract.py tests/test_graphql_api.py tests/test_auth_contract.py -q`
- `VENV_DIR=/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-api/.venv scripts/repo_bin.sh mypy app`
- `scripts/repo_bin.sh pre-commit run --files app/utils/api_contract.py app/controllers/response_contract.py app/controllers/user/contracts.py app/controllers/user/me_resource.py app/services/authenticated_user_payloads.py tests/test_user_contract.py tests/test_controller_response_contract.py .context/feature_contracts/ARC-08-3.json .context/feature_contracts/ARC-08-3.md`
- `git diff --check`