### PR TITLE
feat(dashboard): canonicalize overview ownership

### DIFF
--- a/app/graphql/dashboard_payloads.py
+++ b/app/graphql/dashboard_payloads.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import cast
+
+from app.graphql.types import (
+    DashboardCategoriesType,
+    DashboardCategoryType,
+    DashboardCountsType,
+    DashboardStatusCountsType,
+    DashboardTotalsType,
+    TransactionDashboardPayloadType,
+)
+
+
+def _get_float_value(payload: Mapping[str, object], key: str) -> float:
+    value = payload[key]
+    if not isinstance(value, str | int | float):
+        raise TypeError(f"Campo '{key}' do dashboard deve ser numérico.")
+    return float(value)
+
+
+def _get_int_value(payload: Mapping[str, object], key: str) -> int:
+    value = payload[key]
+    if not isinstance(value, str | int):
+        raise TypeError(f"Campo '{key}' do dashboard deve ser inteiro.")
+    return int(value)
+
+
+def build_dashboard_overview_payload(
+    result: Mapping[str, object],
+) -> TransactionDashboardPayloadType:
+    counts = cast(Mapping[str, object], result["counts"])
+    status_counts = cast(Mapping[str, object], counts["status"])
+    expense_categories = cast(list[dict[str, object]], result["top_expense_categories"])
+    income_categories = cast(list[dict[str, object]], result["top_income_categories"])
+
+    return TransactionDashboardPayloadType(
+        month=str(result["month"]),
+        totals=DashboardTotalsType(
+            income_total=_get_float_value(result, "income_total"),
+            expense_total=_get_float_value(result, "expense_total"),
+            balance=_get_float_value(result, "balance"),
+        ),
+        counts=DashboardCountsType(
+            total_transactions=_get_int_value(counts, "total_transactions"),
+            income_transactions=_get_int_value(counts, "income_transactions"),
+            expense_transactions=_get_int_value(counts, "expense_transactions"),
+            status=DashboardStatusCountsType(
+                paid=_get_int_value(status_counts, "paid"),
+                pending=_get_int_value(status_counts, "pending"),
+                cancelled=_get_int_value(status_counts, "cancelled"),
+                postponed=_get_int_value(status_counts, "postponed"),
+                overdue=_get_int_value(status_counts, "overdue"),
+            ),
+        ),
+        top_categories=DashboardCategoriesType(
+            expense=[
+                DashboardCategoryType(**item)
+                for item in expense_categories
+                if isinstance(item, dict)
+            ],
+            income=[
+                DashboardCategoryType(**item)
+                for item in income_categories
+                if isinstance(item, dict)
+            ],
+        ),
+    )
+
+
+__all__ = ["build_dashboard_overview_payload"]

