### PR TITLE
fix(reminders): add missing CLI command for dispatch-due-soon (#989)

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -56,6 +56,7 @@ from app.extensions.error_handlers import register_error_handlers
 from app.extensions.http_observability import register_http_observability
 from app.extensions.integration_metrics_cli import register_integration_metrics_commands
 from app.extensions.prometheus_metrics import register_prometheus_middleware
+from app.extensions.reminders_cli import register_reminders_commands
 from app.extensions.sentry import init_sentry
 from app.extensions.slow_query_log import install_slow_query_log
 from app.extensions.trial_expiry_cli import register_trial_expiry_cli
@@ -266,6 +267,7 @@ def create_app(*, enable_http_runtime: bool = True) -> Flask:
     register_trial_expiry_cli(app)
     register_integration_metrics_commands(app)
     register_billing_webhooks_commands(app)
+    register_reminders_commands(app)
     app.cli.add_command(features_cli_group, "features")
     register_wallet_dependencies(app)
     register_entitlement_dependencies(app)

--- a/app/extensions/reminders_cli.py
+++ b/app/extensions/reminders_cli.py
@@ -1,0 +1,47 @@
+"""Flask CLI command — transaction due-date reminders.
+
+Dispatches email reminders for transactions approaching their due date:
+
+    flask reminders dispatch-due-soon [--dry-run]
+
+The underlying business logic lives in
+``app.application.services.transaction_reminder_service``.
+"""
+
+from __future__ import annotations
+
+import click
+from flask import Flask
+from flask.cli import AppGroup
+
+reminders_cli = AppGroup("reminders", help="Transaction reminder commands.")
+
+
+@reminders_cli.command("dispatch-due-soon")
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Print what would be sent without dispatching emails.",
+)
+def dispatch_due_soon(dry_run: bool) -> None:
+    """Send reminders for transactions due in 7 days and 1 day."""
+    if dry_run:
+        click.echo("[dry-run] Would dispatch reminders for 7-day and 1-day windows.")
+        return
+
+    from app.application.services.transaction_reminder_service import (
+        dispatch_due_transaction_reminders,
+    )
+
+    for window in (7, 1):
+        result = dispatch_due_transaction_reminders(days_before_due=window)
+        click.echo(
+            f"{window}-day reminders: "
+            f"scanned={result.scanned} sent={result.sent} skipped={result.skipped}"
+        )
+
+
+def register_reminders_commands(app: Flask) -> None:
+    """Register the ``reminders`` CLI group on *app*."""
+    app.cli.add_command(reminders_cli)

--- a/tests/test_reminders_cli.py
+++ b/tests/test_reminders_cli.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import uuid
+from datetime import date, timedelta
+from decimal import Decimal
+
+from app.extensions.database import db
+from app.models.transaction import Transaction, TransactionStatus, TransactionType
+from app.models.user import User
+from app.services.email_provider import get_email_outbox
+
+
+def test_dispatch_due_soon_sends_reminders(app) -> None:
+    today = date(2030, 6, 15)
+    with app.app_context():
+        user = User(
+            id=uuid.uuid4(),
+            name="CLI Test User",
+            email="cli-test@email.com",
+            password="hash",
+        )
+        db.session.add(user)
+        db.session.flush()
+
+        tx_7 = Transaction(
+            user_id=user.id,
+            title="Aluguel",
+            amount=Decimal("1500.00"),
+            type=TransactionType.EXPENSE,
+            status=TransactionStatus.PENDING,
+            due_date=today + timedelta(days=7),
+        )
+        tx_1 = Transaction(
+            user_id=user.id,
+            title="Internet",
+            amount=Decimal("99.90"),
+            type=TransactionType.EXPENSE,
+            status=TransactionStatus.PENDING,
+            due_date=today + timedelta(days=1),
+        )
+        db.session.add_all([tx_7, tx_1])
+        db.session.commit()
+
+        runner = app.test_cli_runner()
+        # Patch today so the CLI picks up the right window.
+        # The service uses date.today() internally, so we monkeypatch it.
+        import unittest.mock as mock
+
+        with mock.patch(
+            "app.application.services.transaction_reminder_service.date"
+        ) as mock_date:
+            mock_date.today.return_value = today
+            mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+            result = runner.invoke(args=["reminders", "dispatch-due-soon"])
+
+        assert result.exit_code == 0
+        assert "7-day reminders:" in result.output
+        assert "1-day reminders:" in result.output
+        assert "sent=1" in result.output
+
+        outbox = get_email_outbox()
+        assert len(outbox) >= 1
+
+
+def test_dispatch_due_soon_dry_run_does_not_send(app) -> None:
+    runner = app.test_cli_runner()
+    result = runner.invoke(args=["reminders", "dispatch-due-soon", "--dry-run"])
+
+    assert result.exit_code == 0
+    assert "[dry-run]" in result.output
+
+    outbox = get_email_outbox()
+    assert len(outbox) == 0


### PR DESCRIPTION
## O que muda
Cria o Flask CLI command `flask reminders dispatch-due-soon` que estava faltando.
O workflow `reminder-job.yml` (cron diário 07:00 UTC via SSM) chamava esse comando,
mas ele nunca foi implementado — o service e os testes existiam, só faltava o entry point.

## Contexto
Closes #989
100% failure rate no reminder-job desde o deploy. Root cause: CLI entry point nunca criado.

## Como testar
- [ ] `flask reminders dispatch-due-soon --dry-run` — deve imprimir mensagem dry-run sem enviar emails
- [ ] `flask reminders dispatch-due-soon` — deve disparar reminders para 7 e 1 dia
- [ ] `pytest tests/test_reminders_cli.py -v` — 2 tests passando

## Quality gates
- [x] ruff format: PASS
- [x] ruff check: PASS
- [x] mypy: PASS
- [x] bandit: PASS
- [x] pytest (cov ≥ 85%): PASS (90.71%)
- [x] full CI-parity: `bash scripts/run_ci_quality_local.sh --local` PASS

## Impacto de contrato
Nenhum — apenas adiciona CLI command interno.

## Risco
LOW — thin wrapper sobre service já testado, sem mudança em endpoints.