### PR TITLE
feat(ci): align local suite bootstrap with ci

### DIFF
--- a/.context/quality_gates.md
+++ b/.context/quality_gates.md
@@ -197,3 +197,5 @@ Quality Gate requerido:
 - O job `ci-runtime-images` constrói uma vez as imagens `auraxis-ci-dev:${GITHUB_SHA}` e `auraxis-ci-prod:${GITHUB_SHA}`.
 - `api-smoke`, `api-integration` e `trivy` baixam artifacts efêmeros e reutilizam essas imagens, evitando rebuild redundante nos gates críticos.
 - `api-smoke` e `api-integration` usam `scripts/ci_stack_bootstrap.py` como bootstrap principal, com report JSON e dumps padronizados em `reports/ci-stack/*`.
+- o caminho local `scripts/run_ci_like_actions_local.sh --local --with-postman` reaproveita a mesma imagem dev e o mesmo bootstrap principal do CI.
+- `scripts/ci_suite_doctor.py` deve ser o primeiro passo para detectar drift operacional local antes de subir a stack.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -17,6 +17,7 @@ Definir pipelines de CI/CD e gates de qualidade, seguranca e deploy.
 ## Gates oficiais de release (Newman/Postman)
 - `CI Runtime Images`: build único das imagens canônicas do CI com artifacts efêmeros para reuso
 - `scripts/ci_stack_bootstrap.py`: bootstrap/dump/teardown canônico compartilhado por smoke/full
+- `scripts/ci_suite_doctor.py`: doctor canônico para detectar drift operacional antes da suíte local
 - `API Release Gate (Postman/Newman Smoke)`: gate rapido obrigatorio de pre-merge para a superficie black-box cross-domain
 - `API Release Gate (Postman/Newman Full)`: gate dedicado obrigatorio de integracao/release para a superficie canonica REST + GraphQL nao-privilegiada
 - `postman-privileged.yml`: workflow manual separado para fluxos privilegiados/admin; nao participa do caminho comum de merge
@@ -36,6 +37,7 @@ Definir pipelines de CI/CD e gates de qualidade, seguranca e deploy.
 - O runner Newman do CI e local usa dependencias Node versionadas com `npm ci`, evitando dependencia de install global.
 - O job `CI Runtime Images` publica artifacts com `retention-days: 1` para reuso entre smoke/full/security com custo controlado.
 - `api-smoke` e `api-integration` compartilham o mesmo bootstrap principal e publicam diagnósticos em `reports/ci-stack/*`.
+- O caminho local recomendado com `scripts/run_ci_like_actions_local.sh --local --with-postman` reutiliza a mesma imagem dev e o mesmo bootstrap do CI.
 - O job `Dependency Security (OSV-Scanner)` publica `osv-results.json` como artifact para auditoria de vulnerabilidades em lockfiles.
 
 ## Padroes obrigatorios

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -50,6 +50,7 @@ Jobs relevantes:
 - usa `scripts/ci_stack_bootstrap.py` como bootstrap canônico
 - executa o gate oficial rapido de release/pre-merge (`smoke`) via `scripts/run_postman_suite.sh`
 - publica `reports/newman-smoke-report.xml`
+- em local, o mesmo caminho é reproduzido por `scripts/run_ci_like_actions_local.sh --local --with-postman`
 
 8. `api-integration`
 - sobe stack local docker isolada para a suite `full`
@@ -112,6 +113,7 @@ Arquitetura canonica de smoke/release gate:
 - pré-merge: Newman roda nos jobs `api-smoke` (`smoke`) e `api-integration` (`full`) do `ci.yml`, ambos reutilizando a mesma imagem canônica
 - pré-merge: smoke/full compartilham o mesmo bootstrap principal em `scripts/ci_stack_bootstrap.py`
 - pré-merge: `api-smoke` tambem executa `scripts/http_latency_budget_gate.py`
+- local: `scripts/ci_suite_doctor.py` detecta drift operacional antes de subir a mesma stack do CI
 - pós-deploy: smoke deterministico em Python dentro do `deploy.yml`
 - fluxos legados paralelos de smoke foram removidos para evitar drift
 - readiness no caminho comum de merge/release exige os dois gates oficiais (`smoke` + `full`) em verde
@@ -242,6 +244,7 @@ Exemplos:
 - `bash scripts/run_ci_like_actions_local.sh`
 - `bash scripts/run_ci_like_actions_local.sh --local --with-postman`
 - `bash scripts/run_ci_like_actions_local.sh --local --with-mutation`
