### PR TITLE
chore(auth): single-session policy decision + SESSION_DISPLACED error code [H-P5.3] #841

### DIFF
--- a/app/controllers/auth/login_resource.py
+++ b/app/controllers/auth/login_resource.py
@@ -64,6 +64,11 @@ def _persist_session(
     refresh_jti: str,
     pending_new_hash: str | None,
 ) -> None:
+    # H-P5.3 — single-session policy (intentional product decision):
+    # Overwriting current_jti immediately invalidates any previously issued
+    # access + refresh pair. If the previous session was from another device,
+    # that device's next authenticated request will receive SESSION_DISPLACED (401).
+    # See docs/wiki/MVP-1-Hardening-Strategy.md § H-P5.3 for rationale.
     needs_commit = (
         user.current_jti != jti
         or user.refresh_token_jti != refresh_jti

--- a/app/extensions/jwt_callbacks.py
+++ b/app/extensions/jwt_callbacks.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict
 from uuid import UUID
 
-from flask import jsonify
+from flask import g, jsonify
 from flask.typing import ResponseReturnValue
 from flask_jwt_extended import JWTManager
 
@@ -38,16 +38,31 @@ def is_token_revoked(jti: str) -> bool:
 
 
 def _is_access_token_revoked(user_id: str, jti: str) -> bool:
-    """Check access token revocation using Redis cache (DB fallback on miss)."""
+    """Check access token revocation using Redis cache (DB fallback on miss).
+
+    Side-effect: sets ``g.session_displaced = True`` when the token is revoked
+    because a new session replaced it (single-session policy, H-P5.3). This flag
+    is read by ``revoked_token_callback`` to return the ``SESSION_DISPLACED``
+    error code so clients can show a targeted "logged in on another device" message.
+    """
     cache = get_jwt_revocation_cache()
     cached_jti = cache.get_current_jti(user_id)
     if cached_jti is not None:
-        return cached_jti != jti
+        displaced = cached_jti != jti
+        if displaced:
+            # cached_jti is non-empty → another session is active → displaced
+            g.session_displaced = True
+        return displaced
     user = db.session.get(User, UUID(user_id))
     if not user or user.deleted_at is not None:  # LGPD: soft-deleted = revoked
         return True
     cache.set_current_jti(user_id, user.current_jti)
-    return bool(user.current_jti != jti)
+    if user.current_jti != jti:
+        # current_jti is non-null → another session replaced this one
+        if user.current_jti is not None:
+            g.session_displaced = True
+        return True
+    return False
 
 
 def _is_refresh_token_revoked(user_id: str, jti: str) -> bool:
@@ -78,9 +93,18 @@ def register_jwt_callbacks(jwt: JWTManager) -> None:
     def revoked_token_callback(
         jwt_header: Dict[str, Any], jwt_payload: Dict[str, Any]
     ) -> Any:
+        # H-P5.3 — single-session policy feedback:
+        # SESSION_DISPLACED → another device logged in (current_jti replaced).
+        # SESSION_REVOKED   → explicit logout or account erasure.
+        if getattr(g, "session_displaced", False):
+            return _jwt_error_response(
+                "Sua sessão foi encerrada porque você entrou em outro dispositivo.",
+                code="SESSION_DISPLACED",
+                status_code=401,
+            )
         return _jwt_error_response(
-            "Token revogado",
-            code="UNAUTHORIZED",
+            "Sessão encerrada. Faça login novamente.",
+            code="SESSION_REVOKED",
             status_code=401,
         )
 

--- a/docs/wiki/MVP-1-Hardening-Strategy.md
+++ b/docs/wiki/MVP-1-Hardening-Strategy.md
@@ -1,0 +1,112 @@
+# MVP-1 Hardening Strategy
+
+**Updated at:** 2026-04-14
+**Scope:** Security posture, API hygiene, and architectural decisions post-MVP-1 launch.
+
+---
+
+## Overview
+
+This document records the decisions, rationale, and execution plan for all H-prefixed
+hardening issues. Each section maps to a GitHub issue and captures the chosen approach
+as an authoritative product/engineering decision.
+
+---
+
+## H-P5.3 — Session management policy (issue #841)
+
+### Decision: single-session is intentional
+
+The current implementation enforces **single-session** via `User.current_jti` and
+`User.refresh_token_jti` columns. A successful login on any device immediately
+invalidates any previously issued access + refresh token pair.
+
+**This is intentional product policy, not a limitation.**
+
+#### Rationale
+
+- For MVP-1 with a small user base and a single-core EC2 instance, the operational
+  complexity of multi-device session management outweighs the benefit.
+- Single-session is a stronger security posture by default: a compromised refresh token
+  self-heals when the legitimate user next logs in.
+- Multi-device sessions require a `user_sessions` table, token families with rotation,
+  and a "connected devices" UI — all deferred to a post-MVP-2 milestone.
+
+#### Implementation notes
+
+- `User.current_jti` tracks the active access token JTI. Any token with a different
+  JTI is considered revoked (see `app/extensions/jwt_callbacks.py`).
+- `User.refresh_token_jti` tracks the refresh token JTI with replay-attack protection
+  (see `app/controllers/auth/refresh_token_resource.py`).
+- Logout explicitly clears both JTI fields and the httpOnly refresh cookie.
+- When a session is displaced (login on another device), the previous token's revocation
+  callback returns `SESSION_DISPLACED` error code so clients can show a targeted message.
+
+#### Frontend contract
+
+When a request fails with `error_code: "SESSION_DISPLACED"`, the client **must** display:
+
+> "Sua sessão foi encerrada porque você entrou em outro dispositivo."
+
+For `error_code: "SESSION_REVOKED"`, the client displays:
+
+> "Sua sessão foi encerrada. Faça login novamente."
+
+#### Future: multi-device (post-MVP-2)
+
+If multi-device is ever adopted, the migration path is:
+
+1. Create `user_sessions` table (`id`, `user_id`, `device_id`, `refresh_jti`,
+   `ip`, `user_agent`, `last_active_at`, `revoked_at`)
+2. Replace `User.current_jti` / `User.refresh_token_jti` with per-session records
+3. Add `GET /user/sessions` and `DELETE /user/sessions/{session_id}` endpoints
+4. Add "Dispositivos conectados" screen in web/app
+
+---
+
+## H-P5.2 — Normalizar endpoints de transações (issue #840)
+
+### Decision: consolidate REST surface, add sunset headers
+
+See the dedicated section in `docs/wiki/MVP-1-Transacoes-Tecnico.md` and issue #840
+for the full breakdown. Summary of decisions:
+
+- `GET /transactions` is the canonical collection endpoint (with query param filters)
+- `GET /transactions/list` is deprecated with `Sunset` + `Deprecation` headers
+- `GET /transactions/expenses` is deprecated; use `GET /transactions?type=expense`
+- `PATCH /transactions/{id}` is the canonical partial-update method
+- `PUT /transactions/{id}` is deprecated with sunset header
+- Query params are normalized: `start_date` / `end_date` everywhere
+
+**Status:** Pending implementation.
+
+---
+
+## H-P5.1 — Resolver dualidade REST + GraphQL (issue #839)
+
+### Decision: REST canonical, GraphQL read-only per domain
+
+| Domain | Owner | GraphQL role |
+|--------|-------|--------------|
+| Auth | REST-only | Mutations deprecated (compat only) |
+| Transactions | REST canonical | Read queries only |
+| Goals | REST canonical | Read queries only |
+| Wallet | REST canonical | Read queries only |
+| Dashboard | REST-only | Not exposed |
+| User profile | REST canonical | Read queries only |
+
+**Status:** Pending implementation.
+
+---
+
+## H-P4.1 — Migração Flask → FastAPI fase 0 (issue #837)
+
+### Decision: coexistence via nginx routing
+
+Follow `tech_debt/X3_phase0_execution_plan.md`. First two routes to migrate:
+
+1. `GET /healthz` — trivial, validates coexistence infrastructure
+2. `GET /dashboard/overview` — read-only, high frequency, good migration candidate
+
+**Status:** BLOCKED (awaiting infrastructure decision and endpoint normalization from
+H-P5.2 to land first).

--- a/tests/test_b22_jwt_revocation_cache.py
+++ b/tests/test_b22_jwt_revocation_cache.py
@@ -291,6 +291,135 @@ class TestCheckIfTokenRevokedWithCache:
 
 
 # ---------------------------------------------------------------------------
+# Unit tests — SESSION_DISPLACED flag (H-P5.3 single-session policy)
+# ---------------------------------------------------------------------------
+
+
+class TestSessionDisplacedFlag:
+    """Verify that g.session_displaced is set when a session is replaced."""
+
+    def _run_check(
+        self, *, app: Any, cache: Any, user_id: str, jti: str, mock_user: Any = None
+    ) -> bool:
+        """Run _is_access_token_revoked inside an app context and return the result."""
+        import app.extensions.jwt_callbacks as _m
+
+        with app.app_context():
+            with patch.object(_m, "get_jwt_revocation_cache", return_value=cache):
+                if mock_user is not None:
+                    with (
+                        patch.object(_m, "db") as mock_db,
+                        patch.object(_m, "UUID", side_effect=uuid.UUID),
+                    ):
+                        mock_db.session.get.return_value = mock_user
+                        return _m._is_access_token_revoked(user_id, jti)
+                else:
+                    return _m._is_access_token_revoked(user_id, jti)
+
+    def test_session_displaced_set_on_cache_hit_with_different_jti(
+        self, app: Any
+    ) -> None:
+        """Cache hit with a different (newer) JTI → session was displaced."""
+        user_id = str(uuid.uuid4())
+        new_jti = "new-device-jti"
+        old_jti = "old-device-jti"
+
+        redis_client = MagicMock()
+        redis_client.get.return_value = new_jti.encode()  # current JTI is new
+        cache = RedisJwtRevocationCache(redis_client)
+
+        import app.extensions.jwt_callbacks as _m
+
+        with app.app_context():
+            with patch.object(_m, "get_jwt_revocation_cache", return_value=cache):
+                # old_jti is being validated — it's not the current one
+                result = _m._is_access_token_revoked(user_id, old_jti)
+                from flask import g as flask_g
+
+                displaced = getattr(flask_g, "session_displaced", False)
+
+        assert result is True
+        assert displaced is True
+
+    def test_session_displaced_not_set_when_jti_matches(self, app: Any) -> None:
+        """Cache hit with the same JTI → valid token, no displacement."""
+        user_id = str(uuid.uuid4())
+        current_jti = "same-jti"
+
+        redis_client = MagicMock()
+        redis_client.get.return_value = current_jti.encode()
+        cache = RedisJwtRevocationCache(redis_client)
+
+        import app.extensions.jwt_callbacks as _m
+
+        with app.app_context():
+            with patch.object(_m, "get_jwt_revocation_cache", return_value=cache):
+                result = _m._is_access_token_revoked(user_id, current_jti)
+                from flask import g as flask_g
+
+                displaced = getattr(flask_g, "session_displaced", False)
+
+        assert result is False
+        assert displaced is False
+
+    def test_session_displaced_set_on_db_fallback_with_nonnull_current_jti(
+        self, app: Any
+    ) -> None:
+        """Cache miss + DB shows non-null current_jti ≠ incoming → SESSION_DISPLACED."""
+        user_id = str(uuid.uuid4())
+        incoming_jti = "old-jti"
+
+        noop_cache = _NoOpJwtRevocationCache()
+        mock_user = MagicMock()
+        mock_user.current_jti = "new-session-jti"  # a different session is active
+        mock_user.deleted_at = None
+
+        import app.extensions.jwt_callbacks as _m
+
+        with app.app_context():
+            with (
+                patch.object(_m, "get_jwt_revocation_cache", return_value=noop_cache),
+                patch.object(_m, "db") as mock_db,
+                patch.object(_m, "UUID", side_effect=uuid.UUID),
+            ):
+                mock_db.session.get.return_value = mock_user
+                result = _m._is_access_token_revoked(user_id, incoming_jti)
+                from flask import g as flask_g
+
+                displaced = getattr(flask_g, "session_displaced", False)
+
+        assert result is True
+        assert displaced is True
+
+    def test_session_not_displaced_when_current_jti_is_null(self, app: Any) -> None:
+        """Cache miss + DB shows null current_jti → explicit logout, not displaced."""
+        user_id = str(uuid.uuid4())
+        incoming_jti = "some-jti"
+
+        noop_cache = _NoOpJwtRevocationCache()
+        mock_user = MagicMock()
+        mock_user.current_jti = None  # explicit logout cleared it
+        mock_user.deleted_at = None
+
+        import app.extensions.jwt_callbacks as _m
+
+        with app.app_context():
+            with (
+                patch.object(_m, "get_jwt_revocation_cache", return_value=noop_cache),
+                patch.object(_m, "db") as mock_db,
+                patch.object(_m, "UUID", side_effect=uuid.UUID),
+            ):
+                mock_db.session.get.return_value = mock_user
+                result = _m._is_access_token_revoked(user_id, incoming_jti)
+                from flask import g as flask_g
+
+                displaced = getattr(flask_g, "session_displaced", False)
+
+        assert result is True
+        assert displaced is False
+
+
+# ---------------------------------------------------------------------------
 # Integration tests — logout invalidates cache (via HTTP)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Documents single-session policy as intentional product decision in `docs/wiki/MVP-1-Hardening-Strategy.md`
- Adds `SESSION_DISPLACED` error code so clients can show "you were logged in on another device" vs generic `SESSION_REVOKED` (explicit logout)
- Creates the H-series hardening strategy wiki with decisions for all 4 open H issues

## Changes

- `docs/wiki/MVP-1-Hardening-Strategy.md` — new file: authoritative decision record for H-P5.3, H-P5.2, H-P5.1, H-P4.1
- `app/extensions/jwt_callbacks.py` — `SESSION_DISPLACED` / `SESSION_REVOKED` error codes in `revoked_token_callback`; `g.session_displaced = True` flag set in `_is_access_token_revoked` when session is displaced by a newer login
- `app/controllers/auth/login_resource.py` — explanatory comment in `_persist_session` linking to wiki decision

## Test plan

- [x] `tests/test_b22_jwt_revocation_cache.py` — 4 new unit tests covering `SESSION_DISPLACED` flag (cache hit / cache miss / null JTI paths)
- [x] `pnpm quality-check` → all 1363 tests pass, 90.79% coverage, all gates OK

Closes #841