### PR TITLE
perf(services): PERF-GAP-04 — retry + exponential backoff for BRAPI, Resend, Asaas

### DIFF
--- a/app/services/billing_adapter.py
+++ b/app/services/billing_adapter.py
@@ -18,6 +18,7 @@ from requests.exceptions import RequestException
 
 from app.config.billing_plans import BillingPlanOffer, resolve_checkout_plan_offer
 from app.models.subscription import BillingCycle
+from app.services.retry_wrapper import with_retry
 
 _ASAAS_PROVIDER = "asaas"
 _STUB_PROVIDER = "stub"
@@ -197,17 +198,24 @@ class AsaasBillingProvider:
     ) -> dict[str, object]:
         self._ensure_enabled()
         url = f"{self._base_url.rstrip('/')}/{path.lstrip('/')}"
-        try:
+
+        @with_retry(provider="asaas")
+        def _do() -> dict[str, object]:
+            # Let RequestException propagate so tenacity can retry on
+            # transient failures. Caught and wrapped after retries exhaust.
             response = self._session.request(
                 method=method,
                 url=url,
                 json=json_payload,
                 timeout=_REQUEST_TIMEOUT_SECONDS,
             )
+            _raise_for_error_response(response)
+            return cast(dict[str, object], response.json())
+
+        try:
+            return _do()
         except RequestException as exc:
             raise BillingProviderError("Asaas request failed") from exc
-        _raise_for_error_response(response)
-        return cast(dict[str, object], response.json())
 
     def _ensure_customer(self, customer: BillingCheckoutCustomer) -> str:
         payload = self._request(

--- a/app/services/email_provider.py
+++ b/app/services/email_provider.py
@@ -15,6 +15,7 @@ from app.http.runtime import (
     runtime_extension,
     set_runtime_extension,
 )
+from app.services.retry_wrapper import with_retry
 
 _DEFAULT_RESEND_BASE_URL = "https://api.resend.com"
 _REQUEST_TIMEOUT_SECONDS = 15.0
@@ -129,20 +130,29 @@ class ResendEmailProvider:
             "text": message.text,
             "tags": [{"name": "kind", "value": message.tag}],
         }
-        try:
+
+        @with_retry(provider="resend")
+        def _post() -> EmailDeliveryResult:
+            # Let RequestException propagate so tenacity can retry on
+            # transient failures (Timeout, ConnectionError, HTTPError).
+            # After retries are exhausted, the exception is caught below
+            # and re-raised as EmailProviderError.
             response = self._session.post(
                 f"{self._base_url.rstrip('/')}/emails",
                 json=payload,
                 timeout=_REQUEST_TIMEOUT_SECONDS,
             )
+            _raise_for_error_response(response)
+            body = cast(dict[str, object], response.json())
+            return EmailDeliveryResult(
+                provider=_RESEND_PROVIDER,
+                provider_message_id=str(body.get("id") or "").strip() or None,
+            )
+
+        try:
+            return _post()
         except RequestException as exc:
             raise EmailProviderError("Resend request failed") from exc
-        _raise_for_error_response(response)
-        body = cast(dict[str, object], response.json())
-        return EmailDeliveryResult(
-            provider=_RESEND_PROVIDER,
-            provider_message_id=str(body.get("id") or "").strip() or None,
-        )
 
 
 def get_default_email_provider() -> EmailProvider:

--- a/app/services/investment_service.py
+++ b/app/services/investment_service.py
@@ -12,6 +12,7 @@ from requests.exceptions import RequestException
 from app.extensions.integration_metrics import increment_metric
 from app.http.runtime import runtime_logger
 from app.services.circuit_breaker import CircuitBreaker
+from app.services.retry_wrapper import with_retry
 from config import Config
 
 
@@ -69,36 +70,32 @@ class InvestmentService:
     def _request_json(
         endpoint: str, *, params: dict[str, Any] | None = None
     ) -> Any | None:
-        timeout_seconds, max_retries, _ = InvestmentService._settings()
+        # PERF-GAP-04: tenacity handles retry + backoff; circuit breaker wraps
+        # the call at the get_market_price level to fail fast when BRAPI is down.
+        timeout_seconds, _, _ = InvestmentService._settings()
         config = Config()
