### PR TITLE
chore(dx): ci-parity — add feature_flags + pytest to local quality sc…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,16 @@ that other agents consume. Use `templates/handoff_template.md` for consistency.
 
 ## Quality Gates (run before every commit)
 
+**Canonical CI-parity command** (mirrors GitHub Actions ci.yml exactly):
+```bash
+bash scripts/run_ci_quality_local.sh --local
+```
+
+This runs in order: check_feature_flags → repo_hygiene → graphql_auth_config →
+alembic_single_head → security_exception_governance → pip_audit → ruff format →
+ruff check → mypy → bandit → pytest (cov ≥ 85%).
+
+**Individual checks** (when debugging a specific gate):
 ```bash
 bash scripts/bootstrap_local_env.sh
 scripts/python_tool.sh ruff format .

--- a/scripts/run_ci_quality_local.sh
+++ b/scripts/run_ci_quality_local.sh
@@ -23,7 +23,8 @@ if [[ "$MODE" == "docker" ]]; then
     -v "$ROOT_DIR:/workspace" \
     -w /workspace \
     "$CI_LOCAL_PYTHON_IMAGE" \
-    bash -lc "python3 scripts/repo_hygiene_check.py && \
+    bash -lc "python3 scripts/check_feature_flags.py && \
+      python3 scripts/repo_hygiene_check.py && \
       python3 scripts/graphql_auth_config_check.py && \
       python3 scripts/alembic_single_head_check.py && \
       python -m pip install --upgrade pip && \
@@ -33,7 +34,8 @@ if [[ "$MODE" == "docker" ]]; then
       python -m ruff format --check . && \
       python -m ruff check app tests config run.py run_without_db.py && \
       python -m mypy --no-incremental app && \
-      python -m bandit -r app -lll -iii"
+      python -m bandit -r app -lll -iii && \
+      pytest -m 'not schemathesis' --cov=app --cov-fail-under=85 --cov-report=term-missing"
   echo "[quality-local] All quality checks passed (Docker / Python 3.13)."
   exit 0
 fi
@@ -41,6 +43,7 @@ fi
 PYTHON_BIN="$(resolve_repo_python "$ROOT_DIR")"
 
 echo "[quality-local] Running CI quality pipeline in local environment with ${PYTHON_BIN}..."
+python3 scripts/check_feature_flags.py
 python3 scripts/repo_hygiene_check.py
 python3 scripts/graphql_auth_config_check.py
 python3 scripts/alembic_single_head_check.py
@@ -50,4 +53,5 @@ python3 scripts/security_exception_governance.py check
 "${PYTHON_BIN}" -m ruff check app tests config run.py run_without_db.py
 "${PYTHON_BIN}" -m mypy --no-incremental app
 "${PYTHON_BIN}" -m bandit -r app -lll -iii
+"${PYTHON_BIN}" -m pytest -m "not schemathesis" --cov=app --cov-fail-under=85 --cov-report=term-missing
 echo "[quality-local] All quality checks passed (local environment)."


### PR DESCRIPTION
## Summary
- `run_ci_quality_local.sh` now mirrors `ci.yml` exactly
- Added `check_feature_flags.py` — was running in CI but missing from local script
- Added `pytest -m "not schemathesis" --cov=app --cov-fail-under=85` — was running in CI but missing from local script
- Updated `CLAUDE.md` to reference the canonical CI-parity command

## Context
Gap found during auraxis-platform governance audit: agents were opening PRs without running the full CI pipeline locally, causing predictable CI failures. This ensures fail-fast locally before any push.

## Test plan
- [ ] `bash scripts/run_ci_quality_local.sh --local` runs all gates including feature_flags and pytest
- [ ] CI pipeline passes with no regressions