### PR TITLE
feat(api): publish billing plan catalog

### DIFF
--- a/api-tests/postman/auraxis.postman_collection.json
+++ b/api-tests/postman/auraxis.postman_collection.json
@@ -3916,6 +3916,49 @@
       "name": "06 - Subscriptions and Entitlements",
       "item": [
         {
+          "name": "00 - List billing plans (REST v2)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/subscriptions/plans",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "subscriptions",
+                "plans"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('subscription plans returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "pm.test('subscription plans returns canonical offers', function () {",
+                  "  pm.expect(body.success).to.eql(true);",
+                  "  pm.expect(body.data.plans).to.be.an('array');",
+                  "  pm.expect(body.data.plans[1].slug).to.eql('premium_monthly');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
           "name": "01 - Get my subscription (REST v2)",
           "request": {
             "method": "GET",
@@ -3988,7 +4031,7 @@
             },
             "body": {
               "mode": "raw",
-              "raw": "{\n                      \"plan_slug\": \"pro_monthly\"\n                    }\n"
+              "raw": "{\n                      \"plan_slug\": \"premium_monthly\"\n                    }\n"
             }
           },
           "event": [
@@ -4000,6 +4043,7 @@
                   "var body = pm.response.json();",
                   "pm.test('subscription checkout returns checkout url', function () {",
                   "  pm.expect(body.success).to.eql(true);",
+                  "  pm.expect(body.data.plan_slug).to.eql('premium_monthly');",
                   "  pm.expect(body.data.checkout_url).to.be.a('string').and.not.empty;",
                   "});"
                 ],

--- a/app/config/billing_plans.py
+++ b/app/config/billing_plans.py
@@ -1,0 +1,145 @@
+"""Canonical billing plan catalog for MVP1 monetization."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TypedDict
+
+from app.models.subscription import BillingCycle
+
+
+class BillingPlanPayload(TypedDict):
+    slug: str
+    plan_code: str
+    tier: str
+    billing_cycle: str | None
+    display_name: str
+    description: str
+    price_cents: int
+    currency: str
+    trial_days: int
+    checkout_enabled: bool
+    highlighted: bool
+
+
+@dataclass(frozen=True)
+class BillingPlanOffer:
+    slug: str
+    plan_code: str
+    tier: str
+    display_name: str
+    description: str
+    price_cents: int
+    billing_cycle: BillingCycle | None = None
+    currency: str = "BRL"
+    trial_days: int = 0
+    checkout_enabled: bool = True
+    highlighted: bool = False
+    legacy_aliases: tuple[str, ...] = ()
+
+
+FREE_PLAN = BillingPlanOffer(
+    slug="free",
+    plan_code="free",
+    tier="free",
+    display_name="Free",
+    description="Controle financeiro essencial e simulacoes basicas.",
+    price_cents=0,
+    billing_cycle=None,
+    trial_days=0,
+    checkout_enabled=False,
+)
+
+PREMIUM_MONTHLY_PLAN = BillingPlanOffer(
+    slug="premium_monthly",
+    plan_code="premium",
+    tier="premium",
+    display_name="Premium Mensal",
+    description="Analises com IA, alertas e briefing semanal.",
+    price_cents=3990,
+    billing_cycle=BillingCycle.MONTHLY,
+    trial_days=7,
+    highlighted=True,
+    legacy_aliases=("pro_monthly",),
+)
+
+PREMIUM_ANNUAL_PLAN = BillingPlanOffer(
+    slug="premium_annual",
+    plan_code="premium",
+    tier="premium",
+    display_name="Premium Anual",
+    description="Mesmo pacote premium com desconto anual.",
+    price_cents=35880,
+    billing_cycle=BillingCycle.ANNUAL,
+    trial_days=7,
+    legacy_aliases=("pro_annual",),
+)
+
+PUBLIC_BILLING_PLANS: tuple[BillingPlanOffer, ...] = (
+    FREE_PLAN,
+    PREMIUM_MONTHLY_PLAN,
+    PREMIUM_ANNUAL_PLAN,
+)
+
+
+def serialize_billing_plan(offer: BillingPlanOffer) -> BillingPlanPayload:
+    return {
+        "slug": offer.slug,
+        "plan_code": offer.plan_code,
+        "tier": offer.tier,
+        "billing_cycle": offer.billing_cycle.value if offer.billing_cycle else None,
+        "display_name": offer.display_name,
+        "description": offer.description,
+        "price_cents": offer.price_cents,
+        "currency": offer.currency,
+        "trial_days": offer.trial_days,
+        "checkout_enabled": offer.checkout_enabled,
+        "highlighted": offer.highlighted,
+    }
+
+
+def list_public_billing_plans() -> list[BillingPlanPayload]:
+    return [serialize_billing_plan(offer) for offer in PUBLIC_BILLING_PLANS]
+
+
+def resolve_checkout_plan_offer(raw_slug: str | None) -> BillingPlanOffer | None:
+    normalized = str(raw_slug or "").strip().lower()
+    if not normalized:
+        return None
+
+    for offer in PUBLIC_BILLING_PLANS:
+        if not offer.checkout_enabled:
+            continue
+        if normalized == offer.slug:
+            return offer
+        if normalized in offer.legacy_aliases:
+            return offer
+    return None
+
+
+def canonical_offer_slug(
+    plan_code: str | None,
+    billing_cycle: BillingCycle | None,
+) -> str | None:
+    normalized_plan = str(plan_code or "").strip().lower()
+    if normalized_plan == "free":
+        return FREE_PLAN.slug
+    if normalized_plan == "trial":
+        if billing_cycle == BillingCycle.ANNUAL:
+            return PREMIUM_ANNUAL_PLAN.slug
+        return PREMIUM_MONTHLY_PLAN.slug
+    if normalized_plan == "premium":
+        if billing_cycle == BillingCycle.ANNUAL:
+            return PREMIUM_ANNUAL_PLAN.slug
+        return PREMIUM_MONTHLY_PLAN.slug
+    return None
+
+
+def parse_billing_cycle(raw_value: str | None) -> BillingCycle | None:
+    normalized = str(raw_value or "").strip().lower()
+    if not normalized:
+        return None
+    try:
+        return BillingCycle(normalized)
+    except ValueError:
+        return None

--- a/app/controllers/subscription_controller.py
+++ b/app/controllers/subscription_controller.py
@@ -1,6 +1,7 @@
 """Subscriptions controller — J9 (billing / plan management).
 
-Exposes four endpoints:
+Exposes five endpoints:
+  GET  /subscriptions/plans    — public billing plan catalog        (public)
   GET  /subscriptions/me       — current user subscription state (auth required)
   POST /subscriptions/checkout — create a checkout session      (auth required)
   POST /subscriptions/cancel   — cancel the subscription        (auth required)
@@ -21,6 +22,11 @@ from flask.ctx import has_app_context
 from flask.typing import ResponseReturnValue
 
 from app.auth import get_active_auth_context
+from app.config.billing_plans import (
+    canonical_offer_slug,
+    list_public_billing_plans,
+    resolve_checkout_plan_offer,
+)
 from app.controllers.response_contract import compat_error_response
 from app.extensions.database import db
 from app.http.request_context import current_request_id
@@ -44,10 +50,12 @@ _FREE_PLAN_CODE = "free"
 
 
 def _serialize_subscription(sub: Subscription) -> dict[str, Any]:
+    offer_code = canonical_offer_slug(sub.plan_code, sub.billing_cycle)
     return {
         "id": str(sub.id),
         "user_id": str(sub.user_id),
         "plan_code": sub.plan_code,
+        "offer_code": offer_code,
         "status": sub.status.value,
         "billing_cycle": sub.billing_cycle.value if sub.billing_cycle else None,
         "provider": sub.provider,
@@ -90,6 +98,17 @@ def _get_provider() -> BillingProvider:
 
 
 # ---------------------------------------------------------------------------
+# GET /subscriptions/plans
+# ---------------------------------------------------------------------------
+
+
+@subscription_bp.get("/plans")
+def list_subscription_plans() -> ResponseReturnValue:
+    """Return the public billing plan catalog for MVP1."""
+    return _ok({"plans": list_public_billing_plans()})
+
+
+# ---------------------------------------------------------------------------
 # GET /subscriptions/me
 # ---------------------------------------------------------------------------
 
@@ -118,11 +137,14 @@ def create_checkout_session() -> ResponseReturnValue:
     plan_slug: str | None = body.get("plan_slug")
     if not plan_slug:
         return _err("plan_slug is required", "VALIDATION_ERROR", 400)
+    offer = resolve_checkout_plan_offer(plan_slug)
+    if offer is None:
+        return _err("Unsupported plan_slug", "VALIDATION_ERROR", 400)
 
     provider = _get_provider()
     try:
         result = provider.create_checkout_session(
-            user_id=str(UUID(auth.subject)), plan_slug=plan_slug
+            user_id=str(UUID(auth.subject)), plan_slug=offer.slug
         )
     except Exception:
         current_app.logger.exception("Failed to create checkout session")
@@ -130,6 +152,11 @@ def create_checkout_session() -> ResponseReturnValue:
 
     return _ok(
         {
+            "plan_slug": offer.slug,
+            "plan_code": offer.plan_code,
+            "billing_cycle": (
+                offer.billing_cycle.value if offer.billing_cycle else None
+            ),
             "checkout_url": result.get("checkout_url"),
             "provider": result.get("provider"),
         },

--- a/app/middleware/auth_guard.py
+++ b/app/middleware/auth_guard.py
@@ -31,6 +31,8 @@ def register_auth_guard(app: Flask) -> None:
             "installment_vs_cash_calculation",
             # Billing webhook — provider calls this directly without JWT
             "handle_webhook",
+            # Public billing catalog for checkout surfaces
+            "list_subscription_plans",
         }
         if not request.endpoint:
             return None

--- a/app/services/billing_adapter.py
+++ b/app/services/billing_adapter.py
@@ -50,7 +50,8 @@ class StubBillingProvider:
         return {
             "provider_id": provider_id,
             "status": "active",
-            "plan_code": "pro_monthly",
+            "plan_code": "premium",
+            "offer_code": "premium_monthly",
             "billing_cycle": "monthly",
             "current_period_start": None,
             "current_period_end": None,

--- a/app/services/subscription_service.py
+++ b/app/services/subscription_service.py
@@ -9,11 +9,32 @@ from __future__ import annotations
 from typing import cast
 from uuid import UUID
 
+from app.config.billing_plans import parse_billing_cycle, resolve_checkout_plan_offer
+from app.config.plan_features import PLAN_FEATURES
 from app.extensions.database import db
-from app.models.subscription import Subscription, SubscriptionStatus
+from app.models.subscription import BillingCycle, Subscription, SubscriptionStatus
 from app.services.billing_adapter import BillingProvider
 
 _FREE_PLAN_CODE = "free"
+
+
+def _normalize_plan_snapshot(
+    *,
+    raw_plan_code: object,
+    raw_billing_cycle: object,
+    raw_offer_code: object,
+) -> tuple[str, BillingCycle | None] | None:
+    offer = resolve_checkout_plan_offer(
+        str(raw_offer_code or raw_plan_code or "").strip().lower()
+    )
+    if offer is not None:
+        return offer.plan_code, offer.billing_cycle
+
+    normalized_plan = str(raw_plan_code or "").strip().lower()
+    if normalized_plan not in PLAN_FEATURES:
+        return None
+
+    return normalized_plan, parse_billing_cycle(str(raw_billing_cycle or ""))
 
 
 def get_or_create_subscription(user_id: UUID) -> Subscription:
@@ -58,8 +79,13 @@ def sync_subscription_from_provider(
         # Unknown status from provider — leave existing status intact.
         pass
 
-    if "plan_code" in data:
-        subscription.plan_code = data["plan_code"]
+    normalized_plan = _normalize_plan_snapshot(
+        raw_plan_code=data.get("plan_code"),
+        raw_billing_cycle=data.get("billing_cycle"),
+        raw_offer_code=data.get("offer_code"),
+    )
+    if normalized_plan is not None:
+        subscription.plan_code, subscription.billing_cycle = normalized_plan
     if "current_period_start" in data and data["current_period_start"] is not None:
         subscription.current_period_start = data["current_period_start"]
     if "current_period_end" in data and data["current_period_end"] is not None:

--- a/scripts/build_postman_collection.py
+++ b/scripts/build_postman_collection.py
@@ -1865,6 +1865,23 @@ def build_collection() -> dict[str, Any]:
 
     subscription_items = [
         _item(
+            "00 - List billing plans (REST v2)",
+            _request(
+                method="GET",
+                raw_url="{{baseUrl}}/subscriptions/plans",
+                headers=contract_headers,
+            ),
+            test_lines=[
+                "pm.test('subscription plans returns 200', function () { pm.response.to.have.status(200); });",
+                "var body = pm.response.json();",
+                "pm.test('subscription plans returns canonical offers', function () {",
+                "  pm.expect(body.success).to.eql(true);",
+                "  pm.expect(body.data.plans).to.be.an('array');",
+                "  pm.expect(body.data.plans[1].slug).to.eql('premium_monthly');",
+                "});",
+            ],
+        ),
+        _item(
             "01 - Get my subscription (REST v2)",
             _request(
                 method="GET",
@@ -1890,7 +1907,7 @@ def build_collection() -> dict[str, Any]:
                 body=_json_body(
                     """
                     {
-                      "plan_slug": "pro_monthly"
+                      "plan_slug": "premium_monthly"
                     }
                     """
                 ),
@@ -1900,6 +1917,7 @@ def build_collection() -> dict[str, Any]:
                 "var body = pm.response.json();",
                 "pm.test('subscription checkout returns checkout url', function () {",
                 "  pm.expect(body.success).to.eql(true);",
+                "  pm.expect(body.data.plan_slug).to.eql('premium_monthly');",
                 "  pm.expect(body.data.checkout_url).to.be.a('string').and.not.empty;",
                 "});",
             ],

--- a/tests/test_j9_billing_subscriptions.py
+++ b/tests/test_j9_billing_subscriptions.py
@@ -9,7 +9,7 @@ import uuid
 from typing import Dict
 from unittest.mock import MagicMock
 
-from app.models.subscription import Subscription, SubscriptionStatus
+from app.models.subscription import BillingCycle, Subscription, SubscriptionStatus
 from app.services.billing_adapter import BillingProvider, StubBillingProvider
 from app.services.subscription_service import (
     cancel_subscription,
@@ -66,9 +66,9 @@ class TestStubBillingProvider:
         assert result["provider"] == "stub"
 
     def test_create_checkout_session_returns_url(self) -> None:
-        result = self.provider.create_checkout_session("user_abc", "pro_monthly")
+        result = self.provider.create_checkout_session("user_abc", "premium_monthly")
         assert "checkout_url" in result
-        assert "pro_monthly" in result["checkout_url"]
+        assert "premium_monthly" in result["checkout_url"]
         assert result["provider"] == "stub"
 
 
@@ -108,7 +108,9 @@ class TestSubscriptionService:
         mock_provider = MagicMock()
         mock_provider.get_subscription.return_value = {
             "status": "active",
-            "plan_code": "pro_monthly",
+            "plan_code": "premium",
+            "offer_code": "premium_monthly",
+            "billing_cycle": "monthly",
         }
         with app.app_context():
             from app.extensions.database import db
@@ -119,7 +121,8 @@ class TestSubscriptionService:
 
             synced = sync_subscription_from_provider(sub, mock_provider)
             assert synced.status == SubscriptionStatus.ACTIVE
-            assert synced.plan_code == "pro_monthly"
+            assert synced.plan_code == "premium"
+            assert synced.billing_cycle == BillingCycle.MONTHLY
             mock_provider.get_subscription.assert_called_once_with("sub_xyz")
 
     def test_cancel_sets_canceled_status(self, app) -> None:
@@ -151,6 +154,17 @@ class TestSubscriptionService:
 
 
 class TestGetMySubscription:
+    def test_get_plans_returns_public_catalog(self, client) -> None:
+        resp = client.get("/subscriptions/plans")
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["success"] is True
+        plans = body["data"]["plans"]
+        assert len(plans) == 3
+        assert plans[0]["slug"] == "free"
+        assert plans[1]["slug"] == "premium_monthly"
+        assert plans[2]["slug"] == "premium_annual"
+
     def test_get_subscription_no_prior_record_returns_free(self, client) -> None:
         """GET /subscriptions/me — returns free defaults when no subscription exists."""
         token = _register_and_login(client, prefix="sub-get")
@@ -183,14 +197,17 @@ class TestGetMySubscription:
                 id=uuid.UUID(sub_id)
             ).first()  # type: ignore[assignment]
             sub.status = SubscriptionStatus.ACTIVE
-            sub.plan_code = "pro_monthly"
+            sub.plan_code = "premium"
+            sub.billing_cycle = BillingCycle.MONTHLY
             db.session.commit()
 
         resp = client.get("/subscriptions/me", headers=_auth_headers(token))
         assert resp.status_code == 200
         body = resp.get_json()
         assert body["data"]["subscription"]["status"] == "active"
-        assert body["data"]["subscription"]["plan_code"] == "pro_monthly"
+        assert body["data"]["subscription"]["plan_code"] == "premium"
+        assert body["data"]["subscription"]["offer_code"] == "premium_monthly"
+        assert body["data"]["subscription"]["billing_cycle"] == "monthly"
 
 
 class TestCreateCheckoutSession:
@@ -198,14 +215,39 @@ class TestCreateCheckoutSession:
         token = _register_and_login(client, prefix="sub-checkout")
         resp = client.post(
             "/subscriptions/checkout",
-            json={"plan_slug": "pro_monthly"},
+            json={"plan_slug": "premium_monthly"},
             headers=_auth_headers(token),
         )
         assert resp.status_code == 201
         body = resp.get_json()
         assert body["success"] is True
         assert "checkout_url" in body["data"]
-        assert "pro_monthly" in body["data"]["checkout_url"]
+        assert body["data"]["plan_slug"] == "premium_monthly"
+        assert body["data"]["plan_code"] == "premium"
+        assert body["data"]["billing_cycle"] == "monthly"
+        assert "premium_monthly" in body["data"]["checkout_url"]
+
+    def test_checkout_legacy_alias_is_normalized(self, client) -> None:
+        token = _register_and_login(client, prefix="sub-checkout-legacy")
+        resp = client.post(
+            "/subscriptions/checkout",
+            json={"plan_slug": "pro_monthly"},
+            headers=_auth_headers(token),
+        )
+        assert resp.status_code == 201
+        body = resp.get_json()
+        assert body["data"]["plan_slug"] == "premium_monthly"
+
+    def test_checkout_unknown_plan_slug_returns_400(self, client) -> None:
+        token = _register_and_login(client, prefix="sub-checkout-unknown")
+        resp = client.post(
+            "/subscriptions/checkout",
+            json={"plan_slug": "invalid-plan"},
+            headers=_auth_headers(token),
+        )
+        assert resp.status_code == 400
+        body = resp.get_json()
+        assert body["error"]["code"] == "VALIDATION_ERROR"
 
     def test_checkout_missing_plan_slug_returns_400(self, client) -> None:
         token = _register_and_login(client, prefix="sub-checkout-err")

--- a/tests/test_postman_collection_contract.py
+++ b/tests/test_postman_collection_contract.py
@@ -207,6 +207,7 @@ def test_postman_collection_covers_critical_rest_routes() -> None:
         ("GET", "/alerts"),
         ("POST", "/alerts/{param}/read"),
         ("DELETE", "/alerts/{param}"),
+        ("GET", "/subscriptions/plans"),
         ("GET", "/subscriptions/me"),
         ("POST", "/subscriptions/checkout"),
         ("POST", "/subscriptions/cancel"),


### PR DESCRIPTION
## Summary
- add the canonical MVP1 billing plan catalog
- expose `GET /subscriptions/plans`
- normalize checkout plan slugs while preserving legacy aliases
- enrich subscription payloads with `offer_code`
- update tests and Postman collection for the new contract

## Validation
- `python3 scripts/build_postman_collection.py`
- `VENV_DIR=/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-api/.venv scripts/repo_bin.sh pytest tests/test_j9_billing_subscriptions.py tests/test_postman_collection_contract.py -q`
- `VENV_DIR=/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-api/.venv scripts/repo_bin.sh mypy app/controllers/subscription_controller.py app/services/subscription_service.py app/services/billing_adapter.py app/config/billing_plans.py app/middleware/auth_guard.py`
- `VENV_DIR=/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-api/.venv scripts/repo_bin.sh pre-commit run --files app/config/billing_plans.py app/controllers/subscription_controller.py app/middleware/auth_guard.py app/services/billing_adapter.py app/services/subscription_service.py tests/test_j9_billing_subscriptions.py tests/test_postman_collection_contract.py scripts/build_postman_collection.py api-tests/postman/auraxis.postman_collection.json`
- `git diff --check`

## Notes
- `pro_monthly` remains accepted as a legacy alias but the canonical checkout slug is now `premium_monthly`