### PR TITLE
feat(ci): add continuous suite canary

### DIFF
--- a/.context/quality_gates.md
+++ b/.context/quality_gates.md
@@ -199,3 +199,4 @@ Quality Gate requerido:
 - `api-smoke` e `api-integration` usam `scripts/ci_stack_bootstrap.py` como bootstrap principal, com report JSON e dumps padronizados em `reports/ci-stack/*`.
 - o caminho local `scripts/run_ci_like_actions_local.sh --local --with-postman` reaproveita a mesma imagem dev e o mesmo bootstrap principal do CI.
 - `scripts/ci_suite_doctor.py` deve ser o primeiro passo para detectar drift operacional local antes de subir a stack.
+- `ci-suite-canary.yml` roda fora do contexto de PR para validar supply chain, bootstrap, smoke HTTP e budget econômico com custo controlado.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -5,6 +5,7 @@ Definir pipelines de CI/CD e gates de qualidade, seguranca e deploy.
 
 ## Workflows principais
 - `ci.yml`: lint, type-check, testes, seguranca, quality gate.
+- `ci-suite-canary.yml`: canário agendado/manual de baixo custo para supply chain, bootstrap, smoke HTTP e budget de latência.
 - `deploy.yml`: deploy automatizado/controlado por ambiente (DEV/PROD).
 - `governance.yml`: auditoria/sincronizacao do ruleset de branch protection via API do GitHub.
 - `aws-security-audit.yml`: auditoria IAM (I8) agendada/manual com artefato JSON.
@@ -18,6 +19,7 @@ Definir pipelines de CI/CD e gates de qualidade, seguranca e deploy.
 - `CI Runtime Images`: build único das imagens canônicas do CI com artifacts efêmeros para reuso
 - `scripts/ci_stack_bootstrap.py`: bootstrap/dump/teardown canônico compartilhado por smoke/full
 - `scripts/ci_suite_doctor.py`: doctor canônico para detectar drift operacional antes da suíte local
+- `scripts/ci_suite_canary.py`: canário contínuo com métricas de duração, custo aproximado e flags de sustentabilidade
 - `API Release Gate (Postman/Newman Smoke)`: gate rapido obrigatorio de pre-merge para a superficie black-box cross-domain
 - `API Release Gate (Postman/Newman Full)`: gate dedicado obrigatorio de integracao/release para a superficie canonica REST + GraphQL nao-privilegiada
 - `postman-privileged.yml`: workflow manual separado para fluxos privilegiados/admin; nao participa do caminho comum de merge
@@ -38,6 +40,7 @@ Definir pipelines de CI/CD e gates de qualidade, seguranca e deploy.
 - O job `CI Runtime Images` publica artifacts com `retention-days: 1` para reuso entre smoke/full/security com custo controlado.
 - `api-smoke` e `api-integration` compartilham o mesmo bootstrap principal e publicam diagnósticos em `reports/ci-stack/*`.
 - O caminho local recomendado com `scripts/run_ci_like_actions_local.sh --local --with-postman` reutiliza a mesma imagem dev e o mesmo bootstrap do CI.
+- `ci-suite-canary.yml` publica `reports/ci-canary/*` com duração total, custo aproximado e guardrails econômicos do fluxo.
 - O job `Dependency Security (OSV-Scanner)` publica `osv-results.json` como artifact para auditoria de vulnerabilidades em lockfiles.
 
 ## Padroes obrigatorios

--- a/.github/workflows/ci-suite-canary.yml
+++ b/.github/workflows/ci-suite-canary.yml
@@ -1,0 +1,59 @@
+name: CI Suite Canary
+
+on:
+  schedule:
+    - cron: "0 12 * * 1-5"
+  workflow_dispatch:
+
+concurrency:
+  group: ci-suite-canary
+  cancel-in-progress: true
+
+jobs:
+  suite-canary:
+    name: Suite Canary
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_CONFIG: /tmp/docker-public
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Prepare environment file
+        run: cp .env.dev.example .env
+
+      - name: Reset Docker auth for public pulls
+        run: |
+          mkdir -p "$DOCKER_CONFIG"
+          printf '{}\n' > "$DOCKER_CONFIG/config.json"
+          docker logout docker.io || true
+          docker logout https://index.docker.io/v1/ || true
+
+      - name: Run canary suite
+        run: |
+          python3 scripts/ci_suite_canary.py \
+            --compose-file docker-compose.ci.yml \
+            --env-file .env \
+            --report-dir reports/ci-canary \
+            --web-image auraxis-ci-dev:canary \
+            --base-url http://localhost:3333 \
+            --env-name canary \
+            --latency-samples 2
+
+      - name: Upload canary artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-suite-canary
+          path: reports/ci-canary
+
+      - name: Append canary summary
+        if: always()
+        run: |
+          cat reports/ci-canary/suite-canary-report.md >> "$GITHUB_STEP_SUMMARY"

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -88,6 +88,22 @@ Governanca de excecoes de seguranca:
 14. `sonar`
 - scan SonarCloud + quality gate + enforce de ratings A
 
