### PR TITLE
perf(user): optimize canonical me and bootstrap preview

### DIFF
--- a/app/application/services/authenticated_user_bootstrap_service.py
+++ b/app/application/services/authenticated_user_bootstrap_service.py
@@ -12,6 +12,7 @@ from app.application.services.authenticated_user_context_service import (
 )
 from app.models.transaction import Transaction
 from app.models.user import User
+from app.models.wallet import Wallet
 from app.services.transaction_serialization import (
     TransactionPayload,
     serialize_transaction_payload,
@@ -19,6 +20,7 @@ from app.services.transaction_serialization import (
 
 DEFAULT_BOOTSTRAP_TRANSACTIONS_LIMIT = 10
 MAX_BOOTSTRAP_TRANSACTIONS_LIMIT = 50
+DEFAULT_BOOTSTRAP_WALLET_LIMIT = 5
 
 
 @dataclass(frozen=True)
@@ -30,15 +32,26 @@ class AuthenticatedUserTransactionsPreview:
 
 
 @dataclass(frozen=True)
+class AuthenticatedUserWalletPreview:
+    items: tuple[AuthenticatedWalletEntry, ...]
+    total: int
+    limit: int
+    returned_items: int
+    has_more: bool
+
+
+@dataclass(frozen=True)
 class AuthenticatedUserBootstrap:
     profile: AuthenticatedUserProfile
-    wallet_entries: tuple[AuthenticatedWalletEntry, ...]
+    wallet_preview: AuthenticatedUserWalletPreview
     transactions_preview: AuthenticatedUserTransactionsPreview
 
 
 @dataclass(frozen=True)
 class AuthenticatedUserBootstrapDependencies:
     list_recent_transactions_by_user_id: Callable[[UUID, int], Sequence[Transaction]]
+    list_wallet_preview_entries_by_user_id: Callable[[UUID, int], Sequence[Wallet]]
+    count_wallet_entries_by_user_id: Callable[[UUID], int]
     context_service_factory: Callable[[], AuthenticatedUserContextService]
 
 
@@ -55,9 +68,30 @@ def _default_list_recent_transactions_by_user_id(
     )
 
 
+def _default_list_wallet_preview_entries_by_user_id(
+    user_id: UUID,
+    limit: int,
+) -> Sequence[Wallet]:
+    return cast(
+        Sequence[Wallet],
+        Wallet.query.filter_by(user_id=user_id)
+        .order_by(Wallet.register_date.desc(), Wallet.created_at.desc())
+        .limit(limit)
+        .all(),
+    )
+
+
+def _default_count_wallet_entries_by_user_id(user_id: UUID) -> int:
+    return int(Wallet.query.filter_by(user_id=user_id).count())
+
+
 def _default_dependencies() -> AuthenticatedUserBootstrapDependencies:
     return AuthenticatedUserBootstrapDependencies(
         list_recent_transactions_by_user_id=_default_list_recent_transactions_by_user_id,
+        list_wallet_preview_entries_by_user_id=(
+            _default_list_wallet_preview_entries_by_user_id
+        ),
+        count_wallet_entries_by_user_id=_default_count_wallet_entries_by_user_id,
         context_service_factory=AuthenticatedUserContextService.with_defaults,
     )
 
@@ -79,19 +113,26 @@ class AuthenticatedUserBootstrapService:
         user: User,
         *,
         transactions_limit: int = DEFAULT_BOOTSTRAP_TRANSACTIONS_LIMIT,
+        wallet_limit: int = DEFAULT_BOOTSTRAP_WALLET_LIMIT,
     ) -> AuthenticatedUserBootstrap:
-        normalized_limit = max(
+        normalized_transactions_limit = max(
             1,
             min(int(transactions_limit), MAX_BOOTSTRAP_TRANSACTIONS_LIMIT),
         )
-        context = self._dependencies.context_service_factory().build_context(user)
+        normalized_wallet_limit = max(1, int(wallet_limit))
+        context_service = self._dependencies.context_service_factory()
         transactions_preview = self._build_transactions_preview(
             user_id=user.id,
-            limit=normalized_limit,
+            limit=normalized_transactions_limit,
+        )
+        wallet_preview = self._build_wallet_preview(
+            context_service=context_service,
+            user_id=user.id,
+            limit=normalized_wallet_limit,
         )
         return AuthenticatedUserBootstrap(
-            profile=context.profile,
-            wallet_entries=context.wallet_entries,
+            profile=context_service.build_profile(user),
+            wallet_preview=wallet_preview,
             transactions_preview=transactions_preview,
         )
 
@@ -116,12 +157,35 @@ class AuthenticatedUserBootstrapService:
             has_more=len(recent_transactions) > limit,
         )
 
+    def _build_wallet_preview(
+        self,
+        *,
+        context_service: AuthenticatedUserContextService,
+        user_id: UUID,
+        limit: int,
+    ) -> AuthenticatedUserWalletPreview:
+        wallet_entries = self._dependencies.list_wallet_preview_entries_by_user_id(
+            user_id,
+            limit,
+        )
+        total_entries = self._dependencies.count_wallet_entries_by_user_id(user_id)
+        visible_items = context_service.build_wallet_entries_snapshot(wallet_entries)
+        return AuthenticatedUserWalletPreview(
+            items=visible_items,
+            total=total_entries,
+            limit=limit,
+            returned_items=len(visible_items),
+            has_more=total_entries > len(visible_items),
+        )
+
 
 __all__ = [
     "AuthenticatedUserBootstrap",
     "AuthenticatedUserBootstrapDependencies",
     "AuthenticatedUserBootstrapService",
     "AuthenticatedUserTransactionsPreview",
+    "AuthenticatedUserWalletPreview",
     "DEFAULT_BOOTSTRAP_TRANSACTIONS_LIMIT",
+    "DEFAULT_BOOTSTRAP_WALLET_LIMIT",
     "MAX_BOOTSTRAP_TRANSACTIONS_LIMIT",
 ]

--- a/app/application/services/authenticated_user_context_service.py
+++ b/app/application/services/authenticated_user_context_service.py
@@ -119,6 +119,12 @@ class AuthenticatedUserContextService:
         self, user_id: UUID
     ) -> tuple[AuthenticatedWalletEntry, ...]:
         wallet_entries = self._dependencies.list_wallet_entries_by_user_id(user_id)