-        attempts = max_retries + 1
-        for attempt in range(attempts):
-            try:
-                resp = requests.get(
-                    endpoint,
-                    headers={"Authorization": f"Bearer {config.BRAPI_KEY}"},
-                    params=params,
-                    timeout=timeout_seconds,
-                )
-                resp.raise_for_status()
-                return resp.json()
-            except RequestException as exc:
-                if isinstance(exc, requests.exceptions.Timeout):
-                    InvestmentService._record_brapi_event("timeout", detail=endpoint)
-                elif isinstance(exc, requests.exceptions.HTTPError):
-                    InvestmentService._record_brapi_event(
-                        "http_error",
-                        detail=endpoint,
-                    )
-                else:
-                    InvestmentService._record_brapi_event(
-                        "request_error",
-                        detail=endpoint,
-                    )
-                if attempt == attempts - 1:
-                    return None
-                time.sleep(0.15 * (attempt + 1))
-        return None
+
+        @with_retry(provider="brapi")
+        def _fetch() -> Any:
+            resp = requests.get(
+                endpoint,
+                headers={"Authorization": f"Bearer {config.BRAPI_KEY}"},
+                params=params,
+                timeout=timeout_seconds,
+            )
+            resp.raise_for_status()
+            return resp.json()
+
+        try:
+            return _fetch()
+        except RequestException as exc:
+            if isinstance(exc, requests.exceptions.Timeout):
+                InvestmentService._record_brapi_event("timeout", detail=endpoint)
+            elif isinstance(exc, requests.exceptions.HTTPError):
+                InvestmentService._record_brapi_event("http_error", detail=endpoint)
+            else:
+                InvestmentService._record_brapi_event("request_error", detail=endpoint)
+            return None
 
     @classmethod
     def _normalize_ticker(cls, ticker: str) -> str | None:

--- a/app/services/retry_wrapper.py
+++ b/app/services/retry_wrapper.py
@@ -1,0 +1,96 @@
+"""retry_wrapper.py — PERF-GAP-04: shared retry + exponential backoff decorator.
+
+Wraps external HTTP calls (Resend, Asaas, BRAPI) with tenacity-based retry so
+that transient 5xx / network errors are retried up to 3 times before surfacing
+to the caller, while Sentry and the structured logger record each attempt.
+
+Usage
+-----
+    from app.services.retry_wrapper import with_retry
+
+    @with_retry(provider="resend")
+    def _send_email() -> ...:
+        ...
+
+Or as a one-shot helper around an existing callable:
+
+    result = with_retry(provider="brapi")(my_fn)(arg1, kwarg=v)
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, TypeVar
+
+import sentry_sdk
+from requests.exceptions import ConnectionError, HTTPError, Timeout
+from tenacity import (
+    RetryCallState,
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+_logger = logging.getLogger("auraxis.retry")
+
+_RETRYABLE = (HTTPError, Timeout, ConnectionError)
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+_MAX_ATTEMPTS = 3
+_WAIT_MULTIPLIER = 1
+_WAIT_MIN = 2
+_WAIT_MAX = 10
+
+
+def _make_before_sleep(provider: str) -> Callable[[RetryCallState], None]:
+    def _before_sleep(retry_state: RetryCallState) -> None:
+        attempt = retry_state.attempt_number
+        exc = retry_state.outcome.exception() if retry_state.outcome else None
+        next_wait: float | None
+        if retry_state.next_action is not None:
+            next_wait = getattr(retry_state.next_action, "sleep", None)
+        else:
+            next_wait = None
+        _logger.warning(
+            "retry provider=%s attempt=%d exception=%r next_wait=%.1fs",
+            provider,
+            attempt,
+            exc,
+            next_wait or 0.0,
+        )
+        sentry_sdk.add_breadcrumb(
+            category="retry",
+            message=f"{provider} transient failure — retrying (attempt {attempt})",
+            level="warning",
+            data={
+                "provider": provider,
+                "attempt": attempt,
+                "exception": repr(exc),
+                "next_wait": next_wait,
+            },
+        )
+
+    return _before_sleep
+
+
+def with_retry(*, provider: str) -> Callable[[F], F]:
+    """Return a tenacity retry decorator configured for the given provider.
+
+    Retries up to 3 times on ``HTTPError``, ``Timeout``, or
+    ``ConnectionError`` with exponential backoff (2 s → 4 s → 10 s cap).
+    Each retry emits a structured log line and a Sentry breadcrumb.
+    """
+    decorator: Callable[[F], F] = retry(
+        stop=stop_after_attempt(_MAX_ATTEMPTS),
+        wait=wait_exponential(
+            multiplier=_WAIT_MULTIPLIER,
+            min=_WAIT_MIN,
+            max=_WAIT_MAX,
+        ),
+        retry=retry_if_exception_type(_RETRYABLE),
+        before_sleep=_make_before_sleep(provider),
+        reraise=True,
+    )
+    return decorator

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,6 +33,7 @@ python-dateutil==2.9.0.post0
 python-dotenv==1.1.0
 requests==2.33.1
 redis==5.3.1
+tenacity==9.1.2
 sentry-sdk[flask]==2.57.0
 SQLAlchemy==2.0.49
 typing_extensions==4.14.0

--- a/tests/test_retry_wrapper.py
+++ b/tests/test_retry_wrapper.py
@@ -1,0 +1,288 @@
+"""PERF-GAP-04 — Tests for retry_wrapper and its integration with Resend,
+Asaas, and BRAPI.
+
+Uses unittest.mock to simulate transient HTTP failures (Timeout, HTTPError,
+ConnectionError) and verify that tenacity retries and ultimately raises on
+exhaustion, and that success on a later attempt is returned correctly.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+from requests.exceptions import ConnectionError, HTTPError, Timeout
+
+from app.services.retry_wrapper import with_retry
+
+# ---------------------------------------------------------------------------
+# retry_wrapper unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestWithRetry:
+    def test_success_on_first_attempt(self) -> None:
+        call_count = 0
+
+        @with_retry(provider="test")
+        def _fn() -> str:
+            nonlocal call_count
+            call_count += 1
+            return "ok"
+
+        assert _fn() == "ok"
+        assert call_count == 1
+
+    def test_retries_on_timeout_then_succeeds(self) -> None:
+        call_count = 0
+
+        @with_retry(provider="test")
+        def _fn() -> str:
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise Timeout("transient timeout")
+            return "ok"
+
+        with patch("tenacity.nap.time"):  # skip actual sleep in tests
+            result = _fn()
+
+        assert result == "ok"
+        assert call_count == 2
+
+    def test_retries_on_http_error_then_succeeds(self) -> None:
+        call_count = 0
+        mock_resp = MagicMock()
+        mock_resp.status_code = 503
+
+        @with_retry(provider="test")
+        def _fn() -> str:
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise HTTPError("boom", response=mock_resp)
+            return "recovered"
+
+        with patch("tenacity.nap.time"):
+            result = _fn()
+
+        assert result == "recovered"
+        assert call_count == 3
+
+    def test_raises_after_max_attempts_exhausted(self) -> None:
+        call_count = 0
+
+        @with_retry(provider="test")
+        def _fn() -> None:
+            nonlocal call_count
+            call_count += 1
+            raise ConnectionError("network down")
+
+        with patch("tenacity.nap.time"), pytest.raises(ConnectionError):
+            _fn()
+
+        assert call_count == 3  # _MAX_ATTEMPTS = 3
+
+    def test_non_retryable_exception_not_retried(self) -> None:
+        call_count = 0
+
+        @with_retry(provider="test")
+        def _fn() -> None:
+            nonlocal call_count
+            call_count += 1
+            raise ValueError("logic error — not retryable")
+
+        with pytest.raises(ValueError):
+            _fn()
+
+        assert call_count == 1  # no retry for non-transient errors
+
+
+# ---------------------------------------------------------------------------
+# ResendEmailProvider retry integration
+# ---------------------------------------------------------------------------
+
+
+class TestResendEmailProviderRetry:
+    def test_send_retries_on_connection_error_then_succeeds(self, app) -> None:
+        from app.services.email_provider import EmailMessage, ResendEmailProvider
+
+        call_count = 0
+        ok_response = MagicMock()
+        ok_response.ok = True
+        ok_response.json.return_value = {"id": "msg-abc"}
+
+        def _mock_post(*args, **kwargs):  # type: ignore[no-untyped-def]
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise ConnectionError("transient")
+            return ok_response
+
+        with app.app_context():
+            provider = ResendEmailProvider()
+            provider._api_key = "test-key"
+            provider._from_email = "from@test.com"
+
+            with (
+                patch.object(provider._session, "post", side_effect=_mock_post),
+                patch("tenacity.nap.time"),
+            ):
+                result = provider.send(
+                    EmailMessage(
+                        to_email="u@example.com",
+                        subject="Test",
+                        html="<p>Hi</p>",
+                        text="Hi",
+                        tag="test",
+                    )
+                )
+
+        assert result.provider == "resend"
+        assert result.provider_message_id == "msg-abc"
+        assert call_count == 2
+
+    def test_send_raises_after_all_retries_exhausted(self, app) -> None:
+        from app.services.email_provider import (
+            EmailMessage,
+            EmailProviderError,
+            ResendEmailProvider,
+        )
+
+        with app.app_context():
+            provider = ResendEmailProvider()
+            provider._api_key = "test-key"
+            provider._from_email = "from@test.com"
+
+            with (
+                patch.object(
+                    provider._session,
+                    "post",
+                    side_effect=Timeout("always timeout"),
+                ),
+                patch("tenacity.nap.time"),
+                pytest.raises(EmailProviderError),
+            ):
+                provider.send(
+                    EmailMessage(
+                        to_email="u@example.com",
+                        subject="Test",
+                        html="<p>Hi</p>",
+                        text="Hi",
+                        tag="test",
+                    )
+                )
+
+
+# ---------------------------------------------------------------------------
+# AsaasBillingProvider retry integration
+# ---------------------------------------------------------------------------
+
+
+class TestAsaasBillingProviderRetry:
+    def test_request_retries_on_timeout_then_succeeds(self, app) -> None:
+        from app.services.billing_adapter import AsaasBillingProvider
+
+        call_count = 0
+        ok_response = MagicMock()
+        ok_response.ok = True
+        ok_response.json.return_value = {"id": "sub-1", "status": "active"}
+
+        def _mock_request(*args, **kwargs):  # type: ignore[no-untyped-def]
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise Timeout("transient")
+            return ok_response
+
+        with app.app_context():
+            provider = AsaasBillingProvider()
+            provider._api_key = "test-key"
+
+            with (
+                patch.object(provider._session, "request", side_effect=_mock_request),
+                patch("tenacity.nap.time"),
+            ):
+                result = provider.get_subscription("sub-1")
+
+        assert result["status"] == "active"
+        assert call_count == 2
+
+    def test_request_raises_after_all_retries_exhausted(self, app) -> None:
+        from app.services.billing_adapter import (
+            AsaasBillingProvider,
+            BillingProviderError,
+        )
+
+        with app.app_context():
+            provider = AsaasBillingProvider()
+            provider._api_key = "test-key"
+
+            with (
+                patch.object(
+                    provider._session,
+                    "request",
+                    side_effect=ConnectionError("always down"),
+                ),
+                patch("tenacity.nap.time"),
+                pytest.raises(BillingProviderError),
+            ):
+                provider.get_subscription("sub-1")
+
+
+# ---------------------------------------------------------------------------
+# InvestmentService BRAPI retry integration
+# ---------------------------------------------------------------------------
+
+
+class TestBrapiRetryIntegration:
+    def test_request_json_retries_on_http_error_then_succeeds(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from app.services.investment_service import InvestmentService
+
+        InvestmentService._clear_cache_for_tests()
+        call_count = 0
+
+        ok_response = MagicMock()
+        ok_response.raise_for_status.return_value = None
+        ok_response.json.return_value = {"results": [{"regularMarketPrice": 10.5}]}
+
+        error_response = MagicMock()
+        error_response.raise_for_status.side_effect = HTTPError("503")
+
+        def _fake_get(*args, **kwargs):  # type: ignore[no-untyped-def]
+            nonlocal call_count
+            call_count += 1
+            return error_response if call_count < 2 else ok_response
+
+        monkeypatch.setattr(requests, "get", _fake_get)
+
+        with patch("tenacity.nap.time"):
+            price = InvestmentService.get_market_price("PETR4")
+
+        assert price == 10.5
+        assert call_count == 2
+
+    def test_request_json_returns_none_after_all_retries_exhausted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from app.services.investment_service import InvestmentService
+
+        InvestmentService._clear_cache_for_tests()
+        call_count = 0
+
+        def _always_timeout(*args, **kwargs):  # type: ignore[no-untyped-def]
+            nonlocal call_count
+            call_count += 1
+            raise Timeout("always timeout")
+
+        monkeypatch.setattr(requests, "get", _always_timeout)
+
+        with patch("tenacity.nap.time"):
+            price = InvestmentService.get_market_price("PETR4")
+
+        # After all retries, investment_service catches and returns None
+        assert price is None
+        assert call_count == 3  # tenacity retried _MAX_ATTEMPTS=3 times


### PR DESCRIPTION
## Summary

- Introduces `app/services/retry_wrapper.py` — shared tenacity-based decorator with `stop_after_attempt(3)`, `wait_exponential(min=2s, max=10s)`, retrying on `HTTPError`, `Timeout`, `ConnectionError`
- Each retry emits a structured log line (`attempt`, `exception`, `next_wait`) and a Sentry breadcrumb
- Applied to `InvestmentService._request_json` (replaces manual sleep loop, circuit breaker stays), `ResendEmailProvider.send`, `AsaasBillingProvider._request`
- 11 unit tests: success, partial retry, full exhaustion, non-retryable pass-through

## Test plan

- [x] `pytest tests/test_retry_wrapper.py` — 11/11 pass
- [x] Full test suite: 1128 passed, 89.85% coverage (≥ 85% gate)
- [x] `ruff check`, `ruff format`, `mypy` — all clean
- [x] All pre-push hooks passed

Closes #942