+- `python3 scripts/ci_suite_doctor.py --web-image "$(bash scripts/ci_image_artifact.sh ref dev)"`
 - `npm ci && npm run smoke:local`
 
 ## Secrets e Vars esperados

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -32,6 +32,7 @@ Scripts operacionais e de engenharia para CI/CD, seguranca, deploy, observabilid
 - Para smoke HTTP pós-deploy (REST + GraphQL): `scripts/python_exec.sh scripts/http_smoke_check.py --base-url <url> --env-name <dev|prod>`.
 - Para build/export/load da imagem canonica do CI: `bash scripts/ci_image_artifact.sh`.
 - Para bootstrap canônico da stack de smoke/full: `scripts/python_exec.sh scripts/ci_stack_bootstrap.py`.
+- Para diagnosticar drift operacional antes da suite local: `scripts/python_exec.sh scripts/ci_suite_doctor.py --web-image <image-ref>`.
 - Para contrato OpenAPI determinístico: `bash scripts/run_schemathesis_contract.sh`.
 - Para sinal de review Cursor Bugbot: `scripts/python_exec.sh scripts/pr_review_signal_check.py --repo <owner/repo> --pr-number <numero> --mode advisory`.
 - Para governanca de branch: `scripts/python_exec.sh scripts/github_ruleset_manager.py --owner <owner> --repo <repo> --mode audit`.

