### PR TITLE
feat(ci): add canonical stack bootstrap

### DIFF
--- a/.context/quality_gates.md
+++ b/.context/quality_gates.md
@@ -196,3 +196,4 @@ Quality Gate requerido:
 - As imagens base críticas (`python`, `postgres`, `redis`) usam os mirrors `public.ecr.aws/docker/library/*`.
 - O job `ci-runtime-images` constrói uma vez as imagens `auraxis-ci-dev:${GITHUB_SHA}` e `auraxis-ci-prod:${GITHUB_SHA}`.
 - `api-smoke`, `api-integration` e `trivy` baixam artifacts efêmeros e reutilizam essas imagens, evitando rebuild redundante nos gates críticos.
+- `api-smoke` e `api-integration` usam `scripts/ci_stack_bootstrap.py` como bootstrap principal, com report JSON e dumps padronizados em `reports/ci-stack/*`.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -16,6 +16,7 @@ Definir pipelines de CI/CD e gates de qualidade, seguranca e deploy.
 
 ## Gates oficiais de release (Newman/Postman)
 - `CI Runtime Images`: build único das imagens canônicas do CI com artifacts efêmeros para reuso
+- `scripts/ci_stack_bootstrap.py`: bootstrap/dump/teardown canônico compartilhado por smoke/full
 - `API Release Gate (Postman/Newman Smoke)`: gate rapido obrigatorio de pre-merge para a superficie black-box cross-domain
 - `API Release Gate (Postman/Newman Full)`: gate dedicado obrigatorio de integracao/release para a superficie canonica REST + GraphQL nao-privilegiada
 - `postman-privileged.yml`: workflow manual separado para fluxos privilegiados/admin; nao participa do caminho comum de merge
@@ -34,6 +35,7 @@ Definir pipelines de CI/CD e gates de qualidade, seguranca e deploy.
 - O job `API Release Gate (Postman/Newman Smoke)` aplica `flask db upgrade` antes da suite Postman para evitar falhas de schema em banco efemero.
 - O runner Newman do CI e local usa dependencias Node versionadas com `npm ci`, evitando dependencia de install global.
 - O job `CI Runtime Images` publica artifacts com `retention-days: 1` para reuso entre smoke/full/security com custo controlado.
+- `api-smoke` e `api-integration` compartilham o mesmo bootstrap principal e publicam diagnósticos em `reports/ci-stack/*`.
 - O job `Dependency Security (OSV-Scanner)` publica `osv-results.json` como artifact para auditoria de vulnerabilidades em lockfiles.
 
 ## Padroes obrigatorios

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,48 +283,12 @@ jobs:
       - name: Load runtime image
         run: bash scripts/ci_image_artifact.sh load reports/ci-images/runtime-dev.tar.gz
 
-      - name: Boot local stack for smoke tests
+      - name: Bootstrap smoke stack
         run: |
-          for attempt in 1 2 3; do
-            if docker compose -f docker-compose.ci.yml up -d db redis web; then
-              echo "Local smoke stack booted on attempt ${attempt}."
-              exit 0
-            fi
-            echo "Smoke stack boot failed on attempt ${attempt}; retrying..." >&2
-            docker compose -f docker-compose.ci.yml down -v --remove-orphans || true
-            sleep $((attempt * 5))
-          done
-          echo "Failed to boot local smoke stack after retries." >&2
-          exit 1
-
-      - name: Apply database migrations for smoke tests
-        run: |
-          for _ in {1..20}; do
-            if docker compose -f docker-compose.ci.yml exec -T web flask db upgrade; then
-              echo "Database migrations applied."
-              exit 0
-            fi
-            echo "Waiting for web/db before migration retry..."
-            sleep 3
-          done
-          echo "Failed to apply database migrations for smoke tests." >&2
-          docker compose -f docker-compose.ci.yml ps
-          docker compose -f docker-compose.ci.yml logs --tail=200 web db
-          exit 1
-
-      - name: Wait for API health
-        run: |
-          for _ in {1..40}; do
-            if curl -fsS http://localhost:3333/healthz >/dev/null; then
-              echo "API is healthy."
-              exit 0
-            fi
-            sleep 3
-          done
-          echo "API did not become healthy in time." >&2
-          docker compose -f docker-compose.ci.yml ps
-          docker compose -f docker-compose.ci.yml logs --tail=200 web db redis
-          exit 1
+          python3 scripts/ci_stack_bootstrap.py bootstrap \
+            --compose-file docker-compose.ci.yml \
+            --reports-dir reports/ci-stack/smoke \
+            --report-path reports/ci-stack/smoke/bootstrap-report.json
 
       - name: Run Postman smoke suite
         run: npm run postman:smoke:ci
