### PR TITLE
security(auth): SEC-GAP-06 — Argon2id password hashing with transparent PBKDF2 migration

### DIFF
--- a/app/application/services/password_verification_service.py
+++ b/app/application/services/password_verification_service.py
@@ -1,9 +1,48 @@
+"""Password verification and hashing service — SEC-GAP-06.
+
+Provides Argon2id as the canonical hashing algorithm with transparent,
+incremental migration from Werkzeug PBKDF2 hashes.
+
+Migration strategy
+------------------
+- New users:  hash produced by ``hash_password()`` starts with ``$argon2id$``.
+- Legacy users: hash starts with ``pbkdf2:sha256:`` (Werkzeug default).
+  On first successful login, the PBKDF2 hash is silently replaced with
+  Argon2id via the ``on_rehash`` callback.  No forced password-reset required.
+
+Argon2id parameters (OWASP 2026 recommendations)
+-------------------------------------------------
+  time_cost=3, memory_cost=65536 (64 MiB), parallelism=4
+"""
+
 from __future__ import annotations
 
 import hashlib
+import logging
 import secrets
+from collections.abc import Callable
 
-from werkzeug.security import check_password_hash
+from passlib.context import CryptContext
+
+from app.extensions.integration_metrics import increment_metric
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Passlib context
+# ---------------------------------------------------------------------------
+
+_CRYPT_CTX = CryptContext(
+    schemes=["argon2", "django_pbkdf2_sha256"],
+    deprecated=["django_pbkdf2_sha256"],
+    argon2__time_cost=3,
+    argon2__memory_cost=65536,
+    argon2__parallelism=4,
+)
+
+# ---------------------------------------------------------------------------
+# Timing-attack guard — used when no user is found
+# ---------------------------------------------------------------------------
 
 _DUMMY_SALT = secrets.token_bytes(16)
 _DUMMY_PBKDF2_ITERATIONS = 600_000
@@ -18,20 +57,105 @@ def _burn_hash_cycles(plain_password: str) -> None:
     )
 
 
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def hash_password(plain_password: str) -> str:
+    """Return an Argon2id hash for *plain_password*."""
+    return str(_CRYPT_CTX.hash(plain_password))
+
+
+def needs_rehash(password_hash: str) -> bool:
+    """Return True if *password_hash* should be upgraded to Argon2id."""
+    if _is_werkzeug_pbkdf2(password_hash):
+        return True
+    try:
+        return bool(_CRYPT_CTX.needs_update(password_hash))
+    except Exception:
+        # Unknown hash format — cannot determine upgrade need; leave as-is.
+        return False
+
+
 def verify_password_with_timing_protection(
     *,
     password_hash: str | None,
     plain_password: str,
+    on_rehash: Callable[[str], None] | None = None,
 ) -> bool:
-    """Verify password while reducing user-existence timing signal.
+    """Verify *plain_password* against *password_hash*.
 
