### PR TITLE
feat(openapi): POSTMAN-01 + POSTMAN-06 — CLI export + drift check (#963, #968)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -12,6 +12,12 @@ paths = [
 ]
 
 [[allowlists]]
+description = "OpenAPI spec — example tokens in API documentation are not real secrets"
+paths = [
+  '''openapi\.json''',
+]
+
+[[allowlists]]
 description = "Test fixture values — known mock credential patterns"
 regexTarget = "match"
 regexes = [

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -13,6 +13,7 @@ from flask_migrate import Migrate
 from sqlalchemy.pool import NullPool
 
 from app.cli.features import features as features_cli_group
+from app.cli.openapi_export import openapi_export_command
 from app.controllers.account import account_bp
 from app.controllers.admin.feature_flags import admin_feature_flags_bp
 from app.controllers.alert_controller import alert_bp, register_alert_dependencies
@@ -269,6 +270,7 @@ def create_app(*, enable_http_runtime: bool = True) -> Flask:
     register_billing_webhooks_commands(app)
     register_reminders_commands(app)
     app.cli.add_command(features_cli_group, "features")
+    app.cli.add_command(openapi_export_command)
     register_wallet_dependencies(app)
     register_entitlement_dependencies(app)
     register_simulation_dependencies(app)

--- a/app/cli/openapi_export.py
+++ b/app/cli/openapi_export.py
@@ -1,0 +1,45 @@
+"""Flask CLI command — deterministic OpenAPI JSON export.
+
+    flask openapi-export --output openapi.json
+
+Produces a stable, reproducible OpenAPI 3.0 JSON file from the live apispec
+registration.  Two consecutive runs must yield byte-identical output (sorted
+keys, no timestamps, deterministic numeric coercion).
+"""
+
+from __future__ import annotations
+
+import json
+
+import click
+from flask import current_app
+from flask.cli import with_appcontext
+
+
+@click.command("openapi-export")
+@click.option(
+    "--output",
+    "-o",
+    default="openapi.json",
+    show_default=True,
+    help="Output file path for the OpenAPI JSON.",
+)
+@with_appcontext
+def openapi_export_command(output: str) -> None:
+    """Export the current OpenAPI spec to a deterministic JSON file."""
+    with current_app.test_client() as client:
+        response = client.get("/docs/swagger/")
+        if response.status_code != 200:
+            raise click.ClickException(
+                f"Swagger endpoint returned HTTP {response.status_code}"
+            )
+        spec = response.get_json()
+        if not spec:
+            raise click.ClickException("Swagger endpoint returned empty payload")
+
+    with open(output, "w", encoding="utf-8") as f:
+        json.dump(spec, f, ensure_ascii=False, indent=2, sort_keys=True)
+        f.write("\n")
+
+    path_count = len(spec.get("paths", {}))
+    click.echo(f"OpenAPI spec written to {output} ({path_count} paths)")

--- a/app/cli/openapi_export.py
+++ b/app/cli/openapi_export.py
@@ -10,10 +10,33 @@ keys, no timestamps, deterministic numeric coercion).
 from __future__ import annotations
 
 import json
+from typing import Any
 
 import click
 from flask import current_app
 from flask.cli import with_appcontext
+
+
+def _stabilize_parameters(spec: dict[str, Any]) -> dict[str, Any]:
+    """Sort parameter arrays inside each path/method for deterministic output.
+
+    OpenAPI parameters are arrays whose order is non-semantic, but
+    non-deterministic ordering causes false drift. Sort by (in, name).
+    """
+    paths = spec.get("paths", {})
+    for _path, methods in paths.items():
+        if not isinstance(methods, dict):
+            continue
+        for _method, operation in methods.items():
+            if not isinstance(operation, dict):
+                continue
+            params = operation.get("parameters")
+            if isinstance(params, list):
+                operation["parameters"] = sorted(
+                    params,
+                    key=lambda p: (p.get("in", ""), p.get("name", "")),
+                )
+    return spec
 
 
 @click.command("openapi-export")
@@ -36,6 +59,8 @@ def openapi_export_command(output: str) -> None:
         spec = response.get_json()
         if not spec:
             raise click.ClickException("Swagger endpoint returned empty payload")
+
+    spec = _stabilize_parameters(spec)
 
     with open(output, "w", encoding="utf-8") as f:
         json.dump(spec, f, ensure_ascii=False, indent=2, sort_keys=True)

