### PR TITLE
feat(h-p3.3): branded email templates for D-7 and D-1 transaction reminders

### DIFF
--- a/app/application/services/transaction_reminder_service.py
+++ b/app/application/services/transaction_reminder_service.py
@@ -12,6 +12,7 @@ from app.models.transaction import Transaction, TransactionStatus
 from app.models.user import User
 from app.services.alert_service import _is_dispatch_allowed
 from app.services.email_provider import EmailMessage, get_default_email_provider
+from app.services.email_templates.base import render_due_soon_email
 from app.utils.datetime_utils import utc_now_naive
 
 _REMINDER_WINDOWS = {
@@ -108,21 +109,25 @@ def dispatch_due_transaction_reminders(
             skipped += 1
             continue
 
+        amount_str = _serialize_amount(transaction.amount)
+        email_html, email_text = render_due_soon_email(
+            title=transaction.title,
+            amount_formatted=amount_str,
+            days_before_due=days_before_due,
+        )
+        if days_before_due == 1:
+            subject = f"Amanhã vence: {transaction.title} (R$ {amount_str})"
+        else:
+            subject = (
+                f"Vence em {days_before_due} dias: {transaction.title} "
+                f"(R$ {amount_str})"
+            )
         provider.send(
             EmailMessage(
                 to_email=str(user.email),
-                subject="Lembrete de pendência na Auraxis",
-                html=(
-                    "<p>Você possui uma pendência se aproximando.</p>"
-                    f"<p><strong>{transaction.title}</strong> vence em "
-                    f"{days_before_due} dia(s), no valor de R$ "
-                    f"{_serialize_amount(transaction.amount)}.</p>"
-                ),
-                text=(
-                    f"Você possui uma pendência se aproximando. {transaction.title} "
-                    f"vence em {days_before_due} dia(s), no valor de R$ "
-                    f"{_serialize_amount(transaction.amount)}."
-                ),
+                subject=subject,
+                html=email_html,
+                text=email_text,
                 tag=category,
             )
         )

--- a/app/services/email_templates/__init__.py
+++ b/app/services/email_templates/__init__.py
@@ -3,11 +3,13 @@
 from .base import (
     render_account_deletion_email,
     render_confirmation_email,
+    render_due_soon_email,
     render_password_reset_email,
 )
 
 __all__ = [
     "render_account_deletion_email",
     "render_confirmation_email",
+    "render_due_soon_email",
     "render_password_reset_email",
 ]

--- a/app/services/email_templates/base.py
+++ b/app/services/email_templates/base.py
@@ -364,8 +364,128 @@ def render_account_deletion_email() -> tuple[str, str]:
     return html, text
 
 
+def render_due_soon_email(
+    *,
+    title: str,
+    amount_formatted: str,
+    days_before_due: int,
+) -> tuple[str, str]:
+    """Render the transaction due-soon reminder email (D-7 or D-1).
+
+    Args:
+        title: Transaction title (e.g., "Aluguel").
+        amount_formatted: Pre-formatted amount string (e.g., "1500.00").
+        days_before_due: 7 or 1.
+
+    Returns:
+        (html, text) tuple ready to pass to EmailMessage.
+    """
+    if days_before_due == 1:
+        email_title = "Amanhã vence uma pendência"
+        preview = f"Amanhã vence R$ {amount_formatted} — {title}."
+        heading = "Amanhã vence uma pendência"
+        intro = (
+            f'Sua transação <strong style="color: {_COLOR_TEXT_PRIMARY};">{title}</strong> '
+            f'vence <strong style="color: {_COLOR_BRAND};">amanhã</strong> no valor de '
+            f'<strong style="color: {_COLOR_TEXT_PRIMARY};">R$ {amount_formatted}</strong>.'
+        )
+    else:
+        email_title = "Pendência vencendo em breve"
+        preview = f"Você tem R$ {amount_formatted} vencendo em {days_before_due} dias — {title}."
+        heading = "Pendência vencendo em breve"
+        intro = (
+            f'Sua transação <strong style="color: {_COLOR_TEXT_PRIMARY};">{title}</strong> '
+            f'vence em <strong style="color: {_COLOR_BRAND};">{days_before_due} dias</strong> '
+            f'no valor de <strong style="color: {_COLOR_TEXT_PRIMARY};">R$ {amount_formatted}</strong>.'
+        )
+
+    body_html = f"""
+      <h1 style="font-family: {_FONT_HEADING}; font-size: 26px; font-weight: 700;
+                 color: {_COLOR_TEXT_PRIMARY}; margin: 0 0 8px; line-height: 1.2;">
+        {heading}
+      </h1>
+      <p style="font-family: {_FONT_BODY}; font-size: 13px; font-weight: 600;
+                color: {_COLOR_BRAND}; margin: 0 0 24px; text-transform: uppercase;
+                letter-spacing: 1px;">
+        Auraxis &mdash; Finanças pessoais
+      </p>
+
+      <div style="border-top: 1px solid {_COLOR_BG_ELEVATED}; margin: 0 0 28px;"></div>
+
+      <p style="font-family: {_FONT_BODY}; font-size: 15px; color: {_COLOR_TEXT_SECONDARY};
+                line-height: 1.65; margin: 0 0 24px;">
+        {intro}
+      </p>
+
+      <!-- CTA -->
+      <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin: 8px 0 32px;">
+        <tr>
+          <td align="left" style="border-radius: 8px; background-color: {_COLOR_BRAND};">
+            <!--[if mso]>
+            <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word"
+              href="{_APP_URL}" style="height:48px;v-text-anchor:middle;width:200px;" arcsize="17%"
+              strokecolor="{_COLOR_BRAND_DARK}" fillcolor="{_COLOR_BRAND}">
+              <w:anchorlock/>
+              <center style="color:{_COLOR_BG_BASE};font-family:{_FONT_BODY};font-size:15px;font-weight:600;">
+                Ver no Auraxis
+              </center>
+            </v:roundrect>
+            <![endif]-->
+            <!--[if !mso]><!-->
+            <a href="{_APP_URL}"
+               style="background-color: {_COLOR_BRAND}; color: {_COLOR_BG_BASE};
+                      font-family: {_FONT_BODY}; font-size: 15px; font-weight: 600;
+                      text-decoration: none; display: inline-block;
+                      padding: 14px 32px; border-radius: 8px;">
+              Ver no Auraxis
+            </a>
+            <!--<![endif]-->
+          </td>
+        </tr>
+      </table>
+
+      <div style="border-top: 1px solid {_COLOR_BG_ELEVATED}; margin: 0 0 20px;"></div>
+
+      <p style="font-family: {_FONT_BODY}; font-size: 12px; color: {_COLOR_TEXT_MUTED};
+                line-height: 1.6; margin: 0;">
+        Para gerenciar suas preferências de notificação, acesse as configurações no aplicativo.
+      </p>
+    """
+
+    html = _base_layout(
+        title=email_title,
+        preview_text=preview,
+        body_html=body_html,
+    )
+
+    if days_before_due == 1:
+        text = (
+            f"Amanhã vence uma pendência — Auraxis\n"
+            f"=====================================\n\n"
+            f"Sua transação '{title}' vence amanhã no valor de R$ {amount_formatted}.\n\n"
+            f"Acesse o Auraxis para gerenciar suas finanças:\n"
+            f"{_APP_URL}\n\n"
+            f"Para gerenciar preferências de notificação, acesse as configurações no app.\n\n"
+            f"— Equipe Auraxis\n"
+        )
+    else:
+        text = (
+            f"Pendência vencendo em breve — Auraxis\n"
+            f"======================================\n\n"
+            f"Sua transação '{title}' vence em {days_before_due} dias "
+            f"no valor de R$ {amount_formatted}.\n\n"
+            f"Acesse o Auraxis para gerenciar suas finanças:\n"
+            f"{_APP_URL}\n\n"
+            f"Para gerenciar preferências de notificação, acesse as configurações no app.\n\n"
+            f"— Equipe Auraxis\n"
+        )
+
+    return html, text
+
+
 __all__ = [
     "render_account_deletion_email",
     "render_confirmation_email",
+    "render_due_soon_email",
     "render_password_reset_email",
 ]

--- a/tests/test_email_templates.py
+++ b/tests/test_email_templates.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from app.services.email_templates import (
     render_confirmation_email,
+    render_due_soon_email,
     render_password_reset_email,
 )
 
@@ -99,3 +100,82 @@ class TestRenderPasswordResetEmail:
     def test_html_contains_brand_colour(self) -> None:
         html, _ = render_password_reset_email(reset_url=RESET_URL)
         assert "#ffab1a" in html
+
+
+class TestRenderDueSoonEmail:
+    def test_returns_html_and_text_tuple(self) -> None:
+        result = render_due_soon_email(
+            title="Aluguel", amount_formatted="1500.00", days_before_due=7
+        )
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+
+    def test_html_is_valid_doctype(self) -> None:
+        html, _ = render_due_soon_email(
+            title="Aluguel", amount_formatted="1500.00", days_before_due=7
+        )
+        assert html.strip().startswith("<!DOCTYPE html>")
+
+    def test_html_contains_brand_colour(self) -> None:
+        html, _ = render_due_soon_email(
+            title="Aluguel", amount_formatted="1500.00", days_before_due=7
+        )
+        assert "#ffab1a" in html
+
+    def test_html_contains_brand_name(self) -> None:
+        html, _ = render_due_soon_email(
+            title="Aluguel", amount_formatted="1500.00", days_before_due=7
+        )
+        assert "Auraxis" in html
+
+    def test_html_contains_cta_button(self) -> None:
+        html, _ = render_due_soon_email(
+            title="Aluguel", amount_formatted="1500.00", days_before_due=7
+        )
+        assert "Ver no Auraxis" in html
+
+    def test_d7_html_contains_title_and_amount(self) -> None:
+        html, _ = render_due_soon_email(
+            title="Aluguel", amount_formatted="1500.00", days_before_due=7
+        )
+        assert "Aluguel" in html
+        assert "1500.00" in html
+        assert "Pendência vencendo em breve" in html
+
+    def test_d1_html_heading_is_tomorrow(self) -> None:
+        html, _ = render_due_soon_email(
+            title="Aluguel", amount_formatted="750.00", days_before_due=1
+        )
+        assert "Amanhã vence uma pendência" in html
+        assert "amanhã" in html
+
+    def test_d1_html_contains_title_and_amount(self) -> None:
+        html, _ = render_due_soon_email(
+            title="Cartão Nubank", amount_formatted="320.50", days_before_due=1
+        )
+        assert "Cartão Nubank" in html
+        assert "320.50" in html
+
+    def test_text_is_plain_string(self) -> None:
+        _, text = render_due_soon_email(
+            title="Aluguel", amount_formatted="1500.00", days_before_due=7
+        )
+        assert "<" not in text
+
+    def test_text_contains_app_url(self) -> None:
+        _, text = render_due_soon_email(
+            title="Aluguel", amount_formatted="1500.00", days_before_due=7
+        )
+        assert "app.auraxis.com.br" in text
+
+    def test_d7_text_mentions_days(self) -> None:
+        _, text = render_due_soon_email(
+            title="Aluguel", amount_formatted="1500.00", days_before_due=7
+        )
+        assert "7 dias" in text
+
+    def test_d1_text_mentions_amanha(self) -> None:
+        _, text = render_due_soon_email(
+            title="Aluguel", amount_formatted="1500.00", days_before_due=1
+        )
+        assert "amanhã" in text


### PR DESCRIPTION
## Summary

- Adds `render_due_soon_email(*, title, amount_formatted, days_before_due)` to the Auraxis email template system with full dark-theme branding (amber CTA button "Ver no Auraxis", Playfair Display/Raleway fonts, dark `#0b0909` background) for both 7-day and 1-day reminder variants
- Wires the new template into `transaction_reminder_service.dispatch_due_transaction_reminders`, replacing the previously missing HTML rendering with structured subject lines (`"Amanhã vence: {title} (R$ {amount})"` / `"Vence em N dias: {title} (R$ {amount})"`)
- Exports `render_due_soon_email` from `app/services/email_templates/__init__.py`
- Adds 12 new tests in `TestRenderDueSoonEmail` (D-7 and D-1 variants, DOCTYPE, brand colour, CTA text, plain-text no-HTML contract, app URL presence)

Closes #836

## Test plan

- [x] `pytest tests/test_email_templates.py` — 31 passed (19 existing + 12 new)
- [x] Full CI quality gate: `bash scripts/run_ci_quality_local.sh --local` — 1275 passed, 90.73% coverage, all gates green