### PR TITLE
feat(auth): harden canonical login identity

### DIFF
--- a/app/application/services/login_identity_service.py
+++ b/app/application/services/login_identity_service.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Literal
+
+from app.models.user import User
+
+LoginIdentifierKind = Literal["email", "name"]
+UserFinder = Callable[[str], User | None]
+
+
+@dataclass(frozen=True)
+class ResolvedLoginIdentity:
+    principal: str
+    identifier_kind: LoginIdentifierKind
+    user: User | None
+
+    @property
+    def uses_legacy_name_identifier(self) -> bool:
+        return self.identifier_kind == "name"
+
+
+def resolve_login_identity(
+    *,
+    email: str | None,
+    name: str | None,
+    find_user_by_email: UserFinder,
+    find_user_by_name: UserFinder,
+) -> ResolvedLoginIdentity:
+    normalized_email = (email or "").strip()
+    if normalized_email:
+        return ResolvedLoginIdentity(
+            principal=normalized_email,
+            identifier_kind="email",
+            user=find_user_by_email(normalized_email),
+        )
+
+    normalized_name = (name or "").strip()
+    return ResolvedLoginIdentity(
+        principal=normalized_name,
+        identifier_kind="name",
+        user=find_user_by_name(normalized_name),
+    )
+
+
+__all__ = ["ResolvedLoginIdentity", "resolve_login_identity"]

--- a/app/controllers/auth/login_resource.py
+++ b/app/controllers/auth/login_resource.py
@@ -5,35 +5,75 @@ from typing import Any
 from flask import Response, current_app
 from flask_apispec.views import MethodResource
 
+from app.application.services.login_identity_service import resolve_login_identity
 from app.docs.openapi_helpers import (
+    DEPRECATION_HEADER_NAME,
+    LEGACY_SUNSET_EXAMPLE,
+    SUCCESSOR_FIELD_HEADER_NAME,
+    SUNSET_HEADER_NAME,
+    WARNING_HEADER_NAME,
     contract_header_param,
+    deprecated_headers_doc,
     json_error_response,
     json_request_body,
     json_success_response,
 )
 from app.extensions.database import db
+from app.extensions.integration_metrics import increment_metric
 from app.http.request_context import get_request_context
 from app.schemas.auth_schema import AuthSchema
+from app.services.login_attempt_guard_service import (
+    LoginAttemptContext,
+    LoginAttemptGuardService,
+)
 from app.utils.typed_decorators import typed_doc as doc
 from app.utils.typed_decorators import typed_use_kwargs as use_kwargs
 
 from .contracts import compat_error, compat_success
-from .dependencies import get_auth_dependencies
+from .dependencies import AuthDependencies, get_auth_dependencies
 from .guard import guard_login_check, guard_register_failure, guard_register_success
 
+NAME_LOGIN_DEPRECATION_WARNING = (
+    "O campo `name` está em deprecação para login. Use `email`."
+)
+NAME_LOGIN_SUNSET = LEGACY_SUNSET_EXAMPLE
+EMAIL_SUCCESSOR_FIELD = "email"
 
