### PR TITLE
perf(observability): PERF-3 — enable slow query log

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -57,6 +57,7 @@ from app.extensions.http_observability import register_http_observability
 from app.extensions.integration_metrics_cli import register_integration_metrics_commands
 from app.extensions.prometheus_metrics import register_prometheus_middleware
 from app.extensions.sentry import init_sentry
+from app.extensions.slow_query_log import install_slow_query_log
 from app.extensions.trial_expiry_cli import register_trial_expiry_cli
 from app.http.request_context import register_request_context_adapter
 from app.middleware.cors import register_cors
@@ -204,6 +205,9 @@ def create_app(*, enable_http_runtime: bool = True) -> Flask:
     ma.init_app(app)
     Migrate(app, db)
     jwt.init_app(app)
+
+    # PERF-3 — slow query log listeners on the default SQLAlchemy engine.
+    install_slow_query_log(app)
 
     # Schema bootstrap deve ser explicito para evitar drift em runtime seguro.
     auto_create_db = os.getenv("AUTO_CREATE_DB", "false").lower() == "true"

--- a/app/extensions/slow_query_log.py
+++ b/app/extensions/slow_query_log.py
@@ -1,0 +1,184 @@
+"""Slow query log (PERF-3).
+
+Hooks SQLAlchemy's engine ``before_cursor_execute`` / ``after_cursor_execute``
+events to measure every statement and emit a structured warning whenever the
+elapsed time crosses a configurable threshold. Threshold and enablement are
+driven by Flask config (and by extension, the environment):
+
+- ``SLOW_QUERY_LOG_ENABLED`` (bool, default ``True``) — master switch.
+- ``SLOW_QUERY_LOG_THRESHOLD_MS`` (int, default ``500``) — minimum duration
+  to log. Anything below stays silent.
+
+The handler is idempotent: installing twice on the same engine is a no-op.
+Metrics are incremented via ``integration_metrics`` so dashboards and CI
+probes can assert on them without parsing log lines.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from collections.abc import Iterable
+from typing import Any
+
+from flask import Flask, has_request_context, request
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+
+from app.extensions.database import db
+from app.extensions.integration_metrics import increment_metric, record_metric_sample
+
+logger = logging.getLogger("auraxis.slow_query")
+
+_QUERY_START_KEY = "auraxis_slow_query_start"
+_INSTALLED_FLAG = "_auraxis_slow_query_log_installed"
+
+DEFAULT_THRESHOLD_MS = 500
+
+
+def _as_bool(value: Any, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _as_int(value: Any, default: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed >= 0 else default
+
+
+def _resolve_config(app: Flask) -> tuple[bool, int]:
+    enabled = _as_bool(
+        app.config.get("SLOW_QUERY_LOG_ENABLED", os.getenv("SLOW_QUERY_LOG_ENABLED")),
+        default=True,
+    )
+    threshold = _as_int(
+        app.config.get(
+            "SLOW_QUERY_LOG_THRESHOLD_MS",
+            os.getenv("SLOW_QUERY_LOG_THRESHOLD_MS"),
+        ),
+        default=DEFAULT_THRESHOLD_MS,
+    )
+    return enabled, threshold
+
+
+def _truncate(statement: str, limit: int = 500) -> str:
+    flat = " ".join(statement.split())
+    if len(flat) <= limit:
+        return flat
+    return flat[: limit - 1] + "…"
+
+
+def _request_context() -> dict[str, str]:
+    if not has_request_context():
+        return {}
+    return {
+        "method": request.method,
+        "path": request.path,
+    }
+
+
+def _emit(
+    *,
+    threshold_ms: int,
+    duration_ms: int,
+    statement: str,
+) -> None:
+    increment_metric("db.slow_query.total")
+    record_metric_sample("db.slow_query.duration_ms", duration_ms)
+    logger.warning(
+        "slow query detected",
+        extra={
+            "duration_ms": duration_ms,
+            "threshold_ms": threshold_ms,
+            "statement": _truncate(statement),
+            **_request_context(),
+        },
+    )
+
+
+def _make_before_listener() -> Any:
+    def _before(
+        _conn: Any,
+        _cursor: Any,
+        _statement: str,
+        _parameters: Any,
+        context: Any,
+        _executemany: bool,
+    ) -> None:
+        if context is not None:
+            context._query_start_time = time.perf_counter()  # noqa: SLF001
+        else:
+            _conn.info[_QUERY_START_KEY] = time.perf_counter()
+
+    return _before
+
+
+def _make_after_listener(threshold_ms: int) -> Any:
+    def _after(
+        conn: Any,
+        _cursor: Any,
+        statement: str,
+        _parameters: Any,
+        context: Any,
+        _executemany: bool,
+    ) -> None:
+        start: float | None = None
+        if context is not None:
+            start = getattr(context, "_query_start_time", None)
+        if start is None:
+            start = conn.info.get(_QUERY_START_KEY) if hasattr(conn, "info") else None
+        if start is None:
+            return
+        duration_ms = int((time.perf_counter() - start) * 1000)
+        if duration_ms < threshold_ms:
+            return
+        _emit(
+            threshold_ms=threshold_ms,
+            duration_ms=duration_ms,
+            statement=statement,
+        )
+
+    return _after
+
+
+def _attach_listeners(engine: Engine, threshold_ms: int) -> bool:
+    if getattr(engine, _INSTALLED_FLAG, False):
+        return False
+    event.listen(engine, "before_cursor_execute", _make_before_listener())
+    event.listen(engine, "after_cursor_execute", _make_after_listener(threshold_ms))
+    engine._auraxis_slow_query_log_installed = True  # type: ignore[attr-defined]
+    logger.info("slow query log installed (threshold=%dms)", threshold_ms)
+    return True
+
+
+def install_slow_query_log(
+    app: Flask,
+    *,
+    engines: Iterable[Engine] | None = None,
+) -> bool:
+    """Install the slow query log listeners.
+
+    Returns ``True`` when at least one engine received new listeners,
+    ``False`` when the feature is disabled or the engines were already
+    instrumented.
+    """
+
+    enabled, threshold_ms = _resolve_config(app)
+    if not enabled:
+        logger.debug("slow query log disabled via config")
+        return False
+
+    if engines is None:
+        with app.app_context():
+            target_engines: list[Engine] = [db.engine]
+    else:
+        target_engines = list(engines)
+
+    return any(_attach_listeners(engine, threshold_ms) for engine in target_engines)

--- a/tests/test_slow_query_log.py
+++ b/tests/test_slow_query_log.py
@@ -1,0 +1,192 @@
+"""Tests for PERF-3 slow query log (``app/extensions/slow_query_log.py``)."""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from flask import Flask
+from sqlalchemy import create_engine, text
+
+from app.extensions import slow_query_log as slow_query_log_module
+from app.extensions.integration_metrics import (
+    reset_metrics_for_tests,
+    snapshot_metric_samples,
+    snapshot_metrics,
+)
+from app.extensions.slow_query_log import (
+    DEFAULT_THRESHOLD_MS,
+    _as_bool,
+    _as_int,
+    _resolve_config,
+    _truncate,
+    install_slow_query_log,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_metrics() -> None:
+    reset_metrics_for_tests()
+
+
+def _make_app(**config_overrides: Any) -> Flask:
+    app = Flask(__name__)
+    app.config.update(config_overrides)
+    return app
+
+
+def _make_engine() -> Any:
+    return create_engine("sqlite+pysqlite:///:memory:")
+
+
+class TestHelpers:
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            (True, True),
+            (False, False),
+            ("1", True),
+            ("true", True),
+            ("YES", True),
+            ("on", True),
+            ("0", False),
+            ("false", False),
+            ("no", False),
+            ("", False),
+        ],
+    )
+    def test_as_bool(self, value: Any, expected: bool) -> None:
+        assert _as_bool(value, default=False) is expected
+
+    def test_as_bool_returns_default_when_none(self) -> None:
+        assert _as_bool(None, default=True) is True
+        assert _as_bool(None, default=False) is False
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("250", 250),
+            (250, 250),
+            ("0", 0),
+            ("-5", DEFAULT_THRESHOLD_MS),
+            ("garbage", DEFAULT_THRESHOLD_MS),
+            (None, DEFAULT_THRESHOLD_MS),
+        ],
+    )
+    def test_as_int(self, value: Any, expected: int) -> None:
+        assert _as_int(value, default=DEFAULT_THRESHOLD_MS) == expected
+
+    def test_truncate_preserves_short_statements(self) -> None:
+        assert _truncate("SELECT 1") == "SELECT 1"
+
+    def test_truncate_collapses_whitespace(self) -> None:
+        assert _truncate("SELECT\n   1\n\t FROM t") == "SELECT 1 FROM t"
+
+    def test_truncate_trims_long_statements(self) -> None:
+        statement = "SELECT " + "a" * 1000
+        truncated = _truncate(statement, limit=50)
+        assert len(truncated) == 50
+        assert truncated.endswith("…")
+
+
+class TestResolveConfig:
+    def test_uses_defaults_when_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("SLOW_QUERY_LOG_ENABLED", raising=False)
+        monkeypatch.delenv("SLOW_QUERY_LOG_THRESHOLD_MS", raising=False)
+        app = _make_app()
+        enabled, threshold = _resolve_config(app)
+        assert enabled is True
+        assert threshold == DEFAULT_THRESHOLD_MS
+
+    def test_disabled_via_flask_config(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("SLOW_QUERY_LOG_ENABLED", raising=False)
+        app = _make_app(SLOW_QUERY_LOG_ENABLED=False)
+        enabled, _ = _resolve_config(app)
+        assert enabled is False
+
+    def test_threshold_via_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SLOW_QUERY_LOG_THRESHOLD_MS", "42")
+        app = _make_app()
+        _, threshold = _resolve_config(app)
+        assert threshold == 42
+
+    def test_flask_config_wins_over_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SLOW_QUERY_LOG_THRESHOLD_MS", "42")
+        app = _make_app(SLOW_QUERY_LOG_THRESHOLD_MS=1500)
+        _, threshold = _resolve_config(app)
+        assert threshold == 1500
+
+
+class TestInstall:
+    def test_skips_when_disabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("SLOW_QUERY_LOG_ENABLED", raising=False)
+        app = _make_app(SLOW_QUERY_LOG_ENABLED=False)
+        engine = _make_engine()
+        assert install_slow_query_log(app, engines=[engine]) is False
+        assert getattr(engine, "_auraxis_slow_query_log_installed", False) is False
+
+    def test_install_is_idempotent(self) -> None:
+        app = _make_app()
+        engine = _make_engine()
+        first = install_slow_query_log(app, engines=[engine])
+        second = install_slow_query_log(app, engines=[engine])
+        assert first is True
+        assert second is False
+        assert engine._auraxis_slow_query_log_installed is True
+
+    def test_fast_queries_are_not_logged(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        app = _make_app(SLOW_QUERY_LOG_THRESHOLD_MS=500)
+        engine = _make_engine()
+        install_slow_query_log(app, engines=[engine])
+
+        caplog.set_level(logging.WARNING, logger="auraxis.slow_query")
+        with engine.connect() as conn:
+            conn.execute(text("SELECT 1"))
+
+        assert caplog.records == []
+        assert snapshot_metrics(prefix="db.slow_query.") == {}
+
+    def test_slow_query_is_logged_and_recorded(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        app = _make_app(SLOW_QUERY_LOG_THRESHOLD_MS=100)
+        engine = _make_engine()
+        install_slow_query_log(app, engines=[engine])
+
+        real_perf_counter = time.perf_counter
+        fake_clock = iter([10.0, 10.3])  # 300ms delta
+
+        def fake_perf_counter() -> float:
+            try:
+                return next(fake_clock)
+            except StopIteration:
+                return real_perf_counter()
+
+        caplog.set_level(logging.WARNING, logger="auraxis.slow_query")
+        with patch.object(
+            slow_query_log_module.time, "perf_counter", side_effect=fake_perf_counter
+        ):
+            with engine.connect() as conn:
+                conn.execute(text("SELECT 2"))
+
+        slow_warnings = [
+            record
+            for record in caplog.records
+            if record.name == "auraxis.slow_query" and record.levelname == "WARNING"
+        ]
+        assert len(slow_warnings) == 1
+        record = slow_warnings[0]
+        assert record.msg == "slow query detected"
+        assert record.duration_ms == 300
+        assert record.threshold_ms == 100
+        assert "SELECT 2" in record.statement
+
+        counters = snapshot_metrics(prefix="db.slow_query.")
+        assert counters.get("db.slow_query.total") == 1
+        samples = snapshot_metric_samples(prefix="db.slow_query.")
+        assert samples.get("db.slow_query.duration_ms") == [300]


### PR DESCRIPTION
## Summary

Adds a configurable SQLAlchemy slow query log that hooks into the engine's \`before_cursor_execute\` / \`after_cursor_execute\` events, measures every statement, and emits a structured warning + integration-metrics counter/sample whenever elapsed time crosses the threshold.

## Why

PERF-3 from \`GAPS_MELHORIAS_MVP1.md\` (Ciclo 1). Zero instrumentation for slow DB calls today — any regression (missing index, accidental full scan, N+1 sneaking in via eager-load refactor) would only surface as a user-visible latency spike. This gives us a cheap, always-on probe we can assert on from CI and dashboards.

## Knobs

- \`SLOW_QUERY_LOG_ENABLED\` (default \`true\`) — master switch.
- \`SLOW_QUERY_LOG_THRESHOLD_MS\` (default \`500\`) — minimum duration to log.
- Flask config takes precedence over env when both are set.
- Install is idempotent per-engine (safe across multiple \`create_app\` calls in tests).

## Observability

- Logger: \`auraxis.slow_query\` — structured \`extra={duration_ms, threshold_ms, statement, method?, path?}\`.
- Metrics:
  - counter: \`db.slow_query.total\`
  - samples: \`db.slow_query.duration_ms\`
- Request context (method + path) attached when emitted inside a Flask request.

## Test plan

- [x] 28 unit tests (\`tests/test_slow_query_log.py\`) covering bool/int parsers, config resolution (defaults, Flask-vs-env precedence), disabled skip, idempotency, fast-query silence, and slow-query detection with mocked \`perf_counter\` + metrics assertions.
- [x] \`ruff format\` / \`ruff check\` / \`mypy\` clean.
- [x] Full suite: \`pytest -m 'not schemathesis'\` → **1250 passed**, coverage **90.76%**.

Ref: GAPS_MELHORIAS_MVP1.md → Ciclo 1 / PERF-3