+        return self.build_wallet_entries_snapshot(wallet_entries)
+
+    def build_wallet_entries_snapshot(
+        self,
+        wallet_entries: Sequence[Wallet],
+    ) -> tuple[AuthenticatedWalletEntry, ...]:
         return tuple(self._build_wallet_entry(entry) for entry in wallet_entries)
 
     def build_context(self, user: User) -> AuthenticatedUserContext:

--- a/app/controllers/user/bootstrap_resource.py
+++ b/app/controllers/user/bootstrap_resource.py
@@ -54,7 +54,7 @@ class UserBootstrapResource(MethodResource):
             "- `/wallet` = coleção canônica de carteira\n"
             "- `/user/bootstrap` = agregado leve para reduzir round-trips na home\n\n"
             "O bootstrap não substitui endpoints canônicos de coleção e expõe apenas "
-            "um preview recente de transações."
+            "previews recentes de transações e carteira."
         ),
         tags=["Usuário"],
         security=[{"BearerAuth": []}],
@@ -80,20 +80,35 @@ class UserBootstrapResource(MethodResource):
                 description="Bootstrap retornado com sucesso",
                 message="Bootstrap do usuário retornado com sucesso",
                 data_example={
-                    "profile": {
-                        "id": "4b2ef64b-b35d-4ea2-a6f2-4ef3cfb295f1",
-                        "name": "Italo",
-                        "email": "italo@email.com",
+                    "user": {
+                        "identity": {
+                            "id": "4b2ef64b-b35d-4ea2-a6f2-4ef3cfb295f1",
+                            "name": "Italo",
+                            "email": "italo@email.com",
+                        },
+                        "profile": {
+                            "gender": "outro",
+                            "birth_date": "1990-01-01",
+                            "state_uf": "SP",
+                            "occupation": "Founder",
+                        },
+                        "financial_profile": {
+                            "monthly_income_net": 1000.0,
+                            "monthly_expenses": 500.0,
+                            "net_worth": 2000.0,
+                            "initial_investment": 200.0,
+                            "monthly_investment": 100.0,
+                            "investment_goal_date": "2026-12-31",
+                        },
+                        "investor_profile": {
+                            "declared": "conservador",
+                            "suggested": "moderado",
+                            "quiz_score": 8,
+                            "taxonomy_version": "2026.1",
+                            "financial_objectives": "crescer",
+                        },
+                        "product_context": {"entitlements_version": 3},
                     },
-                    "wallet_entries": [
-                        {
-                            "id": "wallet-1",
-                            "name": "Caixa",
-                            "value": 100.0,
-                            "quantity": 1,
-                            "asset_class": "cash",
-                        }
-                    ],
                     "transactions_preview": {
                         "items": [
                             {
@@ -107,6 +122,21 @@ class UserBootstrapResource(MethodResource):
                         "limit": 5,
                         "returned_items": 1,
                         "has_more": False,
+                    },
+                    "wallet": {
+                        "items": [
+                            {
+                                "id": "wallet-1",
+                                "name": "Caixa",
+                                "value": 100.0,
+                                "quantity": 1,
+                                "asset_class": "cash",
+                            }
+                        ],
+                        "total": 8,
+                        "returned_items": 1,
+                        "limit": 5,
+                        "has_more": True,
                     },
                 },
             ),

--- a/app/controllers/user/me_resource.py
+++ b/app/controllers/user/me_resource.py
@@ -163,7 +163,6 @@ class UserMeResource(MethodResource):
         user = user_or_response
 
         context_service = AuthenticatedUserContextService.with_defaults()
-        authenticated_user_context = context_service.build_context(user)
 
         if is_v3_contract_request():
             if _has_collection_semantics():
@@ -180,12 +179,14 @@ class UserMeResource(MethodResource):
                     message="Contexto autenticado retornado com sucesso",
                     data={
                         "user": to_authenticated_user_canonical_payload(
-                            authenticated_user_context.profile
+                            context_service.build_profile(user)
                         )
                     },
                 ),
                 status_code=200,
             )
