### PR TITLE
arch(graphql): enforce GraphQL/REST ownership via ADR-0002 — CI gate (#1048)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Repo Hygiene
         run: python scripts/repo_hygiene_check.py
 
+      - name: GraphQL mutation ownership audit (ADR-0002)
+        run: python scripts/graphql_mutation_audit.py
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,12 @@ repos:
     entry: python3 scripts/graphql_auth_config_check.py
     language: system
     pass_filenames: false
+  - id: graphql-mutation-audit
+    name: graphql-mutation-audit (ADR-0002)
+    entry: python3 scripts/graphql_mutation_audit.py
+    language: system
+    pass_filenames: false
+    files: app/graphql/mutations/
   - id: alembic-single-head-check
     name: alembic-single-head-check
     entry: python3 scripts/alembic_single_head_check.py

--- a/app/graphql/mutations/__init__.py
+++ b/app/graphql/mutations/__init__.py
@@ -62,12 +62,26 @@ class Mutation(graphene.ObjectType):
     reset_password = ResetPasswordMutation.Field()
     confirm_email = ConfirmEmailMutation.Field()
     update_user_profile = UpdateUserProfileMutation.Field()
-    create_transaction = CreateTransactionMutation.Field()
-    update_transaction = UpdateTransactionMutation.Field()
-    delete_transaction = DeleteTransactionMutation.Field()
-    create_goal = CreateGoalMutation.Field()
-    update_goal = UpdateGoalMutation.Field()
-    delete_goal = DeleteGoalMutation.Field()
+    # ADR-0002: CRUD mutations deprecated — use REST endpoints.
+    # See docs/adr/0002-graphql-ownership.md for rationale and migration.
+    create_transaction = CreateTransactionMutation.Field(
+        deprecation_reason="ADR-0002: use POST /transactions"
+    )
+    update_transaction = UpdateTransactionMutation.Field(
+        deprecation_reason="ADR-0002: use PATCH /transactions/{id}"
+    )
+    delete_transaction = DeleteTransactionMutation.Field(
+        deprecation_reason="ADR-0002: use DELETE /transactions/{id}"
+    )
+    create_goal = CreateGoalMutation.Field(
+        deprecation_reason="ADR-0002: use POST /goals"
+    )
+    update_goal = UpdateGoalMutation.Field(
+        deprecation_reason="ADR-0002: use PATCH /goals/{id}"
+    )
+    delete_goal = DeleteGoalMutation.Field(
+        deprecation_reason="ADR-0002: use DELETE /goals/{id}"
+    )
     simulate_goal_plan = SimulateGoalPlanMutation.Field()
     save_installment_vs_cash_simulation = (
         SaveInstallmentVsCashSimulationMutation.Field()
@@ -78,17 +92,38 @@ class Mutation(graphene.ObjectType):
     create_planned_expense_from_installment_vs_cash_simulation = (
         CreatePlannedExpenseFromInstallmentVsCashSimulationMutation.Field()
     )
-    add_wallet_entry = AddWalletEntryMutation.Field()
-    update_wallet_entry = UpdateWalletEntryMutation.Field()
-    delete_wallet_entry = DeleteWalletEntryMutation.Field()
-    add_investment_operation = AddInvestmentOperationMutation.Field()
-    update_investment_operation = UpdateInvestmentOperationMutation.Field()
-    delete_investment_operation = DeleteInvestmentOperationMutation.Field()
+    # ADR-0002: CRUD mutations deprecated — use REST endpoints.
+    add_wallet_entry = AddWalletEntryMutation.Field(
+        deprecation_reason="ADR-0002: use POST /wallet"
+    )
+    update_wallet_entry = UpdateWalletEntryMutation.Field(
+        deprecation_reason="ADR-0002: use PATCH /wallet/{id}"
+    )
+    delete_wallet_entry = DeleteWalletEntryMutation.Field(
+        deprecation_reason="ADR-0002: use DELETE /wallet/{id}"
+    )
+    # ADR-0002: CRUD mutations deprecated — use REST endpoints.
+    add_investment_operation = AddInvestmentOperationMutation.Field(
+        deprecation_reason="ADR-0002: use POST /wallet/{id}/operations"
+    )
+    update_investment_operation = UpdateInvestmentOperationMutation.Field(
+        deprecation_reason="ADR-0002: use PATCH /wallet/{id}/operations/{op_id}"
+    )
+    delete_investment_operation = DeleteInvestmentOperationMutation.Field(
+        deprecation_reason="ADR-0002: use DELETE /wallet/{id}/operations/{op_id}"
+    )
     add_ticker = AddTickerMutation.Field()
     delete_ticker = DeleteTickerMutation.Field()
-    create_budget = CreateBudgetMutation.Field()
-    update_budget = UpdateBudgetMutation.Field()
-    delete_budget = DeleteBudgetMutation.Field()
+    # ADR-0002: CRUD mutations deprecated — use REST endpoints.
+    create_budget = CreateBudgetMutation.Field(
+        deprecation_reason="ADR-0002: use POST /budgets"
+    )
+    update_budget = UpdateBudgetMutation.Field(
+        deprecation_reason="ADR-0002: use PATCH /budgets/{id}"
+    )
+    delete_budget = DeleteBudgetMutation.Field(
+        deprecation_reason="ADR-0002: use DELETE /budgets/{id}"
+    )
     create_checkout_session = CreateCheckoutSessionMutation.Field()
     cancel_subscription = CancelSubscriptionMutation.Field()
     update_notification_preferences = UpdateNotificationPreferencesMutation.Field()

--- a/graphql.introspection.json
+++ b/graphql.introspection.json
@@ -7595,9 +7595,9 @@
                   }
                 }
               ],