-    When a user is not found, we still execute one password-hash check against a
-    static dummy hash so invalid logins have a closer runtime profile.
+    - If no hash is stored (user not found), a dummy PBKDF2 computation is
+      executed to equalise timing with the found-but-wrong-password path.
+    - If the hash is a legacy PBKDF2 hash and the password is correct, the
+      ``on_rehash`` callback is invoked with the new Argon2id hash so the
+      caller can persist the upgrade transparently.
+
+    Parameters
+    ----------
+    password_hash:
+        Stored hash from the database (may be None when user not found).
+    plain_password:
+        Plain-text password to verify.
+    on_rehash:
+        Optional callback ``(new_hash: str) -> None`` called when the stored
+        hash is outdated and has been re-hashed successfully.
     """
+    if not password_hash:
+        _burn_hash_cycles(plain_password)
+        return False
 
-    if password_hash:
-        verified: bool = check_password_hash(password_hash, plain_password)
-        return verified
+    # Werkzeug PBKDF2 hashes start with "pbkdf2:sha256:". passlib's
+    # django_pbkdf2_sha256 scheme expects a "pbkdf2_sha256$..." prefix.
+    # We detect Werkzeug format and verify using werkzeug directly so we
+    # don't need to reformat the stored hash.
+    if _is_werkzeug_pbkdf2(password_hash):
+        return _verify_werkzeug_and_maybe_rehash(
+            password_hash=password_hash,
+            plain_password=plain_password,
+            on_rehash=on_rehash,
+        )
 
-    _burn_hash_cycles(plain_password)
-    return False
+    # Argon2id (or any other passlib-managed scheme)
+    verified, new_hash = _CRYPT_CTX.verify_and_update(plain_password, password_hash)
+    if verified and new_hash and on_rehash is not None:
+        try:
+            on_rehash(new_hash)
+            increment_metric("password.hash.migrations")
+            logger.info("password_hash_migrated scheme=argon2id")
+        except Exception:
+            logger.warning("password_hash_migration_failed", exc_info=True)
+    return bool(verified)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_werkzeug_pbkdf2(password_hash: str) -> bool:
+    # Werkzeug hashes: "pbkdf2:sha256:..." (legacy) or "scrypt:..." (newer default).
+    # Both are handled by werkzeug.security.check_password_hash and both should be
+    # migrated to Argon2id.
+    return password_hash.startswith(("pbkdf2:", "scrypt:"))
+
+
+def _verify_werkzeug_and_maybe_rehash(
+    *,
+    password_hash: str,
+    plain_password: str,
+    on_rehash: Callable[[str], None] | None,
+) -> bool:
+    from werkzeug.security import check_password_hash
+
+    verified: bool = check_password_hash(password_hash, plain_password)
+    if verified and on_rehash is not None:
+        try:
+            new_hash = hash_password(plain_password)
+            on_rehash(new_hash)
+            increment_metric("password.hash.migrations")
+            logger.info("password_hash_migrated scheme=argon2id from=werkzeug_pbkdf2")
+        except Exception:
+            logger.warning("password_hash_migration_failed", exc_info=True)
+    return verified

--- a/app/controllers/auth/dependencies.py
+++ b/app/controllers/auth/dependencies.py
@@ -7,7 +7,6 @@ from uuid import UUID
 
 from flask import Flask, current_app
 from flask_jwt_extended import create_access_token, create_refresh_token, get_jti
-from werkzeug.security import generate_password_hash
 
 from app.application.dto.auth_security_policy_dto import AuthSecurityPolicyDTO
 from app.application.services.auth_security_policy_service import (
@@ -23,6 +22,9 @@ from app.application.services.password_reset_service import (
     PasswordResetResult,
     request_password_reset,
     reset_password,
+)
+from app.application.services.password_verification_service import (
+    hash_password as _hash_password_argon2id,
 )
 from app.application.services.password_verification_service import (
     verify_password_with_timing_protection,
@@ -118,7 +120,7 @@ def _default_dependencies() -> AuthDependencies:
         get_login_attempt_guard=get_login_attempt_guard,
         build_login_attempt_context=build_login_attempt_context,
         verify_password=_verify_password,
-        hash_password=generate_password_hash,
+        hash_password=_hash_password_argon2id,
         create_access_token=_create_access_token_with_default_expiry,
         create_refresh_token=_create_refresh_token_with_default_expiry,
         get_token_jti=_get_token_jti,

--- a/app/controllers/auth/login_resource.py
+++ b/app/controllers/auth/login_resource.py
@@ -7,6 +7,7 @@ from flask_apispec.views import MethodResource
 from flask_jwt_extended import set_refresh_cookies
 
 from app.application.services.login_identity_service import resolve_login_identity
+from app.application.services.password_verification_service import needs_rehash
 from app.docs.openapi_helpers import (
     contract_header_param,
     json_error_response,
@@ -53,6 +54,27 @@ def _invalid_credentials_response(
         message="Invalid credentials",
         error_code="UNAUTHORIZED",
     )
+
+
+def _persist_session(
+    *,
+    user: Any,
+    jti: str,
+    refresh_jti: str,
+    pending_new_hash: str | None,
+) -> None:
+    needs_commit = (
+        user.current_jti != jti
+        or user.refresh_token_jti != refresh_jti
+        or pending_new_hash is not None
+    )
+    if not needs_commit:
+        return
+    user.current_jti = jti
+    user.refresh_token_jti = refresh_jti
+    if pending_new_hash is not None:
+        user.password = pending_new_hash
+    db.session.commit()
 
 
 def _too_many_attempts_response(*, retry_after: int | None) -> Response:
@@ -199,6 +221,10 @@ class AuthResource(MethodResource):
 
         password_hash = identity.user.password if identity.user is not None else None
         is_valid_password = dependencies.verify_password(password_hash, str(password))
+        # SEC-GAP-06: transparent Argon2id upgrade for PBKDF2 legacy hashes.
+        _pending_new_hash: str | None = None
+        if is_valid_password and password_hash and needs_rehash(password_hash):
+            _pending_new_hash = dependencies.hash_password(str(password))
         # Treat soft-deleted accounts as invalid credentials (LGPD — do not
         # reveal whether the account ever existed).
         is_deleted = identity.user is not None and identity.user.deleted_at is not None
@@ -220,14 +246,12 @@ class AuthResource(MethodResource):
             refresh_token = dependencies.create_refresh_token(str(identity.user.id))
             jti = dependencies.get_token_jti(token)
             refresh_jti = dependencies.get_token_jti(refresh_token)
-            needs_commit = (
-                identity.user.current_jti != jti
-                or identity.user.refresh_token_jti != refresh_jti
+            _persist_session(
+                user=identity.user,
+                jti=jti,
+                refresh_jti=refresh_jti,
+                pending_new_hash=_pending_new_hash,
             )
-            if needs_commit:
-                identity.user.current_jti = jti
-                identity.user.refresh_token_jti = refresh_jti
-                db.session.commit()
             user_data = {
                 "id": str(identity.user.id),
                 "name": identity.user.name,

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ Jinja2==3.1.6
 Mako==1.3.10
 MarkupSafe==3.0.3
 marshmallow==3.26.2
+passlib[argon2]==1.7.4
 marshmallow-sqlalchemy==1.5.0
 packaging==25.0
 pluggy==1.6.0

--- a/scripts/security_evidence_check.sh
+++ b/scripts/security_evidence_check.sh
@@ -83,7 +83,7 @@ check_contains "app/graphql/security.py" "GRAPHQL_DEPTH_LIMIT_EXCEEDED" "GraphQL
 check_contains "app/graphql/security.py" "GRAPHQL_COMPLEXITY_LIMIT_EXCEEDED" "GraphQL complexity limit guard implemented"
 check_contains "app/middleware/auth_guard.py" "verify_jwt_in_request\(\)|get_active_auth_context\(\)" "Global auth guard verifies JWT for protected routes"
 check_contains "app/controllers/auth/register_resource.py" "dependencies\.hash_password\(" "User registration hashes password via auth dependency"
-check_contains "app/controllers/auth/dependencies.py" "generate_password_hash" "Auth dependency provider uses Werkzeug password hashing"
+check_contains "app/controllers/auth/dependencies.py" "_hash_password_argon2id" "Auth dependency provider uses Argon2id password hashing"
 
 {
   echo

--- a/tests/test_password_verification_service.py
+++ b/tests/test_password_verification_service.py
@@ -1,58 +1,153 @@
+"""Tests for password verification service — SEC-GAP-06."""
+
 from __future__ import annotations
 
 from typing import Any
 
 from werkzeug.security import generate_password_hash
 
-from app.application.services import password_verification_service
 from app.application.services.password_verification_service import (
+    hash_password,
+    needs_rehash,
     verify_password_with_timing_protection,
 )
 
+# ---------------------------------------------------------------------------
+# hash_password
+# ---------------------------------------------------------------------------
 
-def test_verify_password_with_timing_protection_matches_valid_hash() -> None:
-    password = "StrongPass@123"
-    password_hash = generate_password_hash(password)
 
+def test_hash_password_produces_argon2id_hash() -> None:
+    result = hash_password("StrongPass@123")
+    assert result.startswith("$argon2id$")
+
+
+def test_hash_password_different_each_call() -> None:
+    h1 = hash_password("SamePassword@1")
+    h2 = hash_password("SamePassword@1")
+    assert h1 != h2  # different salts
+
+
+# ---------------------------------------------------------------------------
+# needs_rehash
+# ---------------------------------------------------------------------------
+
+
+def test_needs_rehash_returns_false_for_argon2id() -> None:
+    argon2_hash = hash_password("password123")
+    assert needs_rehash(argon2_hash) is False
+
+
+def test_needs_rehash_returns_true_for_werkzeug_pbkdf2() -> None:
+    legacy_hash = generate_password_hash("password123")
+    assert needs_rehash(legacy_hash) is True
+
+
+# ---------------------------------------------------------------------------
+# verify_password_with_timing_protection — happy paths
+# ---------------------------------------------------------------------------
+
+
+def test_verify_argon2id_hash_correct_password() -> None:
+    pw = "StrongPass@123"
+    h = hash_password(pw)
+    assert (
+        verify_password_with_timing_protection(password_hash=h, plain_password=pw)
+        is True
+    )
+
+
+def test_verify_argon2id_hash_wrong_password() -> None:
+    h = hash_password("correct-password")
     assert (
         verify_password_with_timing_protection(
-            password_hash=password_hash,
-            plain_password=password,
+            password_hash=h, plain_password="wrong-password"
+        )
+        is False
+    )
+
+
+def test_verify_werkzeug_pbkdf2_hash_correct_password() -> None:
+    pw = "LegacyPass@456"
+    legacy_hash = generate_password_hash(pw)
+    assert (
+        verify_password_with_timing_protection(
+            password_hash=legacy_hash, plain_password=pw
         )
         is True
     )
 
 
-def test_verify_password_with_timing_protection_burns_hash_cycles_when_user_missing(
-    monkeypatch: Any,
-) -> None:
-    burn_calls: list[str] = []
-    hash_verify_calls: list[tuple[str, str]] = []
-
-    def _fake_burn_hash_cycles(plain_password: str) -> None:
-        burn_calls.append(plain_password)
-
-    def _fake_check_password_hash(password_hash: str, plain_password: str) -> bool:
-        hash_verify_calls.append((password_hash, plain_password))
-        return False
-
-    monkeypatch.setattr(
-        password_verification_service,
-        "_burn_hash_cycles",
-        _fake_burn_hash_cycles,
+def test_verify_werkzeug_pbkdf2_hash_wrong_password() -> None:
+    legacy_hash = generate_password_hash("correct")
+    assert (
+        verify_password_with_timing_protection(
+            password_hash=legacy_hash, plain_password="wrong"
+        )
+        is False
     )
 
-    monkeypatch.setattr(
-        password_verification_service,
-        "check_password_hash",
-        _fake_check_password_hash,
-    )
 
+# ---------------------------------------------------------------------------
+# verify_password_with_timing_protection — user not found
+# ---------------------------------------------------------------------------
+
+
+def test_timing_protection_burns_cycles_when_no_hash(monkeypatch: Any) -> None:
+    burned: list[str] = []
+    monkeypatch.setattr(
+        "app.application.services.password_verification_service._burn_hash_cycles",
+        lambda pw: burned.append(pw),
+    )
     result = verify_password_with_timing_protection(
-        password_hash=None,
-        plain_password="WrongPass@123",
+        password_hash=None, plain_password="any"
+    )
+    assert result is False
+    assert burned == ["any"]
+
+
+# ---------------------------------------------------------------------------
+# on_rehash callback
+# ---------------------------------------------------------------------------
+
+
+def test_rehash_callback_called_for_pbkdf2_on_success() -> None:
+    pw = "MigrateMe@789"
+    legacy_hash = generate_password_hash(pw)
+    new_hashes: list[str] = []
+
+    verify_password_with_timing_protection(
+        password_hash=legacy_hash,
+        plain_password=pw,
+        on_rehash=new_hashes.append,
     )
 
-    assert result is False
-    assert burn_calls == ["WrongPass@123"]
-    assert hash_verify_calls == []
+    assert len(new_hashes) == 1
+    assert new_hashes[0].startswith("$argon2id$")
+
+
+def test_rehash_callback_not_called_for_pbkdf2_on_wrong_password() -> None:
+    legacy_hash = generate_password_hash("correct")
+    calls: list[str] = []
+
+    verify_password_with_timing_protection(
+        password_hash=legacy_hash,
+        plain_password="wrong",
+        on_rehash=calls.append,
+    )
+
+    assert calls == []
+
+
+def test_rehash_callback_not_called_for_argon2id() -> None:
+    pw = "AlreadyArgon@1"
+    argon_hash = hash_password(pw)
+    calls: list[str] = []
+
+    verify_password_with_timing_protection(
+        password_hash=argon_hash,
+        plain_password=pw,
+        on_rehash=calls.append,
+    )
+
+    assert calls == []


### PR DESCRIPTION
## Summary

- Replaces Werkzeug PBKDF2 with **passlib Argon2id** (OWASP 2026 params: `time_cost=3`, `memory_cost=64 MiB`, `parallelism=4`)
- Legacy hashes (`pbkdf2:` and `scrypt:` werkzeug formats) are **transparently upgraded** on the next successful login — no forced password reset
- Adds `_persist_session` helper to `login_resource` to keep McCabe complexity < 10
- Guards `needs_rehash` against unknown hash formats (fail-safe → `False`)
- Updates `security_evidence_check.sh` to verify Argon2id usage (replaces old Werkzeug check)

Closes #938

## Test plan

- [x] `test_hash_password_produces_argon2id_hash` — new hashes start with `$argon2id$`
- [x] `test_hash_password_different_each_call` — salts differ per call
- [x] `test_needs_rehash_returns_false_for_argon2id` — current-format hashes not rehashed
- [x] `test_needs_rehash_returns_true_for_werkzeug_pbkdf2` — legacy hashes trigger rehash
- [x] `test_verify_argon2id_hash_correct/wrong_password` — happy and sad path
- [x] `test_verify_werkzeug_pbkdf2_hash_correct/wrong_password` — legacy format verify
- [x] `test_timing_protection_burns_cycles_when_no_hash` — user-not-found timing guard
- [x] `test_rehash_callback_called_for_pbkdf2_on_success` — upgrade emits Argon2id hash
- [x] `test_rehash_callback_not_called_for_pbkdf2_on_wrong_password` — no rehash on auth failure
- [x] `test_rehash_callback_not_called_for_argon2id` — already-modern hash unchanged
- [x] All 1117 existing tests passing, coverage 89.74% (≥ 85% threshold)