### PR TITLE
feat(auth): Redis cache for JWT revocation check — eliminate DB hit per request (B22)

### DIFF
--- a/app/application/services/password_reset_service.py
+++ b/app/application/services/password_reset_service.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime, timedelta
 from typing import cast
 
 from app.extensions.database import db
+from app.extensions.jwt_revocation_cache import get_jwt_revocation_cache
 from app.http.runtime import (
     runtime_config,
     runtime_debug_or_testing,
@@ -150,6 +151,7 @@ def reset_password(*, token: str, new_password_hash: str) -> PasswordResetResult
     user.password_reset_token_expires_at = None
     user.password_reset_requested_at = None
     db.session.commit()
+    get_jwt_revocation_cache().invalidate(str(user.id))
 
     runtime_logger().info(
         "event=auth.password_reset_completed user_id=%s",

--- a/app/controllers/auth/logout_resource.py
+++ b/app/controllers/auth/logout_resource.py
@@ -9,6 +9,7 @@ from app.docs.openapi_helpers import (
     json_success_response,
 )
 from app.extensions.database import db
+from app.extensions.jwt_revocation_cache import get_jwt_revocation_cache
 from app.utils.typed_decorators import typed_doc as doc
 from app.utils.typed_decorators import typed_jwt_required as jwt_required
 
@@ -43,6 +44,7 @@ class LogoutResource(MethodResource):
         if user:
             user.current_jti = None
             db.session.commit()
+            get_jwt_revocation_cache().invalidate(str(identity))
         return compat_success(
             legacy_payload={"message": "Logout successful"},
             status_code=200,

--- a/app/controllers/auth/refresh_token_resource.py
+++ b/app/controllers/auth/refresh_token_resource.py
@@ -12,6 +12,7 @@ from app.docs.openapi_helpers import (
     json_success_response,
 )
 from app.extensions.database import db
+from app.extensions.jwt_revocation_cache import get_jwt_revocation_cache
 from app.models.user import User
 from app.utils.typed_decorators import typed_doc as doc
 from app.utils.typed_decorators import typed_jwt_required as jwt_required
@@ -92,6 +93,7 @@ class RefreshTokenResource(MethodResource):
             user.current_jti = new_access_jti
             user.refresh_token_jti = new_refresh_jti
             db.session.commit()
+            get_jwt_revocation_cache().set_current_jti(user_id, new_access_jti)
 
             return compat_success(
                 legacy_payload={

--- a/app/extensions/jwt_callbacks.py
+++ b/app/extensions/jwt_callbacks.py
@@ -7,6 +7,7 @@ from flask_jwt_extended import JWTManager
 
 from app.auth import InvalidAuthContextError, current_user_id
 from app.extensions.database import db
+from app.extensions.jwt_revocation_cache import get_jwt_revocation_cache
 from app.models.user import User
 from app.utils.api_contract import is_v2_contract_request
 from app.utils.response_builder import error_payload
@@ -30,10 +31,34 @@ def is_token_revoked(jti: str) -> bool:
         identity = current_user_id(optional=True)
         if identity is None:
             return True
+        cache = get_jwt_revocation_cache()
+        user_id_str = str(identity)
+        cached_jti = cache.get_current_jti(user_id_str)
+        if cached_jti is not None:
+            return cached_jti != jti
+        # Cache miss — fall through to DB.
         user = db.session.get(User, identity)
-        return not user or user.current_jti != jti
+        if not user:
+            return True
+        cache.set_current_jti(user_id_str, user.current_jti)
+        return bool(user.current_jti != jti)
     except InvalidAuthContextError:
         return True
+
+
+def _is_access_token_revoked(user_id: str, jti: str) -> bool:
+    """Check whether an access token is revoked (cache-first, DB fallback)."""
+    cache = get_jwt_revocation_cache()
+    cached_jti = cache.get_current_jti(user_id)
+    if cached_jti is not None:
+        return cached_jti != jti
+
+    # Cache miss — query DB and populate cache.
+    user = db.session.get(User, UUID(user_id))
+    if not user:
+        return True
+    cache.set_current_jti(user_id, user.current_jti)
+    return bool(user.current_jti != jti)
 
 
 def register_jwt_callbacks(jwt: JWTManager) -> None:
@@ -48,13 +73,14 @@ def register_jwt_callbacks(jwt: JWTManager) -> None:
         if not user_id or not jti:
             return True
 
-        user = db.session.get(User, UUID(user_id))
-        if not user:
-            return True
-
         if token_type == "refresh":
+            # Refresh token check always goes to DB (replay attack guard).
+            user = db.session.get(User, UUID(user_id))
+            if not user:
+                return True
             return bool(user.refresh_token_jti != jti)
-        return bool(user.current_jti != jti)
+
+        return _is_access_token_revoked(user_id, jti)
 
     @jwt.revoked_token_loader
     def revoked_token_callback(

--- a/app/extensions/jwt_revocation_cache.py
+++ b/app/extensions/jwt_revocation_cache.py
@@ -1,0 +1,160 @@
+"""Redis cache for JWT revocation checks.
+
+Caches the current_jti value per user to avoid a DB hit on every authenticated
+request.  Falls back to a no-op (always cache-miss) when Redis is unavailable,
+so that a Redis outage never locks out legitimate users.
+
+Cache key: ``jwt:revoked:{user_id}``
+TTL:       300 seconds (configurable via ``JWT_REVOCATION_CACHE_TTL``).
+
+Usage::
+
+    from app.extensions.jwt_revocation_cache import get_jwt_revocation_cache
+
+    cache = get_jwt_revocation_cache()
+    jti = cache.get_current_jti(user_id)   # None on cache-miss or Redis down
+    cache.set_current_jti(user_id, jti)
+    cache.invalidate(user_id)
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_KEY_PREFIX = "jwt:revoked"
+DEFAULT_TTL_SECONDS = 300
+
+
+class _NoOpJwtRevocationCache:
+    """Always reports a cache-miss; used when Redis is unavailable."""
+
+    def get_current_jti(self, user_id: str) -> str | None:
+        return None
+
+    def set_current_jti(self, user_id: str, jti: str | None) -> None:
+        return None
+
+    def invalidate(self, user_id: str) -> None:
+        return None
+
+
+class RedisJwtRevocationCache:
+    """Redis-backed JWT revocation cache."""
+
+    def __init__(
+        self,
+        client: Any,
+        *,
+        key_prefix: str = DEFAULT_KEY_PREFIX,
+        ttl_seconds: int = DEFAULT_TTL_SECONDS,
+    ) -> None:
+        self._client = client
+        self._key_prefix = key_prefix
+        self._ttl_seconds = ttl_seconds
+
+    def _key(self, user_id: str) -> str:
+        return f"{self._key_prefix}:{user_id}"
+
+    def get_current_jti(self, user_id: str) -> str | None:
+        try:
+            raw = self._client.get(self._key(user_id))
+            if raw is None:
+                return None
+            if isinstance(raw, (bytes, bytearray)):
+                return raw.decode("utf-8")
+            return str(raw)
+        except Exception:
+            logger.warning(
+                "jwt_revocation_cache: Redis GET failed for user_id=%s — cache miss",
+                user_id,
+                exc_info=True,
+            )
+            return None
+
+    def set_current_jti(self, user_id: str, jti: str | None) -> None:
+        if jti is None:
+            self.invalidate(user_id)
+            return
+        try:
+            self._client.setex(self._key(user_id), self._ttl_seconds, jti)
+        except Exception:
+            logger.warning(
+                "jwt_revocation_cache: Redis SETEX failed for user_id=%s",
+                user_id,
+                exc_info=True,
+            )
+
+    def invalidate(self, user_id: str) -> None:
+        try:
+            self._client.delete(self._key(user_id))
+        except Exception:
+            logger.warning(
+                "jwt_revocation_cache: Redis DELETE failed for user_id=%s",
+                user_id,
+                exc_info=True,
+            )
+
+
+# Module-level singleton — built once at first use.
+_cache_instance: RedisJwtRevocationCache | _NoOpJwtRevocationCache | None = None
+
+
+def _build_cache() -> RedisJwtRevocationCache | _NoOpJwtRevocationCache:
+    redis_url = str(
+        os.getenv("JWT_REVOCATION_REDIS_URL", os.getenv("REDIS_URL", ""))
+    ).strip()
+    if not redis_url:
+        logger.info(
+            "jwt_revocation_cache: REDIS_URL not set — using no-op (DB fallback active)"
+        )
+        return _NoOpJwtRevocationCache()
+
+    try:
+        redis_cls = importlib.import_module("redis").Redis
+    except Exception:
+        logger.warning("jwt_revocation_cache: redis package unavailable — using no-op")
+        return _NoOpJwtRevocationCache()
+
+    try:
+        client = redis_cls.from_url(redis_url)
+        client.ping()
+    except Exception:
+        logger.warning(
+            "jwt_revocation_cache: Redis unreachable — using no-op (DB fallback active)"
+        )
+        return _NoOpJwtRevocationCache()
+
+    ttl = int(os.getenv("JWT_REVOCATION_CACHE_TTL", str(DEFAULT_TTL_SECONDS)))
+    key_prefix = str(
+        os.getenv("JWT_REVOCATION_CACHE_KEY_PREFIX", DEFAULT_KEY_PREFIX)
+    ).strip()
+    logger.info(
+        "jwt_revocation_cache: Redis backend active (url=%s ttl=%ds prefix=%s)",
+        redis_url,
+        ttl,
+        key_prefix,
+    )
+    return RedisJwtRevocationCache(
+        client,
+        key_prefix=key_prefix or DEFAULT_KEY_PREFIX,
+        ttl_seconds=ttl,
+    )
+
+
+def get_jwt_revocation_cache() -> RedisJwtRevocationCache | _NoOpJwtRevocationCache:
+    """Return the module-level cache singleton (built lazily on first call)."""
+    global _cache_instance
+    if _cache_instance is None:
+        _cache_instance = _build_cache()
+    return _cache_instance
+
+
+def reset_jwt_revocation_cache_for_tests() -> None:
+    """Reset the singleton so tests can inject a fresh instance."""
+    global _cache_instance
+    _cache_instance = None

--- a/tests/test_b22_jwt_revocation_cache.py
+++ b/tests/test_b22_jwt_revocation_cache.py
@@ -1,0 +1,340 @@
+"""Tests for B22 — Redis cache for JWT revocation check.
+
+Covers:
+- Cache hit: second call does not hit DB (mock DB, assert 1 DB query for 2 checks)
+- Cache miss: DB queried, cache populated
+- Cache invalidation: after logout, cache key is deleted
+- Redis unavailable: falls back to DB without raising an exception
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from app.extensions.jwt_revocation_cache import (
+    RedisJwtRevocationCache,
+    _NoOpJwtRevocationCache,
+    reset_jwt_revocation_cache_for_tests,
+)
+
+# ---------------------------------------------------------------------------
+# Unit tests — RedisJwtRevocationCache
+# ---------------------------------------------------------------------------
+
+
+class TestRedisJwtRevocationCache:
+    def _make_cache(self, client: Any) -> RedisJwtRevocationCache:
+        return RedisJwtRevocationCache(
+            client, key_prefix="jwt:revoked", ttl_seconds=300
+        )
+
+    def test_get_returns_none_on_redis_miss(self) -> None:
+        client = MagicMock()
+        client.get.return_value = None
+        cache = self._make_cache(client)
+        assert cache.get_current_jti("user-1") is None
+        client.get.assert_called_once_with("jwt:revoked:user-1")
+
+    def test_get_returns_decoded_string(self) -> None:
+        client = MagicMock()
+        client.get.return_value = b"abc-jti-value"
+        cache = self._make_cache(client)
+        assert cache.get_current_jti("user-1") == "abc-jti-value"
+
+    def test_set_calls_setex_with_ttl(self) -> None:
+        client = MagicMock()
+        cache = self._make_cache(client)
+        cache.set_current_jti("user-1", "my-jti")
+        client.setex.assert_called_once_with("jwt:revoked:user-1", 300, "my-jti")
+
+    def test_set_none_calls_invalidate(self) -> None:
+        client = MagicMock()
+        cache = self._make_cache(client)
+        cache.set_current_jti("user-1", None)
+        client.delete.assert_called_once_with("jwt:revoked:user-1")
+        client.setex.assert_not_called()
+
+    def test_invalidate_calls_delete(self) -> None:
+        client = MagicMock()
+        cache = self._make_cache(client)
+        cache.invalidate("user-1")
+        client.delete.assert_called_once_with("jwt:revoked:user-1")
+
+    def test_get_returns_none_on_redis_exception(self) -> None:
+        client = MagicMock()
+        client.get.side_effect = OSError("connection refused")
+        cache = self._make_cache(client)
+        # Must not raise — should behave as cache miss.
+        result = cache.get_current_jti("user-1")
+        assert result is None
+
+    def test_set_swallows_redis_exception(self) -> None:
+        client = MagicMock()
+        client.setex.side_effect = OSError("connection refused")
+        cache = self._make_cache(client)
+        # Must not raise.
+        cache.set_current_jti("user-1", "some-jti")
+
+    def test_invalidate_swallows_redis_exception(self) -> None:
+        client = MagicMock()
+        client.delete.side_effect = OSError("connection refused")
+        cache = self._make_cache(client)
+        # Must not raise.
+        cache.invalidate("user-1")
+
+
+class TestNoOpJwtRevocationCache:
+    def test_get_always_returns_none(self) -> None:
+        cache = _NoOpJwtRevocationCache()
+        assert cache.get_current_jti("user-1") is None
+
+    def test_set_is_harmless(self) -> None:
+        cache = _NoOpJwtRevocationCache()
+        cache.set_current_jti("user-1", "jti-value")  # should not raise
+
+    def test_invalidate_is_harmless(self) -> None:
+        cache = _NoOpJwtRevocationCache()
+        cache.invalidate("user-1")  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — cache singleton builder
+# ---------------------------------------------------------------------------
+
+
+class TestGetJwtRevocationCache:
+    def setup_method(self) -> None:
+        reset_jwt_revocation_cache_for_tests()
+
+    def teardown_method(self) -> None:
+        reset_jwt_revocation_cache_for_tests()
+
+    def test_returns_noop_when_redis_url_missing(self, monkeypatch: Any) -> None:
+        monkeypatch.delenv("REDIS_URL", raising=False)
+        monkeypatch.delenv("JWT_REVOCATION_REDIS_URL", raising=False)
+        from app.extensions.jwt_revocation_cache import get_jwt_revocation_cache
+
+        cache = get_jwt_revocation_cache()
+        assert isinstance(cache, _NoOpJwtRevocationCache)
+
+    def test_returns_noop_when_redis_unreachable(self, monkeypatch: Any) -> None:
+        monkeypatch.setenv("REDIS_URL", "redis://127.0.0.1:19999")
+
+        fake_redis_cls = MagicMock()
+        fake_client = MagicMock()
+        fake_client.ping.side_effect = OSError("refused")
+        fake_redis_cls.from_url.return_value = fake_client
+
+        fake_module = MagicMock()
+        fake_module.Redis = fake_redis_cls
+
+        with patch("importlib.import_module", return_value=fake_module):
+            from app.extensions.jwt_revocation_cache import get_jwt_revocation_cache
+
+            cache = get_jwt_revocation_cache()
+
+        assert isinstance(cache, _NoOpJwtRevocationCache)
+
+    def test_returns_redis_cache_when_redis_available(self, monkeypatch: Any) -> None:
+        monkeypatch.setenv("REDIS_URL", "redis://127.0.0.1:6379")
+
+        fake_redis_cls = MagicMock()
+        fake_client = MagicMock()
+        fake_client.ping.return_value = True
+        fake_redis_cls.from_url.return_value = fake_client
+
+        fake_module = MagicMock()
+        fake_module.Redis = fake_redis_cls
+
+        with patch("importlib.import_module", return_value=fake_module):
+            from app.extensions.jwt_revocation_cache import get_jwt_revocation_cache
+
+            cache = get_jwt_revocation_cache()
+
+        assert isinstance(cache, RedisJwtRevocationCache)
+
+    def test_singleton_is_reused(self, monkeypatch: Any) -> None:
+        monkeypatch.delenv("REDIS_URL", raising=False)
+        monkeypatch.delenv("JWT_REVOCATION_REDIS_URL", raising=False)
+        from app.extensions.jwt_revocation_cache import get_jwt_revocation_cache
+
+        c1 = get_jwt_revocation_cache()
+        c2 = get_jwt_revocation_cache()
+        assert c1 is c2
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — check_if_token_revoked with cache
+# ---------------------------------------------------------------------------
+
+# Ensure the module is imported before patching so the attribute exists.
+import app.extensions.jwt_callbacks as _jwt_callbacks_mod  # noqa: E402
+
+
+def _make_jwt_manager_and_capture() -> tuple[Any, dict[str, Any]]:
+    jwt_manager = MagicMock()
+    captured: dict[str, Any] = {}
+
+    def token_in_blocklist_loader(fn: Any) -> Any:
+        captured["fn"] = fn
+        return fn
+
+    jwt_manager.token_in_blocklist_loader = token_in_blocklist_loader
+    jwt_manager.revoked_token_loader = lambda fn: fn
+    jwt_manager.invalid_token_loader = lambda fn: fn
+    jwt_manager.expired_token_loader = lambda fn: fn
+    jwt_manager.unauthorized_loader = lambda fn: fn
+    return jwt_manager, captured
+
+
+class TestCheckIfTokenRevokedWithCache:
+    """Tests that register_jwt_callbacks correctly uses the cache."""
+
+    def test_cache_hit_avoids_db_query(self) -> None:
+        """When cache holds the current JTI, db.session.get must NOT be called."""
+        user_id = str(uuid.uuid4())
+        stored_jti = "correct-jti"
+
+        redis_client = MagicMock()
+        redis_client.get.return_value = stored_jti.encode()
+        cache = RedisJwtRevocationCache(redis_client)
+
+        jwt_manager, captured = _make_jwt_manager_and_capture()
+
+        _get_cache = patch.object(
+            _jwt_callbacks_mod, "get_jwt_revocation_cache", return_value=cache
+        )
+        with _get_cache, patch.object(_jwt_callbacks_mod, "db") as mock_db:
+            _jwt_callbacks_mod.register_jwt_callbacks(jwt_manager)
+            check_fn = captured["fn"]
+
+            # First call — cache hit, correct JTI.
+            result1 = check_fn(
+                {}, {"sub": user_id, "jti": stored_jti, "type": "access"}
+            )
+            # Second call — same.
+            result2 = check_fn(
+                {}, {"sub": user_id, "jti": stored_jti, "type": "access"}
+            )
+
+        assert result1 is False
+        assert result2 is False
+        # DB must never be consulted when cache has data.
+        mock_db.session.get.assert_not_called()
+
+    def test_cache_miss_queries_db_and_populates_cache(self) -> None:
+        """On cache miss the DB is queried and the cache is populated."""
+        user_id = str(uuid.uuid4())
+        stored_jti = "correct-jti"
+
+        redis_client = MagicMock()
+        redis_client.get.return_value = None  # cache miss
+        cache = RedisJwtRevocationCache(redis_client)
+
+        mock_user = MagicMock()
+        mock_user.current_jti = stored_jti
+
+        jwt_manager, captured = _make_jwt_manager_and_capture()
+
+        _get_cache = patch.object(
+            _jwt_callbacks_mod, "get_jwt_revocation_cache", return_value=cache
+        )
+        with (
+            _get_cache,
+            patch.object(_jwt_callbacks_mod, "db") as mock_db,
+            patch.object(_jwt_callbacks_mod, "UUID", side_effect=uuid.UUID),
+        ):
+            mock_db.session.get.return_value = mock_user
+
+            _jwt_callbacks_mod.register_jwt_callbacks(jwt_manager)
+            check_fn = captured["fn"]
+
+            result = check_fn({}, {"sub": user_id, "jti": stored_jti, "type": "access"})
+
+        assert result is False
+        mock_db.session.get.assert_called_once()
+        # Cache should now be populated.
+        redis_client.setex.assert_called_once()
+
+    def test_redis_unavailable_falls_back_to_db(self) -> None:
+        """When Redis is unavailable (no-op cache), the DB is queried without error."""
+        user_id = str(uuid.uuid4())
+        stored_jti = "correct-jti"
+
+        noop_cache = _NoOpJwtRevocationCache()
+        mock_user = MagicMock()
+        mock_user.current_jti = stored_jti
+
+        jwt_manager, captured = _make_jwt_manager_and_capture()
+
+        with (
+            patch.object(
+                _jwt_callbacks_mod, "get_jwt_revocation_cache", return_value=noop_cache
+            ),
+            patch.object(_jwt_callbacks_mod, "db") as mock_db,
+            patch.object(_jwt_callbacks_mod, "UUID", side_effect=uuid.UUID),
+        ):
+            mock_db.session.get.return_value = mock_user
+
+            _jwt_callbacks_mod.register_jwt_callbacks(jwt_manager)
+            check_fn = captured["fn"]
+
+            # Must not raise even though cache is a no-op.
+            result = check_fn({}, {"sub": user_id, "jti": stored_jti, "type": "access"})
+
+        assert result is False
+        mock_db.session.get.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — logout invalidates cache (via HTTP)
+# ---------------------------------------------------------------------------
+
+
+class TestLogoutCacheInvalidation:
+    """Verifies that the logout endpoint invalidates the JWT revocation cache."""
+
+    def _register_and_login(self, client: Any) -> tuple[str, str]:
+        suffix = uuid.uuid4().hex[:8]
+        payload = {
+            "name": f"cache-test-{suffix}",
+            "email": f"cache-test-{suffix}@example.com",
+            "password": "StrongPass@123",
+        }
+        reg = client.post("/auth/register", json=payload)
+        assert reg.status_code == 201
+
+        login = client.post(
+            "/auth/login",
+            headers={"X-API-Contract": "v2"},
+            json={"email": payload["email"], "password": payload["password"]},
+        )
+        assert login.status_code == 200
+        token = login.get_json()["data"]["token"]
+        user_id = login.get_json()["data"]["user"]["id"]
+        return token, user_id
+
+    def test_logout_deletes_cache_key(self, client: Any, monkeypatch: Any) -> None:
+        reset_jwt_revocation_cache_for_tests()
+        monkeypatch.delenv("REDIS_URL", raising=False)
+        monkeypatch.delenv("JWT_REVOCATION_REDIS_URL", raising=False)
+
+        token, user_id = self._register_and_login(client)
+
+        redis_client = MagicMock()
+        redis_client.get.return_value = None
+        fake_cache = RedisJwtRevocationCache(redis_client)
+
+        with patch(
+            "app.controllers.auth.logout_resource.get_jwt_revocation_cache",
+            return_value=fake_cache,
+        ):
+            resp = client.post(
+                "/auth/logout",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            assert resp.status_code == 200
+
+        redis_client.delete.assert_called_once_with(f"jwt:revoked:{user_id}")


### PR DESCRIPTION
## Summary

- Introduces `app/extensions/jwt_revocation_cache.py`: a lazy Redis cache singleton with key `jwt:revoked:{user_id}` and TTL 300s (configurable via `JWT_REVOCATION_CACHE_TTL`)
- Every authenticated request revocation check now hits Redis first; DB is queried only on cache miss
- Falls back to DB (no exception, no user lockout) when Redis is unavailable — fail-open design
- Cache is invalidated on: logout, token refresh (B18 JTI rotation), and password reset

## Changed files

- `app/extensions/jwt_revocation_cache.py` — new module, Redis cache with no-op fallback
- `app/extensions/jwt_callbacks.py` — `_is_access_token_revoked` helper + cache integration in blocklist loader and `is_token_revoked`
- `app/controllers/auth/logout_resource.py` — `cache.invalidate(user_id)` after clearing current_jti
- `app/controllers/auth/refresh_token_resource.py` — `cache.set_current_jti` after token rotation
- `app/application/services/password_reset_service.py` — `cache.invalidate(user_id)` after password reset
- `tests/test_b22_jwt_revocation_cache.py` — 19 new tests

## Test plan

- [x] Cache hit: second call does not trigger DB query (mock asserts 0 DB calls for 2 invocations)
- [x] Cache miss: DB queried once, cache populated via setex
- [x] Cache invalidation: logout calls `cache.delete` with correct key
- [x] Redis unavailable: no-op cache returns None, DB queried, no exception raised
- [x] Singleton reuse: same instance returned across calls
- [x] All 861 existing tests pass, coverage 90.44% (threshold 85%)
- [x] All pre-commit hooks pass (ruff, mypy, bandit, gitleaks, sonar, pip-audit)

## Environment variables

| Variable | Default | Purpose |
|---|---|---|
| `REDIS_URL` | (none) | Redis connection URL (shared with rate-limit and login-guard consumers) |
| `JWT_REVOCATION_REDIS_URL` | falls back to REDIS_URL | Override for JWT cache only |
| `JWT_REVOCATION_CACHE_TTL` | 300 | TTL in seconds |
| `JWT_REVOCATION_CACHE_KEY_PREFIX` | jwt:revoked | Key prefix |

Closes B22.