@@ -365,12 +329,21 @@ jobs:
       - name: Dump stack logs on failure
         if: failure()
         run: |
-          docker compose -f docker-compose.ci.yml ps
-          docker compose -f docker-compose.ci.yml logs --tail=200 web db redis
+          python3 scripts/ci_stack_bootstrap.py dump-state \
+            --compose-file docker-compose.ci.yml \
+            --reports-dir reports/ci-stack/smoke \
+            --prefix failure
 
       - name: Tear down local stack
         if: always()
-        run: docker compose -f docker-compose.ci.yml down -v --remove-orphans
+        run: python3 scripts/ci_stack_bootstrap.py teardown --compose-file docker-compose.ci.yml
+
+      - name: Upload smoke stack diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-stack-smoke-diagnostics
+          path: reports/ci-stack/smoke
 
   api-integration:
     name: API Release Gate (Postman/Newman Full)
@@ -413,48 +386,12 @@ jobs:
       - name: Load runtime image
         run: bash scripts/ci_image_artifact.sh load reports/ci-images/runtime-dev.tar.gz
 
-      - name: Boot local stack for integration tests
+      - name: Bootstrap integration stack
         run: |
-          for attempt in 1 2 3; do
-            if docker compose -f docker-compose.ci.yml up -d db redis web; then
-              echo "Local integration stack booted on attempt ${attempt}."
-              exit 0
-            fi
-            echo "Integration stack boot failed on attempt ${attempt}; retrying..." >&2
-            docker compose -f docker-compose.ci.yml down -v --remove-orphans || true
-            sleep $((attempt * 5))
-          done
-          echo "Failed to boot local integration stack after retries." >&2
-          exit 1
-
-      - name: Apply database migrations for integration tests
-        run: |
-          for _ in {1..20}; do
-            if docker compose -f docker-compose.ci.yml exec -T web flask db upgrade; then
-              echo "Database migrations applied."
-              exit 0
-            fi
-            echo "Waiting for web/db before migration retry..."
-            sleep 3
-          done
-          echo "Failed to apply database migrations for integration tests." >&2
-          docker compose -f docker-compose.ci.yml ps
-          docker compose -f docker-compose.ci.yml logs --tail=200 web db
-          exit 1
-
-      - name: Wait for API health
-        run: |
-          for _ in {1..40}; do
-            if curl -fsS http://localhost:3333/healthz >/dev/null; then
-              echo "API is healthy."
-              exit 0
-            fi
-            sleep 3
-          done
-          echo "API did not become healthy in time." >&2
-          docker compose -f docker-compose.ci.yml ps
-          docker compose -f docker-compose.ci.yml logs --tail=200 web db redis
-          exit 1
+          python3 scripts/ci_stack_bootstrap.py bootstrap \
+            --compose-file docker-compose.ci.yml \
+            --reports-dir reports/ci-stack/full \
+            --report-path reports/ci-stack/full/bootstrap-report.json
 
       - name: Run Postman full integration suite
         run: npm run postman:full:ci
@@ -482,12 +419,21 @@ jobs:
       - name: Dump stack logs on failure
         if: failure()
         run: |
-          docker compose -f docker-compose.ci.yml ps
-          docker compose -f docker-compose.ci.yml logs --tail=200 web db redis
+          python3 scripts/ci_stack_bootstrap.py dump-state \
+            --compose-file docker-compose.ci.yml \
+            --reports-dir reports/ci-stack/full \
+            --prefix failure
 
       - name: Tear down local stack
         if: always()
-        run: docker compose -f docker-compose.ci.yml down -v --remove-orphans
+        run: python3 scripts/ci_stack_bootstrap.py teardown --compose-file docker-compose.ci.yml
+
+      - name: Upload full stack diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-stack-full-diagnostics
+          path: reports/ci-stack/full
 
   schemathesis:
     name: API Reliability (Schemathesis)

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -47,11 +47,13 @@ Jobs relevantes:
 7. `api-smoke`
 - sobe stack local docker
 - instala dependencias Node versionadas com `npm ci`