+
+        authenticated_user_context = context_service.build_context(user)
 
         try:
             page = _parse_positive_int_compat(

--- a/app/services/authenticated_user_payloads.py
+++ b/app/services/authenticated_user_payloads.py
@@ -6,6 +6,7 @@ from typing import TypedDict, cast
 from app.application.services.authenticated_user_bootstrap_service import (
     AuthenticatedUserBootstrap,
     AuthenticatedUserTransactionsPreview,
+    AuthenticatedUserWalletPreview,
 )
 from app.application.services.authenticated_user_context_service import (
     AuthenticatedUserProfile,
@@ -88,6 +89,9 @@ class AuthenticatedUserTransactionsPreviewPayload(TypedDict):
 class AuthenticatedUserBootstrapWalletPayload(TypedDict):
     items: list[WalletEntryPayload]
     total: int
+    returned_items: int
+    limit: int
+    has_more: bool
 
 
 class AuthenticatedUserBootstrapPayload(TypedDict):
@@ -166,16 +170,26 @@ def to_transactions_preview_payload(
 def to_authenticated_user_bootstrap_payload(
     bootstrap: AuthenticatedUserBootstrap,
 ) -> AuthenticatedUserBootstrapPayload:
-    wallet_items = to_wallet_payload(bootstrap.wallet_entries)
+    wallet_preview = to_wallet_preview_payload(bootstrap.wallet_preview)
     return {
         "user": to_authenticated_user_canonical_payload(bootstrap.profile),
         "transactions_preview": to_transactions_preview_payload(
             bootstrap.transactions_preview
         ),
-        "wallet": {
-            "items": wallet_items,
-            "total": len(wallet_items),
-        },
+        "wallet": wallet_preview,
+    }
+
+
+def to_wallet_preview_payload(
+    preview: AuthenticatedUserWalletPreview,
+) -> AuthenticatedUserBootstrapWalletPayload:
+    wallet_items = to_wallet_payload(preview.items)
+    return {
+        "items": wallet_items,
+        "total": preview.total,
+        "returned_items": preview.returned_items,
+        "limit": preview.limit,
+        "has_more": preview.has_more,
     }
 
 
@@ -209,4 +223,5 @@ __all__ = [
     "to_user_profile_payload",
     "to_wallet_entry_payload",
     "to_wallet_payload",
+    "to_wallet_preview_payload",
 ]

--- a/tests/test_authenticated_user_bootstrap_service.py
+++ b/tests/test_authenticated_user_bootstrap_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import date
 from decimal import Decimal
@@ -7,6 +8,7 @@ from typing import cast
 from uuid import UUID, uuid4
 
 from app.application.services.authenticated_user_bootstrap_service import (
+    DEFAULT_BOOTSTRAP_WALLET_LIMIT,
     AuthenticatedUserBootstrapDependencies,
     AuthenticatedUserBootstrapService,
 )
@@ -19,6 +21,7 @@ from app.application.services.authenticated_user_context_service import (
 )
 from app.models.transaction import Transaction
 from app.models.user import User
+from app.models.wallet import Wallet
 
 
 @dataclass(frozen=True)
@@ -102,10 +105,17 @@ def _build_context_service() -> AuthenticatedUserContextService:
                 )
             )
 
+        def build_profile(self, _user: User) -> AuthenticatedUserProfile:
+            return profile
+
+        def build_wallet_entries_snapshot(
+            self, _wallet_entries: Sequence[Wallet]
+        ) -> tuple[AuthenticatedWalletEntry, ...]:
+            return (wallet_entry,)
+
         def build_context(self, _user: User) -> AuthenticatedUserContext:
             return AuthenticatedUserContext(
-                profile=profile,
-                wallet_entries=(wallet_entry,),
+                profile=profile, wallet_entries=(wallet_entry,)
             )
 
     return cast(AuthenticatedUserContextService, _FakeContextService())
@@ -131,9 +141,17 @@ def test_authenticated_user_bootstrap_service_builds_preview_and_wallet() -> Non
     ) -> list[Transaction]:
         return cast(list[Transaction], list(transactions))
 
