### PR TITLE
feat(retention): audit event auto-retention — scheduled job, BRIN index, Prometheus counter (#1051)

### DIFF
--- a/.github/workflows/audit-retention-job.yml
+++ b/.github/workflows/audit-retention-job.yml
@@ -1,0 +1,179 @@
+name: Audit Retention Job
+
+on:
+  schedule:
+    # Runs every day at 03:00 UTC — off-peak window
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+    inputs:
+      retention_days:
+        description: "Retention window in days (default: 90)"
+        required: false
+        default: "90"
+
+concurrency:
+  group: audit-retention-job-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+  issues: write
+
+jobs:
+  purge-audit-events:
+    name: Purge Expired Audit Events
+    runs-on: ubuntu-latest
+    environment: prod
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate required variables
+        run: |
+          [ -n "${AWS_REGION:-}" ] || { echo "Missing var AWS_REGION"; exit 1; }
+          [ -n "${AWS_ROLE_ARN_PROD:-}" ] || { echo "Missing var AWS_ROLE_ARN_PROD"; exit 1; }
+          [ -n "${AURAXIS_PROD_INSTANCE_ID:-}" ] || { echo "Missing var AURAXIS_PROD_INSTANCE_ID"; exit 1; }
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+          AWS_ROLE_ARN_PROD: ${{ vars.AWS_ROLE_ARN_PROD }}
+          AURAXIS_PROD_INSTANCE_ID: ${{ vars.AURAXIS_PROD_INSTANCE_ID }}
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN_PROD }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Run audit retention purge via SSM
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+          PROD_INSTANCE_ID: ${{ vars.AURAXIS_PROD_INSTANCE_ID }}
+          RETENTION_DAYS: ${{ github.event.inputs.retention_days || '90' }}
+        run: |
+          COMMAND_ID=$(aws ssm send-command \
+            --region "${AWS_REGION}" \
+            --instance-ids "${PROD_INSTANCE_ID}" \
+            --document-name "AWS-RunShellScript" \
+            --parameters "commands=[
+              \"cd /opt/auraxis\",
+              \"AUDIT_RETENTION_DAYS=${RETENTION_DAYS} docker compose exec -T web flask audit-events purge-expired\"
+            ]" \
+            --query "Command.CommandId" \
+            --output text)
+
+          echo "SSM Command ID: ${COMMAND_ID}"
+
+          for i in $(seq 1 30); do
+            STATUS=$(aws ssm get-command-invocation \
+              --region "${AWS_REGION}" \
+              --command-id "${COMMAND_ID}" \
+              --instance-id "${PROD_INSTANCE_ID}" \
+              --query "StatusDetails" \
+              --output text 2>/dev/null || echo "Pending")
+
+            echo "Attempt ${i}: ${STATUS}"
+
+            if [ "${STATUS}" = "Success" ]; then
+              echo "Audit retention purge completed."
+              aws ssm get-command-invocation \
+                --region "${AWS_REGION}" \
+                --command-id "${COMMAND_ID}" \
+                --instance-id "${PROD_INSTANCE_ID}" \
+                --query "StandardOutputContent" \
+                --output text 2>/dev/null || true
+              exit 0
+            elif [ "${STATUS}" = "Failed" ] || [ "${STATUS}" = "Cancelled" ] || [ "${STATUS}" = "TimedOut" ]; then
+              echo "Audit retention purge failed with status: ${STATUS}"
+              echo "--- stdout ---"
+              aws ssm get-command-invocation \
+                --region "${AWS_REGION}" \
+                --command-id "${COMMAND_ID}" \
+                --instance-id "${PROD_INSTANCE_ID}" \
+                --query "StandardOutputContent" \
+                --output text 2>/dev/null || true
+              echo "--- stderr ---"
+              aws ssm get-command-invocation \
+                --region "${AWS_REGION}" \
+                --command-id "${COMMAND_ID}" \
+                --instance-id "${PROD_INSTANCE_ID}" \
+                --query "StandardErrorContent" \
+                --output text 2>/dev/null || true
+              exit 1
+            fi
+
+            sleep 10
+          done
+
+          echo "Timed out waiting for SSM command to complete."
+          exit 1
+
+      - name: Notify failure via GitHub Issue
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const now = new Date().toISOString();
+            const title = '🚨 [audit-retention-job] Falha na purga de audit_events';
+            const issueBody = [
+              '## Audit Retention Job falhou',
+              '',
+              `**Última falha:** ${now}`,
+              `**Run:** ${runUrl}`,
+              '',
+              'O job agendado de purga de audit_events falhou via SSM.',
+              'Verifique os logs do workflow e o estado da stack de produção.',
+              '',
+              '### Ações sugeridas',
+              '- Revisar logs da execução no link acima',
+              '- Verificar o estado de `docker compose` e do container `web` na instância PROD',
+              '- Executar `flask audit-events purge-expired` manualmente para diagnóstico',
+              '',
+              '_Issue criada automaticamente pelo GitHub Actions._',
+            ].join('\n');
+            const commentBody = [
+              'Nova falha detectada no audit-retention job.',
+              '',
+              `- Data: ${now}`,
+              `- Run: ${runUrl}`,
+            ].join('\n');
+            const query = [
+              `repo:${context.repo.owner}/${context.repo.repo}`,
+              'is:issue',
+              'in:title',
+              `"${title}"`,
+            ].join(' ');
+            const search = await github.rest.search.issuesAndPullRequests({
+              q: query,
+              per_page: 10,
+            });
+            const matchingIssue = search.data.items.find(
+              (item) => item.title === title,
+            );
+            if (matchingIssue) {
+              if (matchingIssue.state === 'closed') {
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: matchingIssue.number,
+                  state: 'open',
+                });
+              }
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: matchingIssue.number,
+                body: commentBody,
+              });
+              return;
+            }
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body: issueBody,
+              labels: ['bug', 'ops', 'database'],
+            });

