### PR TITLE
dx(repo): prevent duplicate AI agent artifacts — three-layer guard (#1060)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,27 @@ docs/PROJECT_PANORAMA_REPORT_*.md
 docs/SECURITY_REASSESSMENT_*.md
 docs/CI_CD 2.md
 docs/CI_CD 3.md
+
+# ── Artefatos duplicados macOS (criados por agentes de IA em worktrees) ──────
+# Padrão: "foo 2.py", "foo 3.md", etc. — cópias macOS quando o destino já existe.
+# O Claude Code hook (pre-tool-use.py) também bloqueia a escrita desses arquivos.
+*[_ ]2.py
+*[_ ]3.py
+*[_ ]2.yml
+*[_ ]3.yml
+*[_ ]2.yaml
+*[_ ]3.yaml
+*[_ ]2.md
+*[_ ]3.md
+*[_ ]2.ts
+*[_ ]3.ts
+*[_ ]2.tsx
+*[_ ]3.tsx
+*[_ ]2.js
+*[_ ]3.js
+*[_ ]2.json
+*[_ ]3.json
+*[_ ]2.tf
+*[_ ]3.tf
+*[_ ]2.hcl
+*[_ ]3.hcl

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,11 @@ repos:
 
 - repo: local
   hooks:
+  - id: no-duplicate-files
+    name: no-duplicate-files (macOS AI agent artifacts)
+    entry: python3 scripts/no_duplicate_files_check.py
+    language: system
+    types: [file]
   - id: repo-hygiene-check
     name: repo-hygiene-check
     entry: python3 scripts/repo_hygiene_check.py

--- a/scripts/no_duplicate_files_check.py
+++ b/scripts/no_duplicate_files_check.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Pre-commit hook: bloqueia arquivos duplicados macOS criados por agentes de IA.
+
+Padrão bloqueado: 'foo 2.py', 'foo 3.py', 'bar 2.yml', etc.
+Causa raiz: agentes de IA escrevem em paths que já existem em worktrees
+com symlinks; o macOS cria automaticamente cópias numeradas.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+# Padrão: espaço + dígito(s) antes da extensão (ou no final do nome)
+DUPLICATE_PATTERN = re.compile(r" \d+(\.[a-zA-Z0-9]+)?$")
+
+
+def main() -> None:
+    bad_files = [
+        f for f in sys.argv[1:] if DUPLICATE_PATTERN.search(pathlib.Path(f).name)
+    ]
+    if not bad_files:
+        sys.exit(0)
+
+    print("BLOQUEADO: arquivos duplicados macOS detectados antes do commit:")
+    for f in bad_files:
+        print(f"  {f}")
+    print(
+        "\nEsses arquivos são artefatos criados pelo macOS quando agentes de IA"
+        " escrevem em paths que já existem. Remova-os antes de commitar:\n"
+        "  git rm --cached <arquivo>"
+    )
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adiciona 3 camadas de proteção contra arquivos duplicados macOS (`foo 2.py`, `foo 3.py`) criados acidentalmente por agentes de IA
- Resolve #1060

## Causa raiz

Agentes de IA (Claude, Codex) escrevem arquivos em worktrees que usam symlinks apontando para o repo principal. Quando o arquivo já existe no symlink target, o macOS cria automaticamente uma cópia com sufixo numérico (`foo 2.py`). Esses arquivos entram no `git status` como untracked e podem ser commitados acidentalmente.

## Camadas de proteção

### Camada 1 — `.gitignore`
Ignora padrões `*[_ ]2.py`, `*[_ ]3.py` e variantes para 11 extensões comuns (`.py`, `.yml`, `.yaml`, `.md`, `.ts`, `.tsx`, `.js`, `.json`, `.tf`, `.hcl`).

### Camada 2 — pre-commit hook `no-duplicate-files`
`scripts/no_duplicate_files_check.py` — bloqueia o commit se qualquer arquivo staged bate no padrão de duplicata macOS. Roda em todos os commits.

### Camada 3 — Claude Code hook (auraxis-platform)
`.claude/hooks/pre-tool-use.py` — bloqueia as tools `Write`/`Edit`/`NotebookEdit` **antes** da escrita quando `file_path` contém o padrão de duplicata. Feedback imediato ao agente antes que o arquivo seja criado.

## Test plan

- [x] Pre-commit hooks passando (ruff, mypy, bandit, sonar)
- [x] `no-duplicate-files` hook ativo e funcionando (`Passed` no commit)
- [x] `.gitignore` ignora os padrões corretamente
- [x] Claude Code hook testado localmente com path `session_service 2.py`

Closes #1060