### PR TITLE
fix(auth): revoke JWT tokens for soft-deleted users + billing canonical wiki

### DIFF
--- a/app/auth/identity.py
+++ b/app/auth/identity.py
@@ -155,6 +155,7 @@ def is_auth_context_revoked(context: AuthContext) -> bool:
     user = _user_from_auth_context(context)
     return (
         user is None
+        or user.deleted_at is not None  # LGPD: soft-deleted accounts are always revoked
         or context.jti is None
         or not hasattr(user, "current_jti")
         or user.current_jti != context.jti

--- a/app/extensions/jwt_callbacks.py
+++ b/app/extensions/jwt_callbacks.py
@@ -32,7 +32,7 @@ def is_token_revoked(jti: str) -> bool:
         if identity is None:
             return True
         user = db.session.get(User, identity)
-        return not user or user.current_jti != jti
+        return not user or user.deleted_at is not None or user.current_jti != jti
     except InvalidAuthContextError:
         return True
 
@@ -44,7 +44,7 @@ def _is_access_token_revoked(user_id: str, jti: str) -> bool:
     if cached_jti is not None:
         return cached_jti != jti
     user = db.session.get(User, UUID(user_id))
-    if not user:
+    if not user or user.deleted_at is not None:  # LGPD: soft-deleted = revoked
         return True
     cache.set_current_jti(user_id, user.current_jti)
     return bool(user.current_jti != jti)
@@ -53,7 +53,7 @@ def _is_access_token_revoked(user_id: str, jti: str) -> bool:
 def _is_refresh_token_revoked(user_id: str, jti: str) -> bool:
     """Check refresh token revocation directly against the DB (not cached)."""
     user = db.session.get(User, UUID(user_id))
-    if not user:
+    if not user or user.deleted_at is not None:  # LGPD: soft-deleted = revoked
         return True
     return bool(user.refresh_token_jti != jti)
 

--- a/scripts/github_ruleset_manager.py
+++ b/scripts/github_ruleset_manager.py
@@ -349,4 +349,4 @@ if __name__ == "__main__":
         raise SystemExit(main())
     except RulesetError as exc:
         print(exc, file=sys.stderr)
-        raise SystemExit(2)
+        raise SystemExit(2) from None

--- a/test_swagger_docs.py
+++ b/test_swagger_docs.py
@@ -116,7 +116,8 @@ def main() -> int:
         print("🎉 Todos os testes passaram!")
         print("📚 A documentação Swagger está configurada corretamente.")
         print(
-            "🌐 Acesse: http://localhost:5000/docs/ (quando a aplicação estiver rodando)"
+            "🌐 Acesse: http://localhost:5000/docs/"
+            " (quando a aplicação estiver rodando)"
         )
         return 0
     else:

--- a/tests/test_auth_identity.py
+++ b/tests/test_auth_identity.py
@@ -91,3 +91,77 @@ def test_get_active_auth_context_raises_for_revoked_context(
 
     with pytest.raises(RevokedTokenError):
         get_active_auth_context()
+
+
+def test_is_auth_context_revoked_for_soft_deleted_user(app) -> None:
+    """A soft-deleted user's token must be treated as revoked (LGPD)."""
+    with app.app_context():
+        from app.extensions.database import db
+        from app.utils.datetime_utils import utc_now_naive
+
+        user = User(
+            name="deleted-user",
+            email="deleted-user@email.com",
+            password="hash",
+        )
+        user.current_jti = "valid-jti"
+        user.deleted_at = utc_now_naive()
+        db.session.add(user)
+        db.session.commit()
+
+        context = AuthContext(
+            subject=str(user.id),
+            email=user.email,
+            roles=(),
+            permissions=(),
+            jti="valid-jti",
+            issued_at=None,
+            expires_at=None,
+            raw_claims={"sub": str(user.id), "jti": "valid-jti"},
+        )
+
+        # Even though jti matches, deleted_at must cause revocation.
+        assert is_auth_context_revoked(context) is True
+
+
+def test_jwt_callback_revokes_deleted_user_access_token(app) -> None:
+    """Access-token revocation check must treat soft-deleted users as revoked."""
+    with app.app_context():
+        from app.extensions.database import db
+        from app.extensions.jwt_callbacks import _is_access_token_revoked
+        from app.utils.datetime_utils import utc_now_naive
+
+        user = User(
+            name="deleted-jwt-user",
+            email="deleted-jwt@email.com",
+            password="hash",
+        )
+        user.current_jti = "valid-jti-access"
+        user.deleted_at = utc_now_naive()
+        db.session.add(user)
+        db.session.commit()
+
+        # Token matches current_jti but user is soft-deleted — must be revoked.
+        result = _is_access_token_revoked(str(user.id), "valid-jti-access")
+        assert result is True
+
+
+def test_jwt_callback_revokes_deleted_user_refresh_token(app) -> None:
+    """Refresh-token revocation check must treat soft-deleted users as revoked."""
+    with app.app_context():
+        from app.extensions.database import db
+        from app.extensions.jwt_callbacks import _is_refresh_token_revoked
+        from app.utils.datetime_utils import utc_now_naive
+
+        user = User(
+            name="deleted-refresh-user",
+            email="deleted-refresh@email.com",
+            password="hash",
+        )
+        user.refresh_token_jti = "valid-jti-refresh"
+        user.deleted_at = utc_now_naive()
+        db.session.add(user)
+        db.session.commit()
+
+        result = _is_refresh_token_revoked(str(user.id), "valid-jti-refresh")
+        assert result is True

--- a/tests/test_b22_jwt_revocation_cache.py
+++ b/tests/test_b22_jwt_revocation_cache.py
@@ -235,6 +235,7 @@ class TestCheckIfTokenRevokedWithCache:
 
         mock_user = MagicMock()
         mock_user.current_jti = stored_jti
+        mock_user.deleted_at = None  # active user
 
         jwt_manager, captured = _make_jwt_manager_and_capture()
 
@@ -266,6 +267,7 @@ class TestCheckIfTokenRevokedWithCache:
         noop_cache = _NoOpJwtRevocationCache()
         mock_user = MagicMock()
         mock_user.current_jti = stored_jti
+        mock_user.deleted_at = None  # active user
 
         jwt_manager, captured = _make_jwt_manager_and_capture()
 


### PR DESCRIPTION
## Summary

- **Closes #1020** — JWT tokens from soft-deleted (LGPD) users are now always treated as revoked, even when the JTI matches
- **Closes #1019** — `TASKS.md` deprecated; `SOURCES.md` updated to point to GitHub Projects
- **Closes #1018** — Canonical pricing wiki created (`docs/wiki/MVP-1-Monetizacao-e-Assinaturas.md`)
- **fix(lint)** — Pre-existing ruff B904 and E501 violations resolved

## Changes

### fix(auth): soft-delete JWT revocation
- `app/auth/identity.py`: `is_auth_context_revoked()` returns `True` when `user.deleted_at is not None`
- `app/extensions/jwt_callbacks.py`: All three revocation helpers (`is_token_revoked`, `_is_access_token_revoked`, `_is_refresh_token_revoked`) return `True` for soft-deleted users
- 3 new integration tests covering each code path; existing mocks updated with `deleted_at=None`

### docs(billing)
- `docs/wiki/MVP-1-Monetizacao-e-Assinaturas.md` — New canonical pricing doc (DEC-168: R$27,90/month, R$220,00/year)
- `billing_plans.py` — Added cross-reference comment to wiki doc
- `TASKS.md` — Replaced with deprecation notice pointing to GitHub Projects
- `.context/01_sources_of_truth.md` — Updated hierarchy to reflect GitHub Projects as #1 source of truth

## Test plan

- [x] `pytest tests/test_auth_identity.py` — 6 passed (3 new covering deleted user revocation)
- [x] `pytest tests/test_b22_jwt_revocation_cache.py` — all passed (mocks updated)
- [x] `pytest tests/test_auth.py` — all passed
- [x] Full suite: 90.79% coverage (> 85% threshold)
- [x] `ruff format` + `ruff check` + `mypy` + `bandit` — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)