### PR TITLE
chore(mypy): remove override block — strict migration fase 3 concluída [#1023]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,26 +36,6 @@ strict = true
 plugins = []
 disallow_subclassing_any = false
 
-# ARC-10 mypy strict migration — override list.
-# Fase 1+2 (13 modules) migrated to per-decorator # type: ignore[misc].
-# Remaining: schemas wildcard + 7 controller/auth modules (Fase 3).
-[[tool.mypy.overrides]]
-module = [
-    # Marshmallow schemas — @pre_load/@post_load/@validates decorators.
-    # Deferred to Fase 3 (schema type-safety refactor).
-    "app.schemas.*",
-    # Controllers with mixed typed_jwt_required + route decorators.
-    # Deferred to Fase 3 (after typed_decorators.py stubs are added).
-    "app.controllers.subscription_controller",
-    "app.controllers.shared_entries.resources",
-    "app.controllers.fiscal.resources",
-    "app.controllers.wallet.valuation_resources",
-    "app.controllers.wallet.operation_resources",
-    "app.controllers.wallet.entry_resources",
-    "app.controllers.auth.error_handlers",
-]
-disable_error_code = ["untyped-decorator"]
-
 [build-system]
 requires = ["setuptools>=82.0.1"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Contexto

O `pyproject.toml` mantinha um bloco `[[tool.mypy.overrides]]` com `disable_error_code = ["untyped-decorator"]` para `app.schemas.*` e 7 módulos de controllers, marcados como "Fase 3 pendente" (issue #1023).

## O que foi encontrado

Ao rodar mypy diretamente nos módulos afetados, **zero erros** — a migração já havia sido completada em PRs anteriores sem remover o bloco de override.

## O que muda

- Remove o bloco `[[tool.mypy.overrides]]` inteiro do `pyproject.toml`
- `strict = true` + `disallow_untyped_defs = true` agora se aplicam a todos os 347 source files sem exceção
- Zero erros mypy no app completo

## CI

- 1364 passed, 90.79% coverage
- `mypy`: Success: no issues found in 347 source files

Closes #1023