+- usa `scripts/ci_stack_bootstrap.py` como bootstrap canônico
 - executa o gate oficial rapido de release/pre-merge (`smoke`) via `scripts/run_postman_suite.sh`
 - publica `reports/newman-smoke-report.xml`
 
 8. `api-integration`
 - sobe stack local docker isolada para a suite `full`
+- usa `scripts/ci_stack_bootstrap.py` como bootstrap canônico
 - executa o gate oficial dedicado de release/integracao da superficie canonica nao-privilegiada
 - publica `reports/newman-full-report.xml`
 
@@ -108,6 +110,7 @@ Controles:
 Arquitetura canonica de smoke/release gate:
 - pré-merge: `ci-runtime-images` constrói a imagem uma vez e distribui artifacts efêmeros
 - pré-merge: Newman roda nos jobs `api-smoke` (`smoke`) e `api-integration` (`full`) do `ci.yml`, ambos reutilizando a mesma imagem canônica
+- pré-merge: smoke/full compartilham o mesmo bootstrap principal em `scripts/ci_stack_bootstrap.py`
 - pré-merge: `api-smoke` tambem executa `scripts/http_latency_budget_gate.py`
 - pós-deploy: smoke deterministico em Python dentro do `deploy.yml`
 - fluxos legados paralelos de smoke foram removidos para evitar drift

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -31,6 +31,7 @@ Scripts operacionais e de engenharia para CI/CD, seguranca, deploy, observabilid
 - Para integracao black-box completa: `npm run postman:full:ci`.
 - Para smoke HTTP pós-deploy (REST + GraphQL): `scripts/python_exec.sh scripts/http_smoke_check.py --base-url <url> --env-name <dev|prod>`.
 - Para build/export/load da imagem canonica do CI: `bash scripts/ci_image_artifact.sh`.
+- Para bootstrap canônico da stack de smoke/full: `scripts/python_exec.sh scripts/ci_stack_bootstrap.py`.
 - Para contrato OpenAPI determinístico: `bash scripts/run_schemathesis_contract.sh`.
 - Para sinal de review Cursor Bugbot: `scripts/python_exec.sh scripts/pr_review_signal_check.py --repo <owner/repo> --pr-number <numero> --mode advisory`.
 - Para governanca de branch: `scripts/python_exec.sh scripts/github_ruleset_manager.py --owner <owner> --repo <repo> --mode audit`.

