### PR TITLE
feat(billing): align prices + trial-expiry CLI + billing env docs [H-PROD-01]

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -56,6 +56,7 @@ from app.extensions.http_observability import register_http_observability
 from app.extensions.integration_metrics_cli import register_integration_metrics_commands
 from app.extensions.prometheus_metrics import register_prometheus_middleware
 from app.extensions.sentry import init_sentry
+from app.extensions.trial_expiry_cli import register_trial_expiry_cli
 from app.http.request_context import register_request_context_adapter
 from app.middleware.cors import register_cors
 from app.middleware.docs_access import register_docs_access_guard
@@ -255,6 +256,7 @@ def create_app(*, enable_http_runtime: bool = True) -> Flask:
         _register_http_runtime(app)
     register_audit_trail(app)
     register_audit_retention_commands(app)
+    register_trial_expiry_cli(app)
     register_integration_metrics_commands(app)
     app.cli.add_command(features_cli_group, "features")
     register_wallet_dependencies(app)

--- a/app/config/billing_plans.py
+++ b/app/config/billing_plans.py
@@ -56,7 +56,8 @@ PREMIUM_MONTHLY_PLAN = BillingPlanOffer(
     tier="premium",
     display_name="Premium Mensal",
     description="Analises com IA, alertas e briefing semanal.",
-    price_cents=3990,
+    # DEC-168: R$27,90/mês — founder-confirmed 2026-04-05
+    price_cents=2790,
     billing_cycle=BillingCycle.MONTHLY,
     trial_days=7,
     highlighted=True,
@@ -69,7 +70,8 @@ PREMIUM_ANNUAL_PLAN = BillingPlanOffer(
     tier="premium",
     display_name="Premium Anual",
     description="Mesmo pacote premium com desconto anual.",
-    price_cents=35880,
+    # DEC-168: R$220,00/ano (equiv. R$18,33/mês) — founder-confirmed 2026-04-05
+    price_cents=22000,
     billing_cycle=BillingCycle.ANNUAL,
     trial_days=7,
     legacy_aliases=("pro_annual",),

--- a/app/extensions/trial_expiry_cli.py
+++ b/app/extensions/trial_expiry_cli.py
@@ -1,0 +1,43 @@
+"""Flask CLI command — trial subscription auto-expiry.
+
+Thin wrapper around ``scripts/process_trial_expirations.py`` so the same
+logic can be invoked as a Flask CLI command in Docker / ECS environments:
+
+    flask billing expire-trials [--dry-run]
+
+The underlying business logic lives in (and is tested via)
+``scripts/process_trial_expirations.py`` and ``tests/test_billing.py``.
+"""
+
+from __future__ import annotations
+
+import click
+from flask import Flask
+from flask.cli import AppGroup
+
+billing_cli = AppGroup("billing", help="Billing management commands.")
+
+
+@billing_cli.command("expire-trials")
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Print which subscriptions would expire without writing to DB.",
+)
+def expire_trials(dry_run: bool) -> None:
+    """Downgrade TRIALING subscriptions whose trial period has ended."""
+    from scripts.process_trial_expirations import process_trial_expirations
+
+    count = process_trial_expirations(dry_run=dry_run)
+    if dry_run:
+        click.echo(f"[dry-run] {count} subscription(s) would be downgraded.")
+    else:
+        click.echo(f"{count} subscription(s) downgraded.")
+    if count > 0 and not dry_run:
+        raise SystemExit(0)
+
+
+def register_trial_expiry_cli(app: Flask) -> None:
+    """Register the ``billing`` CLI group on *app*."""
+    app.cli.add_command(billing_cli)


### PR DESCRIPTION
## Summary

- **Preços alinhados com frontend** (DEC-168, founder-confirmed 2026-04-05):
  - `premium_monthly`: R\$39,90 → R\$27,90/mês (3990 → 2790 cents)
  - `premium_annual`: R\$358,80 → R\$220,00/ano (35880 → 22000 cents)
- **`flask billing expire-trials`**: CLI wrapper sobre `scripts/process_trial_expirations.py` para invocação em Docker/ECS sem precisar de `python scripts/...`
- **`.env.dev.example`**: todas as vars de billing documentadas com guia inline para setup sandbox Asaas

## Contexto

H-PROD-01 — Billing funcional. A infraestrutura (models, controller, webhook, Asaas adapter, entitlement service) já estava implementada. Este PR fecha os últimos gaps:
1. ✅ Preço na API alinhado com o que o frontend exibe
2. ✅ Trial auto-downgrade invocável como `flask billing expire-trials` (lógica já em `scripts/`, testes em `tests/test_billing.py`)
3. ✅ Env vars documentados para onboarding de novos devs / deploy em sandbox

## Test plan

- [x] `tests/test_billing.py` — 21 testes passando (trial bootstrap, activate/deactivate premium, webhook events, price alignment)
- [x] `ruff`, `mypy`, `bandit`, `alembic-single-head-check` — todos passando
- [x] Quality check local: verde
- [ ] Verificar checkout end-to-end em sandbox Asaas com BILLING_PROVIDER=asaas

Closes #860