+    def _list_wallet_preview_entries(
+        _user_id: UUID,
+        _limit: int,
+    ) -> list[Wallet]:
+        return []
+
     service = AuthenticatedUserBootstrapService(
         dependencies=AuthenticatedUserBootstrapDependencies(
             list_recent_transactions_by_user_id=_list_recent_transactions,
+            list_wallet_preview_entries_by_user_id=_list_wallet_preview_entries,
+            count_wallet_entries_by_user_id=lambda _user_id: 1,
             context_service_factory=_build_context_service,
         )
     )
@@ -141,7 +159,11 @@ def test_authenticated_user_bootstrap_service_builds_preview_and_wallet() -> Non
     bootstrap = service.build_bootstrap(cast(User, fake_user), transactions_limit=2)
 
     assert bootstrap.profile.email == "italo@email.com"
-    assert len(bootstrap.wallet_entries) == 1
+    assert len(bootstrap.wallet_preview.items) == 1
+    assert bootstrap.wallet_preview.total == 1
+    assert bootstrap.wallet_preview.limit == DEFAULT_BOOTSTRAP_WALLET_LIMIT
+    assert bootstrap.wallet_preview.returned_items == 1
+    assert bootstrap.wallet_preview.has_more is False
     assert bootstrap.transactions_preview.limit == 2
     assert bootstrap.transactions_preview.returned_items == 2
     assert bootstrap.transactions_preview.has_more is True

--- a/tests/test_openapi_docs_quality.py
+++ b/tests/test_openapi_docs_quality.py
@@ -48,6 +48,12 @@ def test_openapi_docs_cover_mvp1_core_examples_and_headers(client) -> None:
 
     bootstrap = _operation(paths, "/user/bootstrap", "get")
     assert "example" in bootstrap["responses"]["200"]["content"]["application/json"]
+    bootstrap_example = bootstrap["responses"]["200"]["content"]["application/json"][
+        "example"
+    ]
+    assert bootstrap_example["data"]["wallet"]["limit"] >= 1
+    assert "returned_items" in bootstrap_example["data"]["wallet"]
+    assert "has_more" in bootstrap_example["data"]["wallet"]
 
     dashboard = _operation(paths, "/dashboard/overview", "get")
     assert "example" in dashboard["responses"]["200"]["content"]["application/json"]

--- a/tests/test_user_bootstrap_contract.py
+++ b/tests/test_user_bootstrap_contract.py
@@ -4,6 +4,9 @@ import uuid
 from datetime import date, timedelta
 from decimal import Decimal
 
+from app.application.services.authenticated_user_bootstrap_service import (
+    DEFAULT_BOOTSTRAP_WALLET_LIMIT,
+)
 from app.extensions.database import db
 from app.models.transaction import Transaction, TransactionStatus, TransactionType
 from app.models.user import User
@@ -104,6 +107,44 @@ def test_user_bootstrap_v2_contract_returns_aggregated_payload(client, app) -> N
     assert len(body["data"]["transactions_preview"]["items"]) == 2
     assert body["data"]["wallet"]["total"] == 1
     assert len(body["data"]["wallet"]["items"]) == 1