-              "deprecationReason": null,
+              "deprecationReason": "ADR-0002: use POST /transactions",
               "description": null,
-              "isDeprecated": false,
+              "isDeprecated": true,
               "name": "createTransaction",
               "type": {
                 "kind": "OBJECT",
@@ -7828,9 +7828,9 @@
                   }
                 }
               ],
-              "deprecationReason": null,
+              "deprecationReason": "ADR-0002: use PATCH /transactions/{id}",
               "description": null,
-              "isDeprecated": false,
+              "isDeprecated": true,
               "name": "updateTransaction",
               "type": {
                 "kind": "OBJECT",
@@ -7857,9 +7857,9 @@
                   }
                 }
               ],
-              "deprecationReason": null,
+              "deprecationReason": "ADR-0002: use DELETE /transactions/{id}",
               "description": null,
-              "isDeprecated": false,
+              "isDeprecated": true,
               "name": "deleteTransaction",
               "type": {
                 "kind": "OBJECT",
@@ -7974,9 +7974,9 @@
                   }
                 }
               ],
-              "deprecationReason": null,
+              "deprecationReason": "ADR-0002: use POST /goals",
               "description": null,
-              "isDeprecated": false,
+              "isDeprecated": true,
               "name": "createGoal",
               "type": {
                 "kind": "OBJECT",
@@ -8099,9 +8099,9 @@
                   }
                 }
               ],
-              "deprecationReason": null,
+              "deprecationReason": "ADR-0002: use PATCH /goals/{id}",
               "description": null,
-              "isDeprecated": false,
+              "isDeprecated": true,
               "name": "updateGoal",
               "type": {
                 "kind": "OBJECT",
@@ -8128,9 +8128,9 @@
                   }
                 }
               ],
-              "deprecationReason": null,
+              "deprecationReason": "ADR-0002: use DELETE /goals/{id}",
               "description": null,
-              "isDeprecated": false,
+              "isDeprecated": true,
               "name": "deleteGoal",
               "type": {
                 "kind": "OBJECT",
@@ -8805,9 +8805,9 @@
                   }
                 }
               ],
-              "deprecationReason": null,
+              "deprecationReason": "ADR-0002: use POST /wallet",
               "description": null,