+### 1.1) Canary contínuo da suíte
+Arquivo: `.github/workflows/ci-suite-canary.yml`
+
+Fluxo:
+- `schedule` em dias úteis e `workflow_dispatch`
+- constroi uma imagem dev canônica de baixo custo
+- executa `scripts/ci_suite_doctor.py`
+- executa `scripts/ci_stack_bootstrap.py`
+- executa `scripts/http_smoke_check.py`
+- executa `scripts/http_latency_budget_gate.py` com amostragem reduzida
+- publica `reports/ci-canary/suite-canary-report.{md,json}`
+
+Objetivo:
+- detectar drift operacional e degradação da suíte fora do contexto de PR
+- medir duração total, custo aproximado e budget de sustentabilidade do caminho crítico
+
 Notas:
 - `Cursor Bugbot` e camada complementar de review em PR.
 - Bugbot nao eh gate obrigatorio no ruleset (quota/ruido), mas continua util como sinal adicional.
@@ -118,6 +134,7 @@ Arquitetura canonica de smoke/release gate:
 - fluxos legados paralelos de smoke foram removidos para evitar drift
 - readiness no caminho comum de merge/release exige os dois gates oficiais (`smoke` + `full`) em verde
 - o perfil `privileged` continua em workflow manual separado, fora do caminho comum
+- observabilidade contínua: `ci-suite-canary.yml` valida supply chain + bootstrap + smoke HTTP com custo reduzido
 
 Traceability adicional:
 - todo `pull_request` publica resumo advisory via `scripts/pr_traceability_check.py`
@@ -245,6 +262,7 @@ Exemplos:
 - `bash scripts/run_ci_like_actions_local.sh --local --with-postman`
 - `bash scripts/run_ci_like_actions_local.sh --local --with-mutation`
 - `python3 scripts/ci_suite_doctor.py --web-image "$(bash scripts/ci_image_artifact.sh ref dev)"`
+- `python3 scripts/ci_suite_canary.py --web-image "$(bash scripts/ci_image_artifact.sh ref dev)"`
 - `npm ci && npm run smoke:local`
 
 ## Secrets e Vars esperados

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -33,6 +33,7 @@ Scripts operacionais e de engenharia para CI/CD, seguranca, deploy, observabilid
 - Para build/export/load da imagem canonica do CI: `bash scripts/ci_image_artifact.sh`.
 - Para bootstrap canônico da stack de smoke/full: `scripts/python_exec.sh scripts/ci_stack_bootstrap.py`.
 - Para diagnosticar drift operacional antes da suite local: `scripts/python_exec.sh scripts/ci_suite_doctor.py --web-image <image-ref>`.
+- Para o canário contínuo e o relatório econômico da suíte: `scripts/python_exec.sh scripts/ci_suite_canary.py --web-image <image-ref>`.
 - Para contrato OpenAPI determinístico: `bash scripts/run_schemathesis_contract.sh`.
 - Para sinal de review Cursor Bugbot: `scripts/python_exec.sh scripts/pr_review_signal_check.py --repo <owner/repo> --pr-number <numero> --mode advisory`.
 - Para governanca de branch: `scripts/python_exec.sh scripts/github_ruleset_manager.py --owner <owner> --repo <repo> --mode audit`.