--- a/openapi.json
+++ b/openapi.json
@@ -1,0 +1,9999 @@
+{
+  "components": {
+    "schemas": {
+      "InstallmentVsCashCalculation": {
+        "properties": {
+          "cash_price": {
+            "minimum": 0.01,
+            "type": "number"
+          },
+          "fees_enabled": {
+            "default": false,
+            "type": "boolean"
+          },
+          "fees_upfront": {
+            "default": "0.00",
+            "minimum": 0,
+            "type": "number"
+          },
+          "first_payment_delay_days": {
+            "default": 30,
+            "maximum": 3650,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "inflation_rate_annual": {
+            "maximum": 1000,
+            "minimum": 0,
+            "type": "number"
+          },
+          "installment_amount": {
+            "default": null,
+            "minimum": 0.01,
+            "nullable": true,
+            "type": "number"
+          },
+          "installment_count": {
+            "maximum": 60,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "installment_total": {
+            "default": null,
+            "minimum": 0.01,
+            "nullable": true,
+            "type": "number"
+          },
+          "opportunity_rate_annual": {
+            "default": null,
+            "maximum": 1000,
+            "minimum": 0,
+            "nullable": true,
+            "type": "number"
+          },
+          "opportunity_rate_type": {
+            "default": "manual",
+            "enum": [
+              "manual",
+              "product_default",
+              "inflation_only"
+            ],
+            "type": "string"
+          },
+          "scenario_label": {
+            "default": null,
+            "maxLength": 120,
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "cash_price",
+          "inflation_rate_annual",
+          "installment_count"
+        ],
+        "type": "object"
+      },
+      "InstallmentVsCashGoalBridge": {
+        "properties": {
+          "category": {
+            "default": "planned_purchase",
+            "maxLength": 64,
+            "nullable": true,
+            "type": "string"
+          },
+          "current_amount": {
+            "default": "0.00",
+            "minimum": 0,
+            "type": "number"
+          },
+          "description": {
+            "default": null,
+            "maxLength": 500,
+            "nullable": true,
+            "type": "string"
+          },
+          "priority": {
+            "default": 3,
+            "maximum": 5,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "selected_option": {
+            "enum": [
+              "cash",
+              "installment"
+            ],
+            "type": "string"
+          },
+          "target_date": {
+            "default": null,
+            "format": "date",
+            "nullable": true,
+            "type": "string"
+          },
+          "title": {
+            "maxLength": 128,
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "required": [
+          "selected_option",
+          "title"
+        ],
+        "type": "object"
+      },
+      "InstallmentVsCashPlannedExpenseBridge": {
+        "properties": {
+          "account_id": {
+            "default": null,
+            "format": "uuid",
+            "nullable": true,
+            "type": "string"
+          },
+          "credit_card_id": {
+            "default": null,
+            "format": "uuid",
+            "nullable": true,
+            "type": "string"
+          },
+          "currency": {
+            "default": "BRL",
+            "maxLength": 3,
+            "minLength": 3,
+            "type": "string"
+          },
+          "description": {
+            "default": null,
+            "maxLength": 300,
+            "nullable": true,
+            "type": "string"
+          },
+          "due_date": {
+            "default": null,
+            "format": "date",
+            "nullable": true,
+            "type": "string"
+          },
+          "first_due_date": {
+            "default": null,
+            "format": "date",
+            "nullable": true,
+            "type": "string"
+          },
+          "observation": {
+            "default": null,
+            "maxLength": 500,
+            "nullable": true,
+            "type": "string"
+          },
+          "selected_option": {
+            "enum": [
+              "cash",
+              "installment"
+            ],
+            "type": "string"
+          },
+          "status": {
+            "default": "pending",
+            "enum": [
+              "pending",
+              "paid",
+              "cancelled",
+              "postponed",
+              "overdue"
+            ],
+            "type": "string"
+          },
+          "tag_id": {
+            "default": null,
+            "format": "uuid",
+            "nullable": true,
+            "type": "string"
+          },
+          "title": {
+            "maxLength": 120,
+            "minLength": 1,
+            "type": "string"
+          },
+          "upfront_due_date": {
+            "default": null,
+            "format": "date",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "selected_option",
+          "title"
+        ],
+        "type": "object"
+      },
+      "InstallmentVsCashSave": {
+        "properties": {
+          "cash_price": {
+            "minimum": 0.01,
+            "type": "number"
+          },
+          "fees_enabled": {
+            "default": false,
+            "type": "boolean"
+          },
+          "fees_upfront": {
+            "default": "0.00",
+            "minimum": 0,
+            "type": "number"
+          },
+          "first_payment_delay_days": {
+            "default": 30,
+            "maximum": 3650,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "inflation_rate_annual": {
+            "maximum": 1000,
+            "minimum": 0,
+            "type": "number"
+          },
+          "installment_amount": {
+            "default": null,
+            "minimum": 0.01,
+            "nullable": true,
+            "type": "number"
+          },
+          "installment_count": {
+            "maximum": 60,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "installment_total": {
+            "default": null,
+            "minimum": 0.01,
+            "nullable": true,
+            "type": "number"
+          },
+          "opportunity_rate_annual": {
+            "default": null,
+            "maximum": 1000,
+            "minimum": 0,
+            "nullable": true,
+            "type": "number"
+          },
+          "opportunity_rate_type": {
+            "default": "manual",
+            "enum": [
+              "manual",
+              "product_default",
+              "inflation_only"
+            ],
+            "type": "string"
+          },
+          "scenario_label": {
+            "default": null,
+            "maxLength": 120,
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "cash_price",
+          "inflation_rate_annual",
+          "installment_count"
+        ],
+        "type": "object"
+      },
+      "TransactionCreate": {
+        "properties": {
+          "account_id": {
+            "description": "ID da conta bancária associada",
+            "format": "uuid",
+            "nullable": true,
+            "type": "string"
+          },
+          "amount": {
+            "description": "Valor da transação",
+            "example": "150.50",
+            "minimum": 0.01,
+            "type": "number"
+          },
+          "created_at": {
+            "description": "Data de criação da transação",
+            "format": "date-time",
+            "readOnly": true,
+            "type": "string"
+          },
+          "credit_card_id": {
+            "description": "ID do cartão de crédito associado",
+            "format": "uuid",
+            "nullable": true,
+            "type": "string"
+          },
+          "currency": {
+            "description": "Código da moeda (ISO 4217)",
+            "example": "BRL",
+            "maxLength": 3,
+            "minLength": 3,
+            "type": "string"
+          },
+          "description": {
+            "default": null,
+            "description": "Descrição detalhada da transação",
+            "example": "Conta de energia elétrica do mês de janeiro",
+            "maxLength": 300,
+            "nullable": true,
+            "type": "string"
+          },
+          "due_date": {
+            "description": "Data de vencimento da transação",
+            "example": "2024-02-15",
+            "format": "date",
+            "type": "string"
+          },
+          "end_date": {
+            "default": null,
+            "description": "Data de fim (para transações recorrentes)",
+            "example": "2024-12-31",
+            "format": "date",
+            "nullable": true,
+            "type": "string"
+          },
+          "id": {
+            "description": "ID único da transação (gerado automaticamente)",
+            "format": "uuid",
+            "readOnly": true,
+            "type": "string"
+          },
+          "installment_count": {
+            "description": "Número de parcelas (apenas se is_installment=True)",
+            "example": 12,
+            "maximum": 60,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "installment_group_id": {
+            "description": "ID do grupo de parcelas (gerado automaticamente)",
+            "format": "uuid",
+            "readOnly": true,
+            "type": "string"
+          },
+          "is_installment": {
+            "description": "Indica se a transação é parcelada",
+            "example": false,
+            "type": "boolean"
+          },
+          "is_recurring": {
+            "description": "Indica se a transação é recorrente",
+            "example": false,
+            "type": "boolean"
+          },
+          "observation": {
+            "default": null,
+            "description": "Observações adicionais sobre a transação",
+            "example": "Pagar até o dia 10 para evitar multa",
+            "maxLength": 500,
+            "nullable": true,
+            "type": "string"
+          },
+          "paid_at": {
+            "description": "Data e hora do pagamento",
+            "example": "2024-02-10T14:30:00Z",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
+          },
+          "start_date": {
+            "default": null,
+            "description": "Data de início (para transações recorrentes)",
+            "example": "2024-01-01",
+            "format": "date",
+            "nullable": true,
+            "type": "string"
+          },
+          "status": {
+            "description": "Status atual da transação",
+            "enum": [
+              "paid",
+              "pending",
+              "cancelled",
+              "postponed",
+              "overdue"
+            ],
+            "example": "pending",
+            "type": "string"
+          },
+          "tag_id": {
+            "description": "ID da tag associada à transação",
+            "format": "uuid",
+            "nullable": true,
+            "type": "string"
+          },
+          "title": {
+            "description": "Título da transação",
+            "example": "Pagamento da conta de luz",
+            "maxLength": 120,
+            "minLength": 1,
+            "type": "string"
+          },
+          "type": {
+            "description": "Tipo da transação: receita ou despesa",
+            "enum": [
+              "income",
+              "expense"
+            ],
+            "example": "expense",
+            "type": "string"
+          },
+          "updated_at": {
+            "description": "Data da última atualização",
+            "format": "date-time",
+            "readOnly": true,
+            "type": "string"
+          },
+          "user_id": {
+            "description": "ID do usuário proprietário da transação",
+            "format": "uuid",
+            "readOnly": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "amount",
+          "due_date",
+          "title",
+          "type"
+        ],
+        "type": "object"
+      },
+      "TransactionCreate_7d3b606eab": {
+        "properties": {
+          "account_id": {
+            "description": "ID da conta bancária associada",
+            "format": "uuid",
+            "nullable": true,
+            "type": "string"
+          },
+          "amount": {
+            "description": "Valor da transação",
+            "example": "150.50",
+            "minimum": 0.01,
+            "type": "number"
+          },
+          "created_at": {
+            "description": "Data de criação da transação",
+            "format": "date-time",
+            "readOnly": true,
+            "type": "string"
+          },
+          "credit_card_id": {
+            "description": "ID do cartão de crédito associado",
+            "format": "uuid",
+            "nullable": true,
+            "type": "string"
+          },
+          "currency": {
+            "description": "Código da moeda (ISO 4217)",
+            "example": "BRL",
+            "maxLength": 3,
+            "minLength": 3,
+            "type": "string"
+          },
+          "description": {
+            "default": null,
+            "description": "Descrição detalhada da transação",
+            "example": "Conta de energia elétrica do mês de janeiro",
+            "maxLength": 300,
+            "nullable": true,
+            "type": "string"
+          },
+          "due_date": {
+            "description": "Data de vencimento da transação",
+            "example": "2024-02-15",
+            "format": "date",
+            "type": "string"
+          },
+          "end_date": {
+            "default": null,
+            "description": "Data de fim (para transações recorrentes)",
+            "example": "2024-12-31",
+            "format": "date",
+            "nullable": true,
+            "type": "string"
+          },
+          "id": {
+            "description": "ID único da transação (gerado automaticamente)",
+            "format": "uuid",
+            "readOnly": true,
+            "type": "string"
+          },
+          "installment_count": {
+            "description": "Número de parcelas (apenas se is_installment=True)",
+            "example": 12,
+            "maximum": 60,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "installment_group_id": {
+            "description": "ID do grupo de parcelas (gerado automaticamente)",
+            "format": "uuid",
+            "readOnly": true,
+            "type": "string"
+          },
+          "is_installment": {
+            "description": "Indica se a transação é parcelada",
+            "example": false,
+            "type": "boolean"
+          },
+          "is_recurring": {
+            "description": "Indica se a transação é recorrente",
+            "example": false,
+            "type": "boolean"
+          },
+          "observation": {
+            "default": null,
+            "description": "Observações adicionais sobre a transação",
+            "example": "Pagar até o dia 10 para evitar multa",
+            "maxLength": 500,
+            "nullable": true,
+            "type": "string"
+          },
+          "paid_at": {
+            "description": "Data e hora do pagamento",
+            "example": "2024-02-10T14:30:00Z",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
+          },
+          "start_date": {
+            "default": null,
+            "description": "Data de início (para transações recorrentes)",
+            "example": "2024-01-01",
+            "format": "date",
+            "nullable": true,
+            "type": "string"
+          },
+          "status": {
+            "description": "Status atual da transação",
+            "enum": [
+              "paid",
+              "pending",
+              "cancelled",
+              "postponed",
+              "overdue"
+            ],
+            "example": "pending",
+            "type": "string"
+          },
+          "tag_id": {
+            "description": "ID da tag associada à transação",
+            "format": "uuid",
+            "nullable": true,
+            "type": "string"
+          },
+          "title": {
+            "description": "Título da transação",
+            "example": "Pagamento da conta de luz",
+            "maxLength": 120,
+            "minLength": 1,
+            "type": "string"
+          },
+          "type": {
+            "description": "Tipo da transação: receita ou despesa",
+            "enum": [
+              "income",
+              "expense"
+            ],
+            "example": "expense",
+            "type": "string"
+          },
+          "updated_at": {
+            "description": "Data da última atualização",
+            "format": "date-time",
+            "readOnly": true,
+            "type": "string"
+          },
+          "user_id": {
+            "description": "ID do usuário proprietário da transação",
+            "format": "uuid",
+            "readOnly": true,
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "app_schemas_auth_schema_AuthSchema": {
+        "properties": {
+          "captcha_token": {
+            "default": null,
+            "description": "Token Cloudflare Turnstile obtido pelo cliente. Obrigatório quando CAPTCHA está habilitado no servidor.",
+            "example": "0.xxxxxxxxxxx",
+            "nullable": true,
+            "type": "string"
+          },
+          "email": {
+            "description": "Endereço de email do usuário (identificador canônico)",
+            "example": "joao.silva@email.com",
+            "format": "email",
+            "type": "string"
+          },
+          "password": {
+            "description": "Senha do usuário",
+            "example": "minhasenha123",
+            "type": "string"
+          }
+        },
+        "required": [
+          "email",
+          "password"
+        ],
+        "type": "object"
+      },
+      "app_schemas_auth_schema_ConfirmEmailSchema": {
+        "properties": {
+          "token": {
+            "description": "Token de confirmacao recebido por email",
+            "example": "G9Q7zJ6lQ4Vwm6dXj6nQjzH8QqfUuBqbMTe4PmS7p8Q",
+            "maxLength": 512,
+            "minLength": 24,
+            "type": "string"
+          }
+        },
+        "required": [
+          "token"
+        ],
+        "type": "object"
+      },
+      "app_schemas_auth_schema_ForgotPasswordSchema": {
+        "properties": {
+          "email": {
+            "description": "Email da conta que deseja recuperar acesso",
+            "example": "joao.silva@email.com",
+            "format": "email",
+            "type": "string"
+          }
+        },
+        "required": [
+          "email"
+        ],
+        "type": "object"
+      },
+      "app_schemas_auth_schema_ResetPasswordSchema": {
+        "properties": {
+          "new_password": {
+            "description": "Nova senha (mínimo 10 caracteres, com maiúscula, número e símbolo)",
+            "example": "NovaSenha@123",
+            "pattern": "^(?=.*[A-Z])(?=.*\\d)(?=.*[^A-Za-z0-9]).{10,}$",
+            "type": "string",
+            "writeOnly": true
+          },
+          "token": {
+            "description": "Token de recuperação recebido por email",
+            "example": "G9Q7zJ6lQ4Vwm6dXj6nQjzH8QqfUuBqbMTe4PmS7p8Q",
+            "maxLength": 512,
+            "minLength": 24,
+            "type": "string"
+          }
+        },
+        "required": [
+          "new_password",
+          "token"
+        ],
+        "type": "object"
+      },
+      "app_schemas_user_schemas_DeleteAccountSchema": {
+        "properties": {
+          "password": {
+            "description": "Senha atual do usuário para confirmar a exclusão da conta",
+            "example": "MinhaSenha@123",
+            "type": "string",
+            "writeOnly": true
+          }
+        },
+        "required": [
+          "password"
+        ],
+        "type": "object"
+      },
+      "app_schemas_user_schemas_QuestionnaireAnswerSchema": {
+        "properties": {
+          "answers": {
+            "description": "Lista de 5 respostas — pontos da opção escolhida em cada pergunta (1–3).",
+            "items": {
+              "maximum": 3,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "maxItems": 5,
+            "minItems": 5,
+            "type": "array"
+          }
+        },
+        "required": [
+          "answers"
+        ],
+        "type": "object"
+      },
+      "app_schemas_user_schemas_SalaryIncreaseSimulationRequestSchema": {
+        "properties": {
+          "base_date": {
+            "description": "Data base do salário atual",
+            "example": "2022-01-01",
+            "format": "date",
+            "type": "string"
+          },
+          "base_salary": {
+            "description": "Salário base atual",
+            "example": "5000.00",
+            "minimum": "0",
+            "type": "number"
+          },
+          "discounts": {
+            "description": "Descontos aplicáveis",
+            "example": "500.00",
+            "minimum": "0",
+            "type": "number"
+          },
+          "target_real_increase": {
+            "description": "Aumento real desejado (%)",
+            "example": "5.00",
+            "minimum": "0",
+            "type": "number"
+          }
+        },
+        "required": [
+          "base_date",
+          "base_salary",
+          "discounts",
+          "target_real_increase"
+        ],
+        "type": "object"
+      },
+      "app_schemas_user_schemas_UserProfileSchema": {
+        "properties": {
+          "birth_date": {
+            "description": "Data de nascimento",
+            "example": "1990-05-15",
+            "format": "date",
+            "type": "string"
+          },
+          "financial_objectives": {
+            "description": "Objetivos financeiros do usuário",
+            "example": "Aposentar cedo",
+            "type": "string"
+          },
+          "gender": {
+            "description": "Gênero do usuário",
+            "enum": [
+              "masculino",
+              "feminino",
+              "outro"
+            ],
+            "example": "masculino",
+            "type": "string"
+          },
+          "initial_investment": {
+            "description": "Investimento inicial disponível",
+            "example": "10000.00",
+            "minimum": 0,
+            "type": "number"
+          },
+          "investment_goal_date": {
+            "description": "Data meta para atingir objetivo de investimento",
+            "example": "2030-12-31",
+            "format": "date",
+            "type": "string"
+          },
+          "investor_profile": {
+            "description": "Perfil do investidor",
+            "enum": [
+              "conservador",
+              "explorador",
+              "entusiasta"
+            ],
+            "example": "conservador",
+            "type": "string"
+          },
+          "investor_profile_suggested": {
+            "description": "Perfil de investidor sugerido",
+            "example": "explorador",
+            "maxLength": 32,
+            "nullable": true,
+            "type": "string"
+          },
+          "monthly_expenses": {
+            "description": "Gastos mensais totais",
+            "example": "3000.00",
+            "minimum": 0,
+            "type": "number"
+          },
+          "monthly_income": {
+            "description": "Renda mensal em reais",
+            "example": "5000.00",
+            "minimum": 0,
+            "type": "number"
+          },
+          "monthly_income_net": {
+            "description": "Renda líquida mensal em reais",
+            "example": "5000.00",
+            "minimum": 0,
+            "type": "number"
+          },
+          "monthly_investment": {
+            "description": "Valor mensal para investimentos",
+            "example": "1000.00",
+            "minimum": 0,
+            "type": "number"
+          },
+          "net_worth": {
+            "description": "Patrimônio líquido atual",
+            "example": "50000.00",
+            "minimum": 0,
+            "type": "number"
+          },
+          "occupation": {
+            "description": "Profissão do usuário",
+            "example": "Engenheiro de Software",
+            "maxLength": 128,
+            "type": "string"
+          },
+          "profile_quiz_score": {
+            "description": "Pontuação do quiz de perfil",
+            "example": 85,
+            "minimum": 0,
+            "nullable": true,
+            "type": "integer"
+          },
+          "state_uf": {
+            "description": "Estado (UF) do usuário",
+            "example": "SP",
+            "maxLength": 2,
+            "minLength": 2,
+            "type": "string"
+          },
+          "taxonomy_version": {
+            "description": "Versão da taxonomia",
+            "example": "v1.0",
+            "maxLength": 16,
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "app_schemas_user_schemas_UserRegistrationSchema": {
+        "properties": {
+          "captcha_token": {
+            "default": null,
+            "description": "Token Cloudflare Turnstile obtido pelo cliente. Obrigatório quando CAPTCHA está habilitado no servidor.",
+            "example": "0.xxxxxxxxxxx",
+            "nullable": true,
+            "type": "string"
+          },
+          "email": {
+            "description": "Endereço de email único do usuário",
+            "example": "joao.silva@email.com",
+            "format": "email",
+            "type": "string"
+          },
+          "investor_profile": {
+            "description": "Perfil do investidor auto declarado",
+            "enum": [
+              "conservador",
+              "explorador",
+              "entusiasta",
+              null
+            ],
+            "example": "conservador",
+            "nullable": true,
+            "type": "string"
+          },
+          "name": {
+            "description": "Nome completo do usuário",
+            "example": "João Silva",
+            "maxLength": 128,
+            "minLength": 2,
+            "type": "string"
+          },
+          "password": {
+            "description": "Senha do usuário (mínimo 10 caracteres, contendo ao menos uma letra maiúscula, um número e um símbolo)",
+            "example": "MinhaSenha@123",
+            "pattern": "^(?=.*[A-Z])(?=.*\\d)(?=.*[^A-Za-z0-9]).{10,}$",
+            "type": "string",
+            "writeOnly": true
+          }
+        },
+        "required": [
+          "email",
+          "name",
+          "password"
+        ],
+        "type": "object"
+      }
+    },
+    "securitySchemes": {
+      "BearerAuth": {
+        "bearerFormat": "JWT",
+        "description": "Token JWT obtido através do login",
+        "scheme": "bearer",
+        "type": "http"
+      }
+    }
+  },
+  "info": {
+    "contact": {
+      "name": "Italo Chagas",
+      "url": "https://github.com/italofelipe"
+    },
+    "description": "API para gestão financeira pessoal.\n\n- Controle de transações, carteira e dados de usuário.\n- Autenticação JWT.\n- Ticker representa o símbolo de mercado de ativos da carteira.\n- Consulte os documentos técnicos em docs/.",
+    "license": {
+      "name": "MIT",
+      "url": "https://opensource.org/licenses/MIT"
+    },
+    "title": "Auraxis API",
+    "version": "1.0.0"
+  },
+  "openapi": "3.0.2",
+  "paths": {
+    "/auth/email/confirm": {
+      "post": {
+        "description": "Confirma a conta do usuario a partir do token enviado por email.",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/app_schemas_auth_schema_ConfirmEmailSchema"
+            }
+          },
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "description": "Token de confirmacao recebido por email.",
+              "example": {
+                "token": "G9Q7zJ6lQ4Vwm6dXj6nQjzH8QqfUuBqbMTe4PmS7p8Q"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/app_schemas_auth_schema_ConfirmEmailSchema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {},
+                  "message": "Email confirmed successfully."
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Email confirmado com sucesso",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "VALIDATION_ERROR",
+                  "message": "Invalid or expired email confirmation token.",
+                  "status_code": 400
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token inválido, expirado ou payload inválido",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Email confirmation failed",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno ao confirmar email",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Confirmar conta",
+        "tags": [
+          "Autenticação"
+        ]
+      }
+    },
+    "/auth/email/resend": {
+      "post": {
+        "description": "Reenvia o email de confirmacao do usuario autenticado. Requer token JWT valido no header Authorization. A resposta e neutra para evitar enumeracao de contas.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {},
+                  "message": "If an account exists for this email, confirmation instructions were sent."
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Solicitação recebida com resposta neutra",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Missing or invalid authorization token",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token JWT ausente ou inválido",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Email confirmation resend failed",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno ao reenviar confirmacao",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Reenviar confirmacao de conta",
+        "tags": [
+          "Autenticação"
+        ]
+      }
+    },
+    "/auth/login": {
+      "post": {
+        "description": "Autentica o usuário e devolve um token JWT.\n\nHeaders:\n- `X-API-Contract`: opcional; `v2` padroniza o envelope.\n\nPayload:\n- `email` é o identificador obrigatório e canônico de login\n- `password` é obrigatório\n\nSessão:\n- um login bem-sucedido atualiza o `current_jti` do usuário e revoga a sessão JWT anterior\n\nResposta:\n- `data.token`: JWT para chamadas autenticadas\n- `data.user`: dados básicos do usuário autenticado",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/app_schemas_auth_schema_AuthSchema"
+            }
+          },
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "description": "Credenciais para login. `email` é o único identificador aceito para autenticação.",
+              "example": {
+                "email": "italo@auraxis.com.br",
+                "password": "MinhaSenha@123"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/app_schemas_auth_schema_AuthSchema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+                    "user": {
+                      "email": "italo@auraxis.com.br",
+                      "id": "4b2ef64b-b35d-4ea2-a6f2-4ef3cfb295f1",
+                      "name": "Italo Chagas"
+                    }
+                  },
+                  "message": "Login successful"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Login realizado com sucesso",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "VALIDATION_ERROR",
+                  "message": "Missing credentials",
+                  "status_code": 400
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Credenciais ausentes ou payload inválido",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Invalid credentials",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Credenciais inválidas",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "TOO_MANY_ATTEMPTS",
+                  "details": {
+                    "retry_after_seconds": 300
+                  },
+                  "message": "Too many login attempts. Try again later.",
+                  "status_code": 429
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Muitas tentativas de login",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Login failed",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno ao efetuar login",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "AUTH_BACKEND_UNAVAILABLE",
+                  "message": "Authentication temporarily unavailable. Try again later.",
+                  "status_code": 503
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Serviço de autenticação temporariamente indisponível",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Autenticar usuário",
+        "tags": [
+          "Autenticação"
+        ]
+      }
+    },
+    "/auth/logout": {
+      "post": {
+        "description": "Revoga o JWT atual do usuário autenticado.\n\nDepois dessa chamada, o token utilizado deixa de ser aceito nas rotas protegidas.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {},
+                  "message": "Logout successful"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Logout realizado com sucesso",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Revogar sessão atual",
+        "tags": [
+          "Autenticação"
+        ]
+      }
+    },
+    "/auth/password/forgot": {
+      "post": {
+        "description": "Solicita recuperação de senha por link. A resposta é sempre neutra para evitar enumeração de contas.",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/app_schemas_auth_schema_ForgotPasswordSchema"
+            }
+          },
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "description": "Email da conta que deseja recuperar acesso.",
+              "example": {
+                "email": "italo@auraxis.com.br"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/app_schemas_auth_schema_ForgotPasswordSchema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {},
+                  "message": "If an account exists for this email, recovery instructions were sent."
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Solicitação recebida com resposta neutra",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "VALIDATION_ERROR",
+                  "message": "Dados inválidos",
+                  "status_code": 400
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro de validação",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Password reset request failed",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno ao solicitar recuperação",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "AUTH_BACKEND_UNAVAILABLE",
+                  "message": "Authentication temporarily unavailable. Try again later.",
+                  "status_code": 503
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Serviço de autenticação temporariamente indisponível",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Solicitar recuperação de senha",
+        "tags": [
+          "Autenticação"
+        ]
+      }
+    },
+    "/auth/password/reset": {
+      "post": {
+        "description": "Redefine a senha de um usuário a partir de um token de recuperação.",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/app_schemas_auth_schema_ResetPasswordSchema"
+            }
+          },
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "description": "Token de recuperação e nova senha válida.",
+              "example": {
+                "new_password": "NovaSenha@123",
+                "token": "G9Q7zJ6lQ4Vwm6dXj6nQjzH8QqfUuBqbMTe4PmS7p8Q"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/app_schemas_auth_schema_ResetPasswordSchema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {},
+                  "message": "Password updated successfully"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Senha redefinida com sucesso",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "VALIDATION_ERROR",
+                  "message": "Token inválido ou expirado",
+                  "status_code": 400
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token inválido, expirado ou payload inválido",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Password reset failed",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno ao redefinir senha",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Redefinir senha",
+        "tags": [
+          "Autenticação"
+        ]
+      }
+    },
+    "/auth/refresh": {
+      "post": {
+        "description": "Emite um novo par de tokens (access + refresh) usando um refresh token válido.\n\nRotation:\n- Cada uso invalida o refresh token anterior (replay attack prevention).\n- O novo refresh token tem TTL de 7 dias a partir da emissão.\n\nFontes aceitas para o refresh token (SEC-GAP-01):\n- Cookie httpOnly `auraxis_refresh` (recomendado, clientes novos).\n- Header `Authorization: Bearer <refresh_token>` (legado).\n\nHeaders:\n- `X-API-Contract`: opcional; `v2` padroniza o envelope.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "refresh_token": "<access_token>",
+                    "token": "<access_token>"
+                  },
+                  "message": "Token refreshed"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Tokens renovados com sucesso",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "TOKEN_INVALID",
+                  "message": "Token invalid or already used",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Refresh token inválido, expirado ou já utilizado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "RATE_LIMIT_EXCEEDED",
+                  "message": "Too many requests",
+                  "status_code": 429
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Muitas requisições de renovação",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Renovar access token",
+        "tags": [
+          "Autenticação"
+        ]
+      }
+    },
+    "/auth/register": {
+      "post": {
+        "description": "Cria uma nova conta no sistema.\n\nPayload:\n- `name`, `email` e `password` são obrigatórios\n- `investor_profile` é opcional no onboarding inicial\n\nDependendo da política de segurança, conflitos de email podem ser neutralizados com uma resposta de aceite para evitar enumeração.",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/app_schemas_user_schemas_UserRegistrationSchema"
+            }
+          },
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "description": "Dados necessários para criação da conta.",
+              "example": {
+                "email": "italo@auraxis.com.br",
+                "investor_profile": "conservador",
+                "name": "Italo Chagas",
+                "password": "MinhaSenha@123"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/app_schemas_user_schemas_UserRegistrationSchema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "user": {
+                      "email": "italo@auraxis.com.br",
+                      "id": "4b2ef64b-b35d-4ea2-a6f2-4ef3cfb295f1",
+                      "name": "Italo Chagas"
+                    }
+                  },
+                  "message": "User created successfully"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Usuário criado com sucesso",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "VALIDATION_ERROR",
+                  "message": "Erro de validação",
+                  "status_code": 400
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro de validação",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "CONFLICT",
+                  "message": "Email já registrado",
+                  "status_code": 409
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Email já registrado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Failed to create user",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno do servidor",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Registrar usuário",
+        "tags": [
+          "Autenticação"
+        ]
+      }
+    },
+    "/budgets": {
+      "get": {
+        "description": "Lista todos os orçamentos ativos do usuário com valor gasto no período.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Lista de orçamentos com gasto por período"
+          },
+          "401": {
+            "description": "Token inválido"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Orçamentos"
+        ]
+      },
+      "post": {
+        "description": "Cria um novo orçamento para o usuário autenticado.",
+        "parameters": [],
+        "responses": {
+          "201": {
+            "description": "Orçamento criado com sucesso"
+          },
+          "400": {
+            "description": "Dados inválidos"
+          },
+          "401": {
+            "description": "Token inválido"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Orçamentos"
+        ]
+      }
+    },
+    "/budgets/summary": {
+      "get": {
+        "description": "Retorna total orçado vs total gasto no período atual (orçamentos ativos).",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Resumo de orçamentos vs gastos"
+          },
+          "401": {
+            "description": "Token inválido"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Orçamentos"
+        ]
+      }
+    },
+    "/budgets/{budget_id}": {
+      "delete": {
+        "description": "Remove um orçamento específico do usuário autenticado.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "budget_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Orçamento removido"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "403": {
+            "description": "Sem permissão"
+          },
+          "404": {
+            "description": "Orçamento não encontrado"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Orçamentos"
+        ]
+      },
+      "get": {
+        "description": "Retorna um orçamento específico do usuário com valor gasto no período.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "budget_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Orçamento encontrado"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "403": {
+            "description": "Sem permissão"
+          },
+          "404": {
+            "description": "Orçamento não encontrado"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Orçamentos"
+        ]
+      },
+      "patch": {
+        "description": "Atualiza parcialmente um orçamento do usuário autenticado.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "budget_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Orçamento atualizado"
+          },
+          "400": {
+            "description": "Dados inválidos"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "403": {
+            "description": "Sem permissão"
+          },
+          "404": {
+            "description": "Orçamento não encontrado"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Orçamentos"
+        ]
+      }
+    },
+    "/dashboard/overview": {
+      "get": {
+        "description": "Contrato canônico do dashboard financeiro do MVP1. Use esta rota para visão agregada mensal; `/transactions/dashboard` permanece apenas como compatibilidade transitória.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "Mês de referência no formato YYYY-MM",
+            "example": "2026-03",
+            "in": "query",
+            "name": "month",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "counts": {
+                      "expense_transactions": 10,
+                      "income_transactions": 4,
+                      "status": {
+                        "paid": 9,
+                        "pending": 5
+                      },
+                      "total_transactions": 14
+                    },
+                    "month": "2026-03",
+                    "top_categories": {
+                      "expense": [
+                        {
+                          "category_name": "Moradia",
+                          "tag_id": "73c3b094-60bf-45d5-8e32-0f673b2ab4a2",
+                          "total_amount": 1800.0,
+                          "transactions_count": 3
+                        }
+                      ],
+                      "income": [
+                        {
+                          "category_name": "Receitas",
+                          "tag_id": null,
+                          "total_amount": 5000.0,
+                          "transactions_count": 4
+                        }
+                      ]
+                    },
+                    "totals": {
+                      "balance": 1800.0,
+                      "expense_total": 3200.0,
+                      "income_total": 5000.0
+                    }
+                  },
+                  "message": "Overview do dashboard calculado com sucesso"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Overview do dashboard",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "VALIDATION_ERROR",
+                  "message": "Parâmetro 'month' inválido. Use o formato YYYY-MM.",
+                  "status_code": 400
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Parâmetro inválido",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token inválido",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Erro ao calcular overview do dashboard",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Obter overview mensal do dashboard",
+        "tags": [
+          "Dashboard"
+        ]
+      }
+    },
+    "/dashboard/trends": {
+      "get": {
+        "description": "Retorna a série histórica de receitas, despesas e saldo para os últimos N meses (apenas transações pagas).",
+        "parameters": [
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "Número de meses a incluir (1–24, padrão 6)",
+            "example": 6,
+            "in": "query",
+            "name": "months",
+            "required": false,
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "months": 6,
+                    "series": [
+                      {
+                        "balance": 1800.0,
+                        "expenses": 3200.0,
+                        "income": 5000.0,
+                        "month": "2026-04"
+                      }
+                    ]
+                  },
+                  "message": "Tendências calculadas com sucesso"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Série de tendências mensais",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token inválido",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "VALIDATION_ERROR",
+                  "message": "O parâmetro 'months' deve ser um inteiro entre 1 e 24.",
+                  "status_code": 422
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Parâmetro inválido",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Erro ao calcular tendências do dashboard",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Tendências mensais do dashboard",
+        "tags": [
+          "Dashboard"
+        ]
+      }
+    },
+    "/entitlements": {
+      "get": {
+        "description": "Lista os entitlements do usuário autenticado.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Lista de entitlements"
+          },
+          "401": {
+            "description": "Token inválido"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Entitlements"
+        ]
+      }
+    },
+    "/entitlements/admin": {
+      "post": {
+        "description": "Concede um entitlement a um usuário. Requer role 'admin'.",
+        "parameters": [],
+        "responses": {
+          "201": {
+            "description": "Entitlement concedido"
+          },
+          "400": {
+            "description": "Parâmetros inválidos"
+          },
+          "403": {
+            "description": "Acesso negado — requer role admin"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Entitlements"
+        ]
+      }
+    },
+    "/entitlements/admin/{entitlement_id}": {
+      "delete": {
+        "description": "Revoga um entitlement pelo seu UUID. Requer role 'admin'.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "entitlement_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Entitlement revogado"
+          },
+          "403": {
+            "description": "Acesso negado — requer role admin"
+          },
+          "404": {
+            "description": "Entitlement não encontrado"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Entitlements"
+        ]
+      }
+    },
+    "/entitlements/check": {
+      "get": {
+        "description": "Verifica se o usuário autenticado possui um entitlement ativo para a feature especificada. Parâmetro obrigatório: ?feature_key=xxx",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "feature_key",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resultado da verificação"
+          },
+          "400": {
+            "description": "Parâmetro feature_key ausente"
+          },
+          "401": {
+            "description": "Token inválido"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Entitlements"
+        ]
+      }
+    },
+    "/goals": {
+      "get": {
+        "parameters": [],
+        "responses": {}
+      },
+      "options": {
+        "parameters": [],
+        "responses": {}
+      },
+      "post": {
+        "parameters": [],
+        "responses": {}
+      }
+    },
+    "/goals/simulate": {
+      "post": {
+        "description": "Executa simulação de meta sem persistência (what-if), retornando projeção e recomendações acionáveis.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Simulação calculada com sucesso"
+          },
+          "400": {
+            "description": "Dados inválidos"
+          },
+          "401": {
+            "description": "Token inválido"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Metas"
+        ]
+      }
+    },
+    "/goals/{goal_id}": {
+      "delete": {
+        "description": "Remove uma meta específica do usuário autenticado.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "goal_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Meta removida"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "403": {
+            "description": "Sem permissão"
+          },
+          "404": {
+            "description": "Meta não encontrada"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Metas"
+        ]
+      },
+      "get": {
+        "description": "Retorna uma meta específica do usuário autenticado.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "goal_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Meta encontrada"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "403": {
+            "description": "Sem permissão"
+          },
+          "404": {
+            "description": "Meta não encontrada"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Metas"
+        ]
+      },
+      "patch": {
+        "description": "Atualiza parcialmente uma meta específica do usuário autenticado.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "goal_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Meta atualizada"
+          },
+          "400": {
+            "description": "Dados inválidos"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "403": {
+            "description": "Sem permissão"
+          },
+          "404": {
+            "description": "Meta não encontrada"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Metas"
+        ]
+      },
+      "put": {
+        "description": "Alias legado para atualização de metas. Use `PATCH /goals/{goal_id}` como contrato canônico para update parcial.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "goal_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Meta atualizada via compatibilidade legada",
+            "headers": {
+              "Deprecation": {
+                "description": "Indica que a superfície atual está em deprecação.",
+                "example": "true",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Sunset": {
+                "description": "Data prevista para remoção da superfície legada.",
+                "example": "Tue, 30 Jun 2026 23:59:59 GMT",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Auraxis-Successor-Endpoint": {
+                "description": "Endpoint sucessor recomendado.",
+                "example": "/goals/{goal_id}",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Auraxis-Successor-Method": {
+                "description": "Método HTTP recomendado para a superfície sucessora.",
+                "example": "PATCH",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Dados inválidos"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "403": {
+            "description": "Sem permissão"
+          },
+          "404": {
+            "description": "Meta não encontrada"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Metas"
+        ]
+      }
+    },
+    "/goals/{goal_id}/plan": {
+      "get": {
+        "description": "Calcula o plano da meta considerando renda, despesas e capacidade de aporte do usuário.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "goal_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Planejamento calculado com sucesso"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "403": {
+            "description": "Sem permissão"
+          },
+          "404": {
+            "description": "Meta não encontrada"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Metas"
+        ]
+      }
+    },
+    "/goals/{goal_id}/projection": {
+      "get": {
+        "description": "Retorna a projeção de conclusão da meta com base na taxa de retorno do portfólio do usuário e no aporte mensal configurado. Usa juros compostos para calcular o prazo e o aporte sugerido.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "goal_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Projeção calculada com sucesso"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "403": {
+            "description": "Sem permissão"
+          },
+          "404": {
+            "description": "Meta não encontrada"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Metas"
+        ]
+      }
+    },
+    "/healthz": {
+      "get": {
+        "description": "Endpoint público de liveness para probes de infraestrutura.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Serviço saudável"
+          }
+        },
+        "tags": [
+          "Health"
+        ]
+      },
+      "options": {
+        "description": "Endpoint público de liveness para probes de infraestrutura.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Serviço saudável"
+          }
+        },
+        "tags": [
+          "Health"
+        ]
+      }
+    },
+    "/ops/metrics": {
+      "get": {
+        "description": "Exporta métricas em formato texto compatível com scrape simples.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Payload Prometheus text exposition"
+          },
+          "401": {
+            "description": "Chave inválida ou ausente"
+          },
+          "404": {
+            "description": "Export desabilitado"
+          }
+        },
+        "tags": [
+          "Observability"
+        ]
+      },
+      "options": {
+        "description": "Exporta métricas em formato texto compatível com scrape simples.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Payload Prometheus text exposition"
+          },
+          "401": {
+            "description": "Chave inválida ou ausente"
+          },
+          "404": {
+            "description": "Export desabilitado"
+          }
+        },
+        "tags": [
+          "Observability"
+        ]
+      }
+    },
+    "/ops/observability": {
+      "get": {
+        "description": "Exporta snapshot JSON de métricas internas para collector externo.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Snapshot JSON de observabilidade"
+          },
+          "401": {
+            "description": "Chave inválida ou ausente"
+          },
+          "404": {
+            "description": "Export desabilitado"
+          }
+        },
+        "tags": [
+          "Observability"
+        ]
+      },
+      "options": {
+        "description": "Exporta snapshot JSON de métricas internas para collector externo.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Snapshot JSON de observabilidade"
+          },
+          "401": {
+            "description": "Chave inválida ou ausente"
+          },
+          "404": {
+            "description": "Export desabilitado"
+          }
+        },
+        "tags": [
+          "Observability"
+        ]
+      }
+    },
+    "/readiness": {
+      "get": {
+        "description": "Readiness probe: verifica se DB e Redis estão acessíveis. Retorna 200 quando tudo está ok, 503 quando alguma dependência falhou. Protegido por bearer token (READINESS_TOKEN) quando configurado.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Todas as dependências saudáveis"
+          },
+          "401": {
+            "description": "Token de autorização ausente ou inválido"
+          },
+          "503": {
+            "description": "Uma ou mais dependências indisponíveis"
+          }
+        },
+        "tags": [
+          "Health"
+        ]
+      },
+      "options": {
+        "description": "Readiness probe: verifica se DB e Redis estão acessíveis. Retorna 200 quando tudo está ok, 503 quando alguma dependência falhou. Protegido por bearer token (READINESS_TOKEN) quando configurado.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Todas as dependências saudáveis"
+          },
+          "401": {
+            "description": "Token de autorização ausente ou inválido"
+          },
+          "503": {
+            "description": "Uma ou mais dependências indisponíveis"
+          }
+        },
+        "tags": [
+          "Health"
+        ]
+      }
+    },
+    "/simulations": {
+      "get": {
+        "parameters": [],
+        "responses": {}
+      },
+      "options": {
+        "parameters": [],
+        "responses": {}
+      },
+      "post": {
+        "parameters": [],
+        "responses": {}
+      }
+    },
+    "/simulations/installment-vs-cash": {
+      "post": {
+        "description": "Recalcula e persiste uma simulação parcelado vs à vista no subdomínio canônico de `simulations`.",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/InstallmentVsCashSave"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Simulação salva com sucesso"
+          },
+          "400": {
+            "description": "Dados inválidos"
+          },
+          "401": {
+            "description": "Token inválido"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Simulações"
+        ]
+      }
+    },
+    "/simulations/installment-vs-cash/calculate": {
+      "post": {
+        "description": "Executa a simulação pública de parcelado vs à vista, retornando comparativo, cronograma e recomendação.",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/InstallmentVsCashCalculation"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Simulação calculada com sucesso"
+          },
+          "400": {
+            "description": "Dados inválidos"
+          }
+        },
+        "security": [],
+        "tags": [
+          "Simulações"
+        ]
+      }
+    },
+    "/simulations/installment-vs-cash/save": {
+      "post": {
+        "description": "Alias legado do salvamento parcelado vs à vista. Use `POST /simulations/installment-vs-cash` como contrato canônico.",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/InstallmentVsCashSave"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Simulação salva com sucesso via alias legado",
+            "headers": {
+              "Deprecation": {
+                "description": "Indica que a superfície atual está em deprecação.",
+                "example": "true",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Sunset": {
+                "description": "Data prevista para remoção da superfície legada.",
+                "example": "Tue, 30 Jun 2026 23:59:59 GMT",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Auraxis-Successor-Endpoint": {
+                "description": "Endpoint sucessor recomendado.",
+                "example": "/simulations/installment-vs-cash",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Auraxis-Successor-Method": {
+                "description": "Método HTTP recomendado para a superfície sucessora.",
+                "example": "POST",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Dados inválidos"
+          },
+          "401": {
+            "description": "Token inválido"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Simulações"
+        ]
+      }
+    },
+    "/simulations/{simulation_id}": {
+      "delete": {
+        "description": "Remove uma simulação específica do usuário autenticado.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "simulation_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Simulação removida"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "404": {
+            "description": "Simulação não encontrada"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Simulações"
+        ]
+      },
+      "get": {
+        "description": "Retorna uma simulação específica do usuário autenticado.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "simulation_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Simulação encontrada"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "404": {
+            "description": "Simulação não encontrada"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Simulações"
+        ]
+      }
+    },
+    "/simulations/{simulation_id}/goal": {
+      "post": {
+        "description": "Converte uma simulação salva em meta de compra.",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/InstallmentVsCashGoalBridge"
+            }
+          },
+          {
+            "in": "path",
+            "name": "simulation_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Meta criada a partir da simulação"
+          },
+          "400": {
+            "description": "Dados inválidos"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "403": {
+            "description": "Entitlement necessário"
+          },
+          "404": {
+            "description": "Simulação não encontrada"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Simulações"
+        ]
+      }
+    },
+    "/simulations/{simulation_id}/planned-expense": {
+      "post": {
+        "description": "Converte uma simulação salva em despesa planejada.",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/InstallmentVsCashPlannedExpenseBridge"
+            }
+          },
+          {
+            "in": "path",
+            "name": "simulation_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Despesa planejada criada a partir da simulação"
+          },
+          "400": {
+            "description": "Dados inválidos"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "403": {
+            "description": "Entitlement necessário"
+          },
+          "404": {
+            "description": "Simulação não encontrada"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Simulações"
+        ]
+      }
+    },
+    "/transactions": {
+      "get": {
+        "description": "Lista canônica de transações ativas com filtros, ordenação e paginação.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "items": [
+                      {
+                        "account_id": "2d16ea71-b7ae-4da7-adc4-e93e54cd52cb",
+                        "amount": "150.00",
+                        "bank_name": null,
+                        "created_at": "2026-03-01T10:00:00+00:00",
+                        "credit_card_id": null,
+                        "currency": "BRL",
+                        "description": "Fatura mensal de energia",
+                        "due_date": "2026-03-10",
+                        "end_date": null,
+                        "external_id": null,
+                        "id": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+                        "installment_count": null,
+                        "installment_group_id": null,
+                        "is_installment": false,
+                        "is_recurring": false,
+                        "observation": "Pagar antes do dia 10",
+                        "paid_at": null,
+                        "source": "manual",
+                        "start_date": null,
+                        "status": "pending",
+                        "tag_id": "73c3b094-60bf-45d5-8e32-0f673b2ab4a2",
+                        "title": "Conta de luz",
+                        "type": "expense",
+                        "updated_at": "2026-03-01T10:00:00+00:00"
+                      }
+                    ]
+                  },
+                  "message": "Lista de transações retornada com sucesso",
+                  "meta": {
+                    "pagination": {
+                      "page": 1,
+                      "pages": 2,
+                      "per_page": 10,
+                      "total": 14
+                    }
+                  }
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Lista de transações",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token revogado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Erro ao listar transações",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Listar transações",
+        "tags": [
+          "Transações"
+        ]
+      },
+      "post": {
+        "description": "Cria uma nova transação financeira.\n\nAceita receitas e despesas, com suporte a recorrência e parcelamento.",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/TransactionCreate"
+            }
+          },
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "description": "Payload de criação da transação.",
+              "example": {
+                "account_id": "2d16ea71-b7ae-4da7-adc4-e93e54cd52cb",
+                "amount": "150.00",
+                "description": "Fatura mensal de energia",
+                "due_date": "2026-03-10",
+                "observation": "Pagar antes do dia 10",
+                "status": "pending",
+                "tag_id": "73c3b094-60bf-45d5-8e32-0f673b2ab4a2",
+                "title": "Conta de luz",
+                "type": "expense"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/TransactionCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "transaction": {
+                      "account_id": "2d16ea71-b7ae-4da7-adc4-e93e54cd52cb",
+                      "amount": "150.00",
+                      "bank_name": null,
+                      "created_at": "2026-03-01T10:00:00+00:00",
+                      "credit_card_id": null,
+                      "currency": "BRL",
+                      "description": "Fatura mensal de energia",
+                      "due_date": "2026-03-10",
+                      "end_date": null,
+                      "external_id": null,
+                      "id": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+                      "installment_count": null,
+                      "installment_group_id": null,
+                      "is_installment": false,
+                      "is_recurring": false,
+                      "observation": "Pagar antes do dia 10",
+                      "paid_at": null,
+                      "source": "manual",
+                      "start_date": null,
+                      "status": "pending",
+                      "tag_id": "73c3b094-60bf-45d5-8e32-0f673b2ab4a2",
+                      "title": "Conta de luz",
+                      "type": "expense",
+                      "updated_at": "2026-03-01T10:00:00+00:00"
+                    }
+                  },
+                  "message": "Transação criada com sucesso"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Transação criada com sucesso",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "VALIDATION_ERROR",
+                  "message": "Erro de validação",
+                  "status_code": 400
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro de validação",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token revogado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Erro ao criar transação",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Criar transação",
+        "tags": [
+          "Transações"
+        ]
+      }
+    },
+    "/transactions/dashboard": {
+      "get": {
+        "description": "Compatibilidade transitória para o dashboard mensal. Prefira `GET /dashboard/overview`.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "Mês de referência no formato YYYY-MM",
+            "example": "2026-03",
+            "in": "query",
+            "name": "month",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "balance": 1800.0,
+                    "counts": {
+                      "expense_transactions": 10,
+                      "income_transactions": 4,
+                      "total_transactions": 14
+                    },
+                    "expense_total": 3200.0,
+                    "income_total": 5000.0,
+                    "month": "2026-03"
+                  },
+                  "message": "Dashboard mensal retornado com sucesso"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Dashboard mensal legado",
+            "headers": {
+              "Deprecation": {
+                "description": "Indica que a superfície atual está em deprecação.",
+                "example": "true",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Sunset": {
+                "description": "Data prevista para remoção da superfície legada.",
+                "example": "Tue, 30 Jun 2026 23:59:59 GMT",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Auraxis-Successor-Endpoint": {
+                "description": "Endpoint sucessor recomendado.",
+                "example": "/dashboard/overview",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Auraxis-Successor-Method": {
+                "description": "Método HTTP recomendado para a superfície sucessora.",
+                "example": "GET",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "VALIDATION_ERROR",
+                  "message": "Parâmetro 'month' inválido. Use o formato YYYY-MM.",
+                  "status_code": 400
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Parâmetro inválido",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token revogado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Erro ao calcular dashboard mensal",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Obter dashboard mensal legado de transações",
+        "tags": [
+          "Transações"
+        ]
+      }
+    },
+    "/transactions/deleted": {
+      "get": {
+        "description": "Lista a lixeira de transações deletadas do usuário.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "items": [
+                      {
+                        "account_id": "2d16ea71-b7ae-4da7-adc4-e93e54cd52cb",
+                        "amount": "150.00",
+                        "bank_name": null,
+                        "created_at": "2026-03-01T10:00:00+00:00",
+                        "credit_card_id": null,
+                        "currency": "BRL",
+                        "description": "Fatura mensal de energia",
+                        "due_date": "2026-03-10",
+                        "end_date": null,
+                        "external_id": null,
+                        "id": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+                        "installment_count": null,
+                        "installment_group_id": null,
+                        "is_installment": false,
+                        "is_recurring": false,
+                        "observation": "Pagar antes do dia 10",
+                        "paid_at": null,
+                        "source": "manual",
+                        "start_date": null,
+                        "status": "pending",
+                        "tag_id": "73c3b094-60bf-45d5-8e32-0f673b2ab4a2",
+                        "title": "Conta de luz",
+                        "type": "expense",
+                        "updated_at": "2026-03-01T10:00:00+00:00"
+                      }
+                    ]
+                  },
+                  "message": "Lista de transações deletadas"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Lista de transações deletadas",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token revogado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Erro ao listar transações deletadas",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Listar transações deletadas",
+        "tags": [
+          "Transações"
+        ]
+      }
+    },
+    "/transactions/due-range": {
+      "get": {
+        "description": "Lista vencimentos (receitas + despesas) por período com paginação, contadores e ordenação por vencimento.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "counts": {
+                      "expense_transactions": 10,
+                      "income_transactions": 4,
+                      "total_transactions": 14
+                    },
+                    "items": [
+                      {
+                        "account_id": "2d16ea71-b7ae-4da7-adc4-e93e54cd52cb",
+                        "amount": "150.00",
+                        "bank_name": null,
+                        "created_at": "2026-03-01T10:00:00+00:00",
+                        "credit_card_id": null,
+                        "currency": "BRL",
+                        "description": "Fatura mensal de energia",
+                        "due_date": "2026-03-10",
+                        "end_date": null,
+                        "external_id": null,
+                        "id": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+                        "installment_count": null,
+                        "installment_group_id": null,
+                        "is_installment": false,
+                        "is_recurring": false,
+                        "observation": "Pagar antes do dia 10",
+                        "paid_at": null,
+                        "source": "manual",
+                        "start_date": null,
+                        "status": "pending",
+                        "tag_id": "73c3b094-60bf-45d5-8e32-0f673b2ab4a2",
+                        "title": "Conta de luz",
+                        "type": "expense",
+                        "updated_at": "2026-03-01T10:00:00+00:00"
+                      }
+                    ]
+                  },
+                  "message": "Lista de vencimentos retornada com sucesso",
+                  "meta": {
+                    "pagination": {
+                      "page": 1,
+                      "pages": 2,
+                      "per_page": 10,
+                      "total": 14
+                    }
+                  }
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Lista de vencimentos",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "VALIDATION_ERROR",
+                  "message": "Parâmetros de período inválidos.",
+                  "status_code": 400
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Parâmetros inválidos",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token revogado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Erro ao listar vencimentos",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Listar vencimentos por período",
+        "tags": [
+          "Transações"
+        ]
+      }
+    },
+    "/transactions/expenses": {
+      "get": {
+        "description": "Compatibilidade transitória para despesas por período. Prefira `GET /transactions?type=expense&start_date=...&end_date=...`.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "counts": {
+                      "expense_transactions": 10,
+                      "income_transactions": 4,
+                      "total_transactions": 14
+                    },
+                    "expenses": [
+                      {
+                        "account_id": "2d16ea71-b7ae-4da7-adc4-e93e54cd52cb",
+                        "amount": "150.00",
+                        "bank_name": null,
+                        "created_at": "2026-03-01T10:00:00+00:00",
+                        "credit_card_id": null,
+                        "currency": "BRL",
+                        "description": "Fatura mensal de energia",
+                        "due_date": "2026-03-10",
+                        "end_date": null,
+                        "external_id": null,
+                        "id": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+                        "installment_count": null,
+                        "installment_group_id": null,
+                        "is_installment": false,
+                        "is_recurring": false,
+                        "observation": "Pagar antes do dia 10",
+                        "paid_at": null,
+                        "source": "manual",
+                        "start_date": null,
+                        "status": "pending",
+                        "tag_id": "73c3b094-60bf-45d5-8e32-0f673b2ab4a2",
+                        "title": "Conta de luz",
+                        "type": "expense",
+                        "updated_at": "2026-03-01T10:00:00+00:00"
+                      }
+                    ]
+                  },
+                  "message": "Lista de despesas por período",
+                  "meta": {
+                    "pagination": {
+                      "page": 1,
+                      "pages": 2,
+                      "per_page": 10,
+                      "total": 14
+                    }
+                  }
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Lista de despesas",
+            "headers": {
+              "Deprecation": {
+                "description": "Indica que a superfície atual está em deprecação.",
+                "example": "true",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Sunset": {
+                "description": "Data prevista para remoção da superfície legada.",
+                "example": "Tue, 30 Jun 2026 23:59:59 GMT",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Auraxis-Successor-Endpoint": {
+                "description": "Endpoint sucessor recomendado.",
+                "example": "/transactions",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Auraxis-Successor-Method": {
+                "description": "Método HTTP recomendado para a superfície sucessora.",
+                "example": "GET",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "VALIDATION_ERROR",
+                  "message": "Parâmetros de período inválidos.",
+                  "status_code": 400
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Parâmetros inválidos",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token revogado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Erro ao listar despesas por período",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Listar despesas por período (compatibilidade)",
+        "tags": [
+          "Transações"
+        ]
+      }
+    },
+    "/transactions/list": {
+      "get": {
+        "description": "Compatibilidade transitória para listagem de transações ativas. Prefira `GET /transactions`.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "items": [
+                      {
+                        "account_id": "2d16ea71-b7ae-4da7-adc4-e93e54cd52cb",
+                        "amount": "150.00",
+                        "bank_name": null,
+                        "created_at": "2026-03-01T10:00:00+00:00",
+                        "credit_card_id": null,
+                        "currency": "BRL",
+                        "description": "Fatura mensal de energia",
+                        "due_date": "2026-03-10",
+                        "end_date": null,
+                        "external_id": null,
+                        "id": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+                        "installment_count": null,
+                        "installment_group_id": null,
+                        "is_installment": false,
+                        "is_recurring": false,
+                        "observation": "Pagar antes do dia 10",
+                        "paid_at": null,
+                        "source": "manual",
+                        "start_date": null,
+                        "status": "pending",
+                        "tag_id": "73c3b094-60bf-45d5-8e32-0f673b2ab4a2",
+                        "title": "Conta de luz",
+                        "type": "expense",
+                        "updated_at": "2026-03-01T10:00:00+00:00"
+                      }
+                    ]
+                  },
+                  "message": "Lista de transações retornada com sucesso",
+                  "meta": {
+                    "pagination": {
+                      "page": 1,
+                      "pages": 2,
+                      "per_page": 10,
+                      "total": 14
+                    }
+                  }
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Lista de transações (compatibilidade transitória)",
+            "headers": {
+              "Deprecation": {
+                "description": "Indica que a superfície atual está em deprecação.",
+                "example": "true",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Sunset": {
+                "description": "Data prevista para remoção da superfície legada.",
+                "example": "Tue, 30 Jun 2026 23:59:59 GMT",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Auraxis-Successor-Endpoint": {
+                "description": "Endpoint sucessor recomendado.",
+                "example": "/transactions",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Auraxis-Successor-Method": {
+                "description": "Método HTTP recomendado para a superfície sucessora.",
+                "example": "GET",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token revogado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Erro ao listar transações",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Listar transações (compatibilidade /transactions/list)",
+        "tags": [
+          "Transações"
+        ]
+      }
+    },
+    "/transactions/restore/{transaction_id}": {
+      "patch": {
+        "description": "Restaura uma transação deletada logicamente.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "ID da transação",
+            "example": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+            "in": "path",
+            "name": "transaction_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "transaction": {
+                      "account_id": "2d16ea71-b7ae-4da7-adc4-e93e54cd52cb",
+                      "amount": "150.00",
+                      "bank_name": null,
+                      "created_at": "2026-03-01T10:00:00+00:00",
+                      "credit_card_id": null,
+                      "currency": "BRL",
+                      "description": "Fatura mensal de energia",
+                      "due_date": "2026-03-10",
+                      "end_date": null,
+                      "external_id": null,
+                      "id": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+                      "installment_count": null,
+                      "installment_group_id": null,
+                      "is_installment": false,
+                      "is_recurring": false,
+                      "observation": "Pagar antes do dia 10",
+                      "paid_at": null,
+                      "source": "manual",
+                      "start_date": null,
+                      "status": "pending",
+                      "tag_id": "73c3b094-60bf-45d5-8e32-0f673b2ab4a2",
+                      "title": "Conta de luz",
+                      "type": "expense",
+                      "updated_at": "2026-03-01T10:00:00+00:00"
+                    }
+                  },
+                  "message": "Transação restaurada com sucesso"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Transação restaurada",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token revogado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "NOT_FOUND",
+                  "message": "Transação não encontrada",
+                  "status_code": 404
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Transação não encontrada",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Erro ao restaurar transação",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Restaurar transação deletada",
+        "tags": [
+          "Transações"
+        ]
+      }
+    },
+    "/transactions/summary": {
+      "get": {
+        "description": "Resumo mensal de receitas, despesas e itens paginados por mês.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "Mês de referência no formato YYYY-MM",
+            "example": "2026-03",
+            "in": "query",
+            "name": "month",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "expense_total": 3200.0,
+                    "income_total": 5000.0,
+                    "month": "2026-03",
+                    "transactions": [
+                      {
+                        "account_id": "2d16ea71-b7ae-4da7-adc4-e93e54cd52cb",
+                        "amount": "150.00",
+                        "bank_name": null,
+                        "created_at": "2026-03-01T10:00:00+00:00",
+                        "credit_card_id": null,
+                        "currency": "BRL",
+                        "description": "Fatura mensal de energia",
+                        "due_date": "2026-03-10",
+                        "end_date": null,
+                        "external_id": null,
+                        "id": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+                        "installment_count": null,
+                        "installment_group_id": null,
+                        "is_installment": false,
+                        "is_recurring": false,
+                        "observation": "Pagar antes do dia 10",
+                        "paid_at": null,
+                        "source": "manual",
+                        "start_date": null,
+                        "status": "pending",
+                        "tag_id": "73c3b094-60bf-45d5-8e32-0f673b2ab4a2",
+                        "title": "Conta de luz",
+                        "type": "expense",
+                        "updated_at": "2026-03-01T10:00:00+00:00"
+                      }
+                    ]
+                  },
+                  "message": "Resumo mensal retornado com sucesso",
+                  "meta": {
+                    "pagination": {
+                      "page": 1,
+                      "per_page": 10,
+                      "total": 14
+                    }
+                  }
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Resumo mensal",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "VALIDATION_ERROR",
+                  "message": "Parâmetro 'month' inválido. Use o formato YYYY-MM.",
+                  "status_code": 400
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Parâmetro inválido",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token revogado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Erro ao calcular resumo mensal",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Obter resumo mensal de transações",
+        "tags": [
+          "Transações"
+        ]
+      }
+    },
+    "/transactions/{transaction_id}": {
+      "delete": {
+        "description": "Realiza soft delete de uma transação do usuário autenticado.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "ID da transação",
+            "example": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+            "in": "path",
+            "name": "transaction_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "transaction_id": "cfef66a6-a148-49db-a72f-cc63b6080cf8"
+                  },
+                  "message": "Transação deletada com sucesso"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Transação deletada",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token revogado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "FORBIDDEN",
+                  "message": "Sem permissão",
+                  "status_code": 403
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Sem permissão",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "NOT_FOUND",
+                  "message": "Transação não encontrada",
+                  "status_code": 404
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Transação não encontrada",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Erro ao deletar transação",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Remover transação logicamente",
+        "tags": [
+          "Transações"
+        ]
+      },
+      "get": {
+        "description": "Retorna o detalhe canônico de uma transação do usuário.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "ID da transação",
+            "example": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+            "in": "path",
+            "name": "transaction_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "transaction": {
+                      "account_id": "2d16ea71-b7ae-4da7-adc4-e93e54cd52cb",
+                      "amount": "150.00",
+                      "bank_name": null,
+                      "created_at": "2026-03-01T10:00:00+00:00",
+                      "credit_card_id": null,
+                      "currency": "BRL",
+                      "description": "Fatura mensal de energia",
+                      "due_date": "2026-03-10",
+                      "end_date": null,
+                      "external_id": null,
+                      "id": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+                      "installment_count": null,
+                      "installment_group_id": null,
+                      "is_installment": false,
+                      "is_recurring": false,
+                      "observation": "Pagar antes do dia 10",
+                      "paid_at": null,
+                      "source": "manual",
+                      "start_date": null,
+                      "status": "pending",
+                      "tag_id": "73c3b094-60bf-45d5-8e32-0f673b2ab4a2",
+                      "title": "Conta de luz",
+                      "type": "expense",
+                      "updated_at": "2026-03-01T10:00:00+00:00"
+                    }
+                  },
+                  "message": "Detalhe da transação retornado com sucesso"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Detalhe da transação",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token revogado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "FORBIDDEN",
+                  "message": "Sem permissão",
+                  "status_code": 403
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Sem permissão",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "NOT_FOUND",
+                  "message": "Transação não encontrada",
+                  "status_code": 404
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Transação não encontrada",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Erro ao carregar transação",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Obter detalhe de transação",
+        "tags": [
+          "Transações"
+        ]
+      },
+      "patch": {
+        "description": "Atualiza parcialmente uma transação existente. Este é o contrato canônico de update do MVP1.",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/TransactionCreate_7d3b606eab"
+            }
+          },
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "ID da transação",
+            "example": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+            "in": "path",
+            "name": "transaction_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "description": "Campos parciais a serem atualizados.",
+              "example": {
+                "paid_at": "2026-03-10T12:00:00+00:00",
+                "status": "paid"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/TransactionCreate_7d3b606eab"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "transaction": {
+                      "account_id": "2d16ea71-b7ae-4da7-adc4-e93e54cd52cb",
+                      "amount": "150.00",
+                      "bank_name": null,
+                      "created_at": "2026-03-01T10:00:00+00:00",
+                      "credit_card_id": null,
+                      "currency": "BRL",
+                      "description": "Fatura mensal de energia",
+                      "due_date": "2026-03-10",
+                      "end_date": null,
+                      "external_id": null,
+                      "id": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+                      "installment_count": null,
+                      "installment_group_id": null,
+                      "is_installment": false,
+                      "is_recurring": false,
+                      "observation": "Pagar antes do dia 10",
+                      "paid_at": null,
+                      "source": "manual",
+                      "start_date": null,
+                      "status": "paid",
+                      "tag_id": "73c3b094-60bf-45d5-8e32-0f673b2ab4a2",
+                      "title": "Conta de luz",
+                      "type": "expense",
+                      "updated_at": "2026-03-01T10:00:00+00:00"
+                    }
+                  },
+                  "message": "Transação atualizada com sucesso"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Transação atualizada",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "VALIDATION_ERROR",
+                  "message": "Erro de validação",
+                  "status_code": 400
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro de validação",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token revogado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "FORBIDDEN",
+                  "message": "Sem permissão",
+                  "status_code": 403
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Sem permissão",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "NOT_FOUND",
+                  "message": "Transação não encontrada",
+                  "status_code": 404
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Transação não encontrada",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Erro ao atualizar transação",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Atualizar transação parcialmente",
+        "tags": [
+          "Transações"
+        ]
+      },
+      "put": {
+        "description": "Compatibilidade transitória para update parcial. Prefira `PATCH /transactions/{transaction_id}`.",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/TransactionCreate_7d3b606eab"
+            }
+          },
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "ID da transação",
+            "example": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+            "in": "path",
+            "name": "transaction_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "description": "Campos parciais a serem atualizados.",
+              "example": {
+                "paid_at": "2026-03-10T12:00:00+00:00",
+                "status": "paid"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/TransactionCreate_7d3b606eab"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "transaction": {
+                      "account_id": "2d16ea71-b7ae-4da7-adc4-e93e54cd52cb",
+                      "amount": "150.00",
+                      "bank_name": null,
+                      "created_at": "2026-03-01T10:00:00+00:00",
+                      "credit_card_id": null,
+                      "currency": "BRL",
+                      "description": "Fatura mensal de energia",
+                      "due_date": "2026-03-10",
+                      "end_date": null,
+                      "external_id": null,
+                      "id": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+                      "installment_count": null,
+                      "installment_group_id": null,
+                      "is_installment": false,
+                      "is_recurring": false,
+                      "observation": "Pagar antes do dia 10",
+                      "paid_at": null,
+                      "source": "manual",
+                      "start_date": null,
+                      "status": "paid",
+                      "tag_id": "73c3b094-60bf-45d5-8e32-0f673b2ab4a2",
+                      "title": "Conta de luz",
+                      "type": "expense",
+                      "updated_at": "2026-03-01T10:00:00+00:00"
+                    }
+                  },
+                  "message": "Transação atualizada com sucesso"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Transação atualizada (compatibilidade transitória)",
+            "headers": {
+              "Deprecation": {
+                "description": "Indica que a superfície atual está em deprecação.",
+                "example": "true",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Sunset": {
+                "description": "Data prevista para remoção da superfície legada.",
+                "example": "Tue, 30 Jun 2026 23:59:59 GMT",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Auraxis-Successor-Endpoint": {
+                "description": "Endpoint sucessor recomendado.",
+                "example": "/transactions/{transaction_id}",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Auraxis-Successor-Method": {
+                "description": "Método HTTP recomendado para a superfície sucessora.",
+                "example": "PATCH",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "VALIDATION_ERROR",
+                  "message": "Erro de validação",
+                  "status_code": 400
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro de validação",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token revogado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "FORBIDDEN",
+                  "message": "Sem permissão",
+                  "status_code": 403
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Sem permissão",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "NOT_FOUND",
+                  "message": "Transação não encontrada",
+                  "status_code": 404
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Transação não encontrada",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Erro ao atualizar transação",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Atualizar transação (compatibilidade PUT)",
+        "tags": [
+          "Transações"
+        ]
+      }
+    },
+    "/transactions/{transaction_id}/force": {
+      "delete": {
+        "description": "Remove permanentemente uma transação já deletada logicamente.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "ID da transação",
+            "example": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+            "in": "path",
+            "name": "transaction_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "transaction_id": "cfef66a6-a148-49db-a72f-cc63b6080cf8"
+                  },
+                  "message": "Transação removida permanentemente"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Transação removida permanentemente",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token revogado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "NOT_FOUND",
+                  "message": "Transação não encontrada",
+                  "status_code": 404
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Transação não encontrada",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Erro ao remover transação",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Remover transação permanentemente",
+        "tags": [
+          "Transações"
+        ]
+      }
+    },
+    "/user/bootstrap": {
+      "get": {
+        "description": "Retorna o bootstrap explícito da home do usuário autenticado.\n\nOwnership:\n- `/user/me` (`v3`) = contexto autenticado canônico\n- `/transactions` = coleção e filtros completos\n- `/wallet` = coleção canônica de carteira\n- `/user/bootstrap` = agregado leve para reduzir round-trips na home\n\nO bootstrap não substitui endpoints canônicos de coleção e expõe apenas previews recentes de transações e carteira.",
+        "parameters": [
+          {
+            "description": "Opcional. Recomendado enviar `v2` ou `v3` para o envelope padronizado.",
+            "example": "v3",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "transactions_preview": {
+                      "has_more": false,
+                      "items": [
+                        {
+                          "amount": "150.00",
+                          "id": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+                          "status": "pending",
+                          "title": "Conta de luz",
+                          "type": "expense"
+                        }
+                      ],
+                      "limit": 5,
+                      "returned_items": 1
+                    },
+                    "user": {
+                      "financial_profile": {
+                        "initial_investment": 200.0,
+                        "investment_goal_date": "2026-12-31",
+                        "monthly_expenses": 500.0,
+                        "monthly_income_net": 1000.0,
+                        "monthly_investment": 100.0,
+                        "net_worth": 2000.0
+                      },
+                      "identity": {
+                        "email": "italo@email.com",
+                        "id": "4b2ef64b-b35d-4ea2-a6f2-4ef3cfb295f1",
+                        "name": "Italo"
+                      },
+                      "investor_profile": {
+                        "declared": "conservador",
+                        "financial_objectives": "crescer",
+                        "quiz_score": 8,
+                        "suggested": "moderado",
+                        "taxonomy_version": "2026.1"
+                      },
+                      "product_context": {
+                        "entitlements_version": 3
+                      },
+                      "profile": {
+                        "birth_date": "1990-01-01",
+                        "gender": "outro",
+                        "occupation": "Founder",
+                        "state_uf": "SP"
+                      }
+                    },
+                    "wallet": {
+                      "has_more": true,
+                      "items": [
+                        {
+                          "asset_class": "cash",
+                          "id": "wallet-1",
+                          "name": "Caixa",
+                          "quantity": 1,
+                          "value": 100.0
+                        }
+                      ],
+                      "limit": 5,
+                      "returned_items": 1,
+                      "total": 8
+                    }
+                  },
+                  "message": "Bootstrap do usuário retornado com sucesso"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Bootstrap retornado com sucesso",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "VALIDATION_ERROR",
+                  "message": "Parâmetros do bootstrap inválidos.",
+                  "status_code": 400
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro de validação",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token inválido ou expirado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Obter bootstrap da home do usuário",
+        "tags": [
+          "Usuário"
+        ]
+      }
+    },
+    "/user/me": {
+      "delete": {
+        "description": "Anonimiza permanentemente todos os dados pessoais do usuário autenticado (soft-delete LGPD). Requer confirmação de senha.\n\nApós a exclusão:\n- Todos os campos de PII são anonimizados\n- O JWT é revogado (sessão encerrada)\n- O usuário não consegue mais fazer login\n\nEsta ação é irreversível.",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/app_schemas_user_schemas_DeleteAccountSchema"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "description": "Senha atual do usuário para confirmar a exclusão.",
+              "example": {
+                "password": "MinhaSenha@123"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/app_schemas_user_schemas_DeleteAccountSchema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {},
+                  "message": "Account deleted."
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Conta excluída com sucesso",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token inválido ou expirado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INVALID_CREDENTIALS",
+                  "message": "Invalid credentials.",
+                  "status_code": 403
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Senha incorreta",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "VALIDATION_ERROR",
+                  "message": "Validation error",
+                  "status_code": 422
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Campo 'password' ausente ou inválido",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Excluir conta do usuário (LGPD)",
+        "tags": [
+          "Usuário"
+        ]
+      },
+      "get": {
+        "description": "Retorna o contexto do usuário autenticado.\n\nUso recomendado:\n- `X-API-Contract: v3` para o contrato canônico e leve\n- `/user/bootstrap` para agregado da home\n- `/transactions` para coleção paginada e filtros\n\nLegado:\n- `v1`/`v2` ainda aceitam paginação e filtros de coleção\n- respostas legadas enviam headers de deprecação e sunset",
+        "parameters": [
+          {
+            "description": "Opcional. `v2` mantém o shape legado padronizado; `v3` publica o contrato canônico sem coleções.",
+            "example": "v3",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "user": {
+                      "financial_profile": {
+                        "initial_investment": 200.0,
+                        "investment_goal_date": "2026-12-31",
+                        "monthly_expenses": 500.0,
+                        "monthly_income_net": 1000.0,
+                        "monthly_investment": 100.0,
+                        "net_worth": 2000.0
+                      },
+                      "identity": {
+                        "email": "italo@auraxis.com.br",
+                        "id": "4b2ef64b-b35d-4ea2-a6f2-4ef3cfb295f1",
+                        "name": "Italo Chagas"
+                      },
+                      "investor_profile": {
+                        "declared": "conservador",
+                        "financial_objectives": "crescer",
+                        "quiz_score": 8,
+                        "suggested": "moderado",
+                        "taxonomy_version": "2026.1"
+                      },
+                      "product_context": {
+                        "entitlements_version": 3
+                      },
+                      "profile": {
+                        "birth_date": "1990-01-01",
+                        "gender": "outro",
+                        "occupation": "Founder",
+                        "state_uf": "SP"
+                      }
+                    }
+                  },
+                  "message": "Contexto autenticado retornado com sucesso"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Contexto autenticado retornado com sucesso",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token inválido, expirado ou revogado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Obter contexto do usuário autenticado",
+        "tags": [
+          "Usuário"
+        ]
+      }
+    },
+    "/user/notification-preferences": {
+      "get": {
+        "description": "Lista as preferências de notificação do usuário autenticado.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Preferências retornadas com sucesso"
+          },
+          "401": {
+            "description": "Token inválido ou expirado"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Usuário"
+        ]
+      },
+      "patch": {
+        "description": "Atualiza as preferências de notificação do usuário autenticado. Aceita uma lista de preferências para upsert.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Preferências atualizadas com sucesso"
+          },
+          "400": {
+            "description": "Dados inválidos"
+          },
+          "401": {
+            "description": "Token inválido ou expirado"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Usuário"
+        ]
+      }
+    },
+    "/user/profile": {
+      "get": {
+        "description": "Retorna o perfil reduzido do usuário autenticado (sem transações e sem carteira).",
+        "parameters": [
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "user": {
+                      "email": "italo@auraxis.com.br",
+                      "id": "4b2ef64b-b35d-4ea2-a6f2-4ef3cfb295f1",
+                      "investor_profile": "conservador",
+                      "monthly_income_net": "5000.00",
+                      "name": "Italo Chagas"
+                    }
+                  },
+                  "message": "Perfil retornado com sucesso"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Perfil retornado com sucesso",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token revogado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "NOT_FOUND",
+                  "message": "Usuário não encontrado",
+                  "status_code": 404
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Usuário não encontrado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Obter perfil reduzido do usuário",
+        "tags": [
+          "Usuário"
+        ]
+      },
+      "put": {
+        "description": "Atualiza o perfil do usuário autenticado.\n\nCampos aceitos:\n- gender: 'masculino', 'feminino', 'outro'\n- birth_date: 'YYYY-MM-DD'\n- monthly_income, net_worth, monthly_expenses, initial_investment,\n  monthly_investment: decimal\n- investment_goal_date: 'YYYY-MM-DD'\n- investor_profile: 'conservador', 'explorador', 'entusiasta'\n\nExemplo de request:\n{\n  'gender': 'masculino',\n  'birth_date': '1990-05-15',\n  'monthly_income': '5000.00',\n  'net_worth': '100000.00',\n  'monthly_expenses': '2000.00',\n  'initial_investment': '10000.00',\n  'monthly_investment': '500.00',\n  'investment_goal_date': '2025-12-31',\n  'investor_profile': 'conservador'\n}\n\nExemplo de resposta:\n{ 'message': 'Perfil atualizado com sucesso', 'data': { ...dados do usuário... } }",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/app_schemas_user_schemas_UserProfileSchema"
+            }
+          },
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "description": "Campos parciais do perfil financeiro e investidor.",
+              "example": {
+                "birth_date": "1990-05-15",
+                "gender": "masculino",
+                "investor_profile": "conservador",
+                "monthly_expenses": "2000.00",
+                "monthly_income_net": "5000.00",
+                "net_worth": "100000.00",
+                "occupation": "Founder",
+                "state_uf": "SP"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/app_schemas_user_schemas_UserProfileSchema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "user": {
+                      "id": "4b2ef64b-b35d-4ea2-a6f2-4ef3cfb295f1",
+                      "investor_profile": "conservador",
+                      "monthly_expenses": "2000.00",
+                      "monthly_income_net": "5000.00"
+                    }
+                  },
+                  "message": "Perfil atualizado com sucesso"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Perfil atualizado com sucesso",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "VALIDATION_ERROR",
+                  "message": "Erro de validação",
+                  "status_code": 400
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro de validação",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token revogado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "NOT_FOUND",
+                  "message": "Usuário não encontrado",
+                  "status_code": 404
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Usuário não encontrado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Erro ao atualizar perfil",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro ao atualizar perfil",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Atualizar perfil do usuário",
+        "tags": [
+          "Usuário"
+        ]
+      }
+    },
+    "/user/profile/questionnaire": {
+      "get": {
+        "description": "Retorna as 5 perguntas do questionário de perfil de investidor.\n\nCada pergunta contém 3 opções com pontuações de 1 a 3.\nEnvie os pontos via POST para receber o perfil sugerido.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "questions": [
+                      {
+                        "options": [
+                          {
+                            "points": 1,
+                            "text": "Preservar capital"
+                          },
+                          {
+                            "points": 2,
+                            "text": "Crescer com equilíbrio"
+                          },
+                          {
+                            "points": 3,
+                            "text": "Maximizar retorno"
+                          }
+                        ],
+                        "question": "Qual é o seu principal objetivo ao investir?"
+                      }
+                    ]
+                  },
+                  "message": "Questionário retornado com sucesso"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Lista de perguntas retornada com sucesso",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token inválido, expirado ou revogado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Listar questionário de perfil de investidor",
+        "tags": [
+          "Usuário"
+        ]
+      },
+      "post": {
+        "description": "Submete as respostas do questionário e classifica o perfil de investidor.\n\nEnvie exatamente 5 respostas, cada uma com os pontos da opção escolhida (1–3).\n\nPerfis possíveis:\n- **conservador** — score ≤ 7\n- **explorador**  — score de 8 a 11\n- **entusiasta**  — score ≥ 12\n\nO resultado é persistido no perfil do usuário autenticado.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "description": "Lista de 5 respostas, cada uma entre 1 e 3 pontos.",
+              "example": {
+                "answers": [
+                  1,
+                  2,
+                  2,
+                  3,
+                  1
+                ]
+              },
+              "schema": {
+                "$ref": "#/components/schemas/app_schemas_user_schemas_QuestionnaireAnswerSchema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "score": 9,
+                    "suggested_profile": "explorador"
+                  },
+                  "message": "Perfil sugerido calculado com sucesso"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Perfil sugerido calculado e persistido",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INVALID_ANSWER_COUNT",
+                  "message": "O questionário exige exatamente 5 respostas.",
+                  "status_code": 400
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Número de respostas inválido",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token inválido, expirado ou revogado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "VALIDATION_ERROR",
+                  "details": {
+                    "answers": [
+                      "Missing data for required field."
+                    ]
+                  },
+                  "message": "Dados inválidos",
+                  "status_code": 422
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Payload inválido",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Responder questionário de perfil de investidor",
+        "tags": [
+          "Usuário"
+        ]
+      }
+    },
+    "/user/simulate-salary-increase": {
+      "post": {
+        "description": "Simula o aumento salarial e recomposição da inflação.",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/app_schemas_user_schemas_SalaryIncreaseSimulationRequestSchema"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Simulação realizada com sucesso"
+          },
+          "400": {
+            "description": "Erro de validação"
+          },
+          "401": {
+            "description": "Token inválido ou expirado"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Usuário"
+        ]
+      }
+    },
+    "/wallet": {
+      "get": {
+        "description": "Lista os investimentos cadastrados na carteira com paginação.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie 'v2' para o contrato padronizado.",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "per_page",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Lista paginada de investimentos"
+          },
+          "401": {
+            "description": "Token inválido"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Wallet"
+        ]
+      },
+      "options": {
+        "description": "Lista os investimentos cadastrados na carteira com paginação.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie 'v2' para o contrato padronizado.",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "per_page",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Lista paginada de investimentos"
+          },
+          "401": {
+            "description": "Token inválido"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Wallet"
+        ]
+      },
+      "post": {
+        "description": "Adiciona um novo item à carteira do usuário.\n\nVocê pode informar um valor fixo (como R$1000,00 em poupança) ou um ativo com ticker.\n\nRegras:\n- Se informar o campo 'ticker', o campo 'value' será ignorado.\n- Se não informar 'ticker', é obrigatório informar 'value'.\n- Se informar 'ticker', também é obrigatório informar 'quantity'.\n\nExemplo com valor fixo:\n{'name': 'Poupança', 'value': 1500.00, 'register_date': '2024-07-01', 'should_be_on_wallet': true}\n\nExemplo com ticker:\n{'name': 'Investimento PETR4', 'ticker': 'petr4', 'quantity': 10, 'register_date': '2024-07-01', 'should_be_on_wallet': true}\n\nResposta esperada:\n{'message': 'Ativo cadastrado com sucesso'}",
+        "parameters": [],
+        "responses": {
+          "201": {
+            "description": "Ativo cadastrado com sucesso"
+          },
+          "400": {
+            "description": "Erro de validação ou ticker inválido"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "500": {
+            "description": "Erro interno"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Wallet"
+        ]
+      }
+    },
+    "/wallet/valuation": {
+      "get": {
+        "description": "Retorna a valorização atual consolidada da carteira do usuário, com cálculo por investimento.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie 'v2' para o contrato padronizado.",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Valorização retornada com sucesso"
+          },
+          "401": {
+            "description": "Token inválido"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Wallet"
+        ]
+      },
+      "options": {
+        "description": "Retorna a valorização atual consolidada da carteira do usuário, com cálculo por investimento.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie 'v2' para o contrato padronizado.",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Valorização retornada com sucesso"
+          },
+          "401": {
+            "description": "Token inválido"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Wallet"
+        ]
+      }
+    },
+    "/wallet/valuation/history": {
+      "get": {
+        "description": "Retorna histórico diário de evolução da carteira por período, com totais de compra/venda e valor líquido investido acumulado.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie 'v2' para o contrato padronizado.",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "Data final (YYYY-MM-DD). Opcional.",
+            "in": "query",
+            "name": "end_date",
+            "required": false
+          },
+          {
+            "deprecated": true,
+            "description": "Alias legado de `end_date`.",
+            "in": "query",
+            "name": "finalDate",
+            "required": false
+          },
+          {
+            "deprecated": true,
+            "description": "Alias legado de `start_date`.",
+            "in": "query",
+            "name": "startDate",
+            "required": false
+          },
+          {
+            "description": "Data inicial (YYYY-MM-DD). Opcional.",
+            "in": "query",
+            "name": "start_date",
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Histórico retornado com sucesso",
+            "headers": {
+              "Deprecation": {
+                "description": "Indica que a superfície atual está em deprecação.",
+                "example": "true",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Sunset": {
+                "description": "Data prevista para remoção da superfície legada.",
+                "example": "Tue, 30 Jun 2026 23:59:59 GMT",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Warning": {
+                "description": "Mensagem adicional de deprecação enviada em runtime.",
+                "example": "299 - \"Query params startDate/finalDate are deprecated; use start_date/end_date\"",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Auraxis-Successor-Field": {
+                "description": "Campo recomendado para a migração do payload.",
+                "example": "start_date,end_date",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Parâmetros inválidos"
+          },
+          "401": {
+            "description": "Token inválido"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Wallet"
+        ]
+      },
+      "options": {
+        "description": "Retorna histórico diário de evolução da carteira por período, com totais de compra/venda e valor líquido investido acumulado.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie 'v2' para o contrato padronizado.",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "Data final (YYYY-MM-DD). Opcional.",
+            "in": "query",
+            "name": "end_date",
+            "required": false
+          },
+          {
+            "deprecated": true,
+            "description": "Alias legado de `end_date`.",
+            "in": "query",
+            "name": "finalDate",
+            "required": false
+          },
+          {
+            "deprecated": true,
+            "description": "Alias legado de `start_date`.",
+            "in": "query",
+            "name": "startDate",
+            "required": false
+          },
+          {
+            "description": "Data inicial (YYYY-MM-DD). Opcional.",
+            "in": "query",
+            "name": "start_date",
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Histórico retornado com sucesso",
+            "headers": {
+              "Deprecation": {
+                "description": "Indica que a superfície atual está em deprecação.",
+                "example": "true",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Sunset": {
+                "description": "Data prevista para remoção da superfície legada.",
+                "example": "Tue, 30 Jun 2026 23:59:59 GMT",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Warning": {
+                "description": "Mensagem adicional de deprecação enviada em runtime.",
+                "example": "299 - \"Query params startDate/finalDate are deprecated; use start_date/end_date\"",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Auraxis-Successor-Field": {
+                "description": "Campo recomendado para a migração do payload.",
+                "example": "start_date,end_date",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Parâmetros inválidos"
+          },
+          "401": {
+            "description": "Token inválido"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Wallet"
+        ]
+      }
+    },
+    "/wallet/{investment_id}": {
+      "delete": {
+        "description": "Deleta um investimento da carteira do usuário autenticado.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie 'v2' para o contrato padronizado.",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "ID do investimento",
+            "in": "path",
+            "name": "investment_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Investimento deletado com sucesso"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "403": {
+            "description": "Sem permissão para deletar"
+          },
+          "404": {
+            "description": "Investimento não encontrado"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Wallet"
+        ]
+      },
+      "get": {
+        "description": "Retorna o detalhe canônico de um investimento específico da carteira do usuário autenticado.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie 'v2' para o contrato padronizado.",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "ID do investimento",
+            "in": "path",
+            "name": "investment_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Investimento retornado com sucesso"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "403": {
+            "description": "Sem permissão"
+          },
+          "404": {
+            "description": "Investimento não encontrado"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Wallet"
+        ]
+      },
+      "options": {
+        "description": "Compatibilidade transitória para atualização parcial de investimento. Use `PATCH /wallet/{investment_id}` como método canônico.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie 'v2' para o contrato padronizado.",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "ID do investimento",
+            "in": "path",
+            "name": "investment_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Investimento atualizado com sucesso",
+            "headers": {
+              "Deprecation": {
+                "description": "Indica que a superfície atual está em deprecação.",
+                "example": "true",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Sunset": {
+                "description": "Data prevista para remoção da superfície legada.",
+                "example": "Tue, 30 Jun 2026 23:59:59 GMT",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Auraxis-Successor-Endpoint": {
+                "description": "Endpoint sucessor recomendado.",
+                "example": "/wallet/{investment_id}",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Auraxis-Successor-Method": {
+                "description": "Método HTTP recomendado para a superfície sucessora.",
+                "example": "PATCH",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Dados inválidos"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "404": {
+            "description": "Investimento não encontrado"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Wallet"
+        ]
+      },
+      "patch": {
+        "description": "Atualiza parcialmente um investimento existente da carteira do usuário. Este é o método canônico para alterações parciais.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie 'v2' para o contrato padronizado.",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "ID do investimento",
+            "in": "path",
+            "name": "investment_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Investimento atualizado com sucesso"
+          },
+          "400": {
+            "description": "Dados inválidos"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "404": {
+            "description": "Investimento não encontrado"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Wallet"
+        ]
+      },
+      "put": {
+        "description": "Compatibilidade transitória para atualização parcial de investimento. Use `PATCH /wallet/{investment_id}` como método canônico.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie 'v2' para o contrato padronizado.",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "ID do investimento",
+            "in": "path",
+            "name": "investment_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Investimento atualizado com sucesso",
+            "headers": {
+              "Deprecation": {
+                "description": "Indica que a superfície atual está em deprecação.",
+                "example": "true",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Sunset": {
+                "description": "Data prevista para remoção da superfície legada.",
+                "example": "Tue, 30 Jun 2026 23:59:59 GMT",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Auraxis-Successor-Endpoint": {
+                "description": "Endpoint sucessor recomendado.",
+                "example": "/wallet/{investment_id}",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Auraxis-Successor-Method": {
+                "description": "Método HTTP recomendado para a superfície sucessora.",
+                "example": "PATCH",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Dados inválidos"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "404": {
+            "description": "Investimento não encontrado"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Wallet"
+        ]
+      }
+    },
+    "/wallet/{investment_id}/history": {
+      "get": {
+        "description": "Retorna o histórico de alterações de um investimento, paginado e ordenado.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie 'v2' para o contrato padronizado.",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "ID do investimento",
+            "in": "path",
+            "name": "investment_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Histórico paginado"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "403": {
+            "description": "Sem permissão"
+          },
+          "404": {
+            "description": "Investimento não encontrado"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Wallet"
+        ]
+      },
+      "options": {
+        "description": "Retorna o histórico de alterações de um investimento, paginado e ordenado.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie 'v2' para o contrato padronizado.",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "ID do investimento",
+            "in": "path",
+            "name": "investment_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Histórico paginado"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "403": {
+            "description": "Sem permissão"
+          },
+          "404": {
+            "description": "Investimento não encontrado"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Wallet"
+        ]
+      }
+    },
+    "/wallet/{investment_id}/operations": {
+      "get": {
+        "description": "Lista operações de investimento de um item da carteira com paginação.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie 'v2' para o contrato padronizado.",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "ID do investimento",
+            "in": "path",
+            "name": "investment_id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "per_page",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Lista paginada de operações"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "403": {
+            "description": "Sem permissão"
+          },
+          "404": {
+            "description": "Investimento não encontrado"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Wallet"
+        ]
+      },
+      "options": {
+        "description": "Lista operações de investimento de um item da carteira com paginação.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie 'v2' para o contrato padronizado.",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "ID do investimento",
+            "in": "path",
+            "name": "investment_id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "per_page",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Lista paginada de operações"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "403": {
+            "description": "Sem permissão"
+          },
+          "404": {
+            "description": "Investimento não encontrado"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Wallet"
+        ]
+      },
+      "post": {
+        "description": "Registra uma operação de investimento (buy/sell) para um item da carteira.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie 'v2' para o contrato padronizado.",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "ID do investimento",
+            "in": "path",
+            "name": "investment_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Operação criada com sucesso"
+          },
+          "400": {
+            "description": "Dados inválidos"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "403": {
+            "description": "Sem permissão"
+          },
+          "404": {
+            "description": "Investimento não encontrado"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Wallet"
+        ]
+      }
+    },
+    "/wallet/{investment_id}/operations/invested-amount": {
+      "get": {
+        "description": "Retorna o valor investido no dia informado, considerando operações de compra e venda do investimento.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie 'v2' para o contrato padronizado.",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "ID do investimento",
+            "in": "path",
+            "name": "investment_id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "name": "date",
+            "required": true,
+            "schema": {
+              "format": "date",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Cálculo retornado com sucesso"
+          },
+          "400": {
+            "description": "Parâmetro inválido"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "403": {
+            "description": "Sem permissão"
+          },
+          "404": {
+            "description": "Investimento não encontrado"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Wallet"
+        ]
+      },
+      "options": {
+        "description": "Retorna o valor investido no dia informado, considerando operações de compra e venda do investimento.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie 'v2' para o contrato padronizado.",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "ID do investimento",
+            "in": "path",
+            "name": "investment_id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "name": "date",
+            "required": true,
+            "schema": {
+              "format": "date",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Cálculo retornado com sucesso"
+          },
+          "400": {
+            "description": "Parâmetro inválido"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "403": {
+            "description": "Sem permissão"
+          },
+          "404": {
+            "description": "Investimento não encontrado"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Wallet"
+        ]
+      }
+    },
+    "/wallet/{investment_id}/operations/position": {
+      "get": {
+        "description": "Retorna posição atual e custo médio do investimento com base nas operações registradas.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie 'v2' para o contrato padronizado.",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "ID do investimento",
+            "in": "path",
+            "name": "investment_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Posição retornada com sucesso"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "403": {
+            "description": "Sem permissão"
+          },
+          "404": {
+            "description": "Investimento não encontrado"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Wallet"
+        ]
+      },
+      "options": {
+        "description": "Retorna posição atual e custo médio do investimento com base nas operações registradas.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie 'v2' para o contrato padronizado.",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "ID do investimento",
+            "in": "path",
+            "name": "investment_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Posição retornada com sucesso"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "403": {
+            "description": "Sem permissão"
+          },
+          "404": {
+            "description": "Investimento não encontrado"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Wallet"
+        ]
+      }
+    },
+    "/wallet/{investment_id}/operations/summary": {
+      "get": {
+        "description": "Resumo agregado das operações de um investimento.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie 'v2' para o contrato padronizado.",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "ID do investimento",
+            "in": "path",
+            "name": "investment_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resumo retornado com sucesso"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "403": {
+            "description": "Sem permissão"
+          },
+          "404": {
+            "description": "Investimento não encontrado"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Wallet"
+        ]
+      },
+      "options": {
+        "description": "Resumo agregado das operações de um investimento.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie 'v2' para o contrato padronizado.",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "ID do investimento",
+            "in": "path",
+            "name": "investment_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resumo retornado com sucesso"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "403": {
+            "description": "Sem permissão"
+          },
+          "404": {
+            "description": "Investimento não encontrado"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Wallet"
+        ]
+      }
+    },
+    "/wallet/{investment_id}/operations/{operation_id}": {
+      "delete": {
+        "description": "Remove operação de investimento.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie 'v2' para o contrato padronizado.",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "ID do investimento",
+            "in": "path",
+            "name": "investment_id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "ID da operação",
+            "in": "path",
+            "name": "operation_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Operação removida com sucesso"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "403": {
+            "description": "Sem permissão"
+          },
+          "404": {
+            "description": "Operação não encontrada"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Wallet"
+        ]
+      },
+      "options": {
+        "description": "Atualiza operação de investimento existente.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie 'v2' para o contrato padronizado.",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "ID do investimento",
+            "in": "path",
+            "name": "investment_id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "ID da operação",
+            "in": "path",
+            "name": "operation_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Operação atualizada com sucesso"
+          },
+          "400": {
+            "description": "Dados inválidos"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "403": {
+            "description": "Sem permissão"
+          },
+          "404": {
+            "description": "Operação não encontrada"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Wallet"
+        ]
+      },
+      "put": {
+        "description": "Atualiza operação de investimento existente.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie 'v2' para o contrato padronizado.",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "ID do investimento",
+            "in": "path",
+            "name": "investment_id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "ID da operação",
+            "in": "path",
+            "name": "operation_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Operação atualizada com sucesso"
+          },
+          "400": {
+            "description": "Dados inválidos"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "403": {
+            "description": "Sem permissão"
+          },
+          "404": {
+            "description": "Operação não encontrada"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Wallet"
+        ]
+      }
+    },
+    "/wallet/{investment_id}/valuation": {
+      "get": {
+        "description": "Retorna a valorização atual de um investimento específico.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie 'v2' para o contrato padronizado.",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "ID do investimento",
+            "in": "path",
+            "name": "investment_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Valorização retornada com sucesso"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "403": {
+            "description": "Sem permissão"
+          },
+          "404": {
+            "description": "Investimento não encontrado"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Wallet"
+        ]
+      },
+      "options": {
+        "description": "Retorna a valorização atual de um investimento específico.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie 'v2' para o contrato padronizado.",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "ID do investimento",
+            "in": "path",
+            "name": "investment_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Valorização retornada com sucesso"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "403": {
+            "description": "Sem permissão"
+          },
+          "404": {
+            "description": "Investimento não encontrado"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Wallet"
+        ]
+      }
+    }
+  },
+  "tags": [
+    {
+      "description": "Endpoints para registro, login e logout de usuários",
+      "name": "Autenticação"
+    },
+    {
+      "description": "Gerenciamento de dados de usuário e perfil",
+      "name": "Usuários"
+    },
+    {
+      "description": "Criação, edição e consulta de transações financeiras",
+      "name": "Transações"
+    },
+    {
+      "description": "Gerenciamento de metas financeiras e planejamento",
+      "name": "Metas"
+    },
+    {
+      "description": "Gerenciamento da carteira de investimentos",
+      "name": "Wallet"
+    },
+    {
+      "description": "Endpoint público para liveness/readiness de infraestrutura",
+      "name": "Health"
+    },
+    {
+      "description": "Export operacional protegido para métricas e collector externo",
+      "name": "Observability"
+    },
+    {
+      "description": "Gerenciamento de contas bancárias (pendente)",
+      "name": "Contas"
+    },
+    {
+      "description": "Gerenciamento de cartões de crédito (pendente)",
+      "name": "Cartões de Crédito"
+    },
+    {
+      "description": "Sistema de categorização por tags (pendente)",
+      "name": "Tags"
+    }
+  ]
+}

--- a/scripts/check-openapi-drift.sh
+++ b/scripts/check-openapi-drift.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# check-openapi-drift.sh — POSTMAN-06: detect uncommitted OpenAPI spec changes.
+#
+# Generates a fresh openapi.json from the live app and compares it against the
+# committed version. Exits non-zero if they differ, which means someone changed
+# a controller or schema without regenerating the spec.
+#
+# Usage:
+#   bash scripts/check-openapi-drift.sh
+#
+# To fix a drift failure:
+#   flask openapi-export --output openapi.json && git add openapi.json
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+COMMITTED_SPEC="openapi.json"
+TEMP_SPEC="$(mktemp /tmp/openapi-drift-XXXXXX.json)"
+TEMP_DB="$(mktemp /tmp/openapi-drift-XXXXXX.sqlite3)"
+
+cleanup() {
+  rm -f "$TEMP_SPEC" "$TEMP_DB"
+}
+trap cleanup EXIT
+
+if [[ ! -f "$COMMITTED_SPEC" ]]; then
+  echo "[openapi-drift] ERROR: $COMMITTED_SPEC not found."
+  echo "[openapi-drift] Run: flask openapi-export --output openapi.json"
+  exit 1
+fi
+
+# Resolve Python — prefer venv, fallback to system
+PYTHON_BIN="${ROOT_DIR}/.venv/bin/python3"
+if [[ ! -x "$PYTHON_BIN" ]]; then
+  PYTHON_BIN="$(command -v python3 || command -v python)"
+fi
+
+echo "[openapi-drift] Generating fresh spec from live app..."
+FLASK_TESTING=true \
+SECURITY_ENFORCE_STRONG_SECRETS=false \
+DOCS_EXPOSURE_POLICY=public \
+DATABASE_URL="sqlite:///${TEMP_DB}" \
+SECRET_KEY="drift-check-key-with-64-chars-minimum-for-jwt-signing-000001" \
+JWT_SECRET_KEY="drift-check-jwt-key-with-64-chars-minimum-for-signing-002" \
+"$PYTHON_BIN" - "$TEMP_SPEC" <<'PY'
+import json
+import sys
+
+from app import create_app
+from app.cli.openapi_export import _stabilize_parameters
+from app.extensions.database import db
+
+output_path = sys.argv[1]
+app = create_app()
+app.config["TESTING"] = True
+
+with app.app_context():
+    db.drop_all()
+    db.create_all()
+
+with app.test_client() as client:
+    response = client.get("/docs/swagger/")
+    if response.status_code != 200:
+        raise RuntimeError(f"Swagger endpoint returned {response.status_code}")
+    spec = response.get_json() or {}
+
+spec = _stabilize_parameters(spec)
+
+with open(output_path, "w", encoding="utf-8") as f:
+    json.dump(spec, f, ensure_ascii=False, indent=2, sort_keys=True)
+    f.write("\n")
+PY
+
+if diff -q "$COMMITTED_SPEC" "$TEMP_SPEC" > /dev/null 2>&1; then
+  echo "[openapi-drift] OK — openapi.json is up to date."
+  exit 0
+else
+  echo "[openapi-drift] DRIFT DETECTED — openapi.json is stale."
+  echo ""
+  echo "Diff (committed vs live):"
+  diff --unified=3 "$COMMITTED_SPEC" "$TEMP_SPEC" | head -50
+  echo ""
+  echo "To fix:"
+  echo "  flask openapi-export --output openapi.json && git add openapi.json"
+  exit 1
+fi

--- a/tests/test_openapi_export_cli.py
+++ b/tests/test_openapi_export_cli.py
@@ -1,0 +1,66 @@
+"""POSTMAN-01 — Tests for ``flask openapi-export`` CLI command.
+
+Verifies that the command:
+1. Produces a valid OpenAPI 3.0 JSON file.
+2. Is deterministic (two runs → identical output).
+3. Contains expected paths.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def test_openapi_export_produces_valid_json(app, tmp_path: Path) -> None:
+    output = tmp_path / "openapi.json"
+    runner = app.test_cli_runner()
+
+    result = runner.invoke(args=["openapi-export", "--output", str(output)])
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    assert output.exists()
+
+    spec = json.loads(output.read_text(encoding="utf-8"))
+    assert spec.get("openapi", "").startswith("3.0")
+    assert "paths" in spec
+    assert len(spec["paths"]) > 0
+
+
+def test_openapi_export_is_deterministic(app, tmp_path: Path) -> None:
+    """Two consecutive runs must produce byte-identical output."""
+    out1 = tmp_path / "run1.json"
+    out2 = tmp_path / "run2.json"
+    runner = app.test_cli_runner()
+
+    runner.invoke(args=["openapi-export", "--output", str(out1)])
+    runner.invoke(args=["openapi-export", "--output", str(out2)])
+
+    assert out1.read_bytes() == out2.read_bytes(), (
+        "OpenAPI export is not deterministic — two runs produced different output"
+    )
+
+
+def test_openapi_export_contains_known_paths(app, tmp_path: Path) -> None:
+    output = tmp_path / "openapi.json"
+    runner = app.test_cli_runner()
+    runner.invoke(args=["openapi-export", "--output", str(output)])
+
+    spec = json.loads(output.read_text(encoding="utf-8"))
+    paths = set(spec.get("paths", {}).keys())
+
+    # At minimum, health and auth endpoints must be present
+    assert any("/health" in p for p in paths), f"Missing /health in paths: {paths}"
+    assert any("/auth" in p for p in paths), f"Missing /auth in paths: {paths}"
+
+
+def test_openapi_export_default_output(app, tmp_path: Path, monkeypatch) -> None:
+    """Without --output, defaults to openapi.json in cwd."""
+    monkeypatch.chdir(tmp_path)
+    runner = app.test_cli_runner()
+
+    result = runner.invoke(args=["openapi-export"])
+
+    assert result.exit_code == 0
+    default_output = tmp_path / "openapi.json"
+    assert default_output.exists()


### PR DESCRIPTION
## O que muda
1. **POSTMAN-01**: `flask openapi-export --output openapi.json` — CLI command para exportar
   OpenAPI spec de forma determinística (sorted keys, sorted parameters).
2. **POSTMAN-06**: `scripts/check-openapi-drift.sh` — governance script que detecta
   quando alguém altera controllers/schemas sem regenerar openapi.json.
3. **Baseline**: `openapi.json` commitado com 60 paths como snapshot de referência.
4. **Fix**: parameter array stabilization (sort by in+name) para evitar false drift.

## Contexto
Closes #963
Closes #968
Foundation do pipeline Postman auto-sync (Track B). O drift check pode ser
adicionado ao CI e pre-commit para garantir que o spec nunca fica stale.

## Como testar
- [ ] `flask openapi-export --output /tmp/test.json` — gera arquivo válido
- [ ] `bash scripts/check-openapi-drift.sh` — deve sair OK
- [ ] Alterar um controller, rodar drift check — deve falhar
- [ ] `pytest tests/test_openapi_export_cli.py -v` — 4 tests passando

## Quality gates
- [x] ruff format: PASS
- [x] ruff check: PASS
- [x] mypy: PASS
- [x] bandit: PASS
- [x] pytest (cov ≥ 85%): PASS (90.70%)
- [x] full CI-parity: PASS

## Impacto de contrato
Nenhum — adiciona tooling e snapshot, sem mudança em endpoints.

## Risco
LOW — tooling de governança read-only.