+    assert body["data"]["wallet"]["returned_items"] == 1
+    assert body["data"]["wallet"]["limit"] == DEFAULT_BOOTSTRAP_WALLET_LIMIT
+    assert body["data"]["wallet"]["has_more"] is False
+
+
+def test_user_bootstrap_wallet_payload_is_preview_only(client, app) -> None:
+    token = _register_and_login(client)
+    me_response = client.get("/user/me", headers=_auth_headers(token))
+    assert me_response.status_code == 200
+    email = me_response.get_json()["user"]["email"]
+
+    with app.app_context():
+        user = User.query.filter_by(email=email).first()
+        assert user is not None
+        wallet_entries = [
+            Wallet(
+                user_id=user.id,
+                name=f"Reserva {index}",
+                value=Decimal("1500.00"),
+                estimated_value_on_create_date=Decimal("1500.00"),
+                quantity=1,
+                should_be_on_wallet=True,
+                register_date=date.today() - timedelta(days=index),
+            )
+            for index in range(DEFAULT_BOOTSTRAP_WALLET_LIMIT + 2)
+        ]
+        db.session.add_all(wallet_entries)
+        db.session.commit()
+
+    response = client.get("/user/bootstrap", headers=_auth_headers(token, "v2"))
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["data"]["wallet"]["total"] == DEFAULT_BOOTSTRAP_WALLET_LIMIT + 2
+    assert body["data"]["wallet"]["returned_items"] == DEFAULT_BOOTSTRAP_WALLET_LIMIT
+    assert body["data"]["wallet"]["limit"] == DEFAULT_BOOTSTRAP_WALLET_LIMIT
+    assert body["data"]["wallet"]["has_more"] is True
+    assert len(body["data"]["wallet"]["items"]) == DEFAULT_BOOTSTRAP_WALLET_LIMIT
 
 
 def test_user_bootstrap_invalid_limit_returns_validation_error(client) -> None:

--- a/tests/test_user_contract.py
+++ b/tests/test_user_contract.py
@@ -3,6 +3,9 @@ from datetime import date, timedelta
 from decimal import Decimal
 from typing import Dict
 
+from app.application.services.authenticated_user_context_service import (
+    AuthenticatedUserContextService,
+)
 from app.extensions.database import db
 from app.extensions.integration_metrics import (
     build_http_observability_metrics_payload,
@@ -346,6 +349,25 @@ def test_user_me_v3_contract_returns_canonical_context_only(client) -> None:
     assert "wallet" not in body["data"]["user"]
     assert "Deprecation" not in response.headers
     assert "Sunset" not in response.headers
+
+
+def test_user_me_v3_contract_does_not_load_wallet_entries(client, monkeypatch) -> None:
+    token = _register_and_login(client)
+
+    def _raise_wallet_query(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("wallet preview should not be loaded for /user/me v3")
+
+    monkeypatch.setattr(
+        AuthenticatedUserContextService,
+        "build_wallet_entries",
+        _raise_wallet_query,
+    )
+
+    response = client.get("/user/me", headers=_auth_headers(token, "v3"))
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["success"] is True
 
 
 def test_user_me_legacy_contract_emits_deprecation_metrics(client) -> None:


### PR DESCRIPTION
## Summary
- stop `/user/me` v3 from loading wallet entries when returning canonical authenticated context
- turn `/user/bootstrap` into a true preview payload for wallet data instead of returning the whole collection
- align payloads, docs examples, and contract tests with the new lightweight bootstrap shape

## Validation
- VENV_DIR=/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-api/.venv scripts/repo_bin.sh pytest tests/test_authenticated_user_bootstrap_service.py tests/test_user_bootstrap_contract.py tests/test_user_contract.py tests/test_openapi_docs_quality.py -q
- VENV_DIR=/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-api/.venv scripts/repo_bin.sh mypy app
- VENV_DIR=/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-api/.venv scripts/repo_bin.sh pre-commit run --files app/application/services/authenticated_user_context_service.py app/application/services/authenticated_user_bootstrap_service.py app/controllers/user/bootstrap_resource.py app/controllers/user/me_resource.py app/services/authenticated_user_payloads.py tests/test_authenticated_user_bootstrap_service.py tests/test_openapi_docs_quality.py tests/test_user_bootstrap_contract.py tests/test_user_contract.py
- git diff --check