-def _resolve_login_user(
+
+def _uses_legacy_name_login(*, email: str | None, name: str | None) -> bool:
+    return not bool(email) and bool(name)
+
+
+def _record_login_identifier_metric(
+    *, channel: str, uses_legacy_name_login: bool
+) -> None:
+    identifier = "name_legacy" if uses_legacy_name_login else "email"
+    increment_metric(f"auth.login.identifier.{channel}.{identifier}")
+
+
+def _apply_name_login_deprecation_headers(response: Response) -> Response:
+    response.headers[DEPRECATION_HEADER_NAME] = "true"
+    response.headers[SUNSET_HEADER_NAME] = NAME_LOGIN_SUNSET
+    response.headers[SUCCESSOR_FIELD_HEADER_NAME] = EMAIL_SUCCESSOR_FIELD
+    response.headers[WARNING_HEADER_NAME] = NAME_LOGIN_DEPRECATION_WARNING
+    return response
+
+
+def _finalize_login_response(
+    response: Response,
     *,
-    dependencies: Any,
-    email: str | None,
-    name: str | None,
-) -> Any:
-    if email:
-        return dependencies.find_user_by_email(str(email))
-    return dependencies.find_user_by_name(str(name))
+    uses_legacy_name_login: bool,
+) -> Response:
+    if not uses_legacy_name_login:
+        return response
+    return _apply_name_login_deprecation_headers(response)
 
 
-def _invalid_credentials_response(*, login_guard: Any, login_context: Any) -> Response:
+def _invalid_credentials_response(
+    *,
+    login_guard: LoginAttemptGuardService,
+    login_context: LoginAttemptContext,
+) -> Response:
     failure_guard_response = guard_register_failure(
         login_guard=login_guard,
         login_context=login_context,
@@ -65,12 +105,17 @@ class AuthResource(MethodResource):
     @doc(
         summary="Autenticar usuário",
         description=(
-            "Autentica o usuário com email ou nome e devolve um token JWT.\n\n"
+            "Autentica o usuário e devolve um token JWT.\n\n"
             "Headers:\n"
             "- `X-API-Contract`: opcional; `v2` padroniza o envelope.\n\n"
             "Payload:\n"
-            "- `email` ou `name` devem ser informados\n"
+            "- `email` é o identificador canônico de login\n"
+            "- `name` é aceito apenas como compatibilidade transitória e emite "
+            "headers de deprecação\n"
             "- `password` é obrigatório\n\n"
+            "Sessão:\n"
+            "- um login bem-sucedido atualiza o `current_jti` do usuário e "
+            "revoga a sessão JWT anterior\n\n"
             "Resposta:\n"
             "- `data.token`: JWT para chamadas autenticadas\n"
             "- `data.user`: dados básicos do usuário autenticado"
@@ -79,7 +124,10 @@ class AuthResource(MethodResource):
         params=contract_header_param(supported_version="v2"),
         requestBody=json_request_body(
             schema=AuthSchema,
-            description="Credenciais para login via email ou nome.",
+            description=(
+                "Credenciais para login. Use `email` como identificador "
+                "canônico; `name` permanece em compatibilidade transitória."
+            ),
             example={
                 "email": "italo@auraxis.com.br",
                 "password": "MinhaSenha@123",
@@ -97,18 +145,33 @@ class AuthResource(MethodResource):
                         "email": "italo@auraxis.com.br",
                     },
                 },
+                headers=deprecated_headers_doc(
+                    successor_field=EMAIL_SUCCESSOR_FIELD,
+                    warning=NAME_LOGIN_DEPRECATION_WARNING,
+                    sunset=NAME_LOGIN_SUNSET,
+                ),
             ),
             400: json_error_response(
                 description="Credenciais ausentes ou payload inválido",
                 message="Missing credentials",
                 error_code="VALIDATION_ERROR",
                 status_code=400,
+                headers=deprecated_headers_doc(
+                    successor_field=EMAIL_SUCCESSOR_FIELD,
+                    warning=NAME_LOGIN_DEPRECATION_WARNING,
+                    sunset=NAME_LOGIN_SUNSET,
+                ),
             ),
             401: json_error_response(
                 description="Credenciais inválidas",
                 message="Invalid credentials",
                 error_code="UNAUTHORIZED",
                 status_code=401,
+                headers=deprecated_headers_doc(
+                    successor_field=EMAIL_SUCCESSOR_FIELD,
+                    warning=NAME_LOGIN_DEPRECATION_WARNING,
+                    sunset=NAME_LOGIN_SUNSET,
+                ),
             ),
             429: json_error_response(
                 description="Muitas tentativas de login",
@@ -116,18 +179,33 @@ class AuthResource(MethodResource):
                 error_code="TOO_MANY_ATTEMPTS",
                 status_code=429,
                 details_example={"retry_after_seconds": 300},
+                headers=deprecated_headers_doc(
+                    successor_field=EMAIL_SUCCESSOR_FIELD,
+                    warning=NAME_LOGIN_DEPRECATION_WARNING,
+                    sunset=NAME_LOGIN_SUNSET,
+                ),
             ),
             503: json_error_response(
                 description="Serviço de autenticação temporariamente indisponível",
                 message="Authentication temporarily unavailable. Try again later.",
                 error_code="AUTH_BACKEND_UNAVAILABLE",
                 status_code=503,
+                headers=deprecated_headers_doc(
+                    successor_field=EMAIL_SUCCESSOR_FIELD,
+                    warning=NAME_LOGIN_DEPRECATION_WARNING,
+                    sunset=NAME_LOGIN_SUNSET,
+                ),
             ),
             500: json_error_response(
                 description="Erro interno ao efetuar login",
                 message="Login failed",
                 error_code="INTERNAL_ERROR",
                 status_code=500,
+                headers=deprecated_headers_doc(
+                    successor_field=EMAIL_SUCCESSOR_FIELD,
+                    warning=NAME_LOGIN_DEPRECATION_WARNING,
+                    sunset=NAME_LOGIN_SUNSET,
+                ),
             ),
         },
     )
