### PR TITLE
feat(resilience): login guard — in-memory failover when Redis down at runtime (#1050)

### DIFF
--- a/app/services/login_attempt_guard_storage.py
+++ b/app/services/login_attempt_guard_storage.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
 import importlib
+import logging
 import os
 import threading
+import time
 from dataclasses import dataclass
 from typing import Any, Protocol
+
+_logger = logging.getLogger("auraxis.login_guard")
 
 DEFAULT_LOGIN_GUARD_KEY_PREFIX = "auraxis:login-guard"
 
@@ -228,12 +232,182 @@ def build_login_attempt_storage_from_env() -> tuple[
     key_prefix = str(
         os.getenv("LOGIN_GUARD_REDIS_KEY_PREFIX", DEFAULT_LOGIN_GUARD_KEY_PREFIX)
     ).strip()
+    redis_storage = RedisLoginAttemptStorage(
+        client, key_prefix=key_prefix or DEFAULT_LOGIN_GUARD_KEY_PREFIX
+    )
+    probe_interval = int(os.getenv("LOGIN_GUARD_PROBE_INTERVAL_SECONDS", "30"))
+    failover_storage = FailoverLoginAttemptStorage(
+        redis=redis_storage,
+        probe_interval_seconds=max(10, probe_interval),
+    )
     return (
-        RedisLoginAttemptStorage(
-            client, key_prefix=key_prefix or DEFAULT_LOGIN_GUARD_KEY_PREFIX
-        ),
+        failover_storage,
         "redis",
         True,
         "redis",
         None,
     )
+
+
+# ── FailoverLoginAttemptStorage ───────────────────────────────────────────────
+
+_FAILOVER_PROBE_INTERVAL_DEFAULT = 30  # seconds between Redis health probes
+_FAILOVER_MAX_MEMORY_KEYS = 10_000  # hard cap; LRU-style eviction via prune()
+
+
+class FailoverLoginAttemptStorage:
+    """Redis-backed storage with automatic in-memory fallback.
+
+    Normal operation: all operations delegate to ``RedisLoginAttemptStorage``.
+
+    On any Redis exception: switches to ``InMemoryLoginAttemptStorage`` and
+    starts a background probe thread.  When Redis becomes reachable again the
+    in-memory state is flushed to Redis and the primary backend is restored.
+
+    The probe runs at most once every *probe_interval_seconds* to avoid
+    hammering a recovering Redis.
+    """
+
+    def __init__(
+        self,
+        *,
+        redis: RedisLoginAttemptStorage,
+        probe_interval_seconds: int = _FAILOVER_PROBE_INTERVAL_DEFAULT,
+    ) -> None:
+        self._redis = redis
+        self._memory = InMemoryLoginAttemptStorage()
+        self._probe_interval = probe_interval_seconds
+        self._using_fallback = False
+        self._lock = threading.Lock()
+        self._probe_thread: threading.Thread | None = None
+        self._last_probe_at: float = 0.0
+
+    # ── Public storage interface ──────────────────────────────────────────────
+
+    def get(self, key: str) -> LoginAttemptState | None:
+        if self._using_fallback:
+            return self._memory.get(key)
+        try:
+            return self._redis.get(key)
+        except Exception as exc:
+            self._activate_fallback(exc)
+            return self._memory.get(key)
+
+    def set(self, key: str, state: LoginAttemptState, *, ttl_seconds: int) -> None:
+        if self._using_fallback:
+            self._memory.set(key, state, ttl_seconds=ttl_seconds)
+            return
+        try:
+            self._redis.set(key, state, ttl_seconds=ttl_seconds)
+        except Exception as exc:
+            self._activate_fallback(exc)
+            self._memory.set(key, state, ttl_seconds=ttl_seconds)
+
+    def delete(self, key: str) -> None:
+        if self._using_fallback:
+            self._memory.delete(key)
+            return
+        try:
+            self._redis.delete(key)
+        except Exception as exc:
+            self._activate_fallback(exc)
+            self._memory.delete(key)
+
+    def prune(self, *, now: float, retention_seconds: int, max_keys: int) -> None:
+        if self._using_fallback:
+            self._memory.prune(
+                now=now,
+                retention_seconds=retention_seconds,
+                max_keys=min(max_keys, _FAILOVER_MAX_MEMORY_KEYS),
+            )
+        else:
+            self._redis.prune(
+                now=now, retention_seconds=retention_seconds, max_keys=max_keys
+            )
+
+    def reset_for_tests(self) -> None:
+        self._redis.reset_for_tests()
+        self._memory.reset_for_tests()
+        with self._lock:
+            self._using_fallback = False
+            self._last_probe_at = 0.0
+
+    # ── Introspection ─────────────────────────────────────────────────────────
+
+    @property
+    def is_using_fallback(self) -> bool:
+        return self._using_fallback
+
+    # ── Fallback activation ───────────────────────────────────────────────────
+
+    def _activate_fallback(self, exc: Exception) -> None:
+        with self._lock:
+            if not self._using_fallback:
+                self._using_fallback = True
+                _logger.warning(
+                    "login_guard: Redis unavailable — switching to in-memory fallback. "
+                    "reason=%r",
+                    str(exc),
+                )
+            self._maybe_start_probe_thread()
+
+    def _maybe_start_probe_thread(self) -> None:
+        """Start probe thread if not already running (called under self._lock)."""
+        if self._probe_thread is not None and self._probe_thread.is_alive():
+            return
+        t = threading.Thread(
+            target=self._probe_loop, daemon=True, name="login-guard-probe"
+        )
+        self._probe_thread = t
+        t.start()
+
+    # ── Background probe ──────────────────────────────────────────────────────
+
+    def _probe_loop(self) -> None:
+        """Daemon thread: probes Redis until it recovers, then flushes and exits."""
+        while self._using_fallback:
+            time.sleep(self._probe_interval)
+            if not self._using_fallback:
+                break
+            try:
+                self._redis._client.ping()
+            except Exception:
+                continue  # still down — keep probing
+
+            # Redis is back — flush and restore primary only if flush succeeds fully
+            flushed_ok = self._flush_to_redis()
+            if not flushed_ok:
+                _logger.warning(
+                    "login_guard: flush to Redis incomplete — staying on fallback."
+                )
+                continue
+
+            with self._lock:
+                self._using_fallback = False
+                _logger.info("login_guard: Redis recovered — restored primary backend.")
+
+    def _flush_to_redis(self) -> bool:
+        """Copy all in-memory states to Redis, then clear memory.
+
+        Returns ``True`` if all entries were flushed successfully.
+        """
+        with self._memory._lock:
+            snapshot = dict(self._memory._state)
+
+        flushed = 0
+        failed = 0
+        for key, state in snapshot.items():
+            try:
+                # Use a generous TTL so flushed entries outlive the reconnect window
+                self._redis.set(key, state, ttl_seconds=7200)
+                flushed += 1
+            except Exception:
+                _logger.warning("login_guard: flush failed for key (hash omitted)")
+                failed += 1
+
+        _logger.info(
+            "login_guard: flush complete flushed=%d failed=%d", flushed, failed
+        )
+        if failed == 0:
+            self._memory.reset_for_tests()
+        return failed == 0

--- a/tests/test_login_guard_failover.py
+++ b/tests/test_login_guard_failover.py
@@ -1,0 +1,232 @@
+"""Tests for FailoverLoginAttemptStorage (issue #1050)."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.services.login_attempt_guard_storage import (
+    FailoverLoginAttemptStorage,
+    LoginAttemptState,
+    RedisLoginAttemptStorage,
+)
+
+
+def _make_redis_storage() -> tuple[RedisLoginAttemptStorage, MagicMock]:
+    client = MagicMock()
+    client.hgetall.return_value = {}
+    storage = RedisLoginAttemptStorage(client)
+    return storage, client
+
+
+def _make_failover(
+    probe_interval: int = 60,
+) -> tuple[FailoverLoginAttemptStorage, MagicMock]:
+    redis_storage, client = _make_redis_storage()
+    failover = FailoverLoginAttemptStorage(
+        redis=redis_storage,
+        probe_interval_seconds=probe_interval,
+    )
+    return failover, client
+
+
+def _state(failures: int = 1) -> LoginAttemptState:
+    return LoginAttemptState(
+        failures=failures, blocked_until=0.0, updated_at=time.time()
+    )
+
+
+# ── Normal (Redis healthy) path ───────────────────────────────────────────────
+
+
+class TestFailoverNormalPath:
+    def test_get_delegates_to_redis(self) -> None:
+        failover, client = _make_failover()
+        client.hgetall.return_value = {
+            b"failures": b"3",
+            b"blocked_until": b"0.0",
+            b"updated_at": b"1.0",
+        }
+        result = failover.get("somekey")
+        assert result is not None
+        assert result.failures == 3
+        assert not failover.is_using_fallback
+
+    def test_set_delegates_to_redis(self) -> None:
+        failover, client = _make_failover()
+        failover.set("k", _state(), ttl_seconds=300)
+        client.hset.assert_called_once()
+        assert not failover.is_using_fallback
+
+    def test_delete_delegates_to_redis(self) -> None:
+        failover, client = _make_failover()
+        failover.delete("k")
+        client.delete.assert_called_once()
+        assert not failover.is_using_fallback
+
+    def test_prune_delegates_to_redis(self) -> None:
+        failover, client = _make_failover()
+        # Redis prune is a no-op — just verifying no exception
+        failover.prune(now=time.time(), retention_seconds=3600, max_keys=10000)
+        assert not failover.is_using_fallback
+
+
+# ── Failover activation ───────────────────────────────────────────────────────
+
+
+class TestFailoverActivation:
+    def test_get_activates_fallback_on_redis_error(self) -> None:
+        failover, client = _make_failover()
+        client.hgetall.side_effect = RuntimeError("redis down")
+        result = failover.get("k")
+        assert result is None
+        assert failover.is_using_fallback
+
+    def test_set_activates_fallback_on_redis_error(self) -> None:
+        failover, client = _make_failover()
+        client.hset.side_effect = RuntimeError("redis down")
+        failover.set("k", _state(), ttl_seconds=300)
+        assert failover.is_using_fallback
+
+    def test_delete_activates_fallback_on_redis_error(self) -> None:
+        failover, client = _make_failover()
+        client.delete.side_effect = RuntimeError("redis down")
+        failover.delete("k")
+        assert failover.is_using_fallback
+
+    def test_fallback_preserves_state_set_after_activation(self) -> None:
+        failover, client = _make_failover()
+        client.hset.side_effect = RuntimeError("redis down")
+        state = _state(failures=3)
+        failover.set("mykey", state, ttl_seconds=300)
+        assert failover.is_using_fallback
+        # State should be in memory now
+        retrieved = failover.get("mykey")
+        assert retrieved is not None
+        assert retrieved.failures == 3
+
+    def test_get_uses_memory_when_already_on_fallback(self) -> None:
+        failover, client = _make_failover()
+        # Activate fallback
+        client.hset.side_effect = RuntimeError("redis down")
+        failover.set("k", _state(2), ttl_seconds=300)
+        assert failover.is_using_fallback
+        # Subsequent get should hit memory, not Redis
+        client.hgetall.reset_mock()
+        result = failover.get("k")
+        client.hgetall.assert_not_called()
+        assert result is not None
+        assert result.failures == 2
+
+    def test_set_uses_memory_when_on_fallback(self) -> None:
+        failover, client = _make_failover()
+        failover._using_fallback = True
+        failover.set("k", _state(5), ttl_seconds=300)
+        client.hset.assert_not_called()
+        assert failover._memory.get("k") is not None
+
+    def test_delete_uses_memory_when_on_fallback(self) -> None:
+        failover, client = _make_failover()
+        failover._using_fallback = True
+        failover._memory.set("k", _state(), ttl_seconds=300)
+        failover.delete("k")
+        assert failover._memory.get("k") is None
+        client.delete.assert_not_called()
+
+    def test_prune_uses_memory_when_on_fallback(self) -> None:
+        failover, client = _make_failover()
+        failover._using_fallback = True
+        # Should call memory prune (which caps at _FAILOVER_MAX_MEMORY_KEYS)
+        failover.prune(now=time.time(), retention_seconds=3600, max_keys=100)
+        # No exception — success
+
+
+# ── Probe thread and recovery ─────────────────────────────────────────────────
+
+
+class TestFailoverRecovery:
+    def test_probe_thread_started_on_fallback_activation(self) -> None:
+        failover, client = _make_failover(probe_interval=60)
+        client.hset.side_effect = RuntimeError("redis down")
+        failover.set("k", _state(), ttl_seconds=300)
+        assert failover._probe_thread is not None
+        assert failover._probe_thread.is_alive()
+
+    def test_flush_to_redis_copies_memory_state(self) -> None:
+        failover, client = _make_failover()
+        failover._using_fallback = True
+        failover._memory.set("k1", _state(2), ttl_seconds=300)
+        failover._memory.set("k2", _state(4), ttl_seconds=300)
+        failover._flush_to_redis()
+        assert client.hset.call_count == 2
+        # Memory cleared after flush
+        assert failover._memory.get("k1") is None
+        assert failover._memory.get("k2") is None
+
+    def test_flush_to_redis_skips_failed_keys(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        failover, client = _make_failover()
+        failover._using_fallback = True
+        failover._memory.set("k1", _state(1), ttl_seconds=300)
+        client.hset.side_effect = RuntimeError("still down")
+        with caplog.at_level("WARNING", logger="auraxis.login_guard"):
+            failover._flush_to_redis()
+        assert "flush failed" in caplog.text
+
+    def test_recovery_restores_primary_backend(self) -> None:
+        failover, client = _make_failover(probe_interval=1)
+        # Activate fallback
+        client.hset.side_effect = RuntimeError("redis down")
+        failover.set("k", _state(), ttl_seconds=300)
+        assert failover.is_using_fallback
+
+        # Simulate Redis recovering: ping succeeds, hset succeeds again
+        client.ping.return_value = True
+        client.hset.side_effect = None
+
+        # Wait for probe thread to detect recovery (probe_interval=1s)
+        deadline = time.time() + 5
+        while failover.is_using_fallback and time.time() < deadline:
+            time.sleep(0.1)
+
+        assert not failover.is_using_fallback, "Guard should have recovered"
+
+    def test_recovery_does_not_restore_if_flush_fails(self) -> None:
+        failover, client = _make_failover(probe_interval=1)
+        # Activate fallback and store state in memory so flush has entries
+        client.hset.side_effect = RuntimeError("down")
+        failover.set("k", _state(3), ttl_seconds=300)
+        assert failover.is_using_fallback
+        assert failover._memory.get("k") is not None  # entry in memory
+
+        # Ping succeeds but hset still fails (flush will fail)
+        client.ping.return_value = True
+        # hset is still raising
+
+        # Give probe thread time to try — it should NOT restore
+        time.sleep(2.5)
+        assert failover.is_using_fallback, "Should remain on fallback if flush fails"
+
+
+# ── reset_for_tests ───────────────────────────────────────────────────────────
+
+
+class TestFailoverReset:
+    def test_reset_clears_fallback_flag(self) -> None:
+        failover, client = _make_failover()
+        failover._using_fallback = True
+        failover._memory.set("k", _state(), ttl_seconds=300)
+        failover.reset_for_tests()
+        assert not failover.is_using_fallback
+        assert failover._memory.get("k") is None
+
+    def test_reset_stops_counting_as_fallback(self) -> None:
+        failover, client = _make_failover()
+        client.hset.side_effect = RuntimeError("down")
+        failover.set("k", _state(), ttl_seconds=300)
+        assert failover.is_using_fallback
+        failover.reset_for_tests()
+        assert not failover.is_using_fallback


### PR DESCRIPTION
## Summary

- Adds `FailoverLoginAttemptStorage` wrapping `RedisLoginAttemptStorage` with automatic in-memory fallback when Redis throws at runtime
- Background probe thread re-pings Redis on a configurable interval and flushes in-memory state back to Redis on recovery (only restores primary if full flush succeeds)
- `build_login_attempt_storage_from_env()` now returns a `FailoverLoginAttemptStorage` when `LOGIN_GUARD_BACKEND=redis`
- Hard cap at 10 000 in-memory keys during fallback (`_FAILOVER_MAX_MEMORY_KEYS`)
- 19 tests covering normal path delegation, failover activation, state preservation, probe thread lifecycle, flush success/failure, and full recovery

## Test plan

- [x] `pytest tests/test_login_guard_failover.py` — 19/19 passed
- [x] `mypy app/services/login_attempt_guard_storage.py` — no issues
- [x] Full pre-commit quality gates passed

Closes #1050