--- a/scripts/ci_suite_doctor.py
+++ b/scripts/ci_suite_doctor.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Doctor for CI-like local suite prerequisites and operational drift."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class DoctorCheck:
+    name: str
+    success: bool
+    detail: str
+
+
+@dataclass(frozen=True)
+class DoctorReport:
+    status: str
+    checks: list[DoctorCheck]
+    compose_file: str
+    env_file: str
+    web_image: str
+
+
+class DoctorError(RuntimeError):
+    """Raised when the suite doctor detects blocking drift."""
+
+
+def _run(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(args, capture_output=True, text=True, check=False)
+
+
+def _check_command(name: str) -> DoctorCheck:
+    resolved = shutil.which(name)
+    if resolved is None:
+        return DoctorCheck(name=f"command:{name}", success=False, detail="not found")
+    return DoctorCheck(
+        name=f"command:{name}",
+        success=True,
+        detail=resolved,
+    )
+
+
+def _check_docker_compose() -> DoctorCheck:
+    result = _run(["docker", "compose", "version"])
+    if result.returncode != 0:
+        detail = (
+            result.stderr or result.stdout
+        ).strip() or "docker compose unavailable"
+        return DoctorCheck(name="docker:compose", success=False, detail=detail)
+    return DoctorCheck(
+        name="docker:compose",
+        success=True,
+        detail=(result.stdout or result.stderr).strip(),
+    )
+
+
+def _check_file(name: str, path: Path) -> DoctorCheck:
+    if not path.exists():
+        return DoctorCheck(name=name, success=False, detail=f"missing: {path}")
+    return DoctorCheck(name=name, success=True, detail=str(path))
+
+
+def _check_image_local(image_ref: str) -> DoctorCheck:
+    result = _run(["docker", "image", "inspect", image_ref])
+    if result.returncode != 0:
+        return DoctorCheck(
+            name="docker:image",
+            success=False,
+            detail=f"image not present locally: {image_ref}",
+        )
+    return DoctorCheck(
+        name="docker:image",
+        success=True,
+        detail=image_ref,
+    )
+
+
+def _build_report(
+    *,
+    compose_file: Path,
+    env_file: Path,
+    web_image: str,
+) -> DoctorReport:
+    checks = [
+        _check_command("docker"),
+        _check_command("python3"),
+        _check_command("npm"),
+        _check_file("compose:file", compose_file),
+        _check_file("env:file", env_file),
+    ]
+
+    docker_ok = all(
+        check.success for check in checks if check.name.startswith("command:docker")
+    )
+    if docker_ok:
+        checks.append(_check_docker_compose())
+        checks.append(_check_image_local(web_image))
+
+    status = "ok" if all(check.success for check in checks) else "failed"
+    return DoctorReport(
+        status=status,
+        checks=checks,
+        compose_file=str(compose_file),
+        env_file=str(env_file),
+        web_image=web_image,
+    )
+
+
+def _write_report(report: DoctorReport, report_path: Path) -> None:
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(
+        json.dumps(asdict(report), indent=2, ensure_ascii=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _render_summary(report: DoctorReport) -> str:
+    lines = [
+        "## CI suite doctor",
+        "",
+        f"- Status: `{report.status}`",
+        f"- Compose file: `{report.compose_file}`",
+        f"- Env file: `{report.env_file}`",
+        f"- Web image: `{report.web_image}`",
+        "- Checks:",
+    ]
+    for check in report.checks:
+        status = "pass" if check.success else "fail"
+        lines.append(f"  - `{check.name}` = `{status}` ({check.detail})")
+    return "\n".join(lines) + "\n"
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Doctor for CI-like local suite")
+    parser.add_argument("--compose-file", default="docker-compose.ci.yml")
+    parser.add_argument("--env-file", default=".env")
+    parser.add_argument("--web-image", required=True)
+    parser.add_argument("--report-path", default="reports/ci-doctor/report.json")
+    parser.add_argument("--summary-path", default="reports/ci-doctor/summary.md")
+    return parser
+
+
+def main() -> int:
+    args = _build_parser().parse_args()
+    report = _build_report(
+        compose_file=Path(args.compose_file),
+        env_file=Path(args.env_file),
+        web_image=str(args.web_image),
+    )
+    report_path = Path(args.report_path)
+    summary_path = Path(args.summary_path)
+    _write_report(report, report_path)
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    summary_path.write_text(_render_summary(report), encoding="utf-8")
+    if report.status != "ok":
+        raise DoctorError("CI suite doctor detected blocking drift.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_ci_like_actions_local.sh
+++ b/scripts/run_ci_like_actions_local.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 #   --local               run in current environment (no docker wrapper)
 #   --fast                skip schemathesis checks
 #   --with-mutation       include cosmic-ray mutation gate
-#   --with-postman        run Postman/Newman smoke suite (expects API at localhost:3333)
+#   --with-postman        run Postman/Newman smoke suite through the same image/bootstrap path used by CI
 #   --help                show usage
 #
 # Notes:
@@ -27,6 +27,8 @@ RUN_SCHEMATHESIS=1
 RUN_MUTATION=0
 RUN_POSTMAN=0
 PYTHON_BIN=""
+LOCAL_STACK_STARTED=0
+WEB_IMAGE_REF=""
 
 require_command() {
   local cmd="$1"
@@ -68,6 +70,12 @@ EOF
     echo "[ci-like-local] local Newman dependency not installed." >&2
     echo "[ci-like-local] run: npm ci" >&2
     exit 3
+  fi
+}
+
+cleanup_local_stack() {
+  if [[ "$LOCAL_STACK_STARTED" -eq 1 ]]; then
+    python3 scripts/ci_stack_bootstrap.py teardown --compose-file docker-compose.ci.yml || true
   fi
 }
 
@@ -182,6 +190,28 @@ run_core_pipeline() {
   fi
 
   if [[ "$RUN_POSTMAN" -eq 1 ]]; then
+    if [[ ! -f .env ]]; then
+      cp .env.dev.example .env
+    fi
+    WEB_IMAGE_REF="$(bash scripts/ci_image_artifact.sh ref dev)"
+    echo "[ci-like-local] step=doctor:ci-suite"
+    python3 scripts/ci_suite_doctor.py \
+      --compose-file docker-compose.ci.yml \
+      --env-file .env \
+      --web-image "$WEB_IMAGE_REF"
+
+    trap cleanup_local_stack EXIT
+    echo "[ci-like-local] step=ci-runtime-images:build-dev"
+    bash scripts/ci_image_artifact.sh build dev "$WEB_IMAGE_REF"
+
+    echo "[ci-like-local] step=stack:bootstrap"
+    export WEB_IMAGE="$WEB_IMAGE_REF"
+    python3 scripts/ci_stack_bootstrap.py bootstrap \
+      --compose-file docker-compose.ci.yml \
+      --reports-dir reports/ci-stack/local \
+      --report-path reports/ci-stack/local/bootstrap-report.json
+    LOCAL_STACK_STARTED=1
+
     echo "[ci-like-local] step=tests:postman-smoke"
     bash scripts/run_postman_suite.sh \
       api-tests/postman/environments/local.postman_environment.json
@@ -189,6 +219,9 @@ run_core_pipeline() {
     "${PYTHON_BIN}" scripts/http_latency_budget_gate.py \
       --base-url "${API_BASE_URL:-http://localhost:3333}" \
       --samples 3
+    cleanup_local_stack
+    trap - EXIT
+    LOCAL_STACK_STARTED=0
   else
     echo "[ci-like-local] step=tests:postman-smoke skipped (use --with-postman)"
   fi
@@ -209,7 +242,7 @@ run_in_docker() {
   fi
   if [[ "$RUN_POSTMAN" -eq 1 ]]; then
     echo "[ci-like-local] --with-postman is supported only in --local mode." >&2
-    echo "[ci-like-local] Start stack and rerun with --local --with-postman." >&2
+    echo "[ci-like-local] The canonical local stack path builds the same dev image and bootstrap used by CI." >&2
     exit 4
   fi
 

--- a/tests/scripts/test_ci_suite_doctor.py
+++ b/tests/scripts/test_ci_suite_doctor.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+def _load_module():
+    module_path = Path(__file__).resolve().parents[2] / "scripts" / "ci_suite_doctor.py"
+    spec = importlib.util.spec_from_file_location("ci_suite_doctor", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_build_report_marks_missing_image_and_env(tmp_path: Path, monkeypatch) -> None:
+    module = _load_module()
+    compose_file = tmp_path / "docker-compose.ci.yml"
+    compose_file.write_text("services: {}\n", encoding="utf-8")
+    env_file = tmp_path / ".env"
+
+    monkeypatch.setattr(module.shutil, "which", lambda name: f"/usr/bin/{name}")
+
+    def fake_run(args):
+        joined = " ".join(args)
+        if joined == "docker compose version":
+
+            class Result:
+                returncode = 0
+                stdout = "Docker Compose version v2.0.0"
+                stderr = ""
+
+            return Result()
+
+        class Result:
+            returncode = 1
+            stdout = ""
+            stderr = "missing"
+
+        return Result()
+
+    monkeypatch.setattr(module, "_run", fake_run)
+
+    report = module._build_report(
+        compose_file=compose_file,
+        env_file=env_file,
+        web_image="auraxis-ci-dev:test",
+    )
+
+    assert report.status == "failed"
+    checks = {check.name: check for check in report.checks}
+    assert checks["env:file"].success is False
+    assert checks["docker:image"].success is False
+
+
+def test_main_writes_report_and_summary(tmp_path: Path, monkeypatch) -> None:
+    module = _load_module()
+    compose_file = tmp_path / "docker-compose.ci.yml"
+    compose_file.write_text("services: {}\n", encoding="utf-8")
+    env_file = tmp_path / ".env"
+    env_file.write_text("POSTGRES_DB=test\n", encoding="utf-8")
+    report_path = tmp_path / "reports" / "doctor.json"
+    summary_path = tmp_path / "reports" / "doctor.md"
+
+    monkeypatch.setattr(module.shutil, "which", lambda name: f"/usr/bin/{name}")
+
+    def fake_run(args):
+        class Result:
+            returncode = 0
+            stdout = "ok"
+            stderr = ""
+
+        return Result()
+
+    monkeypatch.setattr(module, "_run", fake_run)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "ci_suite_doctor.py",
+            "--compose-file",
+            str(compose_file),
+            "--env-file",
+            str(env_file),
+            "--web-image",
+            "auraxis-ci-dev:test",
+            "--report-path",
+            str(report_path),
+            "--summary-path",
+            str(summary_path),
+        ],
+    )
+
+    exit_code = module.main()
+
+    assert exit_code == 0
+    payload = json.loads(report_path.read_text(encoding="utf-8"))
+    assert payload["status"] == "ok"
+    assert "CI suite doctor" in summary_path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- add a CI suite doctor to detect local drift before booting the stack
- make the local `--with-postman` path reuse the same dev image and canonical bootstrap used by CI
- update existing operational docs for the single recommended suite path

## Validation
- scripts/repo_bin.sh pytest --noconftest tests/scripts/test_ci_suite_doctor.py -q
- scripts/repo_bin.sh pre-commit run --files scripts/ci_suite_doctor.py tests/scripts/test_ci_suite_doctor.py scripts/run_ci_like_actions_local.sh scripts/README.md .github/workflows/README.md docs/CI_CD.md .context/quality_gates.md
- bash scripts/ci_image_artifact.sh build dev "$(bash scripts/ci_image_artifact.sh ref dev)"
- python3 scripts/ci_suite_doctor.py --compose-file docker-compose.ci.yml --env-file .env --web-image "$(bash scripts/ci_image_artifact.sh ref dev)"

Closes #783