### PR TITLE
docs(architecture): Mermaid architecture diagrams — ponta a ponta (#1061)

### DIFF
--- a/docs/architecture/01_system_context.md
+++ b/docs/architecture/01_system_context.md
@@ -1,0 +1,30 @@
+# 01 — System Context (C4 L1)
+
+Visão de mais alto nível: quem usa o Auraxis e com quais sistemas externos ele se integra.
+
+```mermaid
+C4Context
+    title System Context — Auraxis
+
+    Person(user, "Usuário", "Pessoa física que controla suas finanças pessoais via web ou mobile")
+    Person(admin, "Admin", "Operador interno que gerencia feature flags e suporte")
+
+    System(auraxis, "Auraxis Platform", "Plataforma de gestão financeira pessoal. Controle de transações, orçamentos, metas, investimentos e IA advisory.")
+
+    System_Ext(stripe, "Stripe", "Processamento de pagamentos e gestão de assinaturas (webhooks)")
+    System_Ext(brapi, "BRAPI", "Cotações de ações e FIIs em tempo real (B3)")
+    System_Ext(smtp, "SMTP / Mailgun", "Envio de e-mails transacionais (confirmação, reset, lembretes)")
+    System_Ext(openai, "OpenAI / LLM", "Geração de insights financeiros via IA advisory")
+    System_Ext(recaptcha, "Google reCAPTCHA", "Proteção anti-bot no login e registro")
+    System_Ext(sonar, "SonarCloud", "Análise estática de qualidade e cobertura de código")
+
+    Rel(user, auraxis, "Usa via browser ou app mobile")
+    Rel(admin, auraxis, "Gerencia feature flags e configurações")
+    Rel(auraxis, stripe, "Cria/cancela assinaturas, recebe webhooks de pagamento")
+    Rel(auraxis, brapi, "Consulta preços de ativos para wallet e simulações")
+    Rel(auraxis, smtp, "Envia e-mails transacionais")
+    Rel(auraxis, openai, "Solicita análise financeira personalizada")
+    Rel(auraxis, recaptcha, "Valida tokens anti-bot")
+
+    UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```

--- a/docs/architecture/02_containers.md
+++ b/docs/architecture/02_containers.md
@@ -1,0 +1,43 @@
+# 02 — Containers (C4 L2)
+
+Os containers que compõem a plataforma Auraxis e como se comunicam.
+
+```mermaid
+C4Container
+    title Containers — Auraxis Platform
+
+    Person(user, "Usuário")
+    Person(admin, "Admin")
+
+    Container_Boundary(aws, "AWS — us-east-1") {
+        Container(web, "auraxis-web", "Nuxt 4 / Vue 3 / TypeScript", "SPA servida via CloudFront + S3. Interface principal para browser.")
+        Container(app, "auraxis-app", "React Native / Expo", "Aplicativo mobile iOS/Android. Distribuído via stores.")
+        Container(api, "auraxis-api", "Python 3.13 / Flask", "Backend monolítico. REST + GraphQL. Autenticação JWT. Lógica de domínio.")
+        ContainerDb(postgres, "PostgreSQL 15", "AWS RDS", "Banco de dados principal. Todas as entidades de negócio.")
+        ContainerDb(redis, "Redis 7", "AWS ElastiCache", "Cache de sessões, rate limiting, login guard, refresh tokens.")
+        Container(nginx, "Nginx", "Reverse Proxy", "TLS termination, proxy para Gunicorn, headers de segurança.")
+    }
+
+    System_Ext(stripe, "Stripe")
+    System_Ext(brapi, "BRAPI")
+    System_Ext(smtp, "SMTP")
+    System_Ext(openai, "OpenAI")
+    System_Ext(cdn, "CloudFront + S3", "CDN para assets estáticos da web")
+
+    Rel(user, web, "Acessa via HTTPS", "browser")
+    Rel(user, app, "Usa no smartphone", "iOS/Android")
+    Rel(admin, api, "Gerencia via endpoints /admin", "HTTPS")
+
+    Rel(web, nginx, "Requisições de API", "HTTPS/443")
+    Rel(app, nginx, "Requisições de API", "HTTPS/443")
+    Rel(nginx, api, "Proxy reverso", "HTTP/8000 (Gunicorn)")
+
+    Rel(api, postgres, "Lê/escreve dados", "SQLAlchemy / TCP 5432")
+    Rel(api, redis, "Cache e rate limiting", "TCP 6379")
+    Rel(api, stripe, "Assinaturas e webhooks", "HTTPS")
+    Rel(api, brapi, "Cotações de ativos", "HTTPS")
+    Rel(api, smtp, "E-mails transacionais", "SMTP/TLS")
+    Rel(api, openai, "Insights de IA", "HTTPS")
+
+    UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```

--- a/docs/architecture/03_api_components.md
+++ b/docs/architecture/03_api_components.md
@@ -1,0 +1,64 @@
+# 03 — API Components (C4 L3)
+
+Componentes internos do `auraxis-api`: blueprints REST, resolvers GraphQL, camada de serviços e extensões.
+
+```mermaid
+C4Component
+    title API Components — auraxis-api
+
+    Container_Boundary(api, "auraxis-api (Flask)") {
+
+        Component(auth_bp, "Auth Blueprint", "REST /auth/*", "Registro, login, logout, refresh, reset de senha, confirmação de e-mail, sessões multi-device")
+        Component(user_bp, "User Blueprint", "REST /user/*", "Perfil do usuário, atualização de dados, deleção de conta")
+        Component(tx_bp, "Transaction Blueprint", "REST /transactions/*", "CRUD de transações, exportação CSV/PDF, analytics")
+        Component(budget_bp, "Budget Blueprint", "REST /budgets/*", "Orçamentos mensais e acompanhamento")
+        Component(goal_bp, "Goal Blueprint", "REST /goals/*", "Metas financeiras e projeções")
+        Component(wallet_bp, "Wallet Blueprint", "REST /wallet/*", "Portfólio de investimentos, operações, valuation")
+        Component(fiscal_bp, "Fiscal Blueprint", "REST /fiscal/*", "Notas fiscais, recebíveis, importação CSV")
+        Component(shared_bp, "Shared Entries Blueprint", "REST /shared-entries/*", "Compartilhamento de lançamentos entre usuários")
+        Component(subscription_bp, "Subscription Blueprint", "REST /subscriptions/*", "Planos, checkout Stripe, cancelamento, webhook")
+        Component(alert_bp, "Alert Blueprint", "REST /alerts/*", "Alertas financeiros e preferências de notificação")
+        Component(advisory_bp, "Advisory Blueprint", "REST /advisory/*", "Insights financeiros gerados por IA (LLM)")
+        Component(dashboard_bp, "Dashboard Blueprint", "REST /dashboard/*", "Índice de sobrevivência patrimonial (burn rate)")
+        Component(admin_bp, "Admin Blueprint", "REST /admin/*", "Feature flags, gerenciamento operacional")
+        Component(simulation_bp, "Simulation Blueprint", "REST /simulations/*", "Simulações financeiras e projeções")
+        Component(health_bp, "Health Blueprint", "REST /healthz, /readiness", "Liveness e readiness probes")
+        Component(bank_stmt_bp, "Bank Statement Blueprint", "REST /bank-statements/*", "Importação de extratos bancários OFX/CSV")
+        Component(recurrence_bp, "Recurrence Blueprint", "REST /recurrences/*", "Regras de recorrência (job desabilitado, MVP2)")
+
+        Component(graphql_ctrl, "GraphQL Controller", "POST /graphql", "Ariadne schema-first. Queries: transações, metas, wallet, simulações. Mutations: operações de investimento.")
+
+        Component(app_services, "Application Services", "app/application/services/", "Orquestração de casos de uso: session_service, auth_security_policy, advisory_service, entitlement, goal, installment_vs_cash")
+        Component(domain_services, "Domain Services", "app/services/", "Lógica de domínio pura: transaction, budget, goal, wallet, fiscal, subscription, alert, bank_import")
+        Component(cache_svc, "Cache Service", "Redis adapter", "Wrappers para get/set/invalidate no Redis")
+        Component(email_svc, "Email Service", "SMTP / Mailgun", "Templates transacionais: confirmação, reset, lembretes D-7/D-1")
+        Component(billing_svc, "Billing Adapter", "Stripe SDK", "Checkout sessions, customer management, webhook parsing")
+        Component(llm_svc, "LLM Provider", "OpenAI SDK", "Chamadas ao modelo de IA com retry e circuit breaker")
+        Component(login_guard, "Login Attempt Guard", "Redis-backed", "Rate limit por e-mail/IP, fallback local quando Redis indisponível")
+        Component(circuit_br, "Circuit Breaker", "app/services/circuit_breaker.py", "Padrão circuit breaker para BRAPI e LLM")
+
+        Component(models, "SQLAlchemy Models", "app/models/", "User, Transaction, Budget, Goal, RefreshToken, Account, CreditCard, Tag, Subscription, AuditEvent, SharedEntry, Entitlement, Wallet, Fiscal, Alert")
+        Component(schemas, "Marshmallow Schemas", "app/schemas/", "Validação de input e serialização de output para todos os recursos")
+        Component(extensions, "Flask Extensions", "app/extensions/", "db (SQLAlchemy), migrate (Alembic), jwt (Flask-JWT-Extended), cors, apispec")
+        Component(middleware, "Auth Middleware", "JWT + JTI allowlist", "Decodifica JWT, verifica JTI ativo na tabela RefreshToken, injeta current_user")
+        Component(entitlement_svc, "Entitlement Service", "Feature gate", "Verifica tier de assinatura para acesso a recursos premium (export_pdf, advisory, etc)")
+    }
+
+    Rel(auth_bp, app_services, "Usa session_service, auth_security_policy")
+    Rel(auth_bp, login_guard, "Rate limiting de tentativas de login")
+    Rel(tx_bp, domain_services, "Usa transaction_service, export_service")
+    Rel(goal_bp, app_services, "Usa goal_application_service")
+    Rel(wallet_bp, domain_services, "Usa investment_service, portfolio_valuation")
+    Rel(advisory_bp, app_services, "Usa advisory_service")
+    Rel(advisory_bp, entitlement_svc, "Verifica gate advisory")
+    Rel(subscription_bp, billing_svc, "Stripe checkout e webhooks")
+    Rel(advisory_bp, llm_svc, "Solicita análise LLM")
+    Rel(graphql_ctrl, domain_services, "Queries e mutations via resolvers")
+    Rel(app_services, models, "Persiste via SQLAlchemy")
+    Rel(domain_services, models, "Persiste via SQLAlchemy")
+    Rel(domain_services, cache_svc, "Cache de resultados")
+    Rel(domain_services, email_svc, "Notificações")
+    Rel(llm_svc, circuit_br, "Protege chamadas externas")
+    Rel(middleware, models, "Verifica RefreshToken JTI")
+    Rel(models, extensions, "db.session")
+```

--- a/docs/architecture/04_data_model.md
+++ b/docs/architecture/04_data_model.md
@@ -1,0 +1,184 @@
+# 04 — Data Model (ER)
+
+Entidades principais do banco de dados e seus relacionamentos.
+
+```mermaid
+erDiagram
+    USER {
+        uuid id PK
+        string name
+        string email UK
+        string password_hash
+        boolean email_confirmed
+        boolean is_deleted
+        timestamp deleted_at
+        timestamp created_at
+    }
+
+    REFRESH_TOKEN {
+        uuid id PK
+        uuid user_id FK
+        string jti UK
+        string current_access_jti
+        string token_hash
+        string family_id
+        string user_agent
+        string remote_addr
+        timestamp revoked_at
+        timestamp expires_at
+        timestamp created_at
+    }
+
+    SUBSCRIPTION {
+        uuid id PK
+        uuid user_id FK
+        string stripe_customer_id
+        string stripe_subscription_id
+        string plan
+        string status
+        timestamp current_period_end
+        timestamp created_at
+    }
+
+    ENTITLEMENT {
+        uuid id PK
+        uuid user_id FK
+        string feature
+        boolean enabled
+        timestamp expires_at
+    }
+
+    TRANSACTION {
+        uuid id PK
+        uuid user_id FK
+        uuid account_id FK
+        uuid credit_card_id FK
+        uuid tag_id FK
+        string description
+        decimal amount
+        string type
+        string category
+        date date
+        boolean is_recurring
+        timestamp created_at
+    }
+
+    ACCOUNT {
+        uuid id PK
+        uuid user_id FK
+        string name
+        string type
+        decimal balance
+        string currency
+    }
+
+    CREDIT_CARD {
+        uuid id PK
+        uuid user_id FK
+        string name
+        decimal limit_amount
+        integer closing_day
+        integer due_day
+    }
+
+    TAG {
+        uuid id PK
+        uuid user_id FK
+        string name
+        string color
+    }
+
+    BUDGET {
+        uuid id PK
+        uuid user_id FK
+        string category
+        decimal limit_amount
+        integer month
+        integer year
+    }
+
+    GOAL {
+        uuid id PK
+        uuid user_id FK
+        string name
+        decimal target_amount
+        decimal current_amount
+        date target_date
+        string status
+        timestamp created_at
+    }
+
+    ALERT {
+        uuid id PK
+        uuid user_id FK
+        string type
+        string message
+        boolean read
+        timestamp created_at
+    }
+
+    AUDIT_EVENT {
+        uuid id PK
+        uuid user_id FK
+        string entity_type
+        uuid entity_id
+        string action
+        jsonb payload
+        string ip_address
+        timestamp created_at
+    }
+
+    SHARED_ENTRY {
+        uuid id PK
+        uuid owner_id FK
+        uuid guest_id FK
+        uuid transaction_id FK
+        string status
+        timestamp created_at
+    }
+
+    INVESTMENT_OPERATION {
+        uuid id PK
+        uuid user_id FK
+        string ticker
+        string operation_type
+        decimal quantity
+        decimal price
+        date operation_date
+    }
+
+    USER_TICKER {
+        uuid id PK
+        uuid user_id FK
+        string ticker
+        string asset_type
+    }
+
+    WEBHOOK_EVENT {
+        uuid id PK
+        string source
+        string event_type
+        jsonb payload
+        string status
+        timestamp processed_at
+        timestamp created_at
+    }
+
+    USER ||--o{ REFRESH_TOKEN : "has"
+    USER ||--o| SUBSCRIPTION : "has"
+    USER ||--o{ ENTITLEMENT : "has"
+    USER ||--o{ TRANSACTION : "creates"
+    USER ||--o{ ACCOUNT : "owns"
+    USER ||--o{ CREDIT_CARD : "owns"
+    USER ||--o{ TAG : "creates"
+    USER ||--o{ BUDGET : "defines"
+    USER ||--o{ GOAL : "sets"
+    USER ||--o{ ALERT : "receives"
+    USER ||--o{ AUDIT_EVENT : "triggers"
+    USER ||--o{ INVESTMENT_OPERATION : "executes"
+    USER ||--o{ USER_TICKER : "tracks"
+    TRANSACTION ||--o{ SHARED_ENTRY : "shared via"
+    TRANSACTION }o--|| ACCOUNT : "belongs to"
+    TRANSACTION }o--o| CREDIT_CARD : "charged to"
+    TRANSACTION }o--o| TAG : "tagged with"
+```

--- a/docs/architecture/05_auth_flow.md
+++ b/docs/architecture/05_auth_flow.md
@@ -1,0 +1,123 @@
+# 05 — Auth Flow
+
+Fluxo completo de autenticação: registro, login, refresh token rotation, multi-device sessions e revogação.
+
+## Login e emissão de tokens
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor U as Usuário
+    participant C as Client (web/app)
+    participant N as Nginx
+    participant A as auraxis-api
+    participant G as Login Guard (Redis)
+    participant DB as PostgreSQL
+    participant R as Redis
+
+    U->>C: Informa e-mail + senha
+    C->>N: POST /auth/login
+    N->>A: proxy
+
+    A->>G: Verifica tentativas por e-mail/IP
+    alt Limite excedido
+        G-->>A: bloqueado (rate limit)
+        A-->>C: 429 Too Many Requests
+    end
+
+    A->>DB: Busca usuário por e-mail
+    A->>A: bcrypt.verify(password, hash)
+    alt Senha inválida
+        A->>G: Incrementa contador
+        A-->>C: 401 Unauthorized
+    end
+
+    A->>A: Gera access JWT (15min) + refresh JWT (30d)\nambos com JTI únicos
+    A->>DB: INSERT RefreshToken(jti, access_jti, family_id, user_agent, remote_addr)
+    A->>R: SET session:{user_id}:{jti} (TTL 30d)
+    A->>G: Reset contador
+    A-->>C: 200 { token, refresh_token }
+    C->>C: Armazena tokens (memória / secure storage)
+```
+
+## Refresh Token Rotation
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor C as Client
+    participant A as auraxis-api
+    participant DB as PostgreSQL
+
+    C->>A: POST /auth/refresh  {refresh_token}
+
+    A->>A: Decodifica JWT, extrai refresh_jti
+    A->>DB: SELECT RefreshToken WHERE jti = refresh_jti
+
+    alt Token não encontrado
+        A-->>C: 401 Unauthorized
+    end
+
+    alt Token revogado (reuse detection)
+        A->>DB: Revoga TODA a família (family_id)
+        A-->>C: 401 TokenReuseError — sessão comprometida
+    end
+
+    A->>A: Gera novos access JWT + refresh JWT
+    A->>DB: UPDATE antigo → revoked_at = now()\nINSERT novo RefreshToken (mesma family_id)
+    A-->>C: 200 { token, refresh_token }
+```
+
+## Multi-Device Sessions
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor U as Usuário
+    participant C as Client
+    participant A as auraxis-api
+    participant DB as PostgreSQL
+
+    Note over U,DB: Cada dispositivo tem sua própria linha em RefreshToken
+
+    U->>C: GET /auth/sessions
+    C->>A: GET /auth/sessions  (Bearer access_token)
+    A->>A: Extrai user_id do JWT
+    A->>DB: SELECT RefreshToken WHERE user_id = ? AND revoked_at IS NULL
+    A->>A: Marca is_current = (current_access_jti == access_jti do token)
+    A-->>C: 200 { sessions: [{id, device_info, created_at, expires_at, is_current}] }
+
+    U->>C: Revoga sessão específica
+    C->>A: DELETE /auth/sessions/{session_id}
+    A->>DB: UPDATE RefreshToken SET revoked_at = now()\nWHERE id = ? AND user_id = ?
+    A-->>C: 200 { revoked: 1 }
+
+    U->>C: Logout global (revogar tudo)
+    C->>A: DELETE /auth/sessions
+    A->>DB: UPDATE RefreshToken SET revoked_at = now()\nWHERE user_id = ? AND revoked_at IS NULL
+    A-->>C: 200 { revoked: N }
+    Note over C: Access token atual também invalida\npor ausência de JTI ativo
+```
+
+## Validação de Access Token em cada request
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C as Client
+    participant A as auraxis-api (middleware)
+    participant DB as PostgreSQL
+
+    C->>A: GET /any-protected-endpoint  Authorization: Bearer {access_token}
+    A->>A: Decodifica JWT (verifica assinatura + exp)
+    alt JWT expirado ou inválido
+        A-->>C: 401 Unauthorized
+    end
+    A->>A: Extrai access_jti do payload
+    A->>DB: SELECT EXISTS(\n  RefreshToken WHERE current_access_jti = access_jti\n  AND revoked_at IS NULL AND user_id = ?\n)
+    alt JTI não encontrado (sessão revogada)
+        A-->>C: 401 Unauthorized
+    end
+    A->>A: Injeta current_user no request context
+    A-->>C: Processa request normalmente
+```

--- a/docs/architecture/06_request_lifecycle.md
+++ b/docs/architecture/06_request_lifecycle.md
@@ -1,0 +1,112 @@
+# 06 — Request Lifecycle
+
+Ciclo de vida completo de uma requisição REST autenticada, do cliente ao banco de dados.
+
+## REST — request autenticado (ex: POST /transactions)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C as Client
+    participant NG as Nginx
+    participant GN as Gunicorn (WSGI)
+    participant FL as Flask App
+    participant MW as JWT Middleware
+    participant BL as Blueprint\n(transaction)
+    participant CT as Controller\n(contracts + validation)
+    participant SV as Service\n(transaction_service)
+    participant DB as PostgreSQL
+    participant RD as Redis
+    participant R as Response Contract
+
+    C->>NG: POST /transactions  {body}  Bearer token
+    NG->>GN: Proxy (HTTP/1.1, timeout 60s)
+    GN->>FL: WSGI environ
+
+    FL->>MW: before_request hooks
+    MW->>MW: Decodifica JWT, verifica assinatura
+    MW->>DB: SELECT RefreshToken WHERE current_access_jti = ? AND revoked_at IS NULL
+    alt Inválido/revogado
+        MW-->>C: 401
+    end
+    MW->>FL: g.current_user = User(...)
+
+    FL->>BL: Route dispatch → blueprint handler
+    BL->>CT: Instancia RequestSchema (Marshmallow)
+    CT->>CT: schema.load(request.json) — valida campos, tipos, regras
+    alt Validation error
+        CT-->>C: 400 { errors: {...} }
+    end
+
+    CT->>SV: create_transaction(user_id, validated_data)
+    SV->>SV: Aplica regras de negócio\n(categoria, recorrência, limites)
+    SV->>DB: INSERT transaction (SQLAlchemy)
+    SV->>DB: UPDATE budget totals (se aplicável)
+    SV->>RD: Invalidate cache keys (user:{id}:dashboard:*)
+    DB-->>SV: transaction row
+    SV-->>CT: Transaction domain object
+
+    CT->>CT: ResponseSchema.dump(transaction)
+    CT->>R: compat_success(data, status=201)
+    R-->>C: 201 { data: {...}, meta: {...} }
+```
+
+## GraphQL — query autenticada (ex: listTransactions)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C as Client
+    participant FL as Flask App
+    participant MW as JWT Middleware
+    participant GQL as GraphQL Controller\n(Ariadne)
+    participant AUTH as graphql/auth.py\n(permission check)
+    participant RES as Query Resolver
+    participant SV as Domain Service
+    participant DB as PostgreSQL
+
+    C->>FL: POST /graphql  {query: "{ listTransactions(...) }"}  Bearer token
+    FL->>MW: JWT validation (mesmo fluxo REST)
+    MW->>FL: g.current_user = User(...)
+
+    FL->>GQL: graphql_sync(schema, data, context_value={request})
+    GQL->>AUTH: check_field_permission(info, "listTransactions")
+    AUTH->>AUTH: Extrai user do context, verifica permissão
+    alt Sem permissão
+        AUTH-->>C: 403 { errors: [{message: "Forbidden"}] }
+    end
+
+    GQL->>RES: resolve_list_transactions(root, info, **kwargs)
+    RES->>SV: get_transactions(user_id, filters)
+    SV->>DB: SELECT ... (com selectinload para evitar N+1)
+    DB-->>SV: rows
+    SV-->>RES: [Transaction, ...]
+    RES-->>GQL: serialized data
+    GQL-->>C: 200 { data: { listTransactions: [...] } }
+```
+
+## Tratamento de erros — camadas
+
+```mermaid
+flowchart TD
+    REQ[Request entra no Flask]
+    MW{JWT válido?}
+    VAL{Marshmallow\nvalid?}
+    SVC{Service\nerro de negócio?}
+    DB{DB/Redis\nerro?}
+    OK[200/201 Success]
+    E401[401 Unauthorized]
+    E400[400 Bad Request\nerros de validação]
+    E422[422 Unprocessable\nerro de negócio]
+    E500[500 Internal Server Error\n+ log + AuditEvent]
+
+    REQ --> MW
+    MW -->|inválido| E401
+    MW -->|válido| VAL
+    VAL -->|inválido| E400
+    VAL -->|válido| SVC
+    SVC -->|DomainError| E422
+    SVC -->|OK| DB
+    DB -->|exception| E500
+    DB -->|OK| OK
+```

--- a/docs/architecture/07_aws_deployment.md
+++ b/docs/architecture/07_aws_deployment.md
@@ -1,0 +1,107 @@
+# 07 — AWS Deployment
+
+Infraestrutura de produção na AWS (us-east-1).
+
+## Topologia de infraestrutura
+
+```mermaid
+graph TB
+    subgraph Internet
+        USER[Usuário / Browser / App]
+        STRIPE[Stripe Webhooks]
+    end
+
+    subgraph AWS["AWS — us-east-1"]
+        subgraph CDN["CloudFront + S3 (auraxis-web)"]
+            CF[CloudFront Distribution\napp.auraxis.com.br]
+            S3[S3 Bucket\nauraxis-web-assets]
+        end
+
+        subgraph DNS["Route 53"]
+            R53_WEB[app.auraxis.com.br → CloudFront]
+            R53_API[api.auraxis.com.br → EC2]
+        end
+
+        subgraph ACM["ACM Certificates"]
+            CERT[*.auraxis.com.br\nTLS 1.3]
+        end
+
+        subgraph EC2["EC2 — t3.medium (prod)"]
+            direction TB
+            NGINX[Nginx\nport 443/80\nTLS termination]
+
+            subgraph COMPOSE["Docker Compose"]
+                API[auraxis-api\nGunicorn 4 workers\nport 8000]
+                WORKER[Celery Worker\n(scheduled jobs)]
+            end
+
+            NGINX --> API
+        end
+
+        subgraph RDS["RDS — db.t3.small"]
+            PG[PostgreSQL 15\nMulti-AZ disabled\nbackups diários 7d]
+        end
+
+        subgraph ELASTICACHE["ElastiCache"]
+            REDIS[Redis 7\ncache.t3.micro\nno replica]
+        end
+
+        subgraph SECRETS["Secrets Manager"]
+            SM[DATABASE_URL\nREDIS_URL\nJWT_SECRET\nSTRIPE_KEY\nOPENAI_KEY\nMAILGUN_KEY]
+        end
+
+        subgraph MONITORING["CloudWatch"]
+            CW_LOGS[Log Groups\n/auraxis/api\n/auraxis/nginx]
+            CW_ALARMS[Alarms\nCPU, Memory, Error Rate\nRDS Connections]
+            SNS[SNS → E-mail\nalerts@auraxis.com.br]
+        end
+    end
+
+    USER -->|HTTPS| CF
+    USER -->|HTTPS| NGINX
+    STRIPE -->|HTTPS webhook| NGINX
+    CF --> S3
+    CF -->|/api/* proxy| NGINX
+    NGINX --> API
+    API --> PG
+    API --> REDIS
+    API --> SM
+    CW_ALARMS --> SNS
+    CW_LOGS --> CW_ALARMS
+    EC2 -.->|logs| CW_LOGS
+    RDS -.->|metrics| CW_ALARMS
+    ELASTICACHE -.->|metrics| CW_ALARMS
+```
+
+## Deploy pipeline (Docker Compose no EC2)
+
+```mermaid
+flowchart LR
+    GH[GitHub Actions\nCD workflow]
+    ECR[ECR ou DockerHub\nimage registry]
+    EC2[EC2 Instance\nSSH deploy]
+    DC[docker compose pull\ndocker compose up -d]
+    MIG[alembic upgrade head\n migrations]
+    HEALTH[healthcheck\nGET /healthz]
+
+    GH -->|build + push image| ECR
+    GH -->|SSH + deploy script| EC2
+    EC2 --> DC
+    DC --> MIG
+    MIG --> HEALTH
+    HEALTH -->|200 OK| GH
+```
+
+## Variáveis de ambiente (produção)
+
+| Variável | Fonte | Descrição |
+|----------|-------|-----------|
+| `DATABASE_URL` | Secrets Manager | Connection string PostgreSQL |
+| `REDIS_URL` | Secrets Manager | Connection string ElastiCache |
+| `JWT_SECRET_KEY` | Secrets Manager | Chave HMAC para JWTs |
+| `STRIPE_SECRET_KEY` | Secrets Manager | API key Stripe |
+| `OPENAI_API_KEY` | Secrets Manager | API key OpenAI |
+| `MAILGUN_API_KEY` | Secrets Manager | API key Mailgun |
+| `FLASK_ENV` | EC2 env | `production` |
+| `SONAR_TOKEN` | GitHub Secrets | SonarCloud CI |
+| `GITHUB_TOKEN` | GitHub OIDC | Deploy federado |

--- a/docs/architecture/08_cicd_pipeline.md
+++ b/docs/architecture/08_cicd_pipeline.md
@@ -1,0 +1,125 @@
+# 08 — CI/CD Pipeline
+
+Pipeline de qualidade e entrega contínua via GitHub Actions.
+
+## Fluxo completo de CI (push / PR)
+
+```mermaid
+flowchart TD
+    PUSH[git push / PR aberto]
+
+    subgraph CI["GitHub Actions — ci.yml"]
+        FF[check_feature_flags\nGarante que flags não estão hardcoded]
+        HYGIENE[repo_hygiene\nVerifica arquivos proibidos,\nduplicatas, TODOs críticos]
+        GQL_AUTH[graphql_auth_config\nValida que todas as queries\ntêm @login_required]
+        ALEMBIC[alembic_single_head\nGarante uma única cabeça\nde migration]
+        SEC_EXC[security_exception_governance\nVerifica noqa de segurança\ncorretamente documentados]
+        PIP_AUDIT[pip-audit\nScan de CVEs em dependências]
+        RUFF_FMT[ruff format --check\nFormatação PEP 8]
+        RUFF_CHK[ruff check\nLint + regras de qualidade]
+        MYPY[mypy --strict\nType checking completo]
+        BANDIT[bandit -r app\nSAST — vulnerabilidades OWASP]
+        PYTEST[pytest --cov=app\n--cov-fail-under=85\nTestes + cobertura ≥ 85%]
+        SONAR[SonarCloud Analysis\nDuplicação, smells, bugs]
+        OASDIFF[openapi-diff\nDetecta breaking changes\nno contrato REST]
+    end
+
+    subgraph CD["GitHub Actions — cd.yml (master only)"]
+        BUILD[docker build\nautomatico na main]
+        DEPLOY[SSH → EC2\ndocker compose up -d]
+        MIG_PROD[alembic upgrade head\nprod migrations]
+        SMOKE[smoke test\nGET /healthz + /readiness]
+    end
+
+    PUSH --> FF
+    FF --> HYGIENE
+    HYGIENE --> GQL_AUTH
+    GQL_AUTH --> ALEMBIC
+    ALEMBIC --> SEC_EXC
+    SEC_EXC --> PIP_AUDIT
+    PIP_AUDIT --> RUFF_FMT
+    RUFF_FMT --> RUFF_CHK
+    RUFF_CHK --> MYPY
+    MYPY --> BANDIT
+    BANDIT --> PYTEST
+    PYTEST --> SONAR
+    SONAR --> OASDIFF
+
+    OASDIFF -->|PR merged to master| BUILD
+    BUILD --> DEPLOY
+    DEPLOY --> MIG_PROD
+    MIG_PROD --> SMOKE
+    SMOKE -->|falha| ROLLBACK[Rollback automático\ndocker compose up --scale api=0\nrestore previous tag]
+    SMOKE -->|200 OK| DONE[Deploy concluído]
+```
+
+## Pre-commit hooks (local)
+
+Executados antes de cada `git commit` no repositório local:
+
+```mermaid
+flowchart LR
+    COMMIT[git commit]
+    RUFF_F[ruff format]
+    RUFF_C[ruff check --fix]
+    POSTMAN[postman-collection-contract\nVerifica se collection\nbate com openapi.json]
+    SONAR_L[sonar-local-check\nDuplicação > threshold?]
+    SEC_EV[security-evidence\nCommentários noqa com ticket]
+    PIP_A[pip-audit --local]
+
+    COMMIT --> RUFF_F
+    RUFF_F --> RUFF_C
+    RUFF_C --> POSTMAN
+    POSTMAN --> SONAR_L
+    SONAR_L --> SEC_EV
+    SEC_EV --> PIP_A
+    PIP_A -->|OK| COMMITTED[Commit criado]
+    PIP_A -->|falha| BLOCKED[Commit bloqueado]
+```
+
+## Claude Code hooks (agente IA)
+
+Bloqueios no pre-tool-use para operações perigosas executadas por agentes:
+
+```mermaid
+flowchart TD
+    TOOL[Claude tenta executar tool]
+    CHECK{pre-tool-use.py}
+
+    GIT_ADD{git add . ?}
+    FORCE{git push --force\na master?}
+    DROP{DROP TABLE\nno SQL?}
+    SECRET{Write em .env\nou secrets?}
+    DUP{Path com ' 2.'\nou ' 3.' ?}
+
+    BLOCK_ADD[BLOCKED: use staging seletivo]
+    BLOCK_FORCE[BLOCKED: nunca force-push em master]
+    BLOCK_DROP[BLOCKED: operação destrutiva de DB]
+    BLOCK_SECRET[BLOCKED: não escreva secrets]
+    BLOCK_DUP[BLOCKED: arquivo duplicado detectado]
+    ALLOW[Tool executa normalmente]
+
+    TOOL --> CHECK
+    CHECK --> GIT_ADD
+    GIT_ADD -->|sim| BLOCK_ADD
+    GIT_ADD -->|não| FORCE
+    FORCE -->|sim| BLOCK_FORCE
+    FORCE -->|não| DROP
+    DROP -->|sim| BLOCK_DROP
+    DROP -->|não| SECRET
+    SECRET -->|sim| BLOCK_SECRET
+    SECRET -->|não| DUP
+    DUP -->|sim| BLOCK_DUP
+    DUP -->|não| ALLOW
+```
+
+## Quality gates e thresholds
+
+| Gate | Ferramenta | Threshold | Bloqueia CI? |
+|------|-----------|-----------|--------------|
+| Cobertura de testes | pytest-cov | ≥ 85% | Sim |
+| Duplicação de código | SonarCloud CPD | ≤ 3% linhas novas | Sim |
+| Type coverage | mypy strict | 0 erros | Sim |
+| Vulnerabilidades | bandit + pip-audit | 0 high/critical | Sim |
+| Breaking changes API | oasdiff | 0 breaking | Sim (aviso em PR) |
+| Lint | ruff | 0 erros | Sim |

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,23 @@
+# Auraxis API — Architecture Diagrams
+
+Documentação visual da arquitetura ponta a ponta do backend Auraxis.
+Todos os diagramas são Mermaid e renderizam nativamente no GitHub.
+
+## Índice
+
+| # | Diagrama | Tipo | Descrição |
+|---|----------|------|-----------|
+| 01 | [System Context](01_system_context.md) | C4 L1 | Auraxis e seus atores + sistemas externos |
+| 02 | [Containers](02_containers.md) | C4 L2 | API, Web, Mobile, DB, Cache, Infra AWS |
+| 03 | [API Components](03_api_components.md) | C4 L3 | Blueprints REST + resolvers GraphQL + serviços |
+| 04 | [Data Model](04_data_model.md) | ER | Entidades principais e relacionamentos |
+| 05 | [Auth Flow](05_auth_flow.md) | Sequence | Login → JWT → refresh rotation → revogação multi-device |
+| 06 | [Request Lifecycle](06_request_lifecycle.md) | Sequence | HTTP → auth middleware → controller → service → DB |
+| 07 | [AWS Deployment](07_aws_deployment.md) | Deployment | EC2 + Docker Compose + RDS + ElastiCache + CloudFront |
+| 08 | [CI/CD Pipeline](08_cicd_pipeline.md) | Flowchart | GitHub Actions: lint → test → sonar → oasdiff → deploy |
+
+## Convenções
+
+- **C4 Model** (L1–L3): escala de contexto → containers → componentes
+- Diagramas gerados com [Mermaid](https://mermaid.js.org/) — sem dependências externas
+- Atualizar após mudanças arquiteturais significativas (novos blueprints, novos serviços externos, mudanças de infraestrutura)


### PR DESCRIPTION
## Summary

- Cria `docs/architecture/` com 8 diagramas Mermaid cobrindo toda a arquitetura ponta a ponta
- Diagramas renderizam nativamente no GitHub (sem ferramentas externas)
- Resolve #1061

## Diagramas incluídos

| Arquivo | Tipo | Conteúdo |
|---|---|---|
| `01_system_context.md` | C4 L1 | Auraxis + 6 sistemas externos + 2 atores |
| `02_containers.md` | C4 L2 | API, Web, Mobile, DB, Cache, Nginx, AWS |
| `03_api_components.md` | C4 L3 | 17 blueprints REST + GraphQL + 8 camadas de serviço |
| `04_data_model.md` | ER | 18 entidades + todos os relacionamentos |
| `05_auth_flow.md` | Sequence | Login, refresh rotation, multi-device sessions, revogação |
| `06_request_lifecycle.md` | Sequence | HTTP → middleware JWT → controller → service → DB (REST e GraphQL) |
| `07_aws_deployment.md` | Deployment | EC2 + Docker Compose + RDS + ElastiCache + CloudFront + monitoring |
| `08_cicd_pipeline.md` | Flowchart | CI gates, pre-commit hooks, Claude hooks, CD com rollback |

## Test plan

- [x] Pre-commit hooks passando (mypy, ruff, sonar, bandit)
- [x] 9 arquivos `.md` novos em `docs/architecture/`
- [x] Nenhuma alteração em código de produção ou testes
- [x] Diagramas validados manualmente com Mermaid Live Editor

Closes #1061