-              "isDeprecated": false,
+              "isDeprecated": true,
               "name": "addWalletEntry",
               "type": {
                 "kind": "OBJECT",
@@ -8942,9 +8942,9 @@
                   }
                 }
               ],
-              "deprecationReason": null,
+              "deprecationReason": "ADR-0002: use PATCH /wallet/{id}",
               "description": null,
-              "isDeprecated": false,
+              "isDeprecated": true,
               "name": "updateWalletEntry",
               "type": {
                 "kind": "OBJECT",
@@ -8971,9 +8971,9 @@
                   }
                 }
               ],
-              "deprecationReason": null,
+              "deprecationReason": "ADR-0002: use DELETE /wallet/{id}",
               "description": null,
-              "isDeprecated": false,
+              "isDeprecated": true,
               "name": "deleteWalletEntry",
               "type": {
                 "kind": "OBJECT",
@@ -9084,9 +9084,9 @@
                   }
                 }
               ],
-              "deprecationReason": null,
+              "deprecationReason": "ADR-0002: use POST /wallet/{id}/operations",
               "description": null,
-              "isDeprecated": false,
+              "isDeprecated": true,
               "name": "addInvestmentOperation",
               "type": {
                 "kind": "OBJECT",
@@ -9201,9 +9201,9 @@
                   }
                 }
               ],
-              "deprecationReason": null,
+              "deprecationReason": "ADR-0002: use PATCH /wallet/{id}/operations/{op_id}",
               "description": null,
-              "isDeprecated": false,
+              "isDeprecated": true,
               "name": "updateInvestmentOperation",
               "type": {
                 "kind": "OBJECT",
@@ -9246,9 +9246,9 @@
                   }
                 }
               ],
-              "deprecationReason": null,
+              "deprecationReason": "ADR-0002: use DELETE /wallet/{id}/operations/{op_id}",
               "description": null,
-              "isDeprecated": false,
+              "isDeprecated": true,
               "name": "deleteInvestmentOperation",
               "type": {
                 "kind": "OBJECT",
@@ -9441,9 +9441,9 @@
                   }
                 }
               ],
-              "deprecationReason": null,
+              "deprecationReason": "ADR-0002: use POST /budgets",
               "description": null,
-              "isDeprecated": false,
+              "isDeprecated": true,
               "name": "createBudget",
               "type": {
                 "kind": "OBJECT",
@@ -9554,9 +9554,9 @@
                   }
                 }
               ],
-              "deprecationReason": null,
+              "deprecationReason": "ADR-0002: use PATCH /budgets/{id}",
               "description": null,
-              "isDeprecated": false,
+              "isDeprecated": true,
               "name": "updateBudget",
               "type": {
                 "kind": "OBJECT",
@@ -9583,9 +9583,9 @@
                   }
                 }
               ],
-              "deprecationReason": null,
+              "deprecationReason": "ADR-0002: use DELETE /budgets/{id}",
               "description": null,