--- a/scripts/ci_suite_canary.py
+++ b/scripts/ci_suite_canary.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Low-cost canary runner and economic report for the CI suite."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+DEFAULT_WEB_IMAGE = "auraxis-ci-dev:canary"
+DEFAULT_RUNNER_COST_PER_MINUTE_USD = 0.008
+
+
+@dataclass(frozen=True)
+class PhaseResult:
+    name: str
+    success: bool
+    duration_ms: int
+    command: str
+    detail: str
+
+
+@dataclass(frozen=True)
+class CanaryReport:
+    status: str
+    total_duration_ms: int
+    estimated_runner_minutes: float
+    estimated_runner_cost_usd: float
+    redundant_rebuilds: int
+    sustainability_flags: list[str] = field(default_factory=list)
+    phases: list[PhaseResult] = field(default_factory=list)
+
+
+class CanaryError(RuntimeError):
+    """Raised when the canary suite cannot pass."""
+
+
+def _run_command(args: list[str], *, env: dict[str, str] | None = None) -> PhaseResult:
+    started_at = time.perf_counter()
+    result = subprocess.run(args, capture_output=True, text=True, check=False, env=env)
+    duration_ms = int((time.perf_counter() - started_at) * 1000)
+    detail = (result.stderr or result.stdout).strip() or "ok"
+    return PhaseResult(
+        name=" ".join(args[:2]),
+        success=result.returncode == 0,
+        duration_ms=duration_ms,
+        command=" ".join(args),
+        detail=detail,
+    )
+
+
+def _run_named_phase(
+    *,
+    phase_name: str,
+    args: list[str],
+    env: dict[str, str] | None = None,
+) -> PhaseResult:
+    result = _run_command(args, env=env)
+    return PhaseResult(
+        name=phase_name,
+        success=result.success,
+        duration_ms=result.duration_ms,
+        command=result.command,
+        detail=result.detail,
+    )
+
+
+def _phase_or_raise(result: PhaseResult) -> PhaseResult:
+    if not result.success:
+        raise CanaryError(f"{result.name} failed: {result.detail}")
+    return result
+
+
+def _build_flags(
+    *,
+    total_duration_ms: int,
+    bootstrap_duration_ms: int | None,
+    smoke_duration_ms: int | None,
+    max_total_duration_ms: int,
+    max_bootstrap_duration_ms: int,
+    max_smoke_duration_ms: int,
+) -> list[str]:
+    flags: list[str] = []
+    if total_duration_ms > max_total_duration_ms:
+        flags.append("total_duration_budget_exceeded")
+    if (
+        bootstrap_duration_ms is not None
+        and bootstrap_duration_ms > max_bootstrap_duration_ms
+    ):
+        flags.append("bootstrap_duration_budget_exceeded")
+    if smoke_duration_ms is not None and smoke_duration_ms > max_smoke_duration_ms:
+        flags.append("smoke_duration_budget_exceeded")
+    return flags
+
+
+def _render_summary(report: CanaryReport) -> str:
+    lines = [
+        "## CI suite canary",
+        "",
+        f"- Status: `{report.status}`",
+        f"- Total duration ms: `{report.total_duration_ms}`",
+        f"- Estimated runner minutes: `{report.estimated_runner_minutes}`",
+        f"- Estimated runner cost usd: `{report.estimated_runner_cost_usd}`",
+        f"- Redundant rebuilds: `{report.redundant_rebuilds}`",
+        f"- Sustainability flags: `{', '.join(report.sustainability_flags) or 'none'}`",
+        "- Phases:",
+    ]
+    for phase in report.phases:
+        status = "pass" if phase.success else "fail"
+        lines.append(
+            f"  - `{phase.name}` = `{status}` duration_ms=`{phase.duration_ms}`"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _write_report(report: CanaryReport, report_dir: Path) -> None:
+    report_dir.mkdir(parents=True, exist_ok=True)
+    (report_dir / "suite-canary-report.json").write_text(
+        json.dumps(asdict(report), indent=2, ensure_ascii=True) + "\n",
+        encoding="utf-8",
+    )
+    (report_dir / "suite-canary-report.md").write_text(
+        _render_summary(report),
+        encoding="utf-8",
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run low-cost CI suite canary")
+    parser.add_argument("--compose-file", default="docker-compose.ci.yml")
+    parser.add_argument("--env-file", default=".env")
+    parser.add_argument("--report-dir", default="reports/ci-canary")
+    parser.add_argument("--web-image", default=DEFAULT_WEB_IMAGE)
+    parser.add_argument("--base-url", default="http://localhost:3333")
+    parser.add_argument("--env-name", default="canary")
+    parser.add_argument("--latency-samples", type=int, default=2)
+    parser.add_argument(
+        "--runner-cost-per-minute-usd",
+        type=float,
+        default=DEFAULT_RUNNER_COST_PER_MINUTE_USD,
+    )
+    parser.add_argument("--max-total-duration-ms", type=int, default=720000)
+    parser.add_argument("--max-bootstrap-duration-ms", type=int, default=240000)
+    parser.add_argument("--max-smoke-duration-ms", type=int, default=180000)
+    return parser
+
+
+def main() -> int:
+    args = _build_parser().parse_args()
+    report_dir = Path(args.report_dir)
+    report_dir.mkdir(parents=True, exist_ok=True)
+
+    if not Path(args.env_file).exists():
+        Path(args.env_file).write_text(
+            Path(".env.dev.example").read_text(encoding="utf-8"),
+            encoding="utf-8",
+        )
+
+    env = dict(os.environ)
+    env["WEB_IMAGE"] = str(args.web_image)
+
+    started_at = time.perf_counter()
+    phases: list[PhaseResult] = []
+
+    try:
+        phases.append(
+            _phase_or_raise(
+                _run_named_phase(
+                    phase_name="build_image",
+                    args=[
+                        "bash",
+                        "scripts/ci_image_artifact.sh",
+                        "build",
+                        "dev",
+                        str(args.web_image),
+                    ],
+                    env=env,
+                )
+            )
+        )
+        phases.append(
+            _phase_or_raise(
+                _run_named_phase(
+                    phase_name="suite_doctor",
+                    args=[
+                        "python3",
+                        "scripts/ci_suite_doctor.py",
+                        "--compose-file",
+                        str(args.compose_file),
+                        "--env-file",
+                        str(args.env_file),
+                        "--web-image",
+                        str(args.web_image),
+                        "--report-path",
+                        str(report_dir / "doctor-report.json"),
+                        "--summary-path",
+                        str(report_dir / "doctor-summary.md"),
+                    ],
+                    env=env,
+                )
+            )
+        )
+        phases.append(
+            _phase_or_raise(
+                _run_named_phase(
+                    phase_name="stack_bootstrap",
+                    args=[
+                        "python3",
+                        "scripts/ci_stack_bootstrap.py",
+                        "bootstrap",
+                        "--compose-file",
+                        str(args.compose_file),
+                        "--reports-dir",
+                        str(report_dir / "stack"),
+                        "--report-path",
+                        str(report_dir / "stack" / "bootstrap-report.json"),
+                    ],
+                    env=env,
+                )
+            )
+        )
+        phases.append(
+            _phase_or_raise(
+                _run_named_phase(
+                    phase_name="http_smoke",
+                    args=[
+                        "python3",
+                        "scripts/http_smoke_check.py",
+                        "--base-url",
+                        str(args.base_url),
+                        "--env-name",
+                        str(args.env_name),
+                    ],
+                    env=env,
+                )
+            )
+        )
+        phases.append(
+            _phase_or_raise(
+                _run_named_phase(
+                    phase_name="latency_budget",
+                    args=[
+                        "python3",
+                        "scripts/http_latency_budget_gate.py",
+                        "--base-url",
+                        str(args.base_url),
+                        "--samples",
+                        str(args.latency_samples),
+                    ],
+                    env=env,
+                )
+            )
+        )
+        status = "ok"
+    except CanaryError as exc:
+        phases.append(
+            PhaseResult(
+                name="failure",
+                success=False,
+                duration_ms=0,
+                command="n/a",
+                detail=str(exc),
+            )
+        )
+        status = "failed"
+    finally:
+        teardown = _run_named_phase(
+            phase_name="stack_teardown",
+            args=[
+                "python3",
+                "scripts/ci_stack_bootstrap.py",
+                "teardown",
+                "--compose-file",
+                str(args.compose_file),
+            ],
+            env=env,
+        )
+        phases.append(teardown)
+        if not teardown.success:
+            status = "failed"
+
+    total_duration_ms = int((time.perf_counter() - started_at) * 1000)
+    bootstrap_duration_ms = next(
+        (phase.duration_ms for phase in phases if phase.name == "stack_bootstrap"),
+        None,
+    )
+    smoke_duration_ms = next(
+        (phase.duration_ms for phase in phases if phase.name == "http_smoke"),
+        None,
+    )
+    report = CanaryReport(
+        status=status,
+        total_duration_ms=total_duration_ms,
+        estimated_runner_minutes=round(total_duration_ms / 60000, 2),
+        estimated_runner_cost_usd=round(
+            (total_duration_ms / 60000) * float(args.runner_cost_per_minute_usd),
+            4,
+        ),
+        redundant_rebuilds=0,
+        sustainability_flags=_build_flags(
+            total_duration_ms=total_duration_ms,
+            bootstrap_duration_ms=bootstrap_duration_ms,
+            smoke_duration_ms=smoke_duration_ms,
+            max_total_duration_ms=int(args.max_total_duration_ms),
+            max_bootstrap_duration_ms=int(args.max_bootstrap_duration_ms),
+            max_smoke_duration_ms=int(args.max_smoke_duration_ms),
+        ),
+        phases=phases,
+    )
+    _write_report(report, report_dir)
+    return 0 if report.status == "ok" and not report.sustainability_flags else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_ci_suite_canary.py
+++ b/tests/scripts/test_ci_suite_canary.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+def _load_module():
+    module_path = Path(__file__).resolve().parents[2] / "scripts" / "ci_suite_canary.py"
+    spec = importlib.util.spec_from_file_location("ci_suite_canary", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_build_flags_marks_exceeded_thresholds() -> None:
+    module = _load_module()
+    flags = module._build_flags(
+        total_duration_ms=800000,
+        bootstrap_duration_ms=250000,
+        smoke_duration_ms=190000,
+        max_total_duration_ms=720000,
+        max_bootstrap_duration_ms=240000,
+        max_smoke_duration_ms=180000,
+    )
+
+    assert flags == [
+        "total_duration_budget_exceeded",
+        "bootstrap_duration_budget_exceeded",
+        "smoke_duration_budget_exceeded",
+    ]
+
+
+def test_main_writes_report_for_successful_canary(tmp_path: Path, monkeypatch) -> None:
+    module = _load_module()
+    env_file = tmp_path / ".env"
+    env_file.write_text("POSTGRES_DB=test\n", encoding="utf-8")
+    report_dir = tmp_path / "reports"
+
+    def fake_run_named_phase(*, phase_name, args, env=None):
+        return module.PhaseResult(
+            name=phase_name,
+            success=True,
+            duration_ms=100,
+            command=" ".join(args),
+            detail="ok",
+        )
+
+    monkeypatch.setattr(module, "_run_named_phase", fake_run_named_phase)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "ci_suite_canary.py",
+            "--compose-file",
+            "docker-compose.ci.yml",
+            "--env-file",
+            str(env_file),
+            "--report-dir",
+            str(report_dir),
+            "--web-image",
+            "auraxis-ci-dev:test",
+        ],
+    )
+
+    exit_code = module.main()
+
+    assert exit_code == 0
+    payload = json.loads(
+        (report_dir / "suite-canary-report.json").read_text(encoding="utf-8")
+    )
+    assert payload["status"] == "ok"
+    assert payload["redundant_rebuilds"] == 0
+    assert payload["estimated_runner_cost_usd"] >= 0
+
+
+def test_main_fails_when_sustainability_budget_is_exceeded(
+    tmp_path: Path, monkeypatch
+) -> None:
+    module = _load_module()
+    env_file = tmp_path / ".env"
+    env_file.write_text("POSTGRES_DB=test\n", encoding="utf-8")
+    report_dir = tmp_path / "reports"
+
+    def fake_run_named_phase(*, phase_name, args, env=None):
+        duration_ms = 500000 if phase_name == "stack_bootstrap" else 100
+        return module.PhaseResult(
+            name=phase_name,
+            success=True,
+            duration_ms=duration_ms,
+            command=" ".join(args),
+            detail="ok",
+        )
+
+    monkeypatch.setattr(module, "_run_named_phase", fake_run_named_phase)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "ci_suite_canary.py",
+            "--compose-file",
+            "docker-compose.ci.yml",
+            "--env-file",
+            str(env_file),
+            "--report-dir",
+            str(report_dir),
+            "--web-image",
+            "auraxis-ci-dev:test",
+            "--max-bootstrap-duration-ms",
+            "1000",
+        ],
+    )
+
+    exit_code = module.main()
+
+    assert exit_code == 1
+    payload = json.loads(
+        (report_dir / "suite-canary-report.json").read_text(encoding="utf-8")
+    )
+    assert "bootstrap_duration_budget_exceeded" in payload["sustainability_flags"]


### PR DESCRIPTION
## Summary\n- add a scheduled/manual CI suite canary that builds the canonical dev image and runs doctor, bootstrap, smoke and latency checks\n- publish machine-readable and human-readable canary reports with duration, estimated runner cost and sustainability flags\n- document the canary in the existing CI/CD operational docs and quality gates\n\n## Testing\n- scripts/repo_bin.sh pytest --noconftest tests/scripts/test_ci_suite_canary.py -q\n- python3 scripts/ci_suite_canary.py --compose-file docker-compose.ci.yml --env-file .env --report-dir reports/ci-canary/local --web-image auraxis-ci-dev:canary-local --base-url http://localhost:3333 --env-name canary-local --latency-samples 1\n- scripts/repo_bin.sh pre-commit run --files .github/workflows/ci-suite-canary.yml scripts/ci_suite_canary.py tests/scripts/test_ci_suite_canary.py scripts/README.md .github/workflows/README.md docs/CI_CD.md .context/quality_gates.md\n\nCloses #784