### PR TITLE
arch(controllers): enforce response_contract usage — CI gate + subscription fix (#1047)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
       - name: GraphQL mutation ownership audit (ADR-0002)
         run: python scripts/graphql_mutation_audit.py
 
+      - name: Controller response contract check (arch/#1047)
+        run: python scripts/controller_response_contract_check.py
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,6 +49,12 @@ repos:
     language: system
     pass_filenames: false
     files: app/graphql/mutations/
+  - id: controller-response-contract-check
+    name: controller-response-contract-check (arch/#1047)
+    entry: python3 scripts/controller_response_contract_check.py
+    language: system
+    pass_filenames: false
+    files: app/controllers/
   - id: alembic-single-head-check
     name: alembic-single-head-check
     entry: python3 scripts/alembic_single_head_check.py

--- a/app/controllers/subscription_controller.py
+++ b/app/controllers/subscription_controller.py
@@ -14,7 +14,7 @@ import logging
 from typing import Any
 from uuid import UUID
 
-from flask import Blueprint, current_app, jsonify, request
+from flask import Blueprint, current_app, request
 from flask.typing import ResponseReturnValue
 
 from app.application.services.billing_email_service import dispatch_billing_email
@@ -58,6 +58,7 @@ from app.services.subscription_service import (
     sync_subscription_from_provider,
 )
 from app.utils.datetime_utils import utc_now_naive
+from app.utils.response_builder import json_response
 
 logger = logging.getLogger(__name__)
 
@@ -96,7 +97,7 @@ def _serialize_subscription(sub: Subscription) -> dict[str, Any]:
 
 
 def _ok(data: dict[str, Any], status: int = 200) -> ResponseReturnValue:
-    return jsonify({"success": True, "data": data}), status
+    return json_response({"success": True, "data": data}, status_code=status)
 
 
 def _err(

--- a/scripts/controller_response_contract_check.py
+++ b/scripts/controller_response_contract_check.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""CI gate: enforce response_contract usage across REST controllers.
+
+Detects controller files that use `jsonify` directly without going through
+app.controllers.response_contract or app.utils.response_builder, which are
+the canonical wrappers for all JSON responses.
+
+Motivation (issue #1047):
+  - Inconsistent response formats when jsonify is used directly
+  - Hard to add global fields (request_id, timestamp) in one place
+  - Sonar CPD and code review friction
+
+Allowed exceptions (intentional direct jsonify use):
+  - app/utils/response_builder.py — the canonical jsonify wrapper itself
+  - app/controllers/response_contract.py — the contract implementation
+  - app/controllers/observability_controller.py — ops/metrics, non-user-facing
+  - app/controllers/admin/feature_flags.py — admin ops, intentionally minimal
+  - app/controllers/auth/error_handlers.py — webargs low-level error handler
+    (abort() pattern requires raw make_response + jsonify)
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTROLLERS_DIR = ROOT / "app/controllers"
+
+# Files allowed to use jsonify directly (with documented reasons above).
+ALLOWLIST: set[Path] = {
+    ROOT / "app/utils/response_builder.py",
+    ROOT / "app/controllers/response_contract.py",
+    ROOT / "app/controllers/observability_controller.py",
+    ROOT / "app/controllers/admin/feature_flags.py",
+    ROOT / "app/controllers/auth/error_handlers.py",
+}
+
+
+def _imports_jsonify(tree: ast.Module) -> bool:
+    """Return True if the module imports jsonify from flask."""
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom):
+            continue
+        if node.module != "flask":
+            continue
+        if any(alias.name == "jsonify" for alias in node.names):
+            return True
+    return False
+
+
+def _collect_controller_py_files() -> list[Path]:
+    files: list[Path] = []
+    for path in CONTROLLERS_DIR.rglob("*.py"):
+        if "__pycache__" in path.parts:
+            continue
+        files.append(path)
+    return sorted(files)
+
+
+def main() -> int:
+    violations: list[str] = []
+
+    for path in _collect_controller_py_files():
+        if path in ALLOWLIST:
+            continue
+        try:
+            source = path.read_text(encoding="utf-8")
+            tree = ast.parse(source, filename=str(path))
+        except SyntaxError as exc:
+            print(f"  SKIP {path.relative_to(ROOT)}: syntax error — {exc}")
+            continue
+
+        if _imports_jsonify(tree):
+            violations.append(
+                f"  {path.relative_to(ROOT)}: imports jsonify directly. "
+                f"Use app.controllers.response_contract or "
+                f"app.utils.response_builder instead."
+            )
+
+    if violations:
+        print(
+            "controller-response-contract-check FAILED — direct jsonify detected:",
+            file=sys.stderr,
+        )
+        for v in violations:
+            print(v, file=sys.stderr)
+        print(
+            "\nMigrate to compat_success_response / compat_error_response from "
+            "app.controllers.response_contract. To allow an exception, "
+            "add the file to ALLOWLIST in this script with a reason comment.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"[controller-response-contract-check] ok — "
+        f"{len(_collect_controller_py_files()) - len(ALLOWLIST)} "
+        f"controller files audited, 0 direct jsonify usages."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Cria CI gate que previne uso direto de `jsonify` em controllers REST
- Migra `subscription_controller._ok()` para usar `json_response()` canônico
- Resolve #1047

## Contexto

O projeto tem `app/controllers/response_contract.py` como único ponto de geração de respostas JSON. Mas `subscription_controller.py` usava `jsonify` diretamente, criando divergência e tornando impossível adicionar campos globais (ex: `request_id`) em um único lugar.

## O que foi feito

### 1. `scripts/controller_response_contract_check.py` (novo)
- Audita todos os arquivos em `app/controllers/` via AST (parse de imports)
- Falha se qualquer arquivo importa `jsonify` do Flask diretamente
- 5 exceções documentadas no `ALLOWLIST` com justificativa:
  - `response_builder.py` — o wrapper canônico que envolve jsonify
  - `response_contract.py` — a implementação do contrato
  - `observability_controller.py` — ops/metrics, respostas não-standard
  - `admin/feature_flags.py` — admin ops, formato intencional
  - `auth/error_handlers.py` — padrão `abort()` do webargs requer `make_response + jsonify`

### 2. `app/controllers/subscription_controller.py`
- Remove `from flask import jsonify`
- `_ok()` helper: `jsonify({...}), status` → `json_response({...}, status_code=status)`
- Contrato externo inalterado (mesmo payload e status code)

### 3. Gates de CI
- `.pre-commit-config.yaml`: hook `controller-response-contract-check`
- `.github/workflows/ci.yml`: step antes de instalar dependências

## Test plan

- [x] `controller_response_contract_check.py` passa: 146 arquivos auditados, 0 violações
- [x] `tests/test_billing.py` 21 passed — subscription endpoints funcionando
- [x] Pre-commit hook `controller-response-contract-check` ativo e passando
- [x] Todos os quality gates passando

Closes #1047