--- a/scripts/ci_stack_bootstrap.py
+++ b/scripts/ci_stack_bootstrap.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""Canonical CI stack bootstrap for smoke/full release gates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import subprocess
+import time
+import urllib.error
+import urllib.request
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Callable
+
+
+@dataclass(frozen=True)
+class BootstrapConfig:
+    compose_file: str
+    reports_dir: Path
+    health_url: str
+    migration_command: str
+    services: tuple[str, ...]
+    up_attempts: int
+    migration_attempts: int
+    health_attempts: int
+    retry_sleep_seconds: int
+    health_timeout_seconds: int
+
+
+@dataclass(frozen=True)
+class AttemptRecord:
+    phase: str
+    attempt: int
+    success: bool
+    detail: str
+
+
+@dataclass(frozen=True)
+class DiagnosticsArtifacts:
+    ps_path: str
+    logs_path: str
+
+
+@dataclass(frozen=True)
+class BootstrapReport:
+    status: str
+    failed_phase: str | None
+    attempts: list[AttemptRecord] = field(default_factory=list)
+    diagnostics: list[DiagnosticsArtifacts] = field(default_factory=list)
+
+
+class BootstrapError(RuntimeError):
+    def __init__(self, phase: str, detail: str) -> None:
+        super().__init__(detail)
+        self.phase = phase
+        self.detail = detail
+
+
+def _compose_base_args(compose_file: str) -> list[str]:
+    return ["docker", "compose", "-f", compose_file]
+
+
+def _run_subprocess(
+    args: list[str], check: bool = False
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        args,
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _dump_state(
+    *,
+    compose_file: str,
+    reports_dir: Path,
+    prefix: str,
+    services: tuple[str, ...],
+) -> DiagnosticsArtifacts:
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    ps_path = reports_dir / f"{prefix}-ps.txt"
+    logs_path = reports_dir / f"{prefix}-logs.txt"
+
+    ps_result = _run_subprocess(_compose_base_args(compose_file) + ["ps"])
+    logs_result = _run_subprocess(
+        _compose_base_args(compose_file) + ["logs", "--tail=200", *services]
+    )
+
+    _write_text(ps_path, ps_result.stdout + ps_result.stderr)
+    _write_text(logs_path, logs_result.stdout + logs_result.stderr)
+
+    return DiagnosticsArtifacts(ps_path=str(ps_path), logs_path=str(logs_path))
+
+
+def _check_health(health_url: str, timeout_seconds: int) -> None:
+    request = urllib.request.Request(health_url, method="GET")
+    with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
+        if response.status != 200:
+            raise BootstrapError(
+                "health",
+                f"Health endpoint expected 200, got {response.status}",
+            )
+
+
+def _bootstrap_stack(
+    config: BootstrapConfig,
+    *,
+    sleep_fn: Callable[[float], None] = time.sleep,
+) -> BootstrapReport:
+    attempts: list[AttemptRecord] = []
+    diagnostics: list[DiagnosticsArtifacts] = []
+
+    for attempt in range(1, config.up_attempts + 1):
+        result = _run_subprocess(
+            _compose_base_args(config.compose_file) + ["up", "-d", *config.services]
+        )
+        success = result.returncode == 0
+        attempts.append(
+            AttemptRecord(
+                phase="boot",
+                attempt=attempt,
+                success=success,
+                detail=(result.stderr or result.stdout).strip() or "ok",
+            )
+        )
+        if success:
+            break
+        diagnostics.append(
+            _dump_state(
+                compose_file=config.compose_file,
+                reports_dir=config.reports_dir,
+                prefix=f"boot-attempt-{attempt}",
+                services=config.services,
+            )
+        )
+        _run_subprocess(
+            _compose_base_args(config.compose_file) + ["down", "-v", "--remove-orphans"]
+        )
+        sleep_fn(attempt * config.retry_sleep_seconds)
+    else:
+        return BootstrapReport(
+            status="failed",
+            failed_phase="boot",
+            attempts=attempts,
+            diagnostics=diagnostics,
+        )
+
+    migration_args = shlex.split(config.migration_command)
+    for attempt in range(1, config.migration_attempts + 1):
+        result = _run_subprocess(
+            _compose_base_args(config.compose_file)
+            + ["exec", "-T", "web", *migration_args]
+        )
+        success = result.returncode == 0
+        attempts.append(
+            AttemptRecord(
+                phase="migration",
+                attempt=attempt,
+                success=success,
+                detail=(result.stderr or result.stdout).strip() or "ok",
+            )
+        )
+        if success:
+            break
+        sleep_fn(config.retry_sleep_seconds)
+    else:
+        diagnostics.append(
+            _dump_state(
+                compose_file=config.compose_file,
+                reports_dir=config.reports_dir,
+                prefix="migration-failed",
+                services=config.services,
+            )
+        )
+        return BootstrapReport(
+            status="failed",
+            failed_phase="migration",
+            attempts=attempts,
+            diagnostics=diagnostics,
+        )
+
+    for attempt in range(1, config.health_attempts + 1):
+        try:
+            _check_health(config.health_url, config.health_timeout_seconds)
+            attempts.append(
+                AttemptRecord(
+                    phase="health",
+                    attempt=attempt,
+                    success=True,
+                    detail="ok",
+                )
+            )
+            break
+        except (BootstrapError, urllib.error.URLError) as exc:
+            attempts.append(
+                AttemptRecord(
+                    phase="health",
+                    attempt=attempt,
+                    success=False,
+                    detail=str(exc),
+                )
+            )
+            sleep_fn(config.retry_sleep_seconds)
+    else:
+        diagnostics.append(
+            _dump_state(
+                compose_file=config.compose_file,
+                reports_dir=config.reports_dir,
+                prefix="health-failed",
+                services=config.services,
+            )
+        )
+        return BootstrapReport(
+            status="failed",
+            failed_phase="health",
+            attempts=attempts,
+            diagnostics=diagnostics,
+        )
+
+    return BootstrapReport(
+        status="ok",
+        failed_phase=None,
+        attempts=attempts,
+        diagnostics=diagnostics,
+    )
+
+
+def _write_report(path: Path, report: BootstrapReport) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "status": report.status,
+        "failed_phase": report.failed_phase,
+        "attempts": [asdict(record) for record in report.attempts],
+        "diagnostics": [asdict(record) for record in report.diagnostics],
+    }
+    path.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _parse_services(raw: str) -> tuple[str, ...]:
+    parts = tuple(part.strip() for part in raw.split(",") if part.strip())
+    if not parts:
+        raise ValueError("services cannot be empty")
+    return parts
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Canonical CI stack bootstrap")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    shared = argparse.ArgumentParser(add_help=False)
+    shared.add_argument("--compose-file", default="docker-compose.ci.yml")
+    shared.add_argument("--reports-dir", default="reports/ci-stack")
+    shared.add_argument("--services", default="db,redis,web")
+
+    bootstrap = subparsers.add_parser("bootstrap", parents=[shared])
+    bootstrap.add_argument("--health-url", default="http://localhost:3333/healthz")
+    bootstrap.add_argument("--migration-command", default="flask db upgrade")
+    bootstrap.add_argument("--up-attempts", type=int, default=3)
+    bootstrap.add_argument("--migration-attempts", type=int, default=20)
+    bootstrap.add_argument("--health-attempts", type=int, default=40)
+    bootstrap.add_argument("--retry-sleep-seconds", type=int, default=3)
+    bootstrap.add_argument("--health-timeout-seconds", type=int, default=3)
+    bootstrap.add_argument(
+        "--report-path",
+        default="reports/ci-stack/bootstrap-report.json",
+    )
+
+    dump_state = subparsers.add_parser("dump-state", parents=[shared])
+    dump_state.add_argument("--prefix", default="manual")
+
+    subparsers.add_parser("teardown", parents=[shared])
+    return parser
+
+
+def main() -> int:
+    parser = _build_parser()
+    args = parser.parse_args()
+    compose_file = str(args.compose_file)
+    reports_dir = Path(args.reports_dir)
+    services = _parse_services(args.services)
+
+    if args.command == "dump-state":
+        _dump_state(
+            compose_file=compose_file,
+            reports_dir=reports_dir,
+            prefix=str(args.prefix),
+            services=services,
+        )
+        return 0
+
+    if args.command == "teardown":
+        result = _run_subprocess(
+            _compose_base_args(compose_file) + ["down", "-v", "--remove-orphans"]
+        )
+        return result.returncode
+
+    config = BootstrapConfig(
+        compose_file=compose_file,
+        reports_dir=reports_dir,
+        health_url=str(args.health_url),
+        migration_command=str(args.migration_command),
+        services=services,
+        up_attempts=int(args.up_attempts),
+        migration_attempts=int(args.migration_attempts),
+        health_attempts=int(args.health_attempts),
+        retry_sleep_seconds=int(args.retry_sleep_seconds),
+        health_timeout_seconds=int(args.health_timeout_seconds),
+    )
+    report = _bootstrap_stack(config)
+    _write_report(Path(args.report_path), report)
+    return 0 if report.status == "ok" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_ci_stack_bootstrap.py
+++ b/tests/scripts/test_ci_stack_bootstrap.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+def _load_module():
+    module_path = (
+        Path(__file__).resolve().parents[2] / "scripts" / "ci_stack_bootstrap.py"
+    )
+    spec = importlib.util.spec_from_file_location("ci_stack_bootstrap", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_bootstrap_stack_records_successful_bootstrap(
+    tmp_path: Path, monkeypatch
+) -> None:
+    module = _load_module()
+    calls: list[list[str]] = []
+
+    class Result:
+        def __init__(
+            self, returncode: int = 0, stdout: str = "", stderr: str = ""
+        ) -> None:
+            self.returncode = returncode
+            self.stdout = stdout
+            self.stderr = stderr
+
+    def fake_run(args, check=False):
+        calls.append(args)
+        return Result()
+
+    monkeypatch.setattr(module, "_run_subprocess", fake_run)
+    monkeypatch.setattr(module, "_check_health", lambda *args, **kwargs: None)
+
+    config = module.BootstrapConfig(
+        compose_file="docker-compose.ci.yml",
+        reports_dir=tmp_path,
+        health_url="http://localhost:3333/healthz",
+        migration_command="flask db upgrade",
+        services=("db", "redis", "web"),
+        up_attempts=2,
+        migration_attempts=2,
+        health_attempts=2,
+        retry_sleep_seconds=1,
+        health_timeout_seconds=1,
+    )
+
+    report = module._bootstrap_stack(config, sleep_fn=lambda *_: None)
+
+    assert report.status == "ok"
+    assert report.failed_phase is None
+    assert [record.phase for record in report.attempts] == [
+        "boot",
+        "migration",
+        "health",
+    ]
+    assert calls[0] == [
+        "docker",
+        "compose",
+        "-f",
+        "docker-compose.ci.yml",
+        "up",
+        "-d",
+        "db",
+        "redis",
+        "web",
+    ]
+
+
+def test_bootstrap_stack_dumps_diagnostics_when_boot_fails(
+    tmp_path: Path, monkeypatch
+) -> None:
+    module = _load_module()
+
+    class Result:
+        def __init__(
+            self, returncode: int = 0, stdout: str = "", stderr: str = ""
+        ) -> None:
+            self.returncode = returncode
+            self.stdout = stdout
+            self.stderr = stderr
+
+    def fake_run(args, check=False):
+        if args[:6] == [
+            "docker",
+            "compose",
+            "-f",
+            "docker-compose.ci.yml",
+            "up",
+            "-d",
+        ]:
+            return Result(returncode=1, stderr="boot failed")
+        if "ps" in args:
+            return Result(stdout="ps output")
+        if "logs" in args:
+            return Result(stdout="logs output")
+        return Result()
+
+    monkeypatch.setattr(module, "_run_subprocess", fake_run)
+
+    config = module.BootstrapConfig(
+        compose_file="docker-compose.ci.yml",
+        reports_dir=tmp_path,
+        health_url="http://localhost:3333/healthz",
+        migration_command="flask db upgrade",
+        services=("db", "redis", "web"),
+        up_attempts=1,
+        migration_attempts=1,
+        health_attempts=1,
+        retry_sleep_seconds=1,
+        health_timeout_seconds=1,
+    )
+
+    report = module._bootstrap_stack(config, sleep_fn=lambda *_: None)
+
+    assert report.status == "failed"
+    assert report.failed_phase == "boot"
+    assert report.diagnostics
+    ps_path = Path(report.diagnostics[0].ps_path)
+    logs_path = Path(report.diagnostics[0].logs_path)
+    assert ps_path.read_text(encoding="utf-8") == "ps output"
+    assert logs_path.read_text(encoding="utf-8") == "logs output"
+
+
+def test_main_bootstrap_writes_report_file(tmp_path: Path, monkeypatch) -> None:
+    module = _load_module()
+    report_path = tmp_path / "bootstrap-report.json"
+
+    monkeypatch.setattr(
+        module,
+        "_bootstrap_stack",
+        lambda config: module.BootstrapReport(status="ok", failed_phase=None),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "ci_stack_bootstrap.py",
+            "bootstrap",
+            "--report-path",
+            str(report_path),
+            "--reports-dir",
+            str(tmp_path / "diagnostics"),
+        ],
+    )
+
+    exit_code = module.main()
+
+    assert exit_code == 0
+    payload = json.loads(report_path.read_text(encoding="utf-8"))
+    assert payload["status"] == "ok"


### PR DESCRIPTION
## Summary
- add a canonical stack bootstrap script for smoke/full gates with retry, diagnostics and teardown
- reuse the bootstrap entrypoint from CI workflow steps instead of inline shell loops
- publish stack diagnostics artifacts and document the flow in existing operational docs

## Validation
- scripts/repo_bin.sh pytest --noconftest tests/scripts/test_ci_stack_bootstrap.py -q
- scripts/repo_bin.sh pre-commit run --files .github/workflows/ci.yml scripts/ci_stack_bootstrap.py tests/scripts/test_ci_stack_bootstrap.py scripts/README.md .github/workflows/README.md docs/CI_CD.md .context/quality_gates.md
- bash scripts/ci_image_artifact.sh build dev auraxis-ci-dev:test
- python3 scripts/ci_stack_bootstrap.py bootstrap --compose-file docker-compose.ci.yml --reports-dir reports/ci-stack/local --report-path reports/ci-stack/local/bootstrap-report.json
- python3 scripts/ci_stack_bootstrap.py teardown --compose-file docker-compose.ci.yml

Closes #781