--- a/app/extensions/prometheus_metrics.py
+++ b/app/extensions/prometheus_metrics.py
@@ -40,13 +40,18 @@ except ImportError:  # pragma: no cover
 _HTTP_REQUESTS_TOTAL: Any = None
 _HTTP_REQUEST_DURATION: Any = None
 _AUTH_LOGINS_TOTAL: Any = None
+_AUDIT_EVENTS_PURGED_TOTAL: Any = None
 
 _DURATION_BUCKETS = (0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5)
 
 
 def _ensure_metrics_initialized() -> None:
     """Lazily initialise Prometheus metric objects (idempotent)."""
-    global _HTTP_REQUESTS_TOTAL, _HTTP_REQUEST_DURATION, _AUTH_LOGINS_TOTAL
+    global \
+        _HTTP_REQUESTS_TOTAL, \
+        _HTTP_REQUEST_DURATION, \
+        _AUTH_LOGINS_TOTAL, \
+        _AUDIT_EVENTS_PURGED_TOTAL
 
     if not _PROMETHEUS_AVAILABLE:
         return
@@ -73,6 +78,12 @@ def _ensure_metrics_initialized() -> None:
             ["status"],
         )
 
+    if _AUDIT_EVENTS_PURGED_TOTAL is None:
+        _AUDIT_EVENTS_PURGED_TOTAL = Counter(
+            "auraxis_audit_events_purged_total",
+            "Total audit_events rows deleted by the retention job",
+        )
+
 
 def record_http_request(
     *,
@@ -94,6 +105,13 @@ def record_http_request(
             method=method,
             endpoint=endpoint,
         ).observe(duration_seconds)
+
+
+def record_audit_purge(count: int) -> None:
+    """Increment ``auraxis_audit_events_purged_total`` by *count* rows deleted."""
+    _ensure_metrics_initialized()
+    if _AUDIT_EVENTS_PURGED_TOTAL is not None:
+        _AUDIT_EVENTS_PURGED_TOTAL.inc(count)
 
 
 def record_auth_login(*, status: str) -> None:
@@ -155,6 +173,7 @@ def register_prometheus_middleware(app: "Flask") -> None:
 
 __all__ = [
     "generate_latest_metrics",
+    "record_audit_purge",
     "record_auth_login",
     "record_http_request",
     "register_prometheus_middleware",

--- a/app/services/audit_event_service.py
+++ b/app/services/audit_event_service.py
@@ -41,13 +41,18 @@ def search_audit_events_by_request_id(
 
 
 def purge_expired_audit_events(*, retention_days: int) -> int:
+    from app.extensions.prometheus_metrics import record_audit_purge
+
     safe_retention_days = max(int(retention_days), 1)
     cutoff = datetime.now(UTC) - timedelta(days=safe_retention_days)
     deleted = AuditEvent.query.filter(AuditEvent.created_at < cutoff).delete(
         synchronize_session=False
     )
     db.session.commit()
-    return int(deleted)
+    count = int(deleted)
+    if count > 0:
+        record_audit_purge(count)
+    return count
 
 
 def serialize_audit_event(event: AuditEvent) -> dict[str, Any]:

--- a/migrations/versions/hd1051_audit_events_retention_index.py
+++ b/migrations/versions/hd1051_audit_events_retention_index.py
@@ -1,0 +1,43 @@
+"""HD-1051 — Add BRIN index on audit_events.created_at for retention purge
+
+``ix_audit_events_created_at`` (btree) already exists for random-access lookups
+by request_id join.  The retention job deletes all rows older than a configurable
+cutoff, which is a sequential-scan-friendly range query on an append-only table.
+A BRIN index is a far better fit: it is orders-of-magnitude smaller than a btree
+and exploits the physical correlation between insertion order and created_at.
+
+The migration is idempotent — it uses IF NOT EXISTS so running it twice is safe.
+
+Revision ID: hd1051_audit_retention_index
+Revises: h1028_refresh_tokens
+Create Date: 2026-04-15 00:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "hd1051_audit_retention_index"
+down_revision = "h1028_refresh_tokens"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_audit_events_created_at_brin",
+        "audit_events",
+        ["created_at"],
+        postgresql_using="brin",
+        postgresql_with={"pages_per_range": "128"},
+        if_not_exists=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_audit_events_created_at_brin",
+        table_name="audit_events",
+        if_exists=True,
+    )

--- a/tests/test_audit_retention.py
+++ b/tests/test_audit_retention.py
@@ -1,0 +1,191 @@
+"""Tests for audit event retention (issue #1051)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
+
+from app.services.audit_event_service import purge_expired_audit_events
+
+# ── purge_expired_audit_events ────────────────────────────────────────────────
+
+
+class TestPurgeExpiredAuditEvents:
+    def test_deletes_events_older_than_retention_window(self, app) -> None:
+        """Rows older than retention_days must be removed from the DB."""
+        from app.extensions.database import db
+        from app.models.audit_event import AuditEvent
+
+        old_ts = datetime.now(UTC) - timedelta(days=95)
+        recent_ts = datetime.now(UTC) - timedelta(days=10)
+
+        with app.app_context():
+            old_event = AuditEvent(
+                method="GET",
+                path="/old",
+                status=200,
+                created_at=old_ts,
+            )
+            recent_event = AuditEvent(
+                method="GET",
+                path="/recent",
+                status=200,
+                created_at=recent_ts,
+            )
+            db.session.add_all([old_event, recent_event])
+            db.session.commit()
+
+            deleted = purge_expired_audit_events(retention_days=90)
+
+            assert deleted == 1
+            remaining = AuditEvent.query.all()
+            assert len(remaining) == 1
+            assert remaining[0].path == "/recent"
+
+    def test_returns_zero_when_nothing_to_purge(self, app) -> None:
+        from app.extensions.database import db
+        from app.models.audit_event import AuditEvent
+
+        with app.app_context():
+            recent = AuditEvent(
+                method="POST",
+                path="/tx",
+                status=201,
+                created_at=datetime.now(UTC) - timedelta(days=5),
+            )
+            db.session.add(recent)
+            db.session.commit()
+
+            deleted = purge_expired_audit_events(retention_days=90)
+
+            assert deleted == 0
+
+    def test_minimum_retention_days_is_1(self, app) -> None:
+        """Even with retention_days=0 the floor is 1 day — avoid accidental wipe."""
+        from app.extensions.database import db
+        from app.models.audit_event import AuditEvent
+
+        with app.app_context():
+            old = AuditEvent(
+                method="DELETE",
+                path="/gone",
+                status=204,
+                created_at=datetime.now(UTC) - timedelta(days=30),
+            )
+            db.session.add(old)
+            db.session.commit()
+
+            # retention_days=0 should be coerced to 1
+            deleted = purge_expired_audit_events(retention_days=0)
+            assert deleted == 1
+
+    def test_emits_prometheus_counter_when_rows_deleted(self, app) -> None:
+        from app.extensions.database import db
+        from app.models.audit_event import AuditEvent
+
+        with app.app_context():
+            old = AuditEvent(
+                method="GET",
+                path="/metrics-test",
+                status=200,
+                created_at=datetime.now(UTC) - timedelta(days=200),
+            )
+            db.session.add(old)
+            db.session.commit()
+
+            with patch(
+                "app.extensions.prometheus_metrics.record_audit_purge"
+            ) as mock_metric:
+                deleted = purge_expired_audit_events(retention_days=90)
+
+            assert deleted == 1
+            mock_metric.assert_called_once_with(1)
+
+    def test_does_not_emit_metric_when_nothing_deleted(self, app) -> None:
+        from app.extensions.database import db
+        from app.models.audit_event import AuditEvent
+
+        with app.app_context():
+            recent = AuditEvent(
+                method="GET",
+                path="/no-metric",
+                status=200,
+                created_at=datetime.now(UTC) - timedelta(days=1),
+            )
+            db.session.add(recent)
+            db.session.commit()
+
+            with patch(
+                "app.extensions.prometheus_metrics.record_audit_purge"
+            ) as mock_metric:
+                deleted = purge_expired_audit_events(retention_days=90)
+
+            assert deleted == 0
+            mock_metric.assert_not_called()
+
+
+# ── record_audit_purge metric ─────────────────────────────────────────────────
+
+
+class TestRecordAuditPurgeMetric:
+    def test_increments_counter_by_count(self) -> None:
+        from app.extensions.prometheus_metrics import record_audit_purge
+
+        # Should not raise even if prometheus_client registers a duplicate
+        # counter in the same test process — the lazy-init is idempotent.
+        record_audit_purge(42)  # no exception
+
+    def test_zero_count_does_not_raise(self) -> None:
+        from app.extensions.prometheus_metrics import record_audit_purge
+
+        record_audit_purge(0)  # no exception
+
+
+# ── audit_retention_cli ───────────────────────────────────────────────────────
+
+
+class TestAuditRetentionCli:
+    def test_purge_expired_command_reports_deleted_count(self, app) -> None:
+        from click.testing import CliRunner
+
+        from app.extensions.audit_retention_cli import register_audit_retention_commands
+
+        with app.app_context():
+            register_audit_retention_commands(app)
+
+        runner = CliRunner()
+        with patch(
+            "app.extensions.audit_retention_cli.purge_expired_audit_events",
+            return_value=7,
+        ):
+            result = runner.invoke(
+                app.cli,
+                ["audit-events", "purge-expired", "--retention-days", "30"],
+                catch_exceptions=False,
+                obj={"app": app},
+            )
+
+        assert result.exit_code == 0
+        assert "deleted=7" in result.output
+        assert "retention_days=30" in result.output
+
+    def test_purge_expired_command_skips_when_disabled(self, app, monkeypatch) -> None:
+        from click.testing import CliRunner
+
+        from app.extensions.audit_retention_cli import register_audit_retention_commands
+
+        monkeypatch.setenv("AUDIT_RETENTION_ENABLED", "false")
+
+        with app.app_context():
+            register_audit_retention_commands(app)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            app.cli,
+            ["audit-events", "purge-expired"],
+            catch_exceptions=False,
+            obj={"app": app},
+        )
+
+        assert result.exit_code == 0
+        assert "disabled" in result.output


### PR DESCRIPTION
## Summary

- GitHub Actions cron workflow `audit-retention-job.yml` runs daily at **03:00 UTC**, executing `flask audit-events purge-expired` via AWS SSM (same pattern as reminder-job/purge-deleted-accounts)
- Added `auraxis_audit_events_purged_total` Prometheus counter incremented by `purge_expired_audit_events()` when rows are deleted
- Added Alembic migration `hd1051_audit_retention_index` — BRIN index on `audit_events.created_at` (far smaller than btree for append-only time-series data; idempotent via `if_not_exists=True`)
- Workflow supports `workflow_dispatch` with configurable `retention_days` input (defaults to env var `AUDIT_RETENTION_DAYS`, which defaults to 90)
- Failure notification creates/re-opens a GitHub Issue with run URL (same pattern as existing ops workflows)

## Test plan

- [x] `pytest tests/test_audit_retention.py` — 9/9 passed
- [x] Full CI quality gate: 1568 passed, 87.91% coverage
- [x] All pre-commit hooks passed

Closes #1051