@@ -136,32 +214,41 @@ class AuthResource(MethodResource):
         email = kwargs.get("email")
         name = kwargs.get("name")
         password = kwargs.get("password")
+        uses_legacy_name_login = _uses_legacy_name_login(email=email, name=name)
 
         if not password or not (email or name):
-            return compat_error(
-                legacy_payload={"message": "Missing credentials"},
-                status_code=400,
-                message="Missing credentials",
-                error_code="VALIDATION_ERROR",
+            return _finalize_login_response(
+                compat_error(
+                    legacy_payload={"message": "Missing credentials"},
+                    status_code=400,
+                    message="Missing credentials",
+                    error_code="VALIDATION_ERROR",
+                ),
+                uses_legacy_name_login=uses_legacy_name_login,
             )
 
-        dependencies = get_auth_dependencies()
+        dependencies: AuthDependencies = get_auth_dependencies()
         auth_policy = dependencies.get_auth_security_policy()
-        principal = str(email or name or "")
         request_context = get_request_context()
-        user = _resolve_login_user(
-            dependencies=dependencies,
+        identity = resolve_login_identity(
             email=email,
             name=name,
+            find_user_by_email=dependencies.find_user_by_email,
+            find_user_by_name=dependencies.find_user_by_name,
+        )
+        _record_login_identifier_metric(
+            channel="rest",
+            uses_legacy_name_login=identity.uses_legacy_name_identifier,
         )
         login_context = dependencies.build_login_attempt_context(
-            principal=principal,
+            principal=identity.principal,
             remote_addr=request_context.client_ip,
             user_agent=request_context.user_agent,
             forwarded_for=request_context.headers.get("x-forwarded-for"),
             real_ip=request_context.headers.get("x-real-ip"),
             known_principal=(
-                user is not None and auth_policy.login_guard.expose_known_principal
+                identity.user is not None
+                and auth_policy.login_guard.expose_known_principal
             ),
         )
         login_guard = dependencies.get_login_attempt_guard()
@@ -170,18 +257,27 @@ class AuthResource(MethodResource):
             login_context=login_context,
         )
         if isinstance(check_result, Response):
-            return check_result
+            return _finalize_login_response(
+                check_result,
+                uses_legacy_name_login=uses_legacy_name_login,
+            )
         allowed, retry_after = check_result
 
         if not allowed:
-            return _too_many_attempts_response(retry_after=retry_after)
+            return _finalize_login_response(
+                _too_many_attempts_response(retry_after=retry_after),
+                uses_legacy_name_login=uses_legacy_name_login,
+            )
 
-        password_hash = user.password if user is not None else None
+        password_hash = identity.user.password if identity.user is not None else None
         is_valid_password = dependencies.verify_password(password_hash, str(password))
-        if not user or not is_valid_password:
-            return _invalid_credentials_response(
-                login_guard=login_guard,
-                login_context=login_context,
+        if not identity.user or not is_valid_password:
+            return _finalize_login_response(
+                _invalid_credentials_response(
+                    login_guard=login_guard,
+                    login_context=login_context,
+                ),
+                uses_legacy_name_login=uses_legacy_name_login,
             )
 
         try:
@@ -190,33 +286,42 @@ class AuthResource(MethodResource):
                 login_context=login_context,
             )
             if success_guard_response is not None:
-                return success_guard_response
+                return _finalize_login_response(
+                    success_guard_response,
+                    uses_legacy_name_login=uses_legacy_name_login,
+                )
 
-            token = dependencies.create_access_token(str(user.id))
+            token = dependencies.create_access_token(str(identity.user.id))
             jti = dependencies.get_token_jti(token)
-            if user.current_jti != jti:
-                user.current_jti = jti
+            if identity.user.current_jti != jti:
+                identity.user.current_jti = jti
                 db.session.commit()
             user_data = {
-                "id": str(user.id),
-                "name": user.name,
-                "email": user.email,
+                "id": str(identity.user.id),
+                "name": identity.user.name,
+                "email": identity.user.email,
             }
-            return compat_success(
-                legacy_payload={
-                    "message": "Login successful",
-                    "token": token,
-                    "user": user_data,
-                },
-                status_code=200,
-                message="Login successful",
-                data={"token": token, "user": user_data},
+            return _finalize_login_response(
+                compat_success(
+                    legacy_payload={
+                        "message": "Login successful",
+                        "token": token,
+                        "user": user_data,
+                    },
+                    status_code=200,
+                    message="Login successful",
+                    data={"token": token, "user": user_data},
+                ),
+                uses_legacy_name_login=uses_legacy_name_login,
             )
         except Exception:
             current_app.logger.exception("Login failed due to unexpected error.")
-            return compat_error(
-                legacy_payload={"message": "Login failed"},
-                status_code=500,
-                message="Login failed",
-                error_code="INTERNAL_ERROR",
+            return _finalize_login_response(
+                compat_error(
+                    legacy_payload={"message": "Login failed"},
+                    status_code=500,
+                    message="Login failed",
+                    error_code="INTERNAL_ERROR",
+                ),
+                uses_legacy_name_login=uses_legacy_name_login,
             )

--- a/app/docs/openapi_helpers.py
+++ b/app/docs/openapi_helpers.py
@@ -16,6 +16,7 @@ WARNING_HEADER_NAME = "Warning"
 SUCCESSOR_ENDPOINT_HEADER_NAME = "X-Auraxis-Successor-Endpoint"
 SUCCESSOR_METHOD_HEADER_NAME = "X-Auraxis-Successor-Method"
 SUCCESSOR_CONTRACT_HEADER_NAME = "X-Auraxis-Successor-Contract"
+SUCCESSOR_FIELD_HEADER_NAME = "X-Auraxis-Successor-Field"
 LEGACY_SUNSET_EXAMPLE = "Tue, 30 Jun 2026 23:59:59 GMT"
 
 
@@ -56,9 +57,10 @@ def request_id_header_doc() -> OpenAPIDict:
 
 def deprecated_headers_doc(
     *,
-    successor_endpoint: str,
+    successor_endpoint: str | None = None,
     successor_method: str | None = None,
     successor_contract: str | None = None,
+    successor_field: str | None = None,
     warning: str | None = None,
     sunset: str = LEGACY_SUNSET_EXAMPLE,
 ) -> OpenAPIDict:
@@ -73,12 +75,13 @@ def deprecated_headers_doc(
             "schema": {"type": "string"},
             "example": sunset,
         },
-        SUCCESSOR_ENDPOINT_HEADER_NAME: {
+    }
+    if successor_endpoint is not None:
+        headers[SUCCESSOR_ENDPOINT_HEADER_NAME] = {
             "description": "Endpoint sucessor recomendado.",
             "schema": {"type": "string"},
             "example": successor_endpoint,
-        },
-    }
+        }
     if successor_method is not None:
         headers[SUCCESSOR_METHOD_HEADER_NAME] = {
             "description": "Método HTTP recomendado para a superfície sucessora.",
@@ -90,6 +93,12 @@ def deprecated_headers_doc(
             "description": "Versão contratual recomendada para a migração.",
             "schema": {"type": "string"},
             "example": successor_contract,
+        }
+    if successor_field is not None:
+        headers[SUCCESSOR_FIELD_HEADER_NAME] = {
+            "description": "Campo recomendado para a migração do payload.",
+            "schema": {"type": "string"},
+            "example": successor_field,
         }
     if warning is not None:
         headers[WARNING_HEADER_NAME] = {
@@ -218,6 +227,7 @@ def json_error_response(
 __all__ = [
     "CONTRACT_HEADER_NAME",
     "LEGACY_SUNSET_EXAMPLE",
+    "SUCCESSOR_FIELD_HEADER_NAME",
     "contract_header_param",
     "deprecated_headers_doc",
     "error_envelope_example",

--- a/app/graphql/mutations/auth.py
+++ b/app/graphql/mutations/auth.py
@@ -12,6 +12,7 @@ from werkzeug.security import generate_password_hash
 from app.application.services.auth_security_policy_service import (
     get_auth_security_policy,
 )
+from app.application.services.login_identity_service import resolve_login_identity
 from app.application.services.password_reset_service import (
     request_password_reset,
     reset_password,
@@ -21,6 +22,7 @@ from app.application.services.password_verification_service import (
 )
 from app.application.services.user_profile_service import update_user_profile
 from app.extensions.database import db
+from app.extensions.integration_metrics import increment_metric
 from app.graphql.auth import get_current_user_required
 from app.graphql.errors import (
     GRAPHQL_ERROR_CODE_AUTH_BACKEND_UNAVAILABLE,
@@ -187,16 +189,18 @@ class LoginMutation(graphene.Mutation):
                 code=GRAPHQL_ERROR_CODE_VALIDATION,
             )
 
-        principal = str(email or name or "")
-        user = (
-            User.query.filter_by(email=email).first()
-            if email
-            else User.query.filter_by(name=name).first()
+        identity = resolve_login_identity(
+            email=email,
+            name=name,
+            find_user_by_email=lambda value: User.query.filter_by(email=value).first(),
+            find_user_by_name=lambda value: User.query.filter_by(name=value).first(),
         )
+        identifier = "name_legacy" if identity.uses_legacy_name_identifier else "email"
+        increment_metric(f"auth.login.identifier.graphql.{identifier}")
         request_obj = cast(dict[str, Any], info.context).get("request")
         headers = request_obj.headers if request_obj is not None else {}
         login_context = build_login_attempt_context(
-            principal=principal,
+            principal=identity.principal,
             remote_addr=(
                 getattr(request_obj, "remote_addr", None)
                 if request_obj is not None
@@ -206,7 +210,8 @@ class LoginMutation(graphene.Mutation):
             forwarded_for=headers.get("X-Forwarded-For") if headers else None,
             real_ip=headers.get("X-Real-IP") if headers else None,
             known_principal=(
-                user is not None and auth_policy.login_guard.expose_known_principal
+                identity.user is not None
+                and auth_policy.login_guard.expose_known_principal
             ),
         )
         login_guard = get_login_attempt_guard()
@@ -221,12 +226,12 @@ class LoginMutation(graphene.Mutation):
                 retry_after_seconds=retry_after,
             )
 
-        password_hash = user.password if user is not None else None
+        password_hash = identity.user.password if identity.user is not None else None
         is_valid_password = verify_password_with_timing_protection(
             password_hash=password_hash,
             plain_password=password,
         )
-        if not user or not is_valid_password:
+        if not identity.user or not is_valid_password:
             _guard_register_failure_or_raise(
                 login_guard=login_guard,
                 login_context=login_context,
@@ -241,16 +246,16 @@ class LoginMutation(graphene.Mutation):
             login_context=login_context,
         )
         token = create_access_token(
-            identity=str(user.id), expires_delta=timedelta(hours=1)
+            identity=str(identity.user.id), expires_delta=timedelta(hours=1)
         )
         jti = get_jti(token)
-        if user.current_jti != jti:
-            user.current_jti = jti
+        if identity.user.current_jti != jti:
+            identity.user.current_jti = jti
             db.session.commit()
         return AuthPayloadType(
             message="Login successful",
             token=token,
-            user=UserType(**_user_basic_auth_payload(user)),
+            user=UserType(**_user_basic_auth_payload(identity.user)),
         )
 
 

--- a/app/schemas/auth_schema.py
+++ b/app/schemas/auth_schema.py
@@ -16,14 +16,14 @@ class AuthSchema(Schema):
     email = fields.String(
         load_default=None,
         metadata={
-            "description": "Endereço de email do usuário",
+            "description": "Endereço de email do usuário (identificador canônico)",
             "example": "joao.silva@email.com",
         },
     )
     name = fields.String(
         load_default=None,
         metadata={
-            "description": "Nome do usuário (alternativa ao email)",
+            "description": "Nome do usuário (compatibilidade transitória; use email)",
             "example": "João Silva",
         },
     )
@@ -45,7 +45,7 @@ class AuthSchema(Schema):
     @validates_schema
     def validate_identity(self, data: dict[str, str], **kwargs: object) -> None:
         if not data.get("email") and not data.get("name"):
-            raise ValidationError("Either 'email' or 'name' must be provided.")
+            raise ValidationError("Either 'email' or legacy 'name' must be provided.")
 
 
 class AuthSuccessResponseSchema(Schema):

--- a/tests/test_auth_contract.py
+++ b/tests/test_auth_contract.py
@@ -6,6 +6,7 @@ from app.application.services.password_reset_service import (
     PASSWORD_RESET_NEUTRAL_MESSAGE,
     PASSWORD_RESET_SUCCESS_MESSAGE,
 )
+from app.extensions.integration_metrics import snapshot_metrics
 
 
 def _register_payload(suffix: str, password: str = "StrongPass@123") -> Dict[str, str]:
@@ -96,6 +97,51 @@ def test_auth_login_v2_contract(client) -> None:
     assert body["success"] is True
     assert "token" in body["data"]
     assert "user" in body["data"]
+    assert "Deprecation" not in response.headers
+    assert "X-Auraxis-Successor-Field" not in response.headers
+
+
+def test_auth_login_by_legacy_name_emits_deprecation_headers_and_metric(client) -> None:
+    suffix = uuid.uuid4().hex[:8]
+    payload = _register_payload(suffix)
+    register = client.post("/auth/register", json=payload)
+    assert register.status_code == 201
+
+    response = client.post(
+        "/auth/login",
+        headers=_v2_headers(),
+        json={"name": payload["name"], "password": payload["password"]},
+    )
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["success"] is True
+    assert response.headers["Deprecation"] == "true"
+    assert response.headers["X-Auraxis-Successor-Field"] == "email"
+    assert response.headers["Sunset"]
+
+    metrics = snapshot_metrics(prefix="auth.login.identifier.")
+    assert metrics["auth.login.identifier.rest.name_legacy"] >= 1
+
+
+def test_auth_login_invalid_legacy_name_still_emits_deprecation_headers(client) -> None:
+    suffix = uuid.uuid4().hex[:8]
+    payload = _register_payload(suffix)
+    register = client.post("/auth/register", json=payload)
+    assert register.status_code == 201
+
+    response = client.post(
+        "/auth/login",
+        headers=_v2_headers(),
+        json={"name": payload["name"], "password": "WrongPass@123"},
+    )
+
+    assert response.status_code == 401
+    body = response.get_json()
+    assert body["success"] is False
+    assert body["error"]["code"] == "UNAUTHORIZED"
+    assert response.headers["Deprecation"] == "true"
+    assert response.headers["X-Auraxis-Successor-Field"] == "email"
 
 
 def test_auth_login_invalid_credentials_v2_contract(client) -> None:

--- a/tests/test_graphql_api.py
+++ b/tests/test_graphql_api.py
@@ -1,3 +1,4 @@
+import uuid
 from datetime import date, timedelta
 from decimal import Decimal
 from typing import Any, Dict
@@ -7,6 +8,7 @@ from app.application.services.password_reset_service import (
     PASSWORD_RESET_NEUTRAL_MESSAGE,
     PASSWORD_RESET_SUCCESS_MESSAGE,
 )
+from app.extensions.integration_metrics import snapshot_metrics
 from app.graphql.types import UserType
 
 
@@ -741,6 +743,51 @@ def test_graphql_login_requires_email_or_name(client) -> None:
     body = response.get_json()
     assert "errors" in body
     assert body["errors"][0]["message"] == "Missing credentials"
+
+
+def test_graphql_login_by_legacy_name_tracks_metric(client) -> None:
+    suffix = uuid.uuid4().hex[:8]
+    email = f"graphql-name-{suffix}@email.com"
+    password = "StrongPass@123"
+    register_mutation = """
+    mutation Register($name: String!, $email: String!, $password: String!) {
+      registerUser(name: $name, email: $email, password: $password) {
+        message
+      }
+    }
+    """
+    register_response = _graphql(
+        client,
+        register_mutation,
+        {
+            "name": f"graphql-name-{suffix}",
+            "email": email,
+            "password": password,
+        },
+    )
+    assert register_response.status_code == 200
+
+    login_mutation = """
+    mutation LoginByName($name: String!, $password: String!) {
+      login(name: $name, password: $password) {
+        message
+        token
+      }
+    }
+    """
+    response = _graphql(
+        client,
+        login_mutation,
+        {"name": f"graphql-name-{suffix}", "password": password},
+    )
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert "errors" not in body
+    assert body["data"]["login"]["token"]
+
+    metrics = snapshot_metrics(prefix="auth.login.identifier.")
+    assert metrics["auth.login.identifier.graphql.name_legacy"] >= 1
 
 
 def test_graphql_logout_mutation_success(client) -> None:

--- a/tests/test_login_identity_service.py
+++ b/tests/test_login_identity_service.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from app.application.services.login_identity_service import resolve_login_identity
+from app.models.user import User
+
+
+def test_resolve_login_identity_prefers_email() -> None:
+    email_user = User(name="Email User", email="email@test.com", password="hash")
+    name_user = User(name="Legacy Name", email="name@test.com", password="hash")
+
+    resolved = resolve_login_identity(
+        email="email@test.com",
+        name="Legacy Name",
+        find_user_by_email=lambda value: (
+            email_user if value == email_user.email else None
+        ),
+        find_user_by_name=lambda value: name_user if value == name_user.name else None,
+    )
+
+    assert resolved.identifier_kind == "email"
+    assert resolved.principal == "email@test.com"
+    assert resolved.user is email_user
+    assert resolved.uses_legacy_name_identifier is False
+
+
+def test_resolve_login_identity_falls_back_to_name() -> None:
+    user = User(name="Legacy Name", email="legacy@test.com", password="hash")
+
+    resolved = resolve_login_identity(
+        email=None,
+        name="Legacy Name",
+        find_user_by_email=lambda _value: None,
+        find_user_by_name=lambda value: user if value == user.name else None,
+    )
+
+    assert resolved.identifier_kind == "name"
+    assert resolved.principal == "Legacy Name"
+    assert resolved.user is user
+    assert resolved.uses_legacy_name_identifier is True

--- a/tests/test_openapi_docs_quality.py
+++ b/tests/test_openapi_docs_quality.py
@@ -36,6 +36,9 @@ def test_openapi_docs_cover_mvp1_core_examples_and_headers(client) -> None:
     assert isinstance(responses, dict)
     assert "example" in responses["200"]["content"]["application/json"]
     assert "example" in responses["401"]["content"]["application/json"]
+    login_headers = responses["200"]["headers"]
+    assert "Deprecation" in login_headers
+    assert "X-Auraxis-Successor-Field" in login_headers
 
     user_me = _operation(paths, "/user/me", "get")
     params = user_me["parameters"]


### PR DESCRIPTION
## What changed
- introduced a typed shared login identity resolver used by REST and GraphQL
- made `email` the canonical login identifier while keeping `name` as a deprecated compatibility path in REST
- emitted deprecation headers for REST logins that still use `name`
- tracked legacy `name` login usage with new auth metrics for REST and GraphQL
- updated auth OpenAPI docs and added regression coverage for contracts, metrics, and the shared service

## Why
- MVP1 backend needs a stable authentication contract before the FastAPI migration begins
- `name` is not unique in the data model, so it should not remain an undocumented first-class login identifier
- we need observability and an explicit migration path before removing the legacy path

## Validation
- `VENV_DIR=/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-api/.venv scripts/repo_bin.sh pytest tests/test_login_identity_service.py tests/test_auth_contract.py tests/test_graphql_api.py tests/test_openapi_docs_quality.py -q`
- `VENV_DIR=/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-api/.venv scripts/repo_bin.sh mypy app`
- `VENV_DIR=/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-api/.venv scripts/repo_bin.sh pre-commit run --files app/application/services/login_identity_service.py app/controllers/auth/login_resource.py app/docs/openapi_helpers.py app/graphql/mutations/auth.py app/schemas/auth_schema.py tests/test_auth_contract.py tests/test_graphql_api.py tests/test_login_identity_service.py tests/test_openapi_docs_quality.py`
- `git diff --check`
