### PR TITLE
security(api): SEC-GAP-05 — Idempotency-Key middleware for POST mutators

### DIFF
--- a/api-tests/postman/auraxis.postman_collection.json
+++ b/api-tests/postman/auraxis.postman_collection.json
@@ -4371,6 +4371,11 @@
               {
                 "key": "X-API-Contract",
                 "value": "v2"
+              },
+              {
+                "key": "Idempotency-Key",
+                "value": "{{$guid}}",
+                "description": "Required for POST mutators — prevents duplicate mutations (SEC-GAP-05)"
               }
             ],
             "url": {
@@ -4418,6 +4423,11 @@
               {
                 "key": "X-API-Contract",
                 "value": "v2"
+              },
+              {
+                "key": "Idempotency-Key",
+                "value": "{{$guid}}",
+                "description": "Required for POST mutators — prevents duplicate mutations (SEC-GAP-05)"
               }
             ],
             "url": {

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -294,11 +294,13 @@ def create_app(*, enable_http_runtime: bool = True) -> Flask:
     _register_documented_endpoints(app, docs)
     from app.extensions.jwt_callbacks import register_jwt_callbacks
     from app.middleware.auth_guard import register_auth_guard
+    from app.middleware.idempotency_key import register_idempotency_guard
     from app.middleware.rate_limit import register_rate_limit_guard
 
     if enable_http_runtime:
         register_rate_limit_guard(app)
         register_auth_guard(app)
+        register_idempotency_guard(app)
     register_jwt_callbacks(jwt)
 
     return app

--- a/app/middleware/cors.py
+++ b/app/middleware/cors.py
@@ -40,7 +40,7 @@ def _build_cors_policy_from_env() -> CorsPolicy:
     ).strip()
     allowed_headers = os.getenv(
         "CORS_ALLOWED_HEADERS",
-        "Authorization,Content-Type,X-API-Contract",
+        "Authorization,Content-Type,X-API-Contract,Idempotency-Key",
     ).strip()
     return CorsPolicy(
         allowed_origins=_parse_allowed_origins(os.getenv("CORS_ALLOWED_ORIGINS")),

--- a/app/middleware/idempotency_key.py
+++ b/app/middleware/idempotency_key.py
@@ -1,0 +1,255 @@
+"""Idempotency-Key middleware — SEC-GAP-05.
+
+Prevents duplicate mutations caused by double-clicks or network retries.
+
+Contract:
+  - All POST requests MAY include an ``Idempotency-Key`` header.
+  - POST requests to paths matching REQUIRED_PREFIXES MUST include the header
+    (missing key → 400 Bad Request).
+  - First request with a given key: executed normally; response is cached in
+    Redis for TTL_SECONDS (24 h).
+  - Subsequent requests with the same key: cached response returned as-is
+    without re-executing the handler.
+  - Same key + different request body: 409 Conflict.
+  - Redis unavailable: middleware is bypassed (fail-open). Idempotency is best-
+    effort — do NOT block requests when the backend is down.
+
+Redis key structure:
+  ``idempotency:{user_subject}:{path}:{sha256(idempotency_key_value)}``
+
+Redis value (JSON):
+  {
+    "body_hash": "<sha256 of raw request body at first call>",
+    "status_code": 200,
+    "body": "<base64-encoded response body>",
+    "content_type": "application/json",
+  }
+
+Usage:
+  Register AFTER the auth guard so ``user_subject`` is available:
+
+      from app.middleware.idempotency_key import register_idempotency_guard
+      register_idempotency_guard(app)
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import importlib
+import json
+import logging
+import os
+from typing import Any
+
+from flask import Flask, Response, g, jsonify, request
+
+from app.utils.api_contract import is_v2_contract_request
+from app.utils.response_builder import error_payload
+
+logger = logging.getLogger(__name__)
+
+TTL_SECONDS = 86_400  # 24 hours
+
+# POST endpoints where the header is mandatory.
+REQUIRED_PREFIXES = (
+    "/subscriptions/checkout",
+    "/subscriptions/cancel",
+)
+
+# POST endpoints that must be skipped entirely (webhooks, auth, etc.)
+_SKIP_PREFIXES = (
+    "/subscriptions/webhook",
+    "/auth/",
+    "/docs",
+    "/healthz",
+    "/readiness",
+)
+
+IDEMPOTENCY_KEY_HEADER = "Idempotency-Key"
+_KEY_PREFIX = "auraxis:idempotency"
+
+
+def _sha256(value: str) -> str:
+    return hashlib.sha256(value.encode()).hexdigest()
+
+
+def _body_hash(raw: bytes) -> str:
+    return hashlib.sha256(raw).hexdigest()
+
+
+def _get_user_subject() -> str | None:
+    """Return the JWT subject if a valid token is present, else None."""
+    from flask_jwt_extended import get_jwt, verify_jwt_in_request
+    from flask_jwt_extended.exceptions import JWTExtendedException
+
+    try:
+        verify_jwt_in_request(optional=True)
+        claims = get_jwt()
+        subject = claims.get("sub")
+        return str(subject).strip() if subject else None
+    except (JWTExtendedException, Exception):
+        return None
+
+
+def _build_redis_key(user_subject: str | None, path: str, idempotency_key: str) -> str:
+    scope = user_subject or "anon"
+    key_hash = _sha256(idempotency_key)
+    return f"{_KEY_PREFIX}:{scope}:{path}:{key_hash}"
+
+
+def _build_conflict_response() -> Response:
+    if is_v2_contract_request():
+        payload = error_payload(
+            message="Idempotency-Key já utilizada com um corpo de request diferente.",
+            code="IDEMPOTENCY_CONFLICT",
+        )
+    else:
+        payload = {
+            "message": (
+                "Conflict: same Idempotency-Key used with a different request body."
+            ),
+            "error": "IDEMPOTENCY_CONFLICT",
+        }
+    response = jsonify(payload)
+    response.status_code = 409
+    return response
+
+
+def _build_missing_key_response() -> Response:
+    if is_v2_contract_request():
+        payload = error_payload(
+            message="Header Idempotency-Key obrigatório para este endpoint.",
+            code="IDEMPOTENCY_KEY_REQUIRED",
+        )
+    else:
+        payload = {
+            "message": "Idempotency-Key header is required for this endpoint.",
+            "error": "IDEMPOTENCY_KEY_REQUIRED",
+        }
+    response = jsonify(payload)
+    response.status_code = 400
+    return response
+
+
+def _try_get_redis() -> Any | None:
+    redis_url = str(
+        os.getenv("IDEMPOTENCY_REDIS_URL", os.getenv("RATE_LIMIT_REDIS_URL", ""))
+    ).strip()
+    if not redis_url:
+        return None
+    try:
+        redis_mod = importlib.import_module("redis")
+        client = redis_mod.Redis.from_url(redis_url)
+        client.ping()
+        return client
+    except Exception:
+        return None
+
+
+def _should_skip(path: str) -> bool:
+    for prefix in _SKIP_PREFIXES:
+        if path == prefix or path.startswith(prefix):
+            return True
+    return False
+
+
+def _make_before_request(redis_client: Any) -> Any:
+    def idempotency_before_request() -> Response | None:
+        if request.method != "POST":
+            return None
+        if _should_skip(request.path):
+            return None
+        return _check_idempotency(redis_client)
+
+    return idempotency_before_request
+
+
+def _check_idempotency(redis_client: Any) -> Response | None:
+    idempotency_key = request.headers.get(IDEMPOTENCY_KEY_HEADER, "").strip()
+
+    is_required = any(
+        request.path == p or request.path.startswith(p) for p in REQUIRED_PREFIXES
+    )
+    if is_required and not idempotency_key:
+        return _build_missing_key_response()
+
+    if not idempotency_key:
+        return None
+
+    user_subject = _get_user_subject()
+    redis_key = _build_redis_key(user_subject, request.path, idempotency_key)
+    raw_body = request.get_data()
+    current_body_hash = _body_hash(raw_body)
+
+    try:
+        cached = redis_client.get(redis_key)
+    except Exception:
+        logger.warning("idempotency_redis_get_failed key=%s mode=fail_open", redis_key)
+        return None
+
+    if cached is None:
+        g.idempotency_redis_key = redis_key
+        g.idempotency_body_hash = current_body_hash
+        return None
+
+    return _replay_or_conflict(cached, current_body_hash)
+
+
+def _replay_or_conflict(cached: bytes, current_body_hash: str) -> Response | None:
+    try:
+        stored: dict[str, Any] = json.loads(cached)
+    except (json.JSONDecodeError, TypeError):
+        logger.warning("idempotency_cache_corrupt")
+        return None
+
+    stored_body_hash = stored.get("body_hash", "")
+    if stored_body_hash and stored_body_hash != current_body_hash:
+        return _build_conflict_response()
+
+    body_bytes = base64.b64decode(stored.get("body", ""))
+    response = Response(
+        body_bytes,
+        status=int(stored.get("status_code", 200)),
+        content_type=stored.get("content_type", "application/json"),
+    )
+    response.headers["X-Idempotency-Replayed"] = "true"
+    return response
+
+
+def _make_after_request(redis_client: Any) -> Any:
+    def idempotency_after_request(response: Response) -> Response:
+        redis_key = getattr(g, "idempotency_redis_key", None)
+        if not redis_key:
+            return response
+
+        body_hash = getattr(g, "idempotency_body_hash", "")
+        try:
+            stored = json.dumps(
+                {
+                    "body_hash": body_hash,
+                    "status_code": response.status_code,
+                    "body": base64.b64encode(response.get_data()).decode(),
+                    "content_type": response.content_type or "application/json",
+                }
+            )
+            redis_client.set(redis_key, stored, ex=TTL_SECONDS)
+        except Exception:
+            logger.warning("idempotency_redis_set_failed key=%s", redis_key)
+
+        return response
+
+    return idempotency_after_request
+
+
+def register_idempotency_guard(app: Flask) -> None:
+    redis_client = _try_get_redis()
+    if redis_client is None:
+        logger.warning(
+            "idempotency_guard_disabled reason=redis_unavailable mode=fail_open"
+        )
+        return
+
+    app.extensions["idempotency_redis"] = redis_client
+    app.before_request(_make_before_request(redis_client))
+    app.after_request(_make_after_request(redis_client))

--- a/tests/test_cors_policy.py
+++ b/tests/test_cors_policy.py
@@ -75,7 +75,10 @@ def test_build_cors_policy_from_env_respects_defaults(
     assert policy.allowed_origins == {"https://api.auraxis.com.br"}
     assert policy.allow_credentials is True
     assert policy.allow_methods == "GET,POST,PUT,PATCH,DELETE,OPTIONS"
-    assert policy.allow_headers == "Authorization,Content-Type,X-API-Contract"
+    assert (
+        policy.allow_headers
+        == "Authorization,Content-Type,X-API-Contract,Idempotency-Key"
+    )
     assert policy.max_age_seconds == 600
     assert policy.is_production is True
 

--- a/tests/test_idempotency_key.py
+++ b/tests/test_idempotency_key.py
@@ -1,0 +1,250 @@
+"""Tests for the Idempotency-Key middleware (SEC-GAP-05).
+
+Tests run against a minimal Flask app with a fake in-memory Redis to avoid
+any dependency on a real Redis instance.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+import pytest
+from flask import Flask, jsonify
+
+from app.middleware.idempotency_key import (
+    IDEMPOTENCY_KEY_HEADER,
+    register_idempotency_guard,
+)
+
+# ---------------------------------------------------------------------------
+# Fake Redis
+# ---------------------------------------------------------------------------
+
+
+class FakeRedis:
+    """Minimal in-memory Redis stub sufficient for middleware tests."""
+
+    def __init__(self) -> None:
+        self._store: dict[str, bytes] = {}
+        self._lock = threading.Lock()
+
+    def ping(self) -> bool:
+        return True
+
+    def get(self, key: str) -> bytes | None:
+        with self._lock:
+            return self._store.get(key)
+
+    def set(self, key: str, value: Any, ex: int | None = None) -> None:
+        with self._lock:
+            self._store[key] = (
+                value if isinstance(value, bytes) else str(value).encode()
+            )
+
+    def reset(self) -> None:
+        with self._lock:
+            self._store.clear()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_redis() -> FakeRedis:
+    return FakeRedis()
+
+
+@pytest.fixture
+def minimal_app(fake_redis: FakeRedis) -> Flask:
+    """Flask app with idempotency middleware wired to a fake Redis."""
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+
+    # Patch _try_get_redis so it returns our fake
+    import app.middleware.idempotency_key as mid_module
+
+    original = mid_module._try_get_redis
+
+    def _patched() -> FakeRedis:
+        return fake_redis
+
+    mid_module._try_get_redis = _patched  # type: ignore[assignment]
+    register_idempotency_guard(app)
+    mid_module._try_get_redis = original  # type: ignore[assignment]
+
+    # Expose redis on extensions for assertions
+    app.extensions["idempotency_redis"] = fake_redis
+
+    @app.route("/payments/checkout", methods=["POST"])
+    def checkout() -> Any:
+        return jsonify({"order_id": "ord_123"}), 201
+
+    @app.route("/things", methods=["POST"])
+    def create_thing() -> Any:
+        return jsonify({"id": "thing_1"}), 201
+
+    @app.route("/subscriptions/checkout", methods=["POST"])
+    def sub_checkout() -> Any:
+        return jsonify({"subscription": "sub_abc"}), 201
+
+    @app.route("/auth/login", methods=["POST"])
+    def login() -> Any:
+        return jsonify({"token": "jwt_xyz"}), 200
+
+    return app
+
+
+@pytest.fixture
+def client(minimal_app: Flask):
+    with minimal_app.test_client() as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _post(
+    client: Any, path: str, body: dict | None = None, key: str | None = None
+) -> Any:
+    headers = {}
+    if key:
+        headers[IDEMPOTENCY_KEY_HEADER] = key
+    return client.post(path, json=body or {}, headers=headers)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestIdempotencyDuplicatePost:
+    """Same key → same response, handler called once."""
+
+    def test_two_posts_same_key_return_same_response(self, client: Any) -> None:
+        key = "unique-key-abc"
+        first = _post(client, "/payments/checkout", {"amount": 100}, key=key)
+        second = _post(client, "/payments/checkout", {"amount": 100}, key=key)
+
+        assert first.status_code == 201
+        assert second.status_code == 201
+        assert first.get_json() == second.get_json()
+
+    def test_replayed_response_has_replay_header(self, client: Any) -> None:
+        key = "replay-header-key"
+        _post(client, "/payments/checkout", {"amount": 50}, key=key)
+        second = _post(client, "/payments/checkout", {"amount": 50}, key=key)
+
+        assert second.headers.get("X-Idempotency-Replayed") == "true"
+
+    def test_first_response_has_no_replay_header(self, client: Any) -> None:
+        key = "first-call-key"
+        first = _post(client, "/payments/checkout", {"amount": 50}, key=key)
+        assert "X-Idempotency-Replayed" not in first.headers
+
+    def test_different_keys_execute_independently(self, client: Any) -> None:
+        first = _post(client, "/things", {"name": "A"}, key="key-one")
+        second = _post(client, "/things", {"name": "B"}, key="key-two")
+
+        assert first.status_code == 201
+        assert second.status_code == 201
+        # Both reach the handler — both get 201 (handler is idempotent here)
+        assert first.get_json() == second.get_json()
+
+
+class TestIdempotencyConflict:
+    """Same key + different body → 409."""
+
+    def test_same_key_different_body_returns_409(self, client: Any) -> None:
+        key = "conflict-key"
+        _post(client, "/payments/checkout", {"amount": 100}, key=key)
+        conflict = _post(client, "/payments/checkout", {"amount": 999}, key=key)
+
+        assert conflict.status_code == 409
+        body = conflict.get_json()
+        assert body["error"] == "IDEMPOTENCY_CONFLICT"
+
+
+class TestRequiredEndpoints:
+    """Endpoints in REQUIRED_PREFIXES must reject missing key with 400."""
+
+    def test_required_endpoint_without_key_returns_400(self, client: Any) -> None:
+        response = _post(client, "/subscriptions/checkout", {"plan": "pro"})
+        assert response.status_code == 400
+        body = response.get_json()
+        assert body["error"] == "IDEMPOTENCY_KEY_REQUIRED"
+
+    def test_required_endpoint_with_key_succeeds(self, client: Any) -> None:
+        response = _post(
+            client, "/subscriptions/checkout", {"plan": "pro"}, key="sub-key-1"
+        )
+        assert response.status_code == 201
+
+
+class TestSkippedEndpoints:
+    """Auth and webhook-like paths are never intercepted."""
+
+    def test_auth_login_no_key_not_blocked(self, client: Any) -> None:
+        response = _post(client, "/auth/login", {"email": "a@b.com", "password": "pw"})
+        # Middleware doesn't block or require key on /auth/*
+        assert response.status_code == 200
+
+    def test_non_post_methods_not_intercepted(self, client: Any) -> None:
+        # GET never hits the idempotency guard
+        response = client.get("/things")
+        # 405 because /things only allows POST — that's fine; the point is
+        # the middleware didn't return anything for a GET
+        assert response.status_code in {200, 404, 405}
+
+
+class TestNoKeyOptional:
+    """POST without Idempotency-Key on non-required endpoints is fine."""
+
+    def test_post_without_key_on_optional_endpoint_succeeds(self, client: Any) -> None:
+        response = _post(client, "/payments/checkout", {"amount": 42})
+        assert response.status_code == 201
+
+    def test_two_posts_without_key_both_execute(self, client: Any) -> None:
+        first = _post(client, "/things", {"name": "X"})
+        second = _post(client, "/things", {"name": "X"})
+        # Neither is cached — both reach the handler
+        assert first.status_code == 201
+        assert second.status_code == 201
+        assert "X-Idempotency-Replayed" not in first.headers
+        assert "X-Idempotency-Replayed" not in second.headers
+
+
+class TestRedisUnavailable:
+    """When Redis is unavailable the middleware is a no-op (fail-open)."""
+
+    def test_middleware_disabled_when_redis_unavailable(self) -> None:
+        import app.middleware.idempotency_key as mid_module
+
+        original = mid_module._try_get_redis
+
+        def _fail() -> None:
+            return None
+
+        mid_module._try_get_redis = _fail  # type: ignore[assignment]
+        try:
+            app_no_redis = Flask(__name__)
+            app_no_redis.config["TESTING"] = True
+            register_idempotency_guard(app_no_redis)
+
+            @app_no_redis.route("/items", methods=["POST"])
+            def create_item() -> Any:
+                return jsonify({"ok": True}), 201
+
+            with app_no_redis.test_client() as c:
+                # Both calls hit the handler — no idempotency enforcement
+                r1 = c.post("/items", json={}, headers={IDEMPOTENCY_KEY_HEADER: "k1"})
+                r2 = c.post("/items", json={}, headers={IDEMPOTENCY_KEY_HEADER: "k1"})
+                assert r1.status_code == 201
+                assert r2.status_code == 201
+                assert "X-Idempotency-Replayed" not in r2.headers
+        finally:
+            mid_module._try_get_redis = original  # type: ignore[assignment]


### PR DESCRIPTION
## Summary

- Adds `app/middleware/idempotency_key.py`: Redis-backed idempotency guard for POST endpoints
  - Optional header on all POST requests; **mandatory** on `/subscriptions/checkout` and `/subscriptions/cancel` (400 if missing)
  - First call: executed normally, response cached in Redis (TTL 24h) keyed by `(user, path, sha256(key))`
  - Subsequent calls with same key + same body: replayed from cache (`X-Idempotency-Replayed: true` header)
  - Same key + different body: **409 Conflict** — prevents request smuggling/body swap attacks
  - Redis unavailable: **fail-open** — no enforcement, business continues
- `cors.py`: adds `Idempotency-Key` to the default `CORS_ALLOWED_HEADERS` so browsers can send it in cross-origin requests
- `__init__.py`: registers idempotency guard after `register_auth_guard`
- 12 new tests covering all acceptance criteria from the issue

## Motivation

Prevents duplicate charges caused by double-clicks on the checkout button or network retries. Without idempotency keys, a single user action can create multiple Asaas billing records.

## Test plan

- [x] `pytest tests/test_idempotency_key.py` — 12 tests, all pass
- [x] `pytest -m "not schemathesis" --cov=app --cov-fail-under=85` — 89.7% coverage
- [x] `mypy app` — no errors
- [x] `ruff check` / `ruff format` — clean
- [x] All pre-commit hooks pass

Closes #937