### PR TITLE
chore(ops): disable recurrence-job schedule — superseded (#701)

### DIFF
--- a/.github/workflows/openapi-diff.yml
+++ b/.github/workflows/openapi-diff.yml
@@ -34,18 +34,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # Resolve latest tag via gh CLI (avoids GitHub API rate-limit on anonymous curl)
-          VERSION=$(gh release view --repo Tufin/oasdiff --json tagName -q '.tagName')
-          # Try goreleaser naming (Linux_x86_64), fall back to legacy (linux_amd64)
-          URL_NEW="https://github.com/Tufin/oasdiff/releases/download/${VERSION}/oasdiff_Linux_x86_64.tar.gz"
-          URL_OLD="https://github.com/Tufin/oasdiff/releases/download/${VERSION}/oasdiff_linux_amd64.tar.gz"
-          if curl -fsSL "$URL_NEW" | tar xz -C /usr/local/bin oasdiff 2>/dev/null; then
-            echo "Installed oasdiff ${VERSION} (new naming)"
-          elif curl -fsSL "$URL_OLD" | tar xz -C /usr/local/bin oasdiff 2>/dev/null; then
-            echo "Installed oasdiff ${VERSION} (legacy naming)"
-          else
-            echo "::error::Failed to download oasdiff ${VERSION}" && exit 1
-          fi
+          gh release download --repo Tufin/oasdiff --pattern '*linux_amd64.tar.gz' -D /tmp/oasdiff-dl
+          tar xz -C /usr/local/bin oasdiff -f /tmp/oasdiff-dl/*.tar.gz
+          echo "Installed $(oasdiff --version)"
 
       - name: Check for base spec
         id: base_exists

--- a/.github/workflows/openapi-diff.yml
+++ b/.github/workflows/openapi-diff.yml
@@ -31,10 +31,12 @@ jobs:
           path: base
 
       - name: Install oasdiff
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          VERSION=$(curl -sf https://api.github.com/repos/Tufin/oasdiff/releases/latest \
-            | python3 -c "import json,sys; print(json.load(sys.stdin)['tag_name'])")
-          # Try new goreleaser naming first (Linux_x86_64), fall back to old (linux_amd64)
+          # Resolve latest tag via gh CLI (avoids GitHub API rate-limit on anonymous curl)
+          VERSION=$(gh release view --repo Tufin/oasdiff --json tagName -q '.tagName')
+          # Try goreleaser naming (Linux_x86_64), fall back to legacy (linux_amd64)
           URL_NEW="https://github.com/Tufin/oasdiff/releases/download/${VERSION}/oasdiff_Linux_x86_64.tar.gz"
           URL_OLD="https://github.com/Tufin/oasdiff/releases/download/${VERSION}/oasdiff_linux_amd64.tar.gz"
           if curl -fsSL "$URL_NEW" | tar xz -C /usr/local/bin oasdiff 2>/dev/null; then

--- a/.github/workflows/openapi-diff.yml
+++ b/.github/workflows/openapi-diff.yml
@@ -31,12 +31,19 @@ jobs:
           path: base
 
       - name: Install oasdiff
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
-          gh release download --repo Tufin/oasdiff --pattern '*linux_amd64.tar.gz' -D /tmp/oasdiff-dl
-          tar xz -C /usr/local/bin oasdiff -f /tmp/oasdiff-dl/*.tar.gz
-          echo "Installed $(oasdiff --version)"
+          VERSION=$(curl -sf https://api.github.com/repos/Tufin/oasdiff/releases/latest \
+            | python3 -c "import json,sys; print(json.load(sys.stdin)['tag_name'])")
+          # Try new goreleaser naming first (Linux_x86_64), fall back to old (linux_amd64)
+          URL_NEW="https://github.com/Tufin/oasdiff/releases/download/${VERSION}/oasdiff_Linux_x86_64.tar.gz"
+          URL_OLD="https://github.com/Tufin/oasdiff/releases/download/${VERSION}/oasdiff_linux_amd64.tar.gz"
+          if curl -fsSL "$URL_NEW" | tar xz -C /usr/local/bin oasdiff 2>/dev/null; then
+            echo "Installed oasdiff ${VERSION} (new naming)"
+          elif curl -fsSL "$URL_OLD" | tar xz -C /usr/local/bin oasdiff 2>/dev/null; then
+            echo "Installed oasdiff ${VERSION} (legacy naming)"
+          else
+            echo "::error::Failed to download oasdiff ${VERSION}" && exit 1
+          fi
 
       - name: Check for base spec
         id: base_exists

--- a/api-tests/postman/auraxis.postman_collection.json
+++ b/api-tests/postman/auraxis.postman_collection.json
@@ -1,7 +1,7 @@
 {
   "info": {
     "name": "Auraxis API",
-    "description": "Auto-generated from openapi.json (61 paths). Do not edit manually — regenerate with: npm run postman:build",
+    "description": "Auto-generated from openapi.json (62 paths). Do not edit manually — regenerate with: npm run postman:build",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "item": [
@@ -1696,6 +1696,45 @@
               "script": {
                 "exec": [
                   "pm.test('Exportar transações (CSV ou PDF) — status 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "GET — Índice de sobrevivência financeira (burn rate)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/dashboard/survival-index",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "dashboard",
+                "survival-index"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Índice de sobrevivência financeira (burn rate) — status 200', function () {",
                   "  pm.response.to.have.status(200);",
                   "});"
                 ],

--- a/openapi.json
+++ b/openapi.json
@@ -2761,6 +2761,160 @@
         ]
       }
     },
+    "/dashboard/survival-index": {
+      "get": {
+        "description": "Calcula quantos meses o patrimônio atual sustenta o custo de vida médio. Patrimônio = soma das entradas de carteira (should_be_on_wallet=True). Custo médio = média de despesas pagas nos últimos 3 meses completos.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "avg_monthly_expense": 5000.0,
+                    "classification": "comfortable",
+                    "period_analyzed_months": 3,
+                    "survival_months": 8.5,
+                    "total_assets": 42500.0
+                  },
+                  "message": "Índice de sobrevivência calculado com sucesso"
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "data"
+                  ]
+                }
+              }
+            },
+            "description": "Índice de sobrevivência calculado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado",
+                  "status_code": 401
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ]
+                }
+              }
+            },
+            "description": "Token inválido",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Erro ao calcular índice de sobrevivência",
+                  "status_code": 500
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ]
+                }
+              }
+            },
+            "description": "Erro interno",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Índice de sobrevivência financeira (burn rate)",
+        "tags": [
+          "Dashboard"
+        ]
+      }
+    },
     "/dashboard/trends": {
       "get": {
         "description": "Retorna a série histórica de receitas, despesas e saldo para os últimos N meses (apenas transações pagas).",


### PR DESCRIPTION
## Summary

Removes the `schedule` cron from `recurrence-job.yml`. The workflow was firing daily but is labeled obsolete — the Flask-command-based recurrence implementation replaced it. The auto-failure handler kept reopening #701.

`workflow_dispatch` kept so the workflow can still be triggered manually for emergencies.

Closes #701