### PR TITLE
feat(advisory): AI advisory engine — GET /advisory/insights (#1026)

### DIFF
--- a/.github/workflows/openapi-diff.yml
+++ b/.github/workflows/openapi-diff.yml
@@ -34,18 +34,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # Resolve latest tag via gh CLI (avoids GitHub API rate-limit on anonymous curl)
-          VERSION=$(gh release view --repo Tufin/oasdiff --json tagName -q '.tagName')
-          # Try goreleaser naming (Linux_x86_64), fall back to legacy (linux_amd64)
-          URL_NEW="https://github.com/Tufin/oasdiff/releases/download/${VERSION}/oasdiff_Linux_x86_64.tar.gz"
-          URL_OLD="https://github.com/Tufin/oasdiff/releases/download/${VERSION}/oasdiff_linux_amd64.tar.gz"
-          if curl -fsSL "$URL_NEW" | tar xz -C /usr/local/bin oasdiff 2>/dev/null; then
-            echo "Installed oasdiff ${VERSION} (new naming)"
-          elif curl -fsSL "$URL_OLD" | tar xz -C /usr/local/bin oasdiff 2>/dev/null; then
-            echo "Installed oasdiff ${VERSION} (legacy naming)"
-          else
-            echo "::error::Failed to download oasdiff ${VERSION}" && exit 1
-          fi
+          gh release download --repo Tufin/oasdiff --pattern '*linux_amd64.tar.gz' -D /tmp/oasdiff-dl
+          tar xz -C /usr/local/bin oasdiff -f /tmp/oasdiff-dl/*.tar.gz
+          echo "Installed $(oasdiff --version)"
 
       - name: Check for base spec
         id: base_exists

--- a/.github/workflows/openapi-diff.yml
+++ b/.github/workflows/openapi-diff.yml
@@ -32,8 +32,18 @@ jobs:
 
       - name: Install oasdiff
         run: |
-          curl -fsSL https://github.com/Tufin/oasdiff/releases/latest/download/oasdiff_linux_amd64.tar.gz \
-            | tar xz -C /usr/local/bin oasdiff
+          VERSION=$(curl -sf https://api.github.com/repos/Tufin/oasdiff/releases/latest \
+            | python3 -c "import json,sys; print(json.load(sys.stdin)['tag_name'])")
+          # Try new goreleaser naming first (Linux_x86_64), fall back to old (linux_amd64)
+          URL_NEW="https://github.com/Tufin/oasdiff/releases/download/${VERSION}/oasdiff_Linux_x86_64.tar.gz"
+          URL_OLD="https://github.com/Tufin/oasdiff/releases/download/${VERSION}/oasdiff_linux_amd64.tar.gz"
+          if curl -fsSL "$URL_NEW" | tar xz -C /usr/local/bin oasdiff 2>/dev/null; then
+            echo "Installed oasdiff ${VERSION} (new naming)"
+          elif curl -fsSL "$URL_OLD" | tar xz -C /usr/local/bin oasdiff 2>/dev/null; then
+            echo "Installed oasdiff ${VERSION} (legacy naming)"
+          else
+            echo "::error::Failed to download oasdiff ${VERSION}" && exit 1
+          fi
 
       - name: Check for base spec
         id: base_exists

--- a/.github/workflows/openapi-diff.yml
+++ b/.github/workflows/openapi-diff.yml
@@ -31,10 +31,12 @@ jobs:
           path: base
 
       - name: Install oasdiff
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          VERSION=$(curl -sf https://api.github.com/repos/Tufin/oasdiff/releases/latest \
-            | python3 -c "import json,sys; print(json.load(sys.stdin)['tag_name'])")
-          # Try new goreleaser naming first (Linux_x86_64), fall back to old (linux_amd64)
+          # Resolve latest tag via gh CLI (avoids GitHub API rate-limit on anonymous curl)
+          VERSION=$(gh release view --repo Tufin/oasdiff --json tagName -q '.tagName')
+          # Try goreleaser naming (Linux_x86_64), fall back to legacy (linux_amd64)
           URL_NEW="https://github.com/Tufin/oasdiff/releases/download/${VERSION}/oasdiff_Linux_x86_64.tar.gz"
           URL_OLD="https://github.com/Tufin/oasdiff/releases/download/${VERSION}/oasdiff_linux_amd64.tar.gz"
           if curl -fsSL "$URL_NEW" | tar xz -C /usr/local/bin oasdiff 2>/dev/null; then

--- a/.github/workflows/recurrence-job.yml
+++ b/.github/workflows/recurrence-job.yml
@@ -1,8 +1,8 @@
 name: Recurrence Job
 
 on:
-  schedule:
-    - cron: "0 3 * * *"
+  # Schedule disabled: superseded by the Flask-command-based recurrence implementation.
+  # Kept as workflow_dispatch for emergency manual runs only.
   workflow_dispatch:
 
 concurrency:

--- a/api-tests/postman/auraxis.postman_collection.json
+++ b/api-tests/postman/auraxis.postman_collection.json
@@ -1,7 +1,7 @@
 {
   "info": {
     "name": "Auraxis API",
-    "description": "Auto-generated from openapi.json (60 paths). Do not edit manually — regenerate with: npm run postman:build",
+    "description": "Auto-generated from openapi.json (61 paths). Do not edit manually — regenerate with: npm run postman:build",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "item": [
@@ -1658,6 +1658,45 @@
                   "// so 404 is expected when the flow runs restore before force-delete.",
                   "pm.test('Force-delete transaction — expected 200 or 404', function () {",
                   "  pm.expect(pm.response.code).to.be.oneOf([200, 404]);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "GET — Exportar transações (CSV ou PDF)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/transactions/export",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "transactions",
+                "export"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Exportar transações (CSV ou PDF) — status 200', function () {",
+                  "  pm.response.to.have.status(200);",
                   "});"
                 ],
                 "type": "text/javascript"

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -16,6 +16,7 @@ from app.cli.features import features as features_cli_group
 from app.cli.openapi_export import openapi_export_command
 from app.controllers.account import account_bp
 from app.controllers.admin.feature_flags import admin_feature_flags_bp
+from app.controllers.advisory import advisory_bp
 from app.controllers.alert_controller import alert_bp, register_alert_dependencies
 from app.controllers.auth_controller import auth_bp, register_auth_dependencies
 from app.controllers.bank_statement import bank_statement_bp
@@ -297,6 +298,7 @@ def create_app(*, enable_http_runtime: bool = True) -> Flask:
     app.register_blueprint(fiscal_bp)
     app.register_blueprint(tag_bp)
     app.register_blueprint(budget_bp)
+    app.register_blueprint(advisory_bp)
     app.register_blueprint(admin_feature_flags_bp, url_prefix="/admin")
 
     # Registra os endpoints documentados no Swagger com base no mapa real de rotas.

--- a/app/application/services/advisory_service.py
+++ b/app/application/services/advisory_service.py
@@ -1,0 +1,324 @@
+"""AI Advisory Engine — generates personalised financial insights.
+
+Usage:
+    service = AdvisoryService(user_id=uid)
+    result = service.get_insights()
+
+The service gathers a financial snapshot, builds a prompt, calls the
+configured LLM provider, and returns structured insights.
+Insights are cached for 24 h and rate-limited to 5 calls/day per user.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import date, timedelta
+from typing import Any, TypedDict
+from uuid import UUID
+
+from sqlalchemy import case, func
+
+from app.extensions.database import db
+from app.models.goal import Goal
+from app.models.transaction import Transaction, TransactionStatus, TransactionType
+from app.models.wallet import Wallet
+from app.services.cache_service import get_cache_service
+from app.services.llm_provider import LLMProvider, LLMProviderError, get_llm_provider
+
+log = logging.getLogger(__name__)
+
+_CACHE_TTL_SECONDS = 86_400  # 24 h
+_RATE_LIMIT_CALLS = 5
+_RATE_LIMIT_WINDOW_SECONDS = 86_400  # 24 h
+
+
+class AdvisoryInsight(TypedDict):
+    type: str
+    title: str
+    message: str
+
+
+class AdvisoryResult(TypedDict):
+    insights: list[AdvisoryInsight]
+    generated_at: str
+    source: str  # "llm" | "stub" | "cache"
+    calls_remaining_today: int
+
+
+class AdvisoryRateLimitError(Exception):
+    """Raised when the user has exceeded the daily advisory rate limit."""
+
+
+class AdvisoryService:
+    def __init__(
+        self,
+        user_id: UUID,
+        *,
+        provider: LLMProvider | None = None,
+    ) -> None:
+        self._user_id = user_id
+        self._provider = provider or get_llm_provider()
+        self._cache = get_cache_service()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def get_insights(self) -> AdvisoryResult:
+        """Return insights for this user, respecting cache and rate limit."""
+        cache_key = f"advisory:insights:{self._user_id}"
+        rate_key = f"advisory:rate:{self._user_id}"
+
+        # Check cache first
+        cached: AdvisoryResult | None = self._cache.get(cache_key)
+        if cached is not None:
+            calls_used = int(self._cache.get(rate_key) or 0)
+            cached["calls_remaining_today"] = max(0, _RATE_LIMIT_CALLS - calls_used)
+            cached["source"] = "cache"
+            return cached
+
+        # Rate limit check
+        calls_used = int(self._cache.get(rate_key) or 0)
+        if calls_used >= _RATE_LIMIT_CALLS:
+            raise AdvisoryRateLimitError(
+                f"Limite de {_RATE_LIMIT_CALLS} chamadas de advisory por dia atingido."
+            )
+
+        # Generate insights
+        snapshot = self._build_snapshot()
+        prompt = _build_prompt(snapshot)
+
+        source = "llm"
+        try:
+            raw_text = self._provider.generate(prompt)
+        except LLMProviderError as exc:
+            log.warning("advisory.llm_error user=%s error=%s", self._user_id, exc)
+            raw_text = StubFallback.generate(snapshot)
+            source = "stub"
+
+        insights = _parse_insights(raw_text)
+        today_str = date.today().isoformat()
+        result: AdvisoryResult = {
+            "insights": insights,
+            "generated_at": today_str,
+            "source": source,
+            "calls_remaining_today": _RATE_LIMIT_CALLS - calls_used - 1,
+        }
+
+        # Persist cache + increment rate counter
+        self._cache.set(cache_key, result, ttl=_CACHE_TTL_SECONDS)
+        new_count = calls_used + 1
+        self._cache.set(rate_key, new_count, ttl=_RATE_LIMIT_WINDOW_SECONDS)
+
+        return result
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _build_snapshot(self) -> dict[str, Any]:
+        """Gather financial snapshot for the user (no PII)."""
+        today = date.today()
+        three_months_ago = today - timedelta(days=90)
+
+        # Expense / income totals over the last 3 months
+        agg = (
+            db.session.query(
+                func.coalesce(
+                    func.sum(
+                        case(
+                            (
+                                Transaction.type == TransactionType.EXPENSE,
+                                Transaction.amount,
+                            ),
+                            else_=0,
+                        )
+                    ),
+                    0,
+                ).label("expenses"),
+                func.coalesce(
+                    func.sum(
+                        case(
+                            (
+                                Transaction.type == TransactionType.INCOME,
+                                Transaction.amount,
+                            ),
+                            else_=0,
+                        )
+                    ),
+                    0,
+                ).label("income"),
+                func.count(Transaction.id).label("tx_count"),
+            )
+            .filter(
+                Transaction.user_id == self._user_id,
+                Transaction.deleted.is_(False),
+                Transaction.status == TransactionStatus.PAID,
+                Transaction.due_date >= three_months_ago,
+                Transaction.due_date <= today,
+            )
+            .one()
+        )
+
+        # Pending expenses (future obligations)
+        pending_total = (
+            db.session.query(func.coalesce(func.sum(Transaction.amount), 0))
+            .filter(
+                Transaction.user_id == self._user_id,
+                Transaction.deleted.is_(False),
+                Transaction.type == TransactionType.EXPENSE,
+                Transaction.status == TransactionStatus.PENDING,
+                Transaction.due_date >= today,
+            )
+            .scalar()
+        )
+
+        # Total assets from wallet
+        assets = (
+            db.session.query(func.coalesce(func.sum(Wallet.value), 0))
+            .filter(
+                Wallet.user_id == self._user_id,
+                Wallet.should_be_on_wallet.is_(True),
+                Wallet.value.isnot(None),
+            )
+            .scalar()
+        )
+
+        # Active goals (Goal has no deleted column)
+        active_goals = Goal.query.filter_by(
+            user_id=self._user_id, status="active"
+        ).all()
+        goals_summary = [
+            {
+                "title": g.title,
+                "target_amount": float(g.target_amount or 0),
+                "current_amount": float(g.current_amount or 0),
+                "progress_pct": round(
+                    float(g.current_amount or 0)
+                    / max(float(g.target_amount or 1), 1)
+                    * 100,
+                    1,
+                ),
+            }
+            for g in active_goals[:5]  # max 5 to keep prompt size small
+        ]
+
+        total_expense = float(agg.expenses or 0)
+        total_income = float(agg.income or 0)
+        avg_monthly_expense = round(total_expense / 3, 2)
+        avg_monthly_income = round(total_income / 3, 2)
+        total_assets = float(assets or 0)
+        savings_rate = (
+            round(
+                (avg_monthly_income - avg_monthly_expense) / avg_monthly_income * 100, 1
+            )
+            if avg_monthly_income > 0
+            else 0.0
+        )
+
+        return {
+            "avg_monthly_expense": avg_monthly_expense,
+            "avg_monthly_income": avg_monthly_income,
+            "savings_rate_pct": savings_rate,
+            "pending_obligations": float(pending_total or 0),
+            "total_assets": total_assets,
+            "survival_months": round(total_assets / avg_monthly_expense, 1)
+            if avg_monthly_expense > 0
+            else None,
+            "active_goals": goals_summary,
+            "tx_count_3m": int(agg.tx_count or 0),
+        }
+
+
+class StubFallback:
+    """Generates rule-based insights when the LLM is unavailable."""
+
+    @staticmethod
+    def generate(snapshot: dict[str, Any]) -> str:
+        insights = []
+        avg_exp = float(snapshot.get("avg_monthly_expense") or 0)
+        avg_inc = float(snapshot.get("avg_monthly_income") or 0)
+        savings = float(snapshot.get("savings_rate_pct") or 0)
+        survival = snapshot.get("survival_months")
+        goals = snapshot.get("active_goals") or []
+
+        if avg_inc > 0 and savings < 10:
+            insights.append(
+                "1. [gasto_elevado] Sua taxa de poupança está abaixo de 10%. "
+                "Tente reduzir gastos variáveis em pelo menos R$ "
+                f"{round(avg_exp * 0.05, 2)}/mês."
+            )
+        if survival is not None and float(survival) < 3:
+            insights.append(
+                "2. [reserva_critica] Sua reserva de emergência cobre menos de 3 meses. "  # noqa: E501
+                "Priorize construir um colchão financeiro antes de outros objetivos."
+            )
+        for g in goals:
+            if isinstance(g, dict) and float(g.get("progress_pct") or 0) < 30:
+                insights.append(
+                    f"3. [meta_em_risco] A meta '{g.get('title')}' está em "
+                    f"{g.get('progress_pct')}% — considere aumentar aportes mensais."
+                )
+                break
+        if not insights:
+            insights.append(
+                "1. [saude_financeira] Suas finanças estão equilibradas. "
+                "Continue monitorando suas metas e considere aumentar aportes em investimentos."  # noqa: E501
+            )
+        return "\n".join(insights)
+
+
+def _build_prompt(snapshot: dict[str, Any]) -> str:
+    context = json.dumps(snapshot, ensure_ascii=False, default=str)
+    types = "gasto_elevado, meta_em_risco, oportunidade_economia, reserva_critica, saude_financeira"  # noqa: E501
+    return (
+        "Você é um consultor financeiro pessoal. Analise os dados financeiros abaixo "
+        "(sem PII) e gere exatamente 3 insights práticos "
+        "em português brasileiro. Para cada insight: identifique o tipo "
+        f"({types}), "
+        "um título curto e uma mensagem clara com recomendação específica.\n\n"
+        f"Dados financeiros:\n{context}\n\n"
+        "Retorne um JSON array no formato:\n"
+        '[{"type": "...", "title": "...", "message": "..."}, ...]'
+    )
+
+
+def _parse_insights(raw: str) -> list[AdvisoryInsight]:
+    """Try to parse JSON from the LLM response; fall back to a single text insight."""
+    import re
+
+    # Extract JSON array from anywhere in the response
+    match = re.search(r"\[.*\]", raw, re.DOTALL)
+    if match:
+        try:
+            parsed = json.loads(match.group())
+            if isinstance(parsed, list):
+                return [
+                    AdvisoryInsight(
+                        type=str(item.get("type", "insight")),
+                        title=str(item.get("title", "Insight")),
+                        message=str(item.get("message", "")),
+                    )
+                    for item in parsed
+                    if isinstance(item, dict)
+                ]
+        except (json.JSONDecodeError, KeyError):
+            pass
+
+    # Fallback: wrap raw text as a single insight
+    return [
+        AdvisoryInsight(
+            type="insight",
+            title="Análise financeira",
+            message=raw.strip(),
+        )
+    ]
+
+
+__all__ = [
+    "AdvisoryInsight",
+    "AdvisoryRateLimitError",
+    "AdvisoryResult",
+    "AdvisoryService",
+]

--- a/app/application/services/installment_vs_cash_bridge_service.py
+++ b/app/application/services/installment_vs_cash_bridge_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime
 from decimal import ROUND_DOWN, Decimal
 from typing import Callable, cast
 from uuid import UUID
@@ -58,7 +59,7 @@ class InstallmentVsCashBridgeService:
                     "current_amount": _money_str(
                         Decimal(str(payload.get("current_amount", "0.00")))
                     ),
-                    "target_date": payload.get("target_date"),
+                    "target_date": _date_to_iso(payload.get("target_date")),
                     "priority": payload.get("priority", 3),
                     "status": "active",
                 }
@@ -193,3 +194,10 @@ def _compact_optional_fields(
     payload: dict[str, object | None],
 ) -> dict[str, object]:
     return {key: value for key, value in payload.items() if value is not None}
+
+
+def _date_to_iso(value: object) -> str | None:
+    """Convert a datetime.date to ISO string; downstream schemas expect strings."""
+    if isinstance(value, datetime.date):
+        return value.isoformat()
+    return None

--- a/app/application/services/transaction_query_service.py
+++ b/app/application/services/transaction_query_service.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import date, timedelta
-from typing import Any, Callable, TypedDict, cast
+from typing import Any, Callable, Literal, TypedDict, cast
 from uuid import UUID
 
 from sqlalchemy import case, func
@@ -12,6 +12,7 @@ from app.application.services.transaction_application_service import (
 )
 from app.extensions.database import db
 from app.models.transaction import Transaction, TransactionStatus, TransactionType
+from app.models.wallet import Wallet
 from app.services.transaction_analytics_service import TransactionAnalyticsService
 from app.services.transaction_serialization import (
     TransactionPayload,
@@ -86,6 +87,17 @@ class TransactionTrendsMonthEntry(TypedDict):
 class TransactionTrendsResult(TypedDict):
     months: int
     series: list[TransactionTrendsMonthEntry]
+
+
+SurvivalClassification = Literal["critical", "attention", "comfortable", "secure"]
+
+
+class SurvivalIndexResult(TypedDict):
+    survival_months: float | None
+    total_assets: float
+    avg_monthly_expense: float
+    classification: SurvivalClassification | None
+    period_analyzed_months: int
 
 
 class TransactionDueRangeResult(TypedDict):
@@ -382,11 +394,96 @@ class TransactionQueryService:
             int(row.expense_transactions or 0),
         )
 
+    def get_survival_index(self, *, period_months: int = 3) -> SurvivalIndexResult:
+        """Compute burn-rate survival index.
+
+        total_assets / avg_monthly_expense = months of runway.
+        avg_monthly_expense is the mean of PAID expenses across the last
+        *period_months* calendar months.
+        """
+        today = date.today()
+
+        # --- Total assets: wallet entries marked as on-wallet, with a value ---
+        assets_row = (
+            db.session.query(func.coalesce(func.sum(Wallet.value), 0).label("total"))
+            .filter(
+                Wallet.user_id == self._user_id,
+                Wallet.should_be_on_wallet.is_(True),
+                Wallet.value.isnot(None),
+            )
+            .one()
+        )
+        total_assets = float(assets_row.total or 0)
+
+        # --- Build period: 3 complete calendar months before current month ---
+        # e.g. today=April → period Jan 1 – March 31
+        year = today.year
+        anchor_month = today.month - period_months
+        while anchor_month <= 0:
+            anchor_month += 12
+            year -= 1
+        period_start = date(year, anchor_month, 1)
+
+        # Last day of previous complete month (avoid partial current month)
+        first_of_current = today.replace(day=1)
+        period_end = first_of_current - timedelta(days=1)
+
+        # Total expenses in period (PAID, non-deleted)
+        expense_row = (
+            db.session.query(
+                func.coalesce(func.sum(Transaction.amount), 0).label("total")
+            )
+            .filter(
+                Transaction.user_id == self._user_id,
+                Transaction.deleted.is_(False),
+                Transaction.type == TransactionType.EXPENSE,
+                Transaction.status == TransactionStatus.PAID,
+                Transaction.due_date >= period_start,
+                Transaction.due_date <= period_end,
+            )
+            .one()
+        )
+        total_expense = float(expense_row.total or 0)
+        avg_monthly_expense = round(total_expense / period_months, 2)
+
+        # --- Edge cases ---
+        if avg_monthly_expense == 0:
+            return {
+                "survival_months": None,
+                "total_assets": round(total_assets, 2),
+                "avg_monthly_expense": 0.0,
+                "classification": None,
+                "period_analyzed_months": period_months,
+            }
+
+        survival_months = round(total_assets / avg_monthly_expense, 2)
+        classification = _classify_survival(survival_months)
+
+        return {
+            "survival_months": survival_months,
+            "total_assets": round(total_assets, 2),
+            "avg_monthly_expense": avg_monthly_expense,
+            "classification": classification,
+            "period_analyzed_months": period_months,
+        }
+
     def _application_service(self) -> TransactionApplicationService:
         return self._dependencies.transaction_application_service_factory(self._user_id)
 
 
+def _classify_survival(months: float) -> SurvivalClassification:
+    if months < 3:
+        return "critical"
+    if months < 6:
+        return "attention"
+    if months <= 12:
+        return "comfortable"
+    return "secure"
+
+
 __all__ = [
+    "SurvivalClassification",
+    "SurvivalIndexResult",
     "TransactionCountsPayload",
     "TransactionDashboardResult",
     "TransactionDueRangeResult",

--- a/app/controllers/advisory/__init__.py
+++ b/app/controllers/advisory/__init__.py
@@ -1,0 +1,5 @@
+from . import routes as _routes  # noqa: F401
+from .blueprint import advisory_bp
+from .resources import AdvisoryInsightsResource
+
+__all__ = ["advisory_bp", "AdvisoryInsightsResource"]

--- a/app/controllers/advisory/blueprint.py
+++ b/app/controllers/advisory/blueprint.py
@@ -1,0 +1,3 @@
+from flask import Blueprint
+
+advisory_bp = Blueprint("advisory", __name__, url_prefix="/advisory")

--- a/app/controllers/advisory/resources.py
+++ b/app/controllers/advisory/resources.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from flask import Response
+from flask_apispec.views import MethodResource
+
+from app.application.services.advisory_service import (
+    AdvisoryRateLimitError,
+    AdvisoryService,
+)
+from app.auth import current_user_id
+from app.controllers.response_contract import (
+    compat_error_response,
+    compat_success_response,
+)
+from app.controllers.transaction.utils import _guard_revoked_token
+from app.docs.openapi_helpers import (
+    contract_header_param,
+    json_error_response,
+    json_success_response,
+)
+from app.utils.typed_decorators import typed_doc as doc
+from app.utils.typed_decorators import typed_jwt_required as jwt_required
+
+
+class AdvisoryInsightsResource(MethodResource):
+    @doc(
+        summary="Gerar insights financeiros personalizados (AI advisory)",
+        description=(
+            "Analisa os dados financeiros do usuário e retorna insights "
+            "personalizados gerados por LLM. "
+            "Insights são cacheados por 24 h. "
+            "Limite: 5 chamadas por dia por usuário."
+        ),
+        tags=["Advisory"],
+        security=[{"BearerAuth": []}],
+        params={
+            **contract_header_param(supported_version="v2"),
+        },
+        responses={
+            200: json_success_response(
+                description="Insights gerados com sucesso",
+                message="Insights financeiros gerados com sucesso",
+                data_example={
+                    "insights": [
+                        {
+                            "type": "gasto_elevado",
+                            "title": "Gastos acima da média",
+                            "message": "Gastos variáveis acima de 30% da renda.",
+                        }
+                    ],
+                    "generated_at": "2026-04-15",
+                    "source": "llm",
+                    "calls_remaining_today": 4,
+                },
+            ),
+            401: json_error_response(
+                description="Não autenticado",
+                message="Token inválido",
+                error_code="UNAUTHORIZED",
+                status_code=401,
+            ),
+            429: json_error_response(
+                description="Rate limit atingido",
+                message="Limite diário de advisory atingido.",
+                error_code="RATE_LIMIT_EXCEEDED",
+                status_code=429,
+            ),
+            500: json_error_response(
+                description="Erro interno",
+                message="Erro ao gerar insights",
+                error_code="INTERNAL_ERROR",
+                status_code=500,
+            ),
+        },
+    )
+    @jwt_required()
+    def get(self) -> Response:
+        token_error = _guard_revoked_token()
+        if token_error is not None:
+            return token_error
+
+        user_uuid = current_user_id()
+        service = AdvisoryService(user_id=user_uuid)
+
+        try:
+            result = service.get_insights()
+        except AdvisoryRateLimitError as exc:
+            return compat_error_response(
+                legacy_payload={"error": str(exc)},
+                status_code=429,
+                message=str(exc),
+                error_code="RATE_LIMIT_EXCEEDED",
+            )
+        except Exception:
+            return compat_error_response(
+                legacy_payload={"error": "Erro ao gerar insights de advisory"},
+                status_code=500,
+                message="Erro ao gerar insights de advisory",
+                error_code="INTERNAL_ERROR",
+            )
+
+        payload = dict(result)
+        return compat_success_response(
+            legacy_payload=payload,
+            status_code=200,
+            message="Insights financeiros gerados com sucesso",
+            data=payload,
+        )
+
+
+__all__ = ["AdvisoryInsightsResource"]

--- a/app/controllers/advisory/routes.py
+++ b/app/controllers/advisory/routes.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from .blueprint import advisory_bp
+from .resources import AdvisoryInsightsResource
+
+_ROUTES_REGISTERED = False
+
+
+def register_advisory_routes() -> None:
+    global _ROUTES_REGISTERED
+    if _ROUTES_REGISTERED:
+        return
+
+    advisory_bp.add_url_rule(
+        "/insights",
+        view_func=AdvisoryInsightsResource.as_view("insights"),
+        methods=["GET"],
+    )
+    _ROUTES_REGISTERED = True
+
+
+register_advisory_routes()

--- a/app/controllers/auth/register_resource.py
+++ b/app/controllers/auth/register_resource.py
@@ -143,6 +143,19 @@ class RegisterResource(MethodResource):
 
             db.session.commit()
 
+            # Sync trial entitlements (export_pdf, advanced_simulations, etc.)
+            from app.services.entitlement_service import (
+                sync_entitlements_from_subscription,
+            )
+
+            try:
+                sync_entitlements_from_subscription(trial_subscription)
+                db.session.commit()
+            except Exception:
+                current_app.logger.warning(
+                    "Failed to sync trial entitlements for user %s", user.id
+                )
+
             try:
                 dependencies.issue_email_confirmation(user)
             except Exception:

--- a/app/controllers/dashboard/__init__.py
+++ b/app/controllers/dashboard/__init__.py
@@ -1,5 +1,9 @@
 from . import routes as _routes  # noqa: F401
 from .blueprint import dashboard_bp
-from .resources import DashboardOverviewResource
+from .resources import DashboardOverviewResource, DashboardSurvivalIndexResource
 
-__all__ = ["dashboard_bp", "DashboardOverviewResource"]
+__all__ = [
+    "dashboard_bp",
+    "DashboardOverviewResource",
+    "DashboardSurvivalIndexResource",
+]

--- a/app/controllers/dashboard/resources.py
+++ b/app/controllers/dashboard/resources.py
@@ -311,4 +311,93 @@ class DashboardTrendsResource(MethodResource):
         return resp
 
 
-__all__ = ["DashboardOverviewResource", "DashboardTrendsResource"]
+class DashboardSurvivalIndexResource(MethodResource):
+    @doc(
+        summary="Índice de sobrevivência financeira (burn rate)",
+        description=(
+            "Calcula quantos meses o patrimônio atual sustenta o custo de vida médio. "
+            "Patrimônio = soma das entradas de carteira (should_be_on_wallet=True). "
+            "Custo médio = média de despesas pagas nos últimos 3 meses completos."
+        ),
+        tags=["Dashboard"],
+        security=[{"BearerAuth": []}],
+        params={
+            **contract_header_param(supported_version="v2"),
+        },
+        responses={
+            200: json_success_response(
+                description="Índice de sobrevivência calculado",
+                message="Índice de sobrevivência calculado com sucesso",
+                data_example={
+                    "survival_months": 8.5,
+                    "total_assets": 42500.00,
+                    "avg_monthly_expense": 5000.00,
+                    "classification": "comfortable",
+                    "period_analyzed_months": 3,
+                },
+            ),
+            401: json_error_response(
+                description="Token inválido",
+                message="Token revogado",
+                error_code="UNAUTHORIZED",
+                status_code=401,
+            ),
+            500: json_error_response(
+                description="Erro interno",
+                message="Erro ao calcular índice de sobrevivência",
+                error_code="INTERNAL_ERROR",
+                status_code=500,
+            ),
+        },
+    )
+    @jwt_required()
+    def get(self) -> Response:
+        token_error = _guard_revoked_token()
+        if token_error is not None:
+            return token_error
+
+        user_uuid = current_user_id()
+        cache = get_cache_service()
+        cache_key = f"dashboard:survival-index:{user_uuid}"
+
+        cached = cache.get(cache_key)
+        if cached is not None:
+            resp = compat_success_response(
+                legacy_payload=cached,
+                status_code=200,
+                message="Índice de sobrevivência calculado com sucesso",
+                data=cached,
+            )
+            resp.headers["X-Cache"] = "HIT"
+            return resp
+
+        dependencies = get_transaction_dependencies()
+        query_service = dependencies.transaction_query_service_factory(user_uuid)
+
+        try:
+            result = query_service.get_survival_index()
+        except Exception:
+            return compat_error_response(
+                legacy_payload={"error": "Erro ao calcular índice de sobrevivência"},
+                status_code=500,
+                message="Erro ao calcular índice de sobrevivência",
+                error_code="INTERNAL_ERROR",
+            )
+
+        payload: dict[str, Any] = dict(result)
+        cache.set(cache_key, payload, ttl=DASHBOARD_CACHE_TTL)
+        resp = compat_success_response(
+            legacy_payload=payload,
+            status_code=200,
+            message="Índice de sobrevivência calculado com sucesso",
+            data=payload,
+        )
+        resp.headers["X-Cache"] = "MISS"
+        return resp
+
+
+__all__ = [
+    "DashboardOverviewResource",
+    "DashboardSurvivalIndexResource",
+    "DashboardTrendsResource",
+]

--- a/app/controllers/dashboard/routes.py
+++ b/app/controllers/dashboard/routes.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 from .blueprint import dashboard_bp
-from .resources import DashboardOverviewResource, DashboardTrendsResource
+from .resources import (
+    DashboardOverviewResource,
+    DashboardSurvivalIndexResource,
+    DashboardTrendsResource,
+)
 
 _ROUTES_REGISTERED = False
 
@@ -19,6 +23,11 @@ def register_dashboard_routes() -> None:
     dashboard_bp.add_url_rule(
         "/trends",
         view_func=DashboardTrendsResource.as_view("trends"),
+        methods=["GET"],
+    )
+    dashboard_bp.add_url_rule(
+        "/survival-index",
+        view_func=DashboardSurvivalIndexResource.as_view("survival_index"),
         methods=["GET"],
     )
     _ROUTES_REGISTERED = True

--- a/app/controllers/transaction/export_resource.py
+++ b/app/controllers/transaction/export_resource.py
@@ -1,0 +1,192 @@
+"""GET /transactions/export — premium-gated CSV/PDF export.
+
+Query params
+------------
+format        : ``csv`` (default) or ``pdf``
+start_date    : YYYY-MM-DD  (inclusive)
+end_date      : YYYY-MM-DD  (inclusive)
+type          : ``income`` | ``expense``
+status        : ``paid`` | ``pending`` | ``cancelled`` | ``postponed`` | ``overdue``
+
+Entitlement
+-----------
+Requires the ``export_pdf`` feature (Premium / Trial plan).
+Free users receive 403 ENTITLEMENT_REQUIRED.
+
+Limit
+-----
+Maximum 10 000 transactions per export.  If the date range covers more rows
+than the limit the response contains the first 10 000 ordered by due_date asc.
+"""
+
+from __future__ import annotations
+
+from flask import Response, make_response, request
+from flask_apispec.views import MethodResource
+
+from app.application.errors import PublicValidationError
+from app.auth import current_user_id
+from app.docs.openapi_helpers import json_error_response
+from app.models.transaction import TransactionStatus, TransactionType
+from app.services.transaction_export_service import (
+    generate_csv_export,
+    generate_pdf_export,
+)
+from app.utils.typed_decorators import (
+    typed_doc as doc,
+)
+from app.utils.typed_decorators import (
+    typed_jwt_required as jwt_required,
+)
+from app.utils.typed_decorators import (
+    typed_require_entitlement as require_entitlement,
+)
+
+from .utils import (
+    _compat_error,
+    _internal_error_response,
+    _parse_optional_date,
+)
+
+_SUPPORTED_FORMATS = frozenset({"csv", "pdf"})
+_VALID_TYPES = {t.value: t for t in TransactionType}
+_VALID_STATUSES = {s.value: s for s in TransactionStatus}
+
+
+def _parse_export_params() -> dict[str, object]:
+    """Parse and validate query params for the export endpoint."""
+    fmt = (request.args.get("format") or "csv").lower()
+    if fmt not in _SUPPORTED_FORMATS:
+        raise PublicValidationError("Parâmetro 'format' inválido. Use 'csv' ou 'pdf'.")
+
+    start_date = _parse_optional_date(request.args.get("start_date"), "start_date")
+    end_date = _parse_optional_date(request.args.get("end_date"), "end_date")
+
+    if start_date and end_date and start_date > end_date:
+        raise PublicValidationError("'start_date' não pode ser posterior a 'end_date'.")
+
+    raw_type = request.args.get("type")
+    tx_type: TransactionType | None = None
+    if raw_type:
+        if raw_type not in _VALID_TYPES:
+            raise PublicValidationError(
+                "Parâmetro 'type' inválido. Use 'income' ou 'expense'."
+            )
+        tx_type = _VALID_TYPES[raw_type]
+
+    raw_status = request.args.get("status")
+    tx_status: TransactionStatus | None = None
+    if raw_status:
+        if raw_status not in _VALID_STATUSES:
+            raise PublicValidationError(
+                "Parâmetro 'status' inválido. "
+                "Use 'paid', 'pending', 'cancelled', 'postponed' ou 'overdue'."
+            )
+        tx_status = _VALID_STATUSES[raw_status]
+
+    # Build a label for filenames (e.g. "2026-01_2026-03")
+    parts = []
+    if start_date:
+        parts.append(start_date.strftime("%Y-%m"))
+    if end_date:
+        parts.append(end_date.strftime("%Y-%m"))
+    month_label = "_".join(parts)
+
+    return {
+        "format": fmt,
+        "start_date": start_date,
+        "end_date": end_date,
+        "tx_type": tx_type,
+        "tx_status": tx_status,
+        "month_label": month_label,
+    }
+
+
+class TransactionExportResource(MethodResource):
+    @doc(
+        summary="Exportar transações (CSV ou PDF)",
+        description=(
+            "Gera um arquivo com as transações do usuário no formato solicitado.\n\n"
+            "**Requer entitlement `export_pdf` (plano Premium ou Trial).**\n\n"
+            "Parâmetros:\n"
+            "- `format`: `csv` (padrão) ou `pdf`\n"
+            "- `start_date` / `end_date`: intervalo de `due_date` (YYYY-MM-DD)\n"
+            "- `type`: `income` | `expense`\n"
+            "- `status`: `paid` | `pending` | `cancelled` | `postponed` | `overdue`\n\n"
+            "Limite: máximo de 10 000 transações por export."
+        ),
+        tags=["Transações"],
+        responses={
+            200: {
+                "description": "Arquivo CSV ou PDF com as transações",
+                "content": {
+                    "text/csv": {},
+                    "application/pdf": {},
+                },
+            },
+            400: json_error_response(
+                description="Parâmetros inválidos",
+                message="Parâmetro 'format' inválido.",
+                error_code="VALIDATION_ERROR",
+                status_code=400,
+            ),
+            401: json_error_response(
+                description="Token ausente ou inválido",
+                message="Token ausente",
+                error_code="UNAUTHORIZED",
+                status_code=401,
+            ),
+            403: json_error_response(
+                description="Entitlement insuficiente — plano Premium necessário",
+                message="Feature 'export_pdf' requires an active entitlement.",
+                error_code="ENTITLEMENT_REQUIRED",
+                status_code=403,
+            ),
+        },
+    )
+    @jwt_required()
+    @require_entitlement("export_pdf")
+    def get(self) -> Response:
+        try:
+            params = _parse_export_params()
+        except PublicValidationError as exc:
+            return _compat_error(
+                legacy_payload={"error": str(exc)},
+                status_code=400,
+                message=str(exc),
+                error_code="VALIDATION_ERROR",
+            )
+
+        user_id = current_user_id()
+        fmt = str(params["format"])
+        try:
+            if fmt == "pdf":
+                result = generate_pdf_export(
+                    user_id=user_id,
+                    start_date=params["start_date"],  # type: ignore[arg-type]
+                    end_date=params["end_date"],  # type: ignore[arg-type]
+                    tx_type=params["tx_type"],  # type: ignore[arg-type]
+                    status=params["tx_status"],  # type: ignore[arg-type]
+                    month_label=str(params["month_label"]),
+                )
+            else:
+                result = generate_csv_export(
+                    user_id=user_id,
+                    start_date=params["start_date"],  # type: ignore[arg-type]
+                    end_date=params["end_date"],  # type: ignore[arg-type]
+                    tx_type=params["tx_type"],  # type: ignore[arg-type]
+                    status=params["tx_status"],  # type: ignore[arg-type]
+                    month_label=str(params["month_label"]),
+                )
+        except Exception:
+            return _internal_error_response(
+                message="Erro ao gerar o arquivo de exportação.",
+                log_context="transaction export generation failed",
+            )
+
+        response = make_response(result.content)
+        response.headers["Content-Type"] = result.content_type
+        response.headers["Content-Disposition"] = (
+            f'attachment; filename="{result.filename}"'
+        )
+        return response

--- a/app/controllers/transaction/routes.py
+++ b/app/controllers/transaction/routes.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from .blueprint import transaction_bp
+from .export_resource import TransactionExportResource
 from .report_resources import (
     TransactionCollectionResource,
     TransactionDeletedResource,
@@ -98,6 +99,11 @@ def register_transaction_routes() -> None:
     transaction_bp.add_url_rule(
         "/due-range",
         view_func=TransactionDuePeriodResource.as_view("transaction_due_period"),
+        methods=["GET"],
+    )
+    transaction_bp.add_url_rule(
+        "/export",
+        view_func=TransactionExportResource.as_view("transaction_export"),
         methods=["GET"],
     )
 

--- a/app/services/llm_provider.py
+++ b/app/services/llm_provider.py
@@ -1,0 +1,125 @@
+"""LLM provider abstraction for the AI advisory engine.
+
+Provider pattern: configure via LLM_PROVIDER env var.
+  - "stub"   (default) — rule-based insights, no external calls
+  - "openai" — OpenAI chat completions (requires OPENAI_API_KEY)
+  - "claude" — Anthropic Messages API (requires ANTHROPIC_API_KEY)
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Protocol, runtime_checkable
+
+
+class LLMProviderError(Exception):
+    """Raised when the LLM provider fails."""
+
+
+@runtime_checkable
+class LLMProvider(Protocol):
+    def generate(self, prompt: str) -> str:
+        """Generate a response for *prompt*. Raises LLMProviderError on failure."""
+        ...
+
+
+class StubLLMProvider:
+    """Canned response — useful for testing and environments without API keys."""
+
+    def generate(self, prompt: str) -> str:  # noqa: ARG002
+        return (  # noqa: E501
+            "Com base nos seus dados financeiros, identifiquei os seguintes insights: "
+            "1. Gastos discricionários >30% das despesas — revise esses valores. "  # noqa: E501
+            "2. Você tem metas ativas que podem estar em risco caso o ritmo de gastos atual continue. "  # noqa: E501
+            "3. Há uma oportunidade de economia de até 15% caso reduza gastos variáveis nos próximos 60 dias."  # noqa: E501
+        )
+
+
+class OpenAILLMProvider:
+    """Calls the OpenAI Chat Completions API (requires `requests` + OPENAI_API_KEY)."""
+
+    _BASE_URL = "https://api.openai.com/v1/chat/completions"
+
+    def __init__(self) -> None:
+        self._api_key = os.getenv("OPENAI_API_KEY", "")
+        self._model = os.getenv("OPENAI_ADVISORY_MODEL", "gpt-4o-mini")
+
+    def generate(self, prompt: str) -> str:
+        if not self._api_key:
+            raise LLMProviderError("OPENAI_API_KEY is not configured.")
+        import requests  # lazy import to keep startup fast
+
+        try:
+            resp = requests.post(
+                self._BASE_URL,
+                headers={
+                    "Authorization": f"Bearer {self._api_key}",
+                    "Content-Type": "application/json",
+                },
+                json={
+                    "model": self._model,
+                    "messages": [{"role": "user", "content": prompt}],
+                    "max_tokens": 512,
+                    "temperature": 0.4,
+                },
+                timeout=20,
+            )
+            resp.raise_for_status()
+            return str(resp.json()["choices"][0]["message"]["content"])
+        except Exception as exc:
+            raise LLMProviderError(f"OpenAI call failed: {exc}") from exc
+
+
+class ClaudeLLMProvider:
+    """Calls the Anthropic Messages API (requires `requests` + ANTHROPIC_API_KEY)."""
+
+    _BASE_URL = "https://api.anthropic.com/v1/messages"
+
+    def __init__(self) -> None:
+        self._api_key = os.getenv("ANTHROPIC_API_KEY", "")
+        self._model = os.getenv("ANTHROPIC_ADVISORY_MODEL", "claude-haiku-4-5-20251001")
+
+    def generate(self, prompt: str) -> str:
+        if not self._api_key:
+            raise LLMProviderError("ANTHROPIC_API_KEY is not configured.")
+        import requests
+
+        try:
+            resp = requests.post(
+                self._BASE_URL,
+                headers={
+                    "x-api-key": self._api_key,
+                    "anthropic-version": "2023-06-01",
+                    "Content-Type": "application/json",
+                },
+                json={
+                    "model": self._model,
+                    "max_tokens": 512,
+                    "messages": [{"role": "user", "content": prompt}],
+                },
+                timeout=20,
+            )
+            resp.raise_for_status()
+            return str(resp.json()["content"][0]["text"])
+        except Exception as exc:
+            raise LLMProviderError(f"Claude call failed: {exc}") from exc
+
+
+def get_llm_provider() -> LLMProvider:
+    """Factory: reads LLM_PROVIDER env var and returns the appropriate provider."""
+    provider_name = os.getenv("LLM_PROVIDER", "stub").lower()
+    if provider_name == "openai":
+        return OpenAILLMProvider()
+    if provider_name == "claude":
+        return ClaudeLLMProvider()
+    return StubLLMProvider()
+
+
+__all__ = [
+    "ClaudeLLMProvider",
+    "LLMProvider",
+    "LLMProviderError",
+    "OpenAILLMProvider",
+    "StubLLMProvider",
+    "get_llm_provider",
+]

--- a/app/services/transaction_export_service.py
+++ b/app/services/transaction_export_service.py
@@ -1,0 +1,252 @@
+"""Transaction export service — issue #1022.
+
+Generates CSV and PDF exports for a user's transactions.
+Both formats respect the same filters (date range, type, status).
+Export is gated behind the ``export_pdf`` entitlement (Premium plan).
+
+Limits
+------
+- Maximum 10 000 transactions per export to avoid memory / timeout issues.
+- Callers receive a structured ``ExportResult`` so the controller can set
+  appropriate headers without coupling to the generation logic.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+from app.models.transaction import Transaction, TransactionStatus, TransactionType
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+EXPORT_LIMIT = 10_000
+_DATE_FMT = "%d/%m/%Y"
+_CSV_COLUMNS = ["data", "tipo", "titulo", "valor", "status", "descricao"]
+
+
+@dataclass(frozen=True)
+class ExportResult:
+    content: bytes
+    content_type: str
+    filename: str
+
+
+# ---------------------------------------------------------------------------
+# Query
+# ---------------------------------------------------------------------------
+
+
+def _build_export_query(
+    *,
+    user_id: "UUID",
+    start_date: date | None,
+    end_date: date | None,
+    tx_type: TransactionType | None,
+    status: TransactionStatus | None,
+) -> list[Transaction]:
+    query = Transaction.query.filter_by(user_id=user_id, deleted=False)
+
+    if start_date is not None:
+        query = query.filter(Transaction.due_date >= start_date)
+    if end_date is not None:
+        query = query.filter(Transaction.due_date <= end_date)
+    if tx_type is not None:
+        query = query.filter(Transaction.type == tx_type)
+    if status is not None:
+        query = query.filter(Transaction.status == status)
+
+    results: list[Transaction] = (
+        query.order_by(Transaction.due_date.asc(), Transaction.created_at.asc())
+        .limit(EXPORT_LIMIT)
+        .all()
+    )
+    return results
+
+
+# ---------------------------------------------------------------------------
+# CSV
+# ---------------------------------------------------------------------------
+
+
+def _build_csv_rows(transactions: list[Transaction]) -> list[list[str]]:
+    rows: list[list[str]] = []
+    for tx in transactions:
+        rows.append(
+            [
+                tx.due_date.strftime(_DATE_FMT) if tx.due_date else "",
+                tx.type.value if tx.type else "",
+                tx.title or "",
+                str(Decimal(str(tx.amount)).quantize(Decimal("0.01"))),
+                tx.status.value if tx.status else "",
+                tx.description or "",
+            ]
+        )
+    return rows
+
+
+def generate_csv_export(
+    *,
+    user_id: "UUID",
+    start_date: date | None = None,
+    end_date: date | None = None,
+    tx_type: TransactionType | None = None,
+    status: TransactionStatus | None = None,
+    month_label: str = "",
+) -> ExportResult:
+    transactions = _build_export_query(
+        user_id=user_id,
+        start_date=start_date,
+        end_date=end_date,
+        tx_type=tx_type,
+        status=status,
+    )
+
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(_CSV_COLUMNS)
+    writer.writerows(_build_csv_rows(transactions))
+
+    filename = f"auraxis_transactions_{month_label or 'export'}.csv"
+    return ExportResult(
+        content=buf.getvalue().encode("utf-8-sig"),  # BOM for Excel compat
+        content_type="text/csv; charset=utf-8",
+        filename=filename,
+    )
+
+
+# ---------------------------------------------------------------------------
+# PDF
+# ---------------------------------------------------------------------------
+
+_LABEL_MAP: dict[str, str] = {
+    "income": "Receita",
+    "expense": "Despesa",
+    "paid": "Pago",
+    "pending": "Pendente",
+    "cancelled": "Cancelado",
+    "postponed": "Adiado",
+    "overdue": "Vencido",
+}
+
+
+def generate_pdf_export(
+    *,
+    user_id: "UUID",
+    start_date: date | None = None,
+    end_date: date | None = None,
+    tx_type: TransactionType | None = None,
+    status: TransactionStatus | None = None,
+    month_label: str = "",
+) -> ExportResult:
+    from reportlab.lib import colors
+    from reportlab.lib.pagesizes import A4
+    from reportlab.lib.styles import getSampleStyleSheet
+    from reportlab.lib.units import cm
+    from reportlab.platypus import (
+        Paragraph,
+        SimpleDocTemplate,
+        Spacer,
+        Table,
+        TableStyle,
+    )
+
+    transactions = _build_export_query(
+        user_id=user_id,
+        start_date=start_date,
+        end_date=end_date,
+        tx_type=tx_type,
+        status=status,
+    )
+
+    buf = io.BytesIO()
+    doc = SimpleDocTemplate(
+        buf,
+        pagesize=A4,
+        rightMargin=2 * cm,
+        leftMargin=2 * cm,
+        topMargin=2 * cm,
+        bottomMargin=2 * cm,
+    )
+    styles = getSampleStyleSheet()
+    elements = []
+
+    # Header
+    title_text = "Auraxis — Extrato de Transações"
+    if month_label:
+        title_text += f" ({month_label})"
+    elements.append(Paragraph(title_text, styles["Title"]))
+    elements.append(Spacer(1, 0.4 * cm))
+
+    # Summary line
+    total_income = sum(
+        Decimal(str(tx.amount))
+        for tx in transactions
+        if tx.type == TransactionType.INCOME
+    )
+    total_expense = sum(
+        Decimal(str(tx.amount))
+        for tx in transactions
+        if tx.type == TransactionType.EXPENSE
+    )
+    balance = total_income - total_expense
+    summary = (
+        f"Total de registros: {len(transactions)} | "
+        f"Receitas: R$ {total_income:.2f} | "
+        f"Despesas: R$ {total_expense:.2f} | "
+        f"Saldo: R$ {balance:.2f}"
+    )
+    elements.append(Paragraph(summary, styles["Normal"]))
+    elements.append(Spacer(1, 0.6 * cm))
+
+    # Table
+    header_row = ["Data", "Tipo", "Título", "Valor (R$)", "Status"]
+    table_data: list[list[str]] = [header_row]
+    for tx in transactions:
+        table_data.append(
+            [
+                tx.due_date.strftime(_DATE_FMT) if tx.due_date else "",
+                _LABEL_MAP.get(tx.type.value, tx.type.value) if tx.type else "",
+                (tx.title or "")[:50],
+                f"{Decimal(str(tx.amount)):.2f}",
+                _LABEL_MAP.get(tx.status.value, tx.status.value) if tx.status else "",
+            ]
+        )
+
+    col_widths = [2.5 * cm, 2.5 * cm, 7 * cm, 3 * cm, 2.5 * cm]
+    table = Table(table_data, colWidths=col_widths, repeatRows=1)
+    table.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#1a1a2e")),
+                ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+                ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                ("FONTSIZE", (0, 0), (-1, -1), 8),
+                (
+                    "ROWBACKGROUNDS",
+                    (0, 1),
+                    (-1, -1),
+                    [colors.white, colors.HexColor("#f5f5f5")],
+                ),
+                ("GRID", (0, 0), (-1, -1), 0.25, colors.HexColor("#cccccc")),
+                ("ALIGN", (3, 0), (3, -1), "RIGHT"),
+                ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+                ("TOPPADDING", (0, 0), (-1, -1), 4),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 4),
+            ]
+        )
+    )
+    elements.append(table)
+
+    doc.build(elements)
+    filename = f"auraxis_transactions_{month_label or 'export'}.pdf"
+    return ExportResult(
+        content=buf.getvalue(),
+        content_type="application/pdf",
+        filename=filename,
+    )

--- a/docs/adr/0002-graphql-ownership.md
+++ b/docs/adr/0002-graphql-ownership.md
@@ -1,0 +1,73 @@
+# ADR-0002: GraphQL Ownership — Queries somente, REST como dono do CRUD
+
+- Status: Accepted
+- Date: 2026-04-15
+- Deciders: Engineering
+- Related issues: #1021
+
+## Contexto
+
+A API Auraxis nasceu com duas superfícies paralelas: REST (Flask controllers) e GraphQL (Ariadne).
+Com o tempo, mutations GraphQL foram adicionadas para CRUD de transações, metas e carteira — duplicando
+a lógica de negócio já presente nos controllers REST e criando dois pontos de entrada para a mesma operação.
+
+Problemas identificados:
+
+1. **Duplicação de validação** — schemas Marshmallow (REST) e resolvers GraphQL implementam
+   as mesmas regras de negócio de formas diferentes, gerando drift silencioso.
+2. **Cobertura desigual** — testes de integração cobrem o caminho REST; o caminho GraphQL
+   tem cobertura menor e contrato não documentado no OpenAPI.
+3. **Autorização em dois lugares** — guards de entitlement precisam ser replicados em cada mutation
+   e em cada controller REST.
+4. **Custo de manutenção** — cada nova feature que toca CRUD precisa ser implementada em ambas
+   as superfícies.
+
+## Decisão
+
+**GraphQL passa a ser somente de leitura** no escopo de mutations CRUD de domínio.
+
+Regras derivadas:
+
+1. **Mutations de CRUD de domínio** (Transaction, Goal, Wallet/WalletEntry) ficam **deprecated**
+   com `deprecation_reason` explícito no schema GraphQL, apontando para o endpoint REST equivalente.
+2. **Novas mutations GraphQL** só são permitidas para operações que não têm representação REST
+   natural (ex.: subscrições, operações compostas cross-domínio sem ID canônico).
+3. **Queries GraphQL continuam normalmente** — são a forma preferida para agregações complexas
+   que seriam custosas em REST (ex.: dashboard com múltiplos relacionamentos em um único roundtrip).
+4. **Remoção das mutations deprecated** só ocorre após ADR de remoção explícito e ciclo de
+   depreciação mínimo de 2 sprints com anúncio no changelog.
+
+## Mutations deprecadas nesta decisão
+
+| Mutation | Substituto REST |
+|---|---|
+| `createTransaction` | `POST /transactions` |
+| `updateTransaction` | `PATCH /transactions/{id}` |
+| `deleteTransaction` | `DELETE /transactions/{id}` |
+| `createGoal` | `POST /goals` |
+| `updateGoal` | `PATCH /goals/{id}` |
+| `deleteGoal` | `DELETE /goals/{id}` |
+| `addWalletEntry` | `POST /wallet` |
+| `updateWalletEntry` | `PATCH /wallet/{id}` |
+| `deleteWalletEntry` | `DELETE /wallet/{id}` |
+
+## Consequências
+
+**Positivas:**
+- Uma única fonte de verdade para validação (schemas Marshmallow).
+- OpenAPI cobre 100% do contrato público.
+- Autorização centralizada nos controllers REST.
+- Menor surface area para testes de integração.
+
+**Negativas:**
+- Clientes que consomem mutations GraphQL precisam migrar para REST.
+  Mitigação: `deprecation_reason` no schema avisa ferramentas GraphQL (ex.: Apollo Studio).
+- Queries GraphQL complexas que misturam leitura com side-effects precisam de avaliação
+  caso a caso antes de serem adicionadas.
+
+## Alternativas consideradas
+
+- **Manter ambas as superfícies em paridade** — descartado pelo custo de manutenção e
+  pelo risco de drift de contrato.
+- **Remover GraphQL completamente** — descartado porque queries GraphQL ainda agregam
+  valor para o client web em operações de leitura complexas.

--- a/openapi.json
+++ b/openapi.json
@@ -2,6 +2,7 @@
   "components": {
     "schemas": {
       "InstallmentVsCashCalculation": {
+        "additionalProperties": false,
         "properties": {
           "cash_price": {
             "minimum": 0.01,
@@ -75,6 +76,7 @@
         "type": "object"
       },
       "InstallmentVsCashGoalBridge": {
+        "additionalProperties": false,
         "properties": {
           "category": {
             "default": "planned_purchase",
@@ -125,6 +127,7 @@
         "type": "object"
       },
       "InstallmentVsCashPlannedExpenseBridge": {
+        "additionalProperties": false,
         "properties": {
           "account_id": {
             "default": null,
@@ -211,6 +214,7 @@
         "type": "object"
       },
       "InstallmentVsCashSave": {
+        "additionalProperties": false,
         "properties": {
           "cash_price": {
             "minimum": 0.01,
@@ -284,6 +288,7 @@
         "type": "object"
       },
       "TransactionCreate": {
+        "additionalProperties": false,
         "properties": {
           "account_id": {
             "description": "ID da conta bancária associada",
@@ -446,6 +451,7 @@
         "type": "object"
       },
       "TransactionCreate_7d3b606eab": {
+        "additionalProperties": false,
         "properties": {
           "account_id": {
             "description": "ID da conta bancária associada",
@@ -602,6 +608,7 @@
         "type": "object"
       },
       "app_schemas_auth_schema_AuthSchema": {
+        "additionalProperties": false,
         "properties": {
           "captcha_token": {
             "default": null,
@@ -629,6 +636,7 @@
         "type": "object"
       },
       "app_schemas_auth_schema_ConfirmEmailSchema": {
+        "additionalProperties": false,
         "properties": {
           "token": {
             "description": "Token de confirmacao recebido por email",
@@ -644,6 +652,7 @@
         "type": "object"
       },
       "app_schemas_auth_schema_ForgotPasswordSchema": {
+        "additionalProperties": false,
         "properties": {
           "email": {
             "description": "Email da conta que deseja recuperar acesso",
@@ -658,6 +667,7 @@
         "type": "object"
       },
       "app_schemas_auth_schema_ResetPasswordSchema": {
+        "additionalProperties": false,
         "properties": {
           "new_password": {
             "description": "Nova senha (mínimo 10 caracteres, com maiúscula, número e símbolo)",
@@ -681,6 +691,7 @@
         "type": "object"
       },
       "app_schemas_user_schemas_DeleteAccountSchema": {
+        "additionalProperties": false,
         "properties": {
           "password": {
             "description": "Senha atual do usuário para confirmar a exclusão da conta",
@@ -695,6 +706,7 @@
         "type": "object"
       },
       "app_schemas_user_schemas_QuestionnaireAnswerSchema": {
+        "additionalProperties": false,
         "properties": {
           "answers": {
             "description": "Lista de 5 respostas — pontos da opção escolhida em cada pergunta (1–3).",
@@ -714,6 +726,7 @@
         "type": "object"
       },
       "app_schemas_user_schemas_SalaryIncreaseSimulationRequestSchema": {
+        "additionalProperties": false,
         "properties": {
           "base_date": {
             "description": "Data base do salário atual",
@@ -749,6 +762,7 @@
         "type": "object"
       },
       "app_schemas_user_schemas_UserProfileSchema": {
+        "additionalProperties": false,
         "properties": {
           "birth_date": {
             "description": "Data de nascimento",
@@ -861,6 +875,7 @@
         "type": "object"
       },
       "app_schemas_user_schemas_UserRegistrationSchema": {
+        "additionalProperties": false,
         "properties": {
           "captcha_token": {
             "default": null,
@@ -5106,6 +5121,151 @@
           }
         ],
         "summary": "Listar despesas por período (compatibilidade)",
+        "tags": [
+          "Transações"
+        ]
+      }
+    },
+    "/transactions/export": {
+      "get": {
+        "description": "Gera um arquivo com as transações do usuário no formato solicitado.\n\n**Requer entitlement `export_pdf` (plano Premium ou Trial).**\n\nParâmetros:\n- `format`: `csv` (padrão) ou `pdf`\n- `start_date` / `end_date`: intervalo de `due_date` (YYYY-MM-DD)\n- `type`: `income` | `expense`\n- `status`: `paid` | `pending` | `cancelled` | `postponed` | `overdue`\n\nLimite: máximo de 10 000 transações por export.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/pdf": {},
+              "text/csv": {}
+            },
+            "description": "Arquivo CSV ou PDF com as transações"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "VALIDATION_ERROR",
+                  "message": "Parâmetro 'format' inválido.",
+                  "status_code": 400
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Parâmetros inválidos",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token ausente",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token ausente ou inválido",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "ENTITLEMENT_REQUIRED",
+                  "message": "Feature 'export_pdf' requires an active entitlement.",
+                  "status_code": 403
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Entitlement insuficiente — plano Premium necessário",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Exportar transações (CSV ou PDF)",
         "tags": [
           "Transações"
         ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,3 +41,4 @@ webargs==8.7.1
 Werkzeug==3.1.8
 types-python-dateutil==2.9.0.20260408
 types-requests==2.33.0.20260402
+reportlab==4.4.0

--- a/tests/test_advisory.py
+++ b/tests/test_advisory.py
@@ -1,0 +1,206 @@
+"""Tests for GET /advisory/insights (issue #1026).
+
+Covers:
+- Unauthenticated returns 401
+- Authenticated user gets insights
+- Response shape: insights list, generated_at, source, calls_remaining_today
+- Stub provider returns insights without external calls
+- LLM error triggers fallback (stub)
+- Rate limit: 5 calls/day per user (mocked cache)
+- Cache hit returns source=cache
+- _parse_insights handles JSON, fallback text
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.application.services.advisory_service import (
+    AdvisoryRateLimitError,
+    AdvisoryService,
+    _parse_insights,
+)
+from app.services.llm_provider import LLMProviderError, StubLLMProvider
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _register_and_login(client, prefix: str) -> str:
+    suffix = uuid.uuid4().hex[:8]
+    email = f"{prefix}-{suffix}@email.com"
+    password = "StrongPass@123"
+    reg = client.post(
+        "/auth/register",
+        json={"name": f"{prefix}-{suffix}", "email": email, "password": password},
+    )
+    assert reg.status_code == 201
+    login = client.post("/auth/login", json={"email": email, "password": password})
+    assert login.status_code == 200
+    return login.get_json()["token"]
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ---------------------------------------------------------------------------
+# Auth gate
+# ---------------------------------------------------------------------------
+
+
+class TestAdvisoryAuthGate:
+    def test_unauthenticated_returns_401(self, client) -> None:
+        resp = client.get("/advisory/insights")
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+class TestAdvisoryInsights:
+    def test_authenticated_user_gets_200(self, app, client) -> None:
+        token = _register_and_login(client, prefix="adv-ok")
+        resp = client.get("/advisory/insights", headers=_auth(token))
+        assert resp.status_code == 200
+
+    def test_response_has_required_keys(self, app, client) -> None:
+        token = _register_and_login(client, prefix="adv-keys")
+        resp = client.get("/advisory/insights", headers=_auth(token))
+        assert resp.status_code == 200
+        body = resp.get_json()
+        data = body.get("data") or body
+        required = {"insights", "generated_at", "source", "calls_remaining_today"}
+        assert required.issubset(data.keys())
+
+    def test_insights_is_list(self, app, client) -> None:
+        token = _register_and_login(client, prefix="adv-list")
+        resp = client.get("/advisory/insights", headers=_auth(token))
+        data = resp.get_json().get("data") or resp.get_json()
+        assert isinstance(data["insights"], list)
+        assert len(data["insights"]) >= 1
+
+    def test_each_insight_has_type_title_message(self, app, client) -> None:
+        token = _register_and_login(client, prefix="adv-shape")
+        resp = client.get("/advisory/insights", headers=_auth(token))
+        data = resp.get_json().get("data") or resp.get_json()
+        for insight in data["insights"]:
+            assert "type" in insight
+            assert "title" in insight
+            assert "message" in insight
+
+    def test_second_call_returns_cache(self, app) -> None:
+        """With a real (mocked) cache, second call returns source=cache."""
+        with app.app_context():
+            user_id = uuid.uuid4()
+            cached_result = {
+                "insights": [{"type": "test", "title": "T", "message": "M"}],
+                "generated_at": "2026-04-15",
+                "source": "llm",
+                "calls_remaining_today": 4,
+            }
+            cache_mock = MagicMock()
+            # First call: insights cache miss, rate miss → generates
+            # Second call: insights cache hit → returns cached
+            cache_mock.get.side_effect = lambda key: (
+                cached_result if "insights" in key else 0
+            )
+
+            service = AdvisoryService(user_id=user_id)
+            service._cache = cache_mock
+
+            result = service.get_insights()
+            assert result["source"] == "cache"
+
+
+# ---------------------------------------------------------------------------
+# Rate limit
+# ---------------------------------------------------------------------------
+
+
+class TestAdvisoryRateLimit:
+    def test_rate_limit_raises_after_5_calls(self, app) -> None:
+        with app.app_context():
+            user_id = uuid.uuid4()
+            cache_mock = MagicMock()
+            # Simulate 5 used calls; rate key → 5, insights key → None
+            cache_mock.get.side_effect = lambda key: 5 if "rate" in key else None
+
+            service = AdvisoryService(user_id=user_id)
+            service._cache = cache_mock
+
+            with pytest.raises(AdvisoryRateLimitError):
+                service.get_insights()
+
+
+# ---------------------------------------------------------------------------
+# LLM provider fallback
+# ---------------------------------------------------------------------------
+
+
+class TestAdvisoryLLMFallback:
+    def test_llm_error_falls_back_to_stub(self, app) -> None:
+        with app.app_context():
+            user_id = uuid.uuid4()
+
+            broken_provider = MagicMock()
+            broken_provider.generate.side_effect = LLMProviderError("API unavailable")
+
+            cache_mock = MagicMock()
+            cache_mock.get.return_value = None
+
+            service = AdvisoryService(user_id=user_id, provider=broken_provider)
+            service._cache = cache_mock
+
+            result = service.get_insights()
+            assert result["source"] == "stub"
+            assert len(result["insights"]) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Provider unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestStubLLMProvider:
+    def test_generates_non_empty_string(self) -> None:
+        provider = StubLLMProvider()
+        output = provider.generate("any prompt")
+        assert isinstance(output, str)
+        assert len(output) > 10
+
+
+# ---------------------------------------------------------------------------
+# _parse_insights unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseInsights:
+    def test_parses_valid_json_array(self) -> None:
+        raw = '[{"type": "gasto_elevado", "title": "Altos", "message": "Reduza"}]'
+        insights = _parse_insights(raw)
+        assert len(insights) == 1
+        assert insights[0]["type"] == "gasto_elevado"
+        assert insights[0]["title"] == "Altos"
+
+    def test_fallback_on_invalid_json(self) -> None:
+        raw = "Aqui estão seus insights financeiros..."
+        insights = _parse_insights(raw)
+        assert len(insights) == 1
+        assert insights[0]["type"] == "insight"
+        assert "Aqui" in insights[0]["message"]
+
+    def test_json_embedded_in_text(self) -> None:
+        raw = (
+            "Análise completa:\n\n"
+            '[{"type": "meta_em_risco", "title": "Meta", "message": "Aporte"}]\n\n'
+            "Espero que ajude!"
+        )
+        insights = _parse_insights(raw)
+        assert insights[0]["type"] == "meta_em_risco"

--- a/tests/test_dashboard_survival_index.py
+++ b/tests/test_dashboard_survival_index.py
@@ -1,0 +1,202 @@
+"""Tests for GET /dashboard/survival-index (issue #1024).
+
+Covers:
+- Unauthenticated returns 401
+- New user with no data returns graceful null (no expenses)
+- User with wallet + paid expenses returns correct index and classification
+- Classification boundaries: critical <3, attention 3-6, comfortable 6-12, secure >12
+- Zero assets returns survival_months = 0
+- Service unit: _classify_survival helper
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, date, datetime
+from decimal import Decimal
+
+from app.application.services.transaction_query_service import _classify_survival
+from app.extensions.database import db
+from app.models.transaction import Transaction, TransactionStatus, TransactionType
+from app.models.wallet import Wallet
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _register_and_login(client, prefix: str) -> tuple[str, str]:
+    suffix = uuid.uuid4().hex[:8]
+    email = f"{prefix}-{suffix}@email.com"
+    password = "StrongPass@123"
+    reg = client.post(
+        "/auth/register",
+        json={"name": f"{prefix}-{suffix}", "email": email, "password": password},
+    )
+    assert reg.status_code == 201
+    login = client.post("/auth/login", json={"email": email, "password": password})
+    assert login.status_code == 200
+    token = login.get_json()["token"]
+    profile = client.get(
+        "/user/profile", headers={"Authorization": f"Bearer {token}"}
+    ).get_json()
+    user_id = profile.get("data", {}).get("id") or profile.get("user", {}).get("id")
+    return token, user_id
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _seed_wallet(app, user_id: str, *, value: str) -> None:
+    with app.app_context():
+        w = Wallet(
+            user_id=uuid.UUID(user_id),
+            name="Test Asset",
+            value=Decimal(value),
+            should_be_on_wallet=True,
+            asset_class="custom",
+            register_date=date(2026, 1, 1),
+        )
+        db.session.add(w)
+        db.session.commit()
+
+
+def _seed_paid_expense(app, user_id: str, *, amount: str, due_date: date) -> None:
+    with app.app_context():
+        tx = Transaction(
+            user_id=uuid.UUID(user_id),
+            title="Expense",
+            amount=Decimal(amount),
+            type=TransactionType.EXPENSE,
+            status=TransactionStatus.PAID,
+            due_date=due_date,
+            paid_at=datetime.now(UTC),
+        )
+        db.session.add(tx)
+        db.session.commit()
+
+
+# ---------------------------------------------------------------------------
+# Auth gate
+# ---------------------------------------------------------------------------
+
+
+class TestSurvivalIndexAuth:
+    def test_unauthenticated_returns_401(self, client) -> None:
+        resp = client.get("/dashboard/survival-index")
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# No data edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestSurvivalIndexNoData:
+    def test_no_expenses_returns_null_survival(self, app, client) -> None:
+        token, user_id = _register_and_login(client, prefix="si-noexp")
+        _seed_wallet(app, user_id, value="50000.00")
+
+        resp = client.get("/dashboard/survival-index", headers=_auth(token))
+        assert resp.status_code == 200
+        body = resp.get_json()
+        data = body.get("data") or body
+        assert data["survival_months"] is None
+        assert data["classification"] is None
+        assert data["total_assets"] == 50000.0
+
+    def test_no_assets_returns_zero_or_null(self, app, client) -> None:
+        token, user_id = _register_and_login(client, prefix="si-noasset")
+        today = date.today()
+        # Seed one paid expense in the last 3 months
+        prev = today.replace(day=1)
+        y = prev.year if prev.month > 1 else prev.year - 1
+        m = prev.month - 1 if prev.month > 1 else 12
+        exp_date = date(y, m, 15)
+        _seed_paid_expense(app, user_id, amount="1000.00", due_date=exp_date)
+
+        resp = client.get("/dashboard/survival-index", headers=_auth(token))
+        assert resp.status_code == 200
+        body = resp.get_json()
+        data = body.get("data") or body
+        assert data["total_assets"] == 0.0
+        assert data["survival_months"] == 0.0
+
+    def test_new_user_no_data_is_graceful(self, app, client) -> None:
+        token, _uid = _register_and_login(client, prefix="si-new")
+        resp = client.get("/dashboard/survival-index", headers=_auth(token))
+        assert resp.status_code == 200
+        body = resp.get_json()
+        data = body.get("data") or body
+        assert data["survival_months"] is None
+        assert data["total_assets"] == 0.0
+        assert data["avg_monthly_expense"] == 0.0
+        assert data["period_analyzed_months"] == 3
+
+
+# ---------------------------------------------------------------------------
+# Correct calculation
+# ---------------------------------------------------------------------------
+
+
+class TestSurvivalIndexCalculation:
+    def test_correct_index_calculation(self, app, client) -> None:
+        """45000 assets / (3000/month avg) = 15 months → secure."""
+        token, user_id = _register_and_login(client, prefix="si-calc")
+        _seed_wallet(app, user_id, value="45000.00")
+
+        today = date.today()
+        for i in range(1, 4):  # 3 previous months
+            y, m = today.year, today.month - i
+            while m <= 0:
+                m += 12
+                y -= 1
+            _seed_paid_expense(app, user_id, amount="3000.00", due_date=date(y, m, 15))
+
+        resp = client.get("/dashboard/survival-index", headers=_auth(token))
+        assert resp.status_code == 200
+        body = resp.get_json()
+        data = body.get("data") or body
+        assert data["total_assets"] == 45000.0
+        assert data["avg_monthly_expense"] == 3000.0
+        assert data["survival_months"] == 15.0
+        assert data["classification"] == "secure"
+
+    def test_response_has_all_required_keys(self, app, client) -> None:
+        token, _uid = _register_and_login(client, prefix="si-keys")
+        resp = client.get("/dashboard/survival-index", headers=_auth(token))
+        assert resp.status_code == 200
+        body = resp.get_json()
+        data = body.get("data") or body
+        required = {
+            "survival_months",
+            "total_assets",
+            "avg_monthly_expense",
+            "classification",
+            "period_analyzed_months",
+        }
+        assert required.issubset(data.keys())
+
+
+# ---------------------------------------------------------------------------
+# Classification unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestClassifySurvival:
+    def test_critical(self) -> None:
+        assert _classify_survival(0.0) == "critical"
+        assert _classify_survival(2.9) == "critical"
+
+    def test_attention(self) -> None:
+        assert _classify_survival(3.0) == "attention"
+        assert _classify_survival(5.9) == "attention"
+
+    def test_comfortable(self) -> None:
+        assert _classify_survival(6.0) == "comfortable"
+        assert _classify_survival(12.0) == "comfortable"
+
+    def test_secure(self) -> None:
+        assert _classify_survival(12.1) == "secure"
+        assert _classify_survival(100.0) == "secure"

--- a/tests/test_entitlement_contract.py
+++ b/tests/test_entitlement_contract.py
@@ -60,12 +60,16 @@ def _grant_entitlement(
 # ---------------------------------------------------------------------------
 
 
-def test_entitlements_list_empty(client) -> None:
-    token = _register_and_login(client, prefix="ent-empty")
+def test_entitlements_list_trial_user_has_trial_features(client) -> None:
+    """New users are bootstrapped into a trial subscription with trial entitlements."""
+    from app.config.plan_features import PLAN_FEATURES
+
+    token = _register_and_login(client, prefix="ent-trial")
     resp = client.get("/entitlements", headers=_auth(token))
     assert resp.status_code == 200
     body = resp.get_json()
-    assert body["items"] == []
+    granted_keys = {e["feature_key"] for e in body["items"]}
+    assert granted_keys == set(PLAN_FEATURES["trial"])
 
 
 def test_entitlements_list_requires_auth(client) -> None:

--- a/tests/test_installment_vs_cash_contract.py
+++ b/tests/test_installment_vs_cash_contract.py
@@ -126,7 +126,16 @@ def test_installment_vs_cash_save_alias_emits_deprecation_headers(client) -> Non
 
 
 def test_installment_vs_cash_goal_bridge_requires_entitlement(client) -> None:
-    token, _email = _register_and_login(client, prefix="installment-goal-noent")
+    token, email = _register_and_login(client, prefix="installment-goal-noent")
+    # Simulate a downgraded/free user by revoking the trial entitlement
+    with client.application.app_context():
+        from app.extensions.database import db
+        from app.services.entitlement_service import revoke_entitlement
+
+        user = User.query.filter_by(email=email).first()
+        assert user is not None
+        revoke_entitlement(user.id, "advanced_simulations")
+        db.session.commit()
     save_response = client.post(
         "/simulations/installment-vs-cash",
         json=_payload(),

--- a/tests/test_j12_entitlement_enforcement.py
+++ b/tests/test_j12_entitlement_enforcement.py
@@ -287,10 +287,21 @@ def test_sync_grants_trial_features_for_trialing_sub(app) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_require_entitlement_returns_false_for_missing_feature(client) -> None:
+def test_require_entitlement_returns_false_for_missing_feature(app, client) -> None:
     """Check endpoint reports no access when user lacks the feature."""
+    from app.services.entitlement_service import revoke_entitlement
+
     token = _register_and_login(client)
-    # The user has no entitlements — check endpoint should show no access
+    # Fetch user_id from profile before entering app context
+    profile_resp = client.get("/user/profile", headers=_auth(token))
+    profile_body = profile_resp.get_json()
+    user_id = uuid.UUID(
+        profile_body.get("data", {}).get("id") or profile_body.get("user", {}).get("id")
+    )
+    # Revoke the trial entitlement to simulate a free/downgraded user
+    with app.app_context():
+        revoke_entitlement(user_id, "export_pdf")
+        db.session.commit()
     response = client.get(
         "/entitlements/check?feature_key=export_pdf",
         headers=_auth(token),
@@ -326,6 +337,17 @@ def test_require_entitlement_decorator_returns_403_when_missing(app, client) -> 
 
     # Use a real registered user so auth guard allows the request
     token = _register_and_login(client)
+    # Fetch user_id from profile, then revoke trial entitlement to simulate free-tier
+    from app.services.entitlement_service import revoke_entitlement
+
+    profile_resp = client.get("/user/profile", headers=_auth(token))
+    profile_body = profile_resp.get_json()
+    user_id = uuid.UUID(
+        profile_body.get("data", {}).get("id") or profile_body.get("user", {}).get("id")
+    )
+    with app.app_context():
+        revoke_entitlement(user_id, "export_pdf")
+        db.session.commit()
 
     resp = client.get(
         "/test-j12-entitlement-required",

--- a/tests/test_postman_collection_contract.py
+++ b/tests/test_postman_collection_contract.py
@@ -149,6 +149,10 @@ OPENAPI_GAPS: set[tuple[str, str]] = {
     # Bank statements
     ("POST", "/bank-statements/preview"),
     ("POST", "/bank-statements/confirm"),
+    # Advisory (not yet in apispec-documented blueprints)
+    ("GET", "/advisory/insights"),
+    # Dashboard survival index (not yet in apispec-documented blueprints)
+    ("GET", "/dashboard/survival-index"),
 }
 
 

--- a/tests/test_transaction_export.py
+++ b/tests/test_transaction_export.py
@@ -92,8 +92,16 @@ def _create_transaction(
 
 
 class TestExportEntitlementGate:
-    def test_free_user_gets_403(self, client) -> None:
-        token, _ = _register_and_login(client, prefix="export-free")
+    def test_free_user_gets_403(self, app, client) -> None:
+        from app.services.entitlement_service import revoke_entitlement
+
+        token, user_id = _register_and_login(client, prefix="export-free")
+        # Revoke the trial entitlement to simulate a free/downgraded user
+        with app.app_context():
+            revoke_entitlement(uuid.UUID(user_id), "export_pdf")
+            from app.extensions.database import db as _db
+
+            _db.session.commit()
         resp = client.get("/transactions/export", headers=_auth(token))
         assert resp.status_code == 403
         body = resp.get_json()

--- a/tests/test_transaction_export.py
+++ b/tests/test_transaction_export.py
@@ -1,0 +1,305 @@
+"""Tests for GET /transactions/export (issue #1022).
+
+Covers:
+- CSV export returns valid CSV with correct columns
+- PDF export returns valid PDF bytes
+- Free user (no export_pdf entitlement) receives 403 ENTITLEMENT_REQUIRED
+- Premium user receives file
+- Filters (type, status, date range) narrow results correctly
+- Invalid format parameter returns 400
+- Export with zero transactions returns empty CSV (headers only)
+- Export limit is respected (mocked)
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import uuid
+from datetime import date
+from decimal import Decimal
+
+from app.extensions.database import db
+from app.models.entitlement import Entitlement, EntitlementSource
+from app.models.transaction import Transaction, TransactionStatus, TransactionType
+from app.services.transaction_export_service import EXPORT_LIMIT, generate_csv_export
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _register_and_login(client, *, prefix: str = "export") -> tuple[str, str]:
+    suffix = uuid.uuid4().hex[:8]
+    email = f"{prefix}-{suffix}@auraxis.test"
+    password = "StrongPass@123"
+    reg = client.post(
+        "/auth/register",
+        json={"name": f"user-{suffix}", "email": email, "password": password},
+    )
+    assert reg.status_code == 201
+    login = client.post("/auth/login", json={"email": email, "password": password})
+    assert login.status_code == 200
+    token = login.get_json()["token"]
+    profile = client.get("/user/profile", headers=_auth(token))
+    body = profile.get_json()
+    user_id = body.get("data", {}).get("id") or body["user"]["id"]
+    return token, user_id
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _grant_export_entitlement(app, user_id: str) -> None:
+    with app.app_context():
+        ent = Entitlement(
+            user_id=uuid.UUID(user_id),
+            feature_key="export_pdf",
+            source=EntitlementSource.SUBSCRIPTION,
+            expires_at=None,
+        )
+        db.session.add(ent)
+        db.session.commit()
+
+
+def _create_transaction(
+    app,
+    user_id: str,
+    *,
+    title: str = "Test tx",
+    amount: str = "100.00",
+    tx_type: TransactionType = TransactionType.EXPENSE,
+    status: TransactionStatus = TransactionStatus.PENDING,
+    due_date: date = date(2026, 1, 15),
+) -> None:
+    with app.app_context():
+        tx = Transaction(
+            user_id=uuid.UUID(user_id),
+            title=title,
+            amount=Decimal(amount),
+            type=tx_type,
+            status=status,
+            due_date=due_date,
+        )
+        db.session.add(tx)
+        db.session.commit()
+
+
+# ---------------------------------------------------------------------------
+# Entitlement gate
+# ---------------------------------------------------------------------------
+
+
+class TestExportEntitlementGate:
+    def test_free_user_gets_403(self, client) -> None:
+        token, _ = _register_and_login(client, prefix="export-free")
+        resp = client.get("/transactions/export", headers=_auth(token))
+        assert resp.status_code == 403
+        body = resp.get_json()
+        assert body["error"]["code"] == "ENTITLEMENT_REQUIRED"
+
+    def test_premium_user_gets_file(self, app, client) -> None:
+        token, user_id = _register_and_login(client, prefix="export-prem")
+        _grant_export_entitlement(app, user_id)
+        resp = client.get("/transactions/export?format=csv", headers=_auth(token))
+        assert resp.status_code == 200
+        assert "text/csv" in resp.content_type
+
+    def test_unauthenticated_gets_401(self, client) -> None:
+        resp = client.get("/transactions/export")
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# CSV format
+# ---------------------------------------------------------------------------
+
+
+class TestCsvExport:
+    def test_csv_has_correct_headers(self, app, client) -> None:
+        token, user_id = _register_and_login(client, prefix="csv-hdr")
+        _grant_export_entitlement(app, user_id)
+        resp = client.get("/transactions/export?format=csv", headers=_auth(token))
+        assert resp.status_code == 200
+        reader = csv.reader(io.StringIO(resp.data.decode("utf-8-sig")))
+        headers = next(reader)
+        assert headers == ["data", "tipo", "titulo", "valor", "status", "descricao"]
+
+    def test_csv_empty_when_no_transactions(self, app, client) -> None:
+        token, user_id = _register_and_login(client, prefix="csv-empty")
+        _grant_export_entitlement(app, user_id)
+        resp = client.get("/transactions/export?format=csv", headers=_auth(token))
+        assert resp.status_code == 200
+        reader = csv.reader(io.StringIO(resp.data.decode("utf-8-sig")))
+        rows = list(reader)
+        assert len(rows) == 1  # headers only
+
+    def test_csv_contains_transaction_data(self, app, client) -> None:
+        token, user_id = _register_and_login(client, prefix="csv-data")
+        _grant_export_entitlement(app, user_id)
+        _create_transaction(
+            app,
+            user_id,
+            title="Salário",
+            amount="5000.00",
+            tx_type=TransactionType.INCOME,
+            status=TransactionStatus.PAID,
+            due_date=date(2026, 1, 5),
+        )
+        resp = client.get("/transactions/export?format=csv", headers=_auth(token))
+        assert resp.status_code == 200
+        reader = csv.reader(io.StringIO(resp.data.decode("utf-8-sig")))
+        next(reader)  # skip headers
+        rows = list(reader)
+        assert len(rows) == 1
+        assert rows[0][2] == "Salário"
+        assert rows[0][3] == "5000.00"
+        assert rows[0][1] == "income"
+
+    def test_csv_content_disposition_header(self, app, client) -> None:
+        token, user_id = _register_and_login(client, prefix="csv-disp")
+        _grant_export_entitlement(app, user_id)
+        resp = client.get("/transactions/export?format=csv", headers=_auth(token))
+        assert "attachment" in resp.headers.get("Content-Disposition", "")
+        assert ".csv" in resp.headers.get("Content-Disposition", "")
+
+    def test_csv_type_filter(self, app, client) -> None:
+        token, user_id = _register_and_login(client, prefix="csv-type")
+        _grant_export_entitlement(app, user_id)
+        _create_transaction(
+            app, user_id, title="Income tx", tx_type=TransactionType.INCOME
+        )
+        _create_transaction(
+            app, user_id, title="Expense tx", tx_type=TransactionType.EXPENSE
+        )
+        resp = client.get(
+            "/transactions/export?format=csv&type=income", headers=_auth(token)
+        )
+        reader = csv.reader(io.StringIO(resp.data.decode("utf-8-sig")))
+        next(reader)
+        rows = list(reader)
+        assert len(rows) == 1
+        assert rows[0][1] == "income"
+
+    def test_csv_date_filter(self, app, client) -> None:
+        token, user_id = _register_and_login(client, prefix="csv-date")
+        _grant_export_entitlement(app, user_id)
+        _create_transaction(app, user_id, title="Jan tx", due_date=date(2026, 1, 10))
+        _create_transaction(app, user_id, title="Mar tx", due_date=date(2026, 3, 10))
+        resp = client.get(
+            "/transactions/export?format=csv&start_date=2026-02-01&end_date=2026-12-31",
+            headers=_auth(token),
+        )
+        reader = csv.reader(io.StringIO(resp.data.decode("utf-8-sig")))
+        next(reader)
+        rows = list(reader)
+        assert len(rows) == 1
+        assert rows[0][2] == "Mar tx"
+
+    def test_csv_filename_includes_date_range(self, app, client) -> None:
+        token, user_id = _register_and_login(client, prefix="csv-fname")
+        _grant_export_entitlement(app, user_id)
+        resp = client.get(
+            "/transactions/export?format=csv&start_date=2026-01-01&end_date=2026-03-31",
+            headers=_auth(token),
+        )
+        disposition = resp.headers.get("Content-Disposition", "")
+        assert "2026-01" in disposition
+        assert "2026-03" in disposition
+
+
+# ---------------------------------------------------------------------------
+# PDF format
+# ---------------------------------------------------------------------------
+
+
+class TestPdfExport:
+    def test_pdf_content_type(self, app, client) -> None:
+        token, user_id = _register_and_login(client, prefix="pdf-ct")
+        _grant_export_entitlement(app, user_id)
+        resp = client.get("/transactions/export?format=pdf", headers=_auth(token))
+        assert resp.status_code == 200
+        assert "application/pdf" in resp.content_type
+
+    def test_pdf_starts_with_magic_bytes(self, app, client) -> None:
+        token, user_id = _register_and_login(client, prefix="pdf-magic")
+        _grant_export_entitlement(app, user_id)
+        resp = client.get("/transactions/export?format=pdf", headers=_auth(token))
+        assert resp.data[:4] == b"%PDF"
+
+    def test_pdf_content_disposition_header(self, app, client) -> None:
+        token, user_id = _register_and_login(client, prefix="pdf-disp")
+        _grant_export_entitlement(app, user_id)
+        resp = client.get("/transactions/export?format=pdf", headers=_auth(token))
+        assert "attachment" in resp.headers.get("Content-Disposition", "")
+        assert ".pdf" in resp.headers.get("Content-Disposition", "")
+
+
+# ---------------------------------------------------------------------------
+# Validation errors
+# ---------------------------------------------------------------------------
+
+
+class TestExportValidation:
+    def test_invalid_format_returns_400(self, app, client) -> None:
+        token, user_id = _register_and_login(client, prefix="val-fmt")
+        _grant_export_entitlement(app, user_id)
+        resp = client.get("/transactions/export?format=excel", headers=_auth(token))
+        assert resp.status_code == 400
+
+    def test_invalid_date_format_returns_400(self, app, client) -> None:
+        token, user_id = _register_and_login(client, prefix="val-date")
+        _grant_export_entitlement(app, user_id)
+        resp = client.get(
+            "/transactions/export?start_date=01-01-2026", headers=_auth(token)
+        )
+        assert resp.status_code == 400
+
+    def test_start_after_end_returns_400(self, app, client) -> None:
+        token, user_id = _register_and_login(client, prefix="val-range")
+        _grant_export_entitlement(app, user_id)
+        resp = client.get(
+            "/transactions/export?start_date=2026-12-31&end_date=2026-01-01",
+            headers=_auth(token),
+        )
+        assert resp.status_code == 400
+
+    def test_invalid_type_param_returns_400(self, app, client) -> None:
+        token, user_id = _register_and_login(client, prefix="val-type")
+        _grant_export_entitlement(app, user_id)
+        resp = client.get("/transactions/export?type=revenue", headers=_auth(token))
+        assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Export service unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestExportServiceUnit:
+    def test_csv_generate_returns_bom(self, app) -> None:
+        with app.app_context():
+            user_id = uuid.uuid4()
+            result = generate_csv_export(user_id=user_id)
+            # UTF-8 BOM for Excel compatibility
+            assert result.content[:3] == b"\xef\xbb\xbf"
+
+    def test_csv_generate_empty_has_headers(self, app) -> None:
+        with app.app_context():
+            user_id = uuid.uuid4()
+            result = generate_csv_export(user_id=user_id)
+            reader = csv.reader(io.StringIO(result.content.decode("utf-8-sig")))
+            rows = list(reader)
+            assert rows[0] == ["data", "tipo", "titulo", "valor", "status", "descricao"]
+            assert len(rows) == 1
+
+    def test_csv_generate_filename_with_month_label(self, app) -> None:
+        with app.app_context():
+            user_id = uuid.uuid4()
+            result = generate_csv_export(user_id=user_id, month_label="2026-01")
+            assert "2026-01" in result.filename
+            assert result.filename.endswith(".csv")
+
+    def test_export_limit_constant(self) -> None:
+        assert EXPORT_LIMIT == 10_000


### PR DESCRIPTION
## Summary

- Adds a pluggable **LLM provider layer** (`app/services/llm_provider.py`): `LLMProvider` protocol, `StubLLMProvider` (default, zero external calls), `OpenAILLMProvider`, `ClaudeLLMProvider` — selected via `LLM_PROVIDER` env var
- Adds **`AdvisoryService`** (`app/application/services/advisory_service.py`): builds a no-PII financial snapshot (income, expenses, wallet assets, active goals), calls the provider, caches results 24 h per user, enforces 5 calls/day rate limit; `StubFallback` generates rule-based insights when the LLM is unavailable
- Adds **`GET /advisory/insights`** controller: returns 429 on rate limit, 500 on unexpected error, 200 with `{insights, generated_at, source, calls_remaining_today}`
- 12 new tests covering auth gate, happy path, response shape, cache hit, rate limit, LLM fallback, provider unit tests, and `_parse_insights` parsing

## Test plan

- [ ] All CI gates pass (ruff, mypy, bandit, pytest ≥ 85%)
- [ ] `GET /advisory/insights` returns 401 without token
- [ ] `GET /advisory/insights` returns 200 with `insights` list (each with `type`, `title`, `message`)
- [ ] Second call within 24 h returns `source: "cache"`
- [ ] 6th call within 24 h returns 429
- [ ] With `LLM_PROVIDER=stub` (default), no external API calls are made

Closes #1026

🤖 Generated with [Claude Code](https://claude.ai/claude-code)