--- a/app/graphql/docs_catalog.py
+++ b/app/graphql/docs_catalog.py
@@ -7,6 +7,7 @@ GraphQLOperationType = Literal["query", "mutation"]
 GraphQLOperationAccess = Literal["public", "auth_required"]
 GraphQLDomain = Literal[
     "auth",
+    "dashboard",
     "goals",
     "investments",
     "simulations",
@@ -16,6 +17,7 @@ GraphQLDomain = Literal[
 ]
 
 QUERY_USER_MODULE = "app.graphql.queries.user"
+QUERY_DASHBOARD_MODULE = "app.graphql.queries.dashboard"
 QUERY_TRANSACTION_MODULE = "app.graphql.queries.transaction"
 QUERY_GOAL_MODULE = "app.graphql.queries.goal"
 QUERY_SIMULATION_MODULE = "app.graphql.queries.simulation"
@@ -65,6 +67,14 @@ GRAPHQL_OPERATION_CATALOG: tuple[GraphQLOperationDoc, ...] = (
         source_module=QUERY_USER_MODULE,
     ),
     GraphQLOperationDoc(
+        name="dashboardOverview",
+        operation_type="query",
+        domain="dashboard",
+        access="auth_required",
+        summary="Retorna o read model canônico do dashboard financeiro mensal.",
+        source_module=QUERY_DASHBOARD_MODULE,
+    ),
+    GraphQLOperationDoc(
         name="transactions",
         operation_type="query",
         domain="transactions",
@@ -93,7 +103,10 @@ GRAPHQL_OPERATION_CATALOG: tuple[GraphQLOperationDoc, ...] = (
         operation_type="query",
         domain="transactions",
         access="auth_required",
-        summary="Entrega visão consolidada mensal de receitas, despesas e categorias.",
+        summary=(
+            "Compatibilidade transitória do dashboard mensal; "
+            "prefira dashboardOverview."
+        ),
         source_module=QUERY_TRANSACTION_MODULE,
     ),
     GraphQLOperationDoc(

--- a/app/graphql/queries/__init__.py
+++ b/app/graphql/queries/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import graphene
 
+from .dashboard import DashboardQueryMixin
 from .goal import GoalQueryMixin
 from .investment import InvestmentQueryMixin
 from .simulation import SimulationQueryMixin
@@ -12,6 +13,7 @@ from .wallet import WalletQueryMixin
 
 class Query(
     UserQueryMixin,
+    DashboardQueryMixin,
     TransactionQueryMixin,
     GoalQueryMixin,
     SimulationQueryMixin,
@@ -25,6 +27,7 @@ class Query(
 __all__ = [
     "Query",
     "UserQueryMixin",
+    "DashboardQueryMixin",
     "TransactionQueryMixin",
     "GoalQueryMixin",
     "SimulationQueryMixin",

--- a/app/graphql/queries/dashboard.py
+++ b/app/graphql/queries/dashboard.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import graphene
+
+from app.application.services.transaction_application_service import (
+    TransactionApplicationError,
+)
+from app.application.services.transaction_query_service import TransactionQueryService
+from app.graphql.auth import get_current_user_required
+from app.graphql.dashboard_payloads import build_dashboard_overview_payload
+from app.graphql.errors import build_public_graphql_error, to_public_graphql_code
+from app.graphql.types import TransactionDashboardPayloadType
+
+
+class DashboardQueryMixin:
+    dashboard_overview = graphene.Field(
+        TransactionDashboardPayloadType,
+        month=graphene.String(required=True),
+    )
+
+    def resolve_dashboard_overview(
+        self,
+        _info: graphene.ResolveInfo,
+        month: str,
+    ) -> TransactionDashboardPayloadType:
+        user = get_current_user_required()
+        query_service = TransactionQueryService.with_defaults(user.id)
+        try:
+            result = query_service.get_dashboard_overview(month=month)
+        except TransactionApplicationError as exc:
+            raise build_public_graphql_error(
+                exc.message,
+                code=to_public_graphql_code(exc.code),
+            ) from exc
+        return build_dashboard_overview_payload(result)
+
+
+__all__ = ["DashboardQueryMixin"]

--- a/app/graphql/queries/transaction.py
+++ b/app/graphql/queries/transaction.py
@@ -10,6 +10,7 @@ from app.application.services.transaction_application_service import (
 )
 from app.application.services.transaction_query_service import TransactionQueryService
 from app.graphql.auth import get_current_user_required
+from app.graphql.dashboard_payloads import build_dashboard_overview_payload
 from app.graphql.errors import build_public_graphql_error, to_public_graphql_code
 from app.graphql.queries.common import paginate
 from app.graphql.schema_utils import (
@@ -20,11 +21,6 @@ from app.graphql.schema_utils import (
     _validate_pagination_values,
 )
 from app.graphql.types import (
-    DashboardCategoriesType,
-    DashboardCategoryType,
-    DashboardCountsType,
-    DashboardStatusCountsType,
-    DashboardTotalsType,
     TransactionDashboardPayloadType,
     TransactionDueCountsType,
     TransactionDueRangePayloadType,
@@ -60,6 +56,7 @@ class TransactionQueryMixin:
     transaction_dashboard = graphene.Field(
         TransactionDashboardPayloadType,
         month=graphene.String(required=True),
+        deprecation_reason="Use dashboardOverview.",
     )
     transaction_due_range = graphene.Field(
         TransactionDueRangePayloadType,
@@ -196,38 +193,7 @@ class TransactionQueryMixin:
                 code=to_public_graphql_code(exc.code),
             ) from exc
 
-        return TransactionDashboardPayloadType(
-            month=str(result["month"]),
-            totals=DashboardTotalsType(
-                income_total=float(result["income_total"]),
-                expense_total=float(result["expense_total"]),
-                balance=float(result["balance"]),
-            ),
-            counts=DashboardCountsType(
-                total_transactions=int(result["counts"]["total_transactions"]),
-                income_transactions=int(result["counts"]["income_transactions"]),
-                expense_transactions=int(result["counts"]["expense_transactions"]),
-                status=DashboardStatusCountsType(
-                    paid=int(result["counts"]["status"]["paid"]),
-                    pending=int(result["counts"]["status"]["pending"]),
-                    cancelled=int(result["counts"]["status"]["cancelled"]),
-                    postponed=int(result["counts"]["status"]["postponed"]),
-                    overdue=int(result["counts"]["status"]["overdue"]),
-                ),
-            ),
-            top_categories=DashboardCategoriesType(
-                expense=[
-                    DashboardCategoryType(**item)
-                    for item in result["top_expense_categories"]
-                    if isinstance(item, dict)
-                ],
-                income=[
-                    DashboardCategoryType(**item)
-                    for item in result["top_income_categories"]
-                    if isinstance(item, dict)
-                ],
-            ),
-        )
+        return build_dashboard_overview_payload(result)
 
     def resolve_transaction_due_range(
         self,

--- a/graphql.introspection.json
+++ b/graphql.introspection.json
@@ -941,9 +941,9 @@
                   }
                 }
               ],
-              "deprecationReason": null,
+              "deprecationReason": "Use dashboardOverview.",
               "description": null,
-              "isDeprecated": false,
+              "isDeprecated": true,
               "name": "transactionDashboard",
               "type": {
                 "kind": "OBJECT",
@@ -1074,6 +1074,35 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "TransactionTypeObject",
+                "ofType": null
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "month",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "dashboardOverview",
+              "type": {
+                "kind": "OBJECT",
+                "name": "TransactionDashboardPayloadType",
                 "ofType": null
               }
             },

--- a/graphql.operations.manifest.json
+++ b/graphql.operations.manifest.json
@@ -9,6 +9,14 @@
   },
   {
     "access": "auth_required",
+    "domain": "dashboard",
+    "name": "dashboardOverview",
+    "operation_type": "query",
+    "source_module": "app.graphql.queries.dashboard",
+    "summary": "Retorna o read model canônico do dashboard financeiro mensal."
+  },
+  {
+    "access": "auth_required",
     "domain": "transactions",
     "name": "transactions",
     "operation_type": "query",
@@ -37,7 +45,7 @@
     "name": "transactionDashboard",
     "operation_type": "query",
     "source_module": "app.graphql.queries.transaction",
-    "summary": "Entrega visão consolidada mensal de receitas, despesas e categorias."
+    "summary": "Compatibilidade transitória do dashboard mensal; prefira dashboardOverview."
   },
   {
     "access": "auth_required",

--- a/schema.graphql
+++ b/schema.graphql
@@ -15,9 +15,10 @@ type Query {
   goalPlan(goalId: UUID!): GoalPlanType
   transactions(page: Int = 1, perPage: Int = 10, type: String, status: String, startDate: String, endDate: String, tagId: UUID, accountId: UUID, creditCardId: UUID): TransactionListPayloadType
   transactionSummary(month: String!, page: Int = 1, perPage: Int = 10, pageSize: Int @deprecated(reason: "Use perPage.")): TransactionSummaryPayloadType
-  transactionDashboard(month: String!): TransactionDashboardPayloadType
+  transactionDashboard(month: String!): TransactionDashboardPayloadType @deprecated(reason: "Use dashboardOverview.")
   transactionDueRange(startDate: String, endDate: String, initialDate: String @deprecated(reason: "Use startDate."), finalDate: String @deprecated(reason: "Use endDate."), page: Int = 1, perPage: Int = 10, orderBy: String = "overdue_first"): TransactionDueRangePayloadType
   transaction(transactionId: UUID!): TransactionTypeObject
+  dashboardOverview(month: String!): TransactionDashboardPayloadType
   me: UserType
 }
 

--- a/tests/test_graphql_api.py
+++ b/tests/test_graphql_api.py
@@ -392,10 +392,14 @@ def test_graphql_transactions_summary_and_dashboard(app, client) -> None:
 
     dashboard_query = """
     query Dashboard($month: String!) {
-      transactionDashboard(month: $month) {
+      dashboardOverview(month: $month) {
         month
         totals { incomeTotal expenseTotal balance }
         counts { totalTransactions incomeTransactions expenseTransactions }
+      }
+      transactionDashboard(month: $month) {
+        month
+        totals { incomeTotal expenseTotal balance }
       }
     }
     """
@@ -405,7 +409,12 @@ def test_graphql_transactions_summary_and_dashboard(app, client) -> None:
     assert dashboard_response.status_code == 200
     dashboard_body = dashboard_response.get_json()
     assert "errors" not in dashboard_body
+    assert dashboard_body["data"]["dashboardOverview"]["month"] == month_ref
     assert dashboard_body["data"]["transactionDashboard"]["month"] == month_ref
+    assert (
+        dashboard_body["data"]["dashboardOverview"]["totals"]["expenseTotal"]
+        == dashboard_body["data"]["transactionDashboard"]["totals"]["expenseTotal"]
+    )
 
     due_range_query = """
     query DueRange($startDate: String!, $endDate: String!) {


### PR DESCRIPTION
## Summary
- publish `dashboardOverview` as the canonical GraphQL read model for MVP1 dashboard
- keep `transactionDashboard` as a deprecated compatibility alias
- refresh versioned GraphQL contracts used by frontend consumers

## Testing
- VENV_DIR=/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-api/.venv scripts/repo_bin.sh python scripts/export_graphql_docs.py --source runtime
- VENV_DIR=/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-api/.venv scripts/repo_bin.sh pytest tests/test_graphql_api.py tests/test_graphql_docs_export.py tests/test_graphql_error_catalog.py tests/test_graphql_security.py tests/test_graphql_resource_authorization.py -q
- VENV_DIR=/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-api/.venv scripts/repo_bin.sh mypy app
- scripts/repo_bin.sh pre-commit run --files app/graphql/dashboard_payloads.py app/graphql/queries/dashboard.py app/graphql/queries/transaction.py app/graphql/queries/__init__.py app/graphql/docs_catalog.py tests/test_graphql_api.py schema.graphql graphql.introspection.json graphql.operations.manifest.json
