### PR TITLE
perf(retry): PERF-4 — add jitter + structured logging to retry wrapper

### DIFF
--- a/app/services/retry_wrapper.py
+++ b/app/services/retry_wrapper.py
@@ -29,7 +29,7 @@ from tenacity import (
     retry,
     retry_if_exception_type,
     stop_after_attempt,
-    wait_exponential,
+    wait_exponential_jitter,
 )
 
 _logger = logging.getLogger("auraxis.retry")
@@ -39,24 +39,29 @@ _RETRYABLE = (HTTPError, Timeout, ConnectionError)
 F = TypeVar("F", bound=Callable[..., Any])
 
 _MAX_ATTEMPTS = 3
-_WAIT_MULTIPLIER = 1
-_WAIT_MIN = 2
+_WAIT_INITIAL = 2
 _WAIT_MAX = 10
+_JITTER_MAX = 1  # up to 1 s random jitter to avoid thundering herd
 
 
 def _make_before_sleep(provider: str) -> Callable[[RetryCallState], None]:
     def _before_sleep(retry_state: RetryCallState) -> None:
         attempt = retry_state.attempt_number
-        exc = retry_state.outcome.exception() if retry_state.outcome else None
+        outcome = retry_state.outcome
+        exc = outcome.exception() if outcome else None
+        elapsed = retry_state.seconds_since_start
         next_wait: float | None
         if retry_state.next_action is not None:
             next_wait = getattr(retry_state.next_action, "sleep", None)
         else:
             next_wait = None
         _logger.warning(
-            "retry provider=%s attempt=%d exception=%r next_wait=%.1fs",
+            "retry provider=%s attempt=%d elapsed=%.2fs outcome=%s "
+            "exception=%r next_wait=%.1fs",
             provider,
             attempt,
+            elapsed,
+            "failure",
             exc,
             next_wait or 0.0,
         )
@@ -67,6 +72,8 @@ def _make_before_sleep(provider: str) -> Callable[[RetryCallState], None]:
             data={
                 "provider": provider,
                 "attempt": attempt,
+                "elapsed": elapsed,
+                "outcome": "failure",
                 "exception": repr(exc),
                 "next_wait": next_wait,
             },
@@ -79,15 +86,16 @@ def with_retry(*, provider: str) -> Callable[[F], F]:
     """Return a tenacity retry decorator configured for the given provider.
 
     Retries up to 3 times on ``HTTPError``, ``Timeout``, or
-    ``ConnectionError`` with exponential backoff (2 s → 4 s → 10 s cap).
+    ``ConnectionError`` with exponential backoff + random jitter
+    (2 s base → 4 s → 10 s cap, ±1 s jitter to avoid thundering herd).
     Each retry emits a structured log line and a Sentry breadcrumb.
     """
     decorator: Callable[[F], F] = retry(
         stop=stop_after_attempt(_MAX_ATTEMPTS),
-        wait=wait_exponential(
-            multiplier=_WAIT_MULTIPLIER,
-            min=_WAIT_MIN,
+        wait=wait_exponential_jitter(
+            initial=_WAIT_INITIAL,
             max=_WAIT_MAX,
+            jitter=_JITTER_MAX,
         ),
         retry=retry_if_exception_type(_RETRYABLE),
         before_sleep=_make_before_sleep(provider),

--- a/tests/test_retry_wrapper.py
+++ b/tests/test_retry_wrapper.py
@@ -13,8 +13,15 @@ from unittest.mock import MagicMock, patch
 import pytest
 import requests
 from requests.exceptions import ConnectionError, HTTPError, Timeout
+from tenacity import wait_exponential_jitter
 
-from app.services.retry_wrapper import with_retry
+from app.services.retry_wrapper import (
+    _JITTER_MAX,
+    _WAIT_INITIAL,
+    _WAIT_MAX,
+    _make_before_sleep,
+    with_retry,
+)
 
 # ---------------------------------------------------------------------------
 # retry_wrapper unit tests
@@ -97,6 +104,35 @@ class TestWithRetry:
             _fn()
 
         assert call_count == 1  # no retry for non-transient errors
+
+    def test_jitter_produces_varying_wait_times(self) -> None:
+        """Verify that wait_exponential_jitter produces non-identical waits."""
+        strategy = wait_exponential_jitter(
+            initial=_WAIT_INITIAL, max=_WAIT_MAX, jitter=_JITTER_MAX
+        )
+        mock_state = MagicMock()
+        mock_state.attempt_number = 1
+        # Sample wait times — with jitter they should vary
+        waits = {strategy(retry_state=mock_state) for _ in range(20)}
+        # With jitter > 0, we expect more than 1 distinct wait value
+        assert len(waits) > 1, "Jitter should produce varying wait times"
+
+    def test_before_sleep_logs_elapsed_and_outcome(self) -> None:
+        callback = _make_before_sleep("test-provider")
+        mock_state = MagicMock()
+        mock_state.attempt_number = 2
+        mock_state.seconds_since_start = 3.45
+        mock_state.outcome.exception.return_value = Timeout("transient")
+        mock_state.next_action = MagicMock()
+        mock_state.next_action.sleep = 4.0
+
+        with patch("app.services.retry_wrapper._logger") as mock_logger:
+            callback(mock_state)
+
+        call_args = mock_logger.warning.call_args
+        log_msg = call_args[0][0]
+        assert "elapsed=" in log_msg
+        assert "outcome=" in log_msg
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## O que muda
Adiciona random jitter (±1s) ao exponential backoff do retry decorator para
evitar thundering herd quando múltiplos workers retentam simultaneamente.
Enriquece logs de retry com `elapsed` e `outcome` para melhor observabilidade.

## Contexto
Closes #974
O decorator `with_retry` já estava aplicado em Resend, BRAPI e Asaas.
Faltavam jitter e campos de log estruturado conforme acceptance criteria.

## Como testar
- [ ] `pytest tests/test_retry_wrapper.py -v` — 15 tests passando
- [ ] Verificar que jitter produz wait times variados (test_jitter_produces_varying_wait_times)
- [ ] Verificar logs com elapsed/outcome (test_before_sleep_logs_elapsed_and_outcome)

## Quality gates
- [x] ruff format: PASS
- [x] ruff check: PASS
- [x] mypy: PASS
- [x] bandit: PASS
- [x] pytest (cov ≥ 85%): PASS (90.71%)
- [x] full CI-parity: PASS

## Impacto de contrato
Nenhum — mudança interna no retry timing. Behavior externo (max 3 attempts) inalterado.

## Risco
LOW — jitter adiciona apenas variação no timing de retry, sem mudança funcional.