-              "isDeprecated": false,
+              "isDeprecated": true,
               "name": "deleteBudget",
               "type": {
                 "kind": "OBJECT",

--- a/schema.graphql
+++ b/schema.graphql
@@ -527,27 +527,27 @@ type Mutation {
   resetPassword(newPassword: String!, token: String!): AuthPayloadType
   confirmEmail(token: String!): AuthPayloadType
   updateUserProfile(birthDate: String, financialObjectives: String, gender: String, initialInvestment: Float, investmentGoalDate: String, investorProfile: String, investorProfileSuggested: String, monthlyExpenses: Float, monthlyIncome: Float, monthlyIncomeNet: Float, monthlyInvestment: Float, netWorth: Float, occupation: String, profileQuizScore: Int, stateUf: String, taxonomyVersion: String): UpdateUserProfileMutation
-  createTransaction(accountId: UUID, amount: String!, creditCardId: UUID, currency: String = "BRL", description: String, dueDate: String!, endDate: String, installmentCount: Int, isInstallment: Boolean = false, isRecurring: Boolean = false, observation: String, startDate: String, status: String = "pending", tagId: UUID, title: String!, type: String!): CreateTransactionMutation
-  updateTransaction(accountId: UUID, amount: String, creditCardId: UUID, currency: String, description: String, dueDate: String, endDate: String, installmentCount: Int, isInstallment: Boolean, isRecurring: Boolean, observation: String, paidAt: String, startDate: String, status: String, tagId: UUID, title: String, transactionId: UUID!, type: String): UpdateTransactionMutation
-  deleteTransaction(transactionId: UUID!): DeleteTransactionMutation
-  createGoal(category: String, currentAmount: String, description: String, priority: Int, status: String, targetAmount: String!, targetDate: String, title: String!): CreateGoalMutation
-  updateGoal(category: String, currentAmount: String, description: String, goalId: UUID!, priority: Int, status: String, targetAmount: String, targetDate: String, title: String): UpdateGoalMutation
-  deleteGoal(goalId: UUID!): DeleteGoalMutation
+  createTransaction(accountId: UUID, amount: String!, creditCardId: UUID, currency: String = "BRL", description: String, dueDate: String!, endDate: String, installmentCount: Int, isInstallment: Boolean = false, isRecurring: Boolean = false, observation: String, startDate: String, status: String = "pending", tagId: UUID, title: String!, type: String!): CreateTransactionMutation @deprecated(reason: "ADR-0002: use POST /transactions")
+  updateTransaction(accountId: UUID, amount: String, creditCardId: UUID, currency: String, description: String, dueDate: String, endDate: String, installmentCount: Int, isInstallment: Boolean, isRecurring: Boolean, observation: String, paidAt: String, startDate: String, status: String, tagId: UUID, title: String, transactionId: UUID!, type: String): UpdateTransactionMutation @deprecated(reason: "ADR-0002: use PATCH /transactions/{id}")
+  deleteTransaction(transactionId: UUID!): DeleteTransactionMutation @deprecated(reason: "ADR-0002: use DELETE /transactions/{id}")
+  createGoal(category: String, currentAmount: String, description: String, priority: Int, status: String, targetAmount: String!, targetDate: String, title: String!): CreateGoalMutation @deprecated(reason: "ADR-0002: use POST /goals")
+  updateGoal(category: String, currentAmount: String, description: String, goalId: UUID!, priority: Int, status: String, targetAmount: String, targetDate: String, title: String): UpdateGoalMutation @deprecated(reason: "ADR-0002: use PATCH /goals/{id}")
+  deleteGoal(goalId: UUID!): DeleteGoalMutation @deprecated(reason: "ADR-0002: use DELETE /goals/{id}")
   simulateGoalPlan(currentAmount: String, monthlyContribution: String, monthlyExpenses: String, monthlyIncome: String, targetAmount: String!, targetDate: String): SimulateGoalPlanMutation
   saveInstallmentVsCashSimulation(cashPrice: String!, feesEnabled: Boolean = false, feesUpfront: String = "0.00", firstPaymentDelayDays: Int = 30, inflationRateAnnual: String!, installmentAmount: String, installmentCount: Int!, installmentTotal: String, opportunityRateAnnual: String, opportunityRateType: String = "manual", scenarioLabel: String): SaveInstallmentVsCashSimulationMutation
   createGoalFromInstallmentVsCashSimulation(category: String = "planned_purchase", currentAmount: String = "0.00", description: String, priority: Int = 3, selectedOption: String!, simulationId: UUID!, targetDate: String, title: String!): CreateGoalFromInstallmentVsCashSimulationMutation
   createPlannedExpenseFromInstallmentVsCashSimulation(accountId: UUID, creditCardId: UUID, currency: String = "BRL", description: String, dueDate: String, firstDueDate: String, observation: String, selectedOption: String!, simulationId: UUID!, status: String = "pending", tagId: UUID, title: String!, upfrontDueDate: String): CreatePlannedExpenseFromInstallmentVsCashSimulationMutation
-  addWalletEntry(annualRate: Float, assetClass: String, name: String!, quantity: Int, registerDate: String, shouldBeOnWallet: Boolean!, targetWithdrawDate: String, ticker: String, value: Float): AddWalletEntryMutation
-  updateWalletEntry(annualRate: Float, assetClass: String, investmentId: UUID!, name: String, quantity: Int, registerDate: String, shouldBeOnWallet: Boolean, targetWithdrawDate: String, ticker: String, value: Float): UpdateWalletEntryMutation
-  deleteWalletEntry(investmentId: UUID!): DeleteWalletEntryMutation
-  addInvestmentOperation(executedAt: String, fees: String, investmentId: UUID!, notes: String, operationType: String!, quantity: String!, unitPrice: String!): AddInvestmentOperationMutation
-  updateInvestmentOperation(executedAt: String, fees: String, investmentId: UUID!, notes: String, operationId: UUID!, operationType: String, quantity: String, unitPrice: String): UpdateInvestmentOperationMutation
-  deleteInvestmentOperation(investmentId: UUID!, operationId: UUID!): DeleteInvestmentOperationMutation
+  addWalletEntry(annualRate: Float, assetClass: String, name: String!, quantity: Int, registerDate: String, shouldBeOnWallet: Boolean!, targetWithdrawDate: String, ticker: String, value: Float): AddWalletEntryMutation @deprecated(reason: "ADR-0002: use POST /wallet")
+  updateWalletEntry(annualRate: Float, assetClass: String, investmentId: UUID!, name: String, quantity: Int, registerDate: String, shouldBeOnWallet: Boolean, targetWithdrawDate: String, ticker: String, value: Float): UpdateWalletEntryMutation @deprecated(reason: "ADR-0002: use PATCH /wallet/{id}")
+  deleteWalletEntry(investmentId: UUID!): DeleteWalletEntryMutation @deprecated(reason: "ADR-0002: use DELETE /wallet/{id}")
+  addInvestmentOperation(executedAt: String, fees: String, investmentId: UUID!, notes: String, operationType: String!, quantity: String!, unitPrice: String!): AddInvestmentOperationMutation @deprecated(reason: "ADR-0002: use POST /wallet/{id}/operations")
+  updateInvestmentOperation(executedAt: String, fees: String, investmentId: UUID!, notes: String, operationId: UUID!, operationType: String, quantity: String, unitPrice: String): UpdateInvestmentOperationMutation @deprecated(reason: "ADR-0002: use PATCH /wallet/{id}/operations/{op_id}")
+  deleteInvestmentOperation(investmentId: UUID!, operationId: UUID!): DeleteInvestmentOperationMutation @deprecated(reason: "ADR-0002: use DELETE /wallet/{id}/operations/{op_id}")
   addTicker(quantity: Float!, symbol: String!, type: String): AddTickerMutation
   deleteTicker(symbol: String!): DeleteTickerMutation
-  createBudget(amount: String!, endDate: String, isActive: Boolean, name: String!, period: String!, startDate: String, tagId: String): CreateBudgetMutation
-  updateBudget(amount: String, budgetId: UUID!, endDate: String, isActive: Boolean, name: String, period: String, startDate: String, tagId: String): UpdateBudgetMutation
-  deleteBudget(budgetId: UUID!): DeleteBudgetMutation
+  createBudget(amount: String!, endDate: String, isActive: Boolean, name: String!, period: String!, startDate: String, tagId: String): CreateBudgetMutation @deprecated(reason: "ADR-0002: use POST /budgets")
+  updateBudget(amount: String, budgetId: UUID!, endDate: String, isActive: Boolean, name: String, period: String, startDate: String, tagId: String): UpdateBudgetMutation @deprecated(reason: "ADR-0002: use PATCH /budgets/{id}")
+  deleteBudget(budgetId: UUID!): DeleteBudgetMutation @deprecated(reason: "ADR-0002: use DELETE /budgets/{id}")
   createCheckoutSession(billingCycle: String, planSlug: String!): CreateCheckoutSessionMutation
   cancelSubscription: CancelSubscriptionMutation
   updateNotificationPreferences(preferences: [PreferenceInput!]!): UpdateNotificationPreferencesMutation

--- a/scripts/graphql_mutation_audit.py
+++ b/scripts/graphql_mutation_audit.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""CI gate: enforce GraphQL/REST ownership per ADR-0002.
+
+Verifies that all CRUD mutations listed in ADR-0002 have a deprecation_reason
+set in app/graphql/mutations/__init__.py. Fails if any of the required mutations
+are missing the deprecation marker, preventing silent regressions.
+
+Rules (from docs/adr/0002-graphql-ownership.md):
+  - REST is the canonical surface for CRUD operations.
+  - GraphQL mutations for CRUD of domain entities must carry deprecation_reason.
+  - New CRUD mutations without deprecation_reason are forbidden.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MUTATIONS_INIT = ROOT / "app/graphql/mutations/__init__.py"
+
+# Mutations that MUST have a deprecation_reason per ADR-0002.
+# Any new CRUD mutation added here without deprecation_reason will fail CI.
+ADR_0002_CRUD_MUTATIONS: set[str] = {
+    "create_transaction",
+    "update_transaction",
+    "delete_transaction",
+    "create_goal",
+    "update_goal",
+    "delete_goal",
+    "add_wallet_entry",
+    "update_wallet_entry",
+    "delete_wallet_entry",
+    "add_investment_operation",
+    "update_investment_operation",
+    "delete_investment_operation",
+    "create_budget",
+    "update_budget",
+    "delete_budget",
+}
+
+# Mutations that match CRUD verb patterns but are ALLOWED without deprecation:
+# - No REST equivalent exists (ticker, notification) OR
+# - They are auth-specific (update_user_profile) OR
+# - They are simulation composite operations (no canonical REST resource)
+ADR_0002_ALLOWED_CRUD_VERBS: set[str] = {
+    "add_ticker",  # No REST equivalent — GraphQL-only ticker management
+    "delete_ticker",  # No REST equivalent — GraphQL-only ticker management
+    "update_user_profile",  # Auth-domain, no REST CRUD equivalent
+    "update_notification_preferences",  # No REST equivalent
+    "create_goal_from_installment_vs_cash_simulation",  # Simulation composite
+    "create_planned_expense_from_installment_vs_cash_simulation",  # Simulation
+    "create_checkout_session",  # Stripe-specific, no domain CRUD equivalent
+}
+
+# Keywords that, if present in a mutation name without deprecation, indicate
+# a likely-new CRUD mutation that should be flagged for ADR-0002 review.
+CRUD_VERBS = ("create_", "update_", "delete_", "add_", "remove_", "patch_")
+
+
+def _parse_mutation_class(source: str) -> dict[str, bool]:
+    """Return {mutation_field_name: has_deprecation_reason} for the Mutation class."""
+    tree = ast.parse(source)
+    result: dict[str, bool] = {}
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef) or node.name != "Mutation":
+            continue
+        for stmt in node.body:
+            if not isinstance(stmt, ast.Assign):
+                continue
+            for target in stmt.targets:
+                if not isinstance(target, ast.Name):
+                    continue
+                field_name = target.id
+                call = stmt.value
+                if not isinstance(call, ast.Call):
+                    continue
+                has_dep = any(
+                    isinstance(kw, ast.keyword) and kw.arg == "deprecation_reason"
+                    for kw in call.keywords
+                )
+                result[field_name] = has_dep
+
+    return result
+
+
+def main() -> int:
+    source = MUTATIONS_INIT.read_text(encoding="utf-8")
+    mutations = _parse_mutation_class(source)
+
+    failures: list[str] = []
+
+    # 1. Check that all ADR-0002 CRUD mutations have deprecation_reason
+    for name in sorted(ADR_0002_CRUD_MUTATIONS):
+        if name not in mutations:
+            failures.append(
+                f"  MISSING field '{name}' — should exist in Mutation class"
+            )
+        elif not mutations[name]:
+            failures.append(
+                f"  MISSING deprecation_reason on '{name}' "
+                f"(ADR-0002 requires it — see docs/adr/0002-graphql-ownership.md)"
+            )
+
+    # 2. Detect new CRUD mutations not in ADR-0002 list and not deprecated
+    for name, has_dep in mutations.items():
+        if name in ADR_0002_CRUD_MUTATIONS:
+            continue
+        if name in ADR_0002_ALLOWED_CRUD_VERBS:
+            continue
+        if any(name.startswith(verb) for verb in CRUD_VERBS) and not has_dep:
+            failures.append(
+                f"  NEW CRUD mutation '{name}' lacks deprecation_reason. "
+                f"Per ADR-0002, new CRUD mutations must be deprecated with "
+                f"a pointer to the REST equivalent, or added to "
+                f"ADR_0002_ALLOWED_CRUD_VERBS in this script "
+                f"if no REST equivalent exists."
+            )
+
+    if failures:
+        print(
+            "graphql-mutation-audit FAILED — ADR-0002 violation(s) detected:",
+            file=sys.stderr,
+        )
+        for f in failures:
+            print(f, file=sys.stderr)
+        print(
+            "\nSee docs/adr/0002-graphql-ownership.md for the rule.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"[graphql-mutation-audit] ok — {len(ADR_0002_CRUD_MUTATIONS)} CRUD mutations "
+        f"correctly deprecated, {len(mutations) - len(ADR_0002_CRUD_MUTATIONS)} "
+        f"non-CRUD mutations allowed."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Implementa CI gate que previne regressão silenciosa no ADR-0002 (GraphQL/REST ownership)
- Depreca 15 mutations CRUD no schema GraphQL com pointer para os endpoints REST equivalentes
- Cria `scripts/graphql_mutation_audit.py` rodando em pre-commit e CI
- Resolve #1048

## Contexto

O ADR-0002 define que REST é canonical para CRUD e GraphQL é somente leitura. Sem enforcement automatizado, qualquer agente ou dev poderia adicionar uma nova mutation CRUD sem perceber. Este PR fecha esse gap.

## O que foi feito

### 1. Deprecações no schema (`app/graphql/mutations/__init__.py`)
15 mutations CRUD agora carregam `deprecation_reason` apontando para o REST equivalente:
- `createTransaction`, `updateTransaction`, `deleteTransaction` → `POST/PATCH/DELETE /transactions`
- `createGoal`, `updateGoal`, `deleteGoal` → `POST/PATCH/DELETE /goals`
- `addWalletEntry`, `updateWalletEntry`, `deleteWalletEntry` → `POST/PATCH/DELETE /wallet`
- `addInvestmentOperation`, `updateInvestmentOperation`, `deleteInvestmentOperation` → `POST/PATCH/DELETE /wallet/{id}/operations`
- `createBudget`, `updateBudget`, `deleteBudget` → `POST/PATCH/DELETE /budgets`

Mutations sem REST equivalente (ticker, notifications, simulations, auth) mantidas ativas.

### 2. `scripts/graphql_mutation_audit.py`
- Valida que todas as 15 mutations CRUD têm `deprecation_reason`
- Detecta novas mutations que começam com verbo CRUD sem deprecation (e não estão no allowlist)
- Mensagem de erro clara com link para o ADR

### 3. Gates de CI
- `.pre-commit-config.yaml`: hook `graphql-mutation-audit` (trigger: mudanças em `app/graphql/mutations/`)
- `.github/workflows/ci.yml`: step `GraphQL mutation ownership audit (ADR-0002)` antes de instalar dependências

## Test plan

- [x] `graphql_mutation_audit.py` passa localmente
- [x] `test_committed_graphql_docs_match_runtime_bundle` passa (schema.graphql regenerado)
- [x] `test_graphql_budget_api` passa (mutations ainda funcionam apesar da deprecação)
- [x] Pre-commit hook `graphql-mutation-audit (ADR-0002)` ativo e passando
- [x] Todos os quality gates passando

Closes #1048