### PR TITLE
feat(audit): soft-delete audit trail — entity-level events, admin query endpoint (#1052)

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -15,6 +15,7 @@ from sqlalchemy.pool import NullPool
 from app.cli.features import features as features_cli_group
 from app.cli.openapi_export import openapi_export_command
 from app.controllers.account import account_bp
+from app.controllers.admin.audit_trail import admin_audit_trail_bp
 from app.controllers.admin.feature_flags import admin_feature_flags_bp
 from app.controllers.advisory import advisory_bp
 from app.controllers.alert_controller import alert_bp, register_alert_dependencies
@@ -303,6 +304,7 @@ def create_app(*, enable_http_runtime: bool = True) -> Flask:
     app.register_blueprint(budget_bp)
     app.register_blueprint(advisory_bp)
     app.register_blueprint(admin_feature_flags_bp, url_prefix="/admin")
+    app.register_blueprint(admin_audit_trail_bp)
 
     # Registra os endpoints documentados no Swagger com base no mapa real de rotas.
     _register_documented_endpoints(app, docs)

--- a/app/application/services/transaction_ledger_service.py
+++ b/app/application/services/transaction_ledger_service.py
@@ -346,6 +346,13 @@ class TransactionLedgerService:
 
         try:
             transaction.deleted = True
+            from app.extensions.audit_trail import record_entity_delete
+
+            record_entity_delete(
+                entity_type="transaction",
+                entity_id=str(transaction_id),
+                actor_id=str(self._user_id),
+            )
             db.session.commit()
             self._invalidate_dashboard_cache()
         except Exception:

--- a/app/controllers/admin/audit_trail.py
+++ b/app/controllers/admin/audit_trail.py
@@ -1,0 +1,88 @@
+"""Admin endpoint for querying entity-level audit trail (issue #1052).
+
+Endpoint
+--------
+    GET /admin/audit-trail/<entity_type>/<entity_id>
+        Returns up to 100 audit events for the given entity, newest first.
+        Requires a valid JWT with the ``admin`` role.
+
+Example
+-------
+    GET /admin/audit-trail/transaction/550e8400-e29b-41d4-a716-446655440000
+    GET /admin/audit-trail/user/550e8400-e29b-41d4-a716-446655440000
+"""
+
+from __future__ import annotations
+
+from flask import Blueprint, request
+from flask.typing import ResponseReturnValue
+
+from app.auth import get_active_auth_context
+from app.controllers.response_contract import (
+    compat_error_response,
+    compat_success_response,
+)
+from app.services.audit_event_service import (
+    list_entity_audit_events,
+    serialize_audit_event,
+)
+
+admin_audit_trail_bp = Blueprint("admin_audit_trail", __name__)
+
+_ALLOWED_ENTITY_TYPES = frozenset({"transaction", "user"})
+
+
+def _is_admin() -> bool:
+    try:
+        ctx = get_active_auth_context()
+        return "admin" in ctx.roles
+    except Exception:
+        return False
+
+
+@admin_audit_trail_bp.get("/admin/audit-trail/<entity_type>/<entity_id>")
+def get_entity_audit_trail(entity_type: str, entity_id: str) -> ResponseReturnValue:
+    if not _is_admin():
+        return compat_error_response(
+            legacy_payload={"error": "Forbidden", "code": "FORBIDDEN"},
+            status_code=403,
+            message="Forbidden",
+            error_code="FORBIDDEN",
+        )
+
+    if entity_type not in _ALLOWED_ENTITY_TYPES:
+        return compat_error_response(
+            legacy_payload={
+                "error": (
+                    f"Unknown entity_type '{entity_type}'. "
+                    f"Allowed: {sorted(_ALLOWED_ENTITY_TYPES)}"
+                ),
+                "code": "INVALID_ENTITY_TYPE",
+            },
+            status_code=400,
+            message=f"Unknown entity_type '{entity_type}'",
+            error_code="INVALID_ENTITY_TYPE",
+        )
+
+    try:
+        limit = min(int(request.args.get("limit", 100)), 500)
+    except (TypeError, ValueError):
+        limit = 100
+
+    events = list_entity_audit_events(entity_type, entity_id, limit=limit)
+    return compat_success_response(
+        legacy_payload={
+            "entity_type": entity_type,
+            "entity_id": entity_id,
+            "count": len(events),
+            "events": [serialize_audit_event(e) for e in events],
+        },
+        status_code=200,
+        message="ok",
+        data={
+            "entity_type": entity_type,
+            "entity_id": entity_id,
+            "count": len(events),
+            "events": [serialize_audit_event(e) for e in events],
+        },
+    )

--- a/app/controllers/user/delete_me_resource.py
+++ b/app/controllers/user/delete_me_resource.py
@@ -146,6 +146,22 @@ class DeleteMeResource(MethodResource):
         _anonymise_user(user)
         db.session.commit()
 
+        # Record soft-delete audit trail — best-effort; never block the response.
+        try:
+            from app.extensions.audit_trail import record_entity_delete
+
+            record_entity_delete(
+                entity_type="user",
+                entity_id=str(user.id),
+                actor_id=str(user.id),
+            )
+            db.session.commit()
+        except Exception:
+            current_app.logger.exception(
+                "account_deletion: failed to record audit trail for user %s",
+                user.id,
+            )
+
         # Send deletion confirmation — best-effort; never block the response.
         try:
             html, text = render_account_deletion_email()

--- a/app/extensions/audit_trail.py
+++ b/app/extensions/audit_trail.py
@@ -99,6 +99,54 @@ def _log_retention_strategy(
     )
 
 
+def record_entity_delete(
+    *,
+    entity_type: str,
+    entity_id: str,
+    actor_id: str | None,
+    extra: str | None = None,
+) -> None:
+    """Persist a soft-delete audit event for a domain entity.
+
+    This is separate from the HTTP-level audit hook — it is called directly
+    from service/controller code when a soft-delete operation occurs.
+
+    Parameters
+    ----------
+    entity_type:
+        Domain label for the deleted entity, e.g. ``"transaction"`` or ``"user"``.
+    entity_id:
+        String representation of the entity's primary key (UUID).
+    actor_id:
+        The authenticated user who performed the delete, or ``None`` for
+        system-initiated deletes.
+    extra:
+        Optional JSON-serializable string with additional metadata
+        (e.g. reason, deleted_at).
+    """
+    if not _is_audit_persistence_enabled():
+        return
+    try:
+        event = AuditEvent(
+            method="SYSTEM",
+            path="",
+            status=0,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            action="soft_delete",
+            actor_id=actor_id,
+            extra=extra,
+        )
+        db.session.add(event)
+        db.session.flush()
+    except Exception:
+        current_app.logger.exception(
+            "audit_entity_delete_failed entity_type=%s entity_id=%s",
+            entity_type,
+            entity_id,
+        )
+
+
 def register_audit_trail(app: Flask) -> None:
     if not _is_audit_trail_enabled():
         return

--- a/app/models/audit_event.py
+++ b/app/models/audit_event.py
@@ -13,16 +13,23 @@ class AuditEvent(db.Model):
     __table_args__ = (
         db.Index("ix_audit_events_request_id", "request_id"),
         db.Index("ix_audit_events_created_at", "created_at"),
+        db.Index("ix_audit_events_entity", "entity_type", "entity_id"),
     )
 
     id = db.Column(db.UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     request_id = db.Column(db.String(64), nullable=True)
-    method = db.Column(db.String(12), nullable=False)
-    path = db.Column(db.String(256), nullable=False)
-    status = db.Column(db.Integer, nullable=False)
+    method = db.Column(db.String(12), nullable=False, server_default="SYSTEM")
+    path = db.Column(db.String(256), nullable=False, server_default="")
+    status = db.Column(db.Integer, nullable=False, server_default="0")
     user_id = db.Column(db.String(64), nullable=True)
     ip = db.Column(db.String(64), nullable=True)
     user_agent = db.Column(db.String(512), nullable=True)
+    # Entity-level audit fields for soft-delete trail (#1052)
+    entity_type = db.Column(db.String(64), nullable=True)
+    entity_id = db.Column(db.String(64), nullable=True)
+    action = db.Column(db.String(32), nullable=True)
+    actor_id = db.Column(db.String(64), nullable=True)
+    extra = db.Column(db.Text, nullable=True)
     created_at = db.Column(
         db.DateTime(timezone=True),
         nullable=False,

--- a/app/services/audit_event_service.py
+++ b/app/services/audit_event_service.py
@@ -50,8 +50,24 @@ def purge_expired_audit_events(*, retention_days: int) -> int:
     return int(deleted)
 
 
+def list_entity_audit_events(
+    entity_type: str,
+    entity_id: str,
+    *,
+    limit: int = 100,
+) -> list[AuditEvent]:
+    """Return audit events for a specific entity, newest first."""
+    safe_limit = min(max(int(limit), 1), 500)
+    return list(
+        AuditEvent.query.filter_by(entity_type=entity_type, entity_id=entity_id)
+        .order_by(AuditEvent.created_at.desc())
+        .limit(safe_limit)
+        .all()
+    )
+
+
 def serialize_audit_event(event: AuditEvent) -> dict[str, Any]:
-    return {
+    result: dict[str, Any] = {
         "id": str(event.id),
         "request_id": event.request_id,
         "method": event.method,
@@ -62,3 +78,10 @@ def serialize_audit_event(event: AuditEvent) -> dict[str, Any]:
         "user_agent": event.user_agent,
         "created_at": event.created_at.isoformat(),
     }
+    if event.entity_type is not None:
+        result["entity_type"] = event.entity_type
+        result["entity_id"] = event.entity_id
+        result["action"] = event.action
+        result["actor_id"] = event.actor_id
+        result["extra"] = event.extra
+    return result

--- a/migrations/versions/hd1052_audit_event_entity_fields.py
+++ b/migrations/versions/hd1052_audit_event_entity_fields.py
@@ -1,0 +1,56 @@
+"""HD-1052 — Add entity-level audit fields to audit_events
+
+Adds nullable columns for recording soft-delete operations at the entity
+level (not just the HTTP request level):
+  - entity_type  — e.g. "transaction", "user"
+  - entity_id    — UUID of the deleted entity as text
+  - action       — e.g. "soft_delete"
+  - actor_id     — UUID of the authenticated user who performed the action
+  - extra        — JSON blob with reason, metadata, etc.
+
+Existing HTTP-level audit rows are unaffected (all new columns are nullable).
+Composite index on (entity_type, entity_id) supports the
+``GET /admin/audit-trail/{entity_type}/{entity_id}`` query.
+
+Revision ID: hd1052_audit_entity_fields
+Revises: h1028_refresh_tokens
+Create Date: 2026-04-15 00:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "hd1052_audit_entity_fields"
+down_revision = "h1028_refresh_tokens"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("audit_events") as batch_op:
+        batch_op.add_column(sa.Column("entity_type", sa.String(64), nullable=True))
+        batch_op.add_column(sa.Column("entity_id", sa.String(64), nullable=True))
+        batch_op.add_column(sa.Column("action", sa.String(32), nullable=True))
+        batch_op.add_column(sa.Column("actor_id", sa.String(64), nullable=True))
+        batch_op.add_column(sa.Column("extra", sa.Text, nullable=True))
+
+    op.create_index(
+        "ix_audit_events_entity",
+        "audit_events",
+        ["entity_type", "entity_id"],
+        if_not_exists=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_audit_events_entity", table_name="audit_events", if_exists=True)
+
+    with op.batch_alter_table("audit_events") as batch_op:
+        batch_op.drop_column("extra")
+        batch_op.drop_column("actor_id")
+        batch_op.drop_column("action")
+        batch_op.drop_column("entity_id")
+        batch_op.drop_column("entity_type")

--- a/tests/test_postman_collection_contract.py
+++ b/tests/test_postman_collection_contract.py
@@ -146,6 +146,8 @@ OPENAPI_GAPS: set[tuple[str, str]] = {
     ("POST", "/admin/feature-flags"),
     ("GET", "/admin/feature-flags/{param}"),
     ("DELETE", "/admin/feature-flags/{param}"),
+    # Admin audit trail (#1052)
+    ("GET", "/admin/audit-trail/{param}/{param}"),
     # Bank statements
     ("POST", "/bank-statements/preview"),
     ("POST", "/bank-statements/confirm"),

--- a/tests/test_soft_delete_audit_trail.py
+++ b/tests/test_soft_delete_audit_trail.py
@@ -1,0 +1,261 @@
+"""Tests for soft-delete audit trail (issue #1052)."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Generator
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+
+# ── Admin app fixture (auth guard disabled) ───────────────────────────────────
+
+_TEST_ENV = {
+    "SECRET_KEY": "test-secret-key-with-64-chars-minimum-for-jwt-signing-0001",
+    "JWT_SECRET_KEY": "test-jwt-secret-key-with-64-chars-minimum-for-signing-0002",
+    "FLASK_TESTING": "true",
+    "SECURITY_ENFORCE_STRONG_SECRETS": "false",
+    "DOCS_EXPOSURE_POLICY": "public",
+    "CORS_ALLOWED_ORIGINS": "https://frontend.local",
+    "GRAPHQL_ALLOW_INTROSPECTION": "true",
+    "BILLING_WEBHOOK_ALLOW_UNSIGNED": "true",
+}
+
+
+@pytest.fixture()
+def admin_app(tmp_path: Path):
+    os.environ["DATABASE_URL"] = f"sqlite:///{tmp_path / 'test.sqlite3'}"
+    for k, v in _TEST_ENV.items():
+        os.environ[k] = v
+
+    from app import create_app
+    from app.extensions.database import db
+
+    flask_app = create_app(enable_http_runtime=False)
+    flask_app.config["TESTING"] = True
+
+    with flask_app.app_context():
+        db.drop_all()
+        db.create_all()
+
+    yield flask_app
+
+    with flask_app.app_context():
+        db.session.remove()
+        db.drop_all()
+        db.engine.dispose()
+
+
+@pytest.fixture()
+def admin_client(admin_app) -> Generator:
+    with admin_app.test_client() as c:
+        yield c
+
+
+# ── record_entity_delete ──────────────────────────────────────────────────────
+
+
+class TestRecordEntityDelete:
+    def test_persists_audit_event_when_persistence_enabled(self, app) -> None:
+        from app.extensions.audit_trail import record_entity_delete
+
+        with app.app_context():
+            from app.extensions.database import db
+            from app.models.audit_event import AuditEvent
+
+            entity_id = str(uuid4())
+            actor_id = str(uuid4())
+
+            with patch(
+                "app.extensions.audit_trail._is_audit_persistence_enabled",
+                return_value=True,
+            ):
+                record_entity_delete(
+                    entity_type="transaction",
+                    entity_id=entity_id,
+                    actor_id=actor_id,
+                )
+                db.session.commit()
+
+            events = AuditEvent.query.filter_by(
+                entity_type="transaction", entity_id=entity_id
+            ).all()
+            assert len(events) == 1
+            event = events[0]
+            assert event.action == "soft_delete"
+            assert event.actor_id == actor_id
+            assert event.method == "SYSTEM"
+
+    def test_noop_when_persistence_disabled(self, app) -> None:
+        from app.extensions.audit_trail import record_entity_delete
+
+        with app.app_context():
+            from app.models.audit_event import AuditEvent
+
+            entity_id = str(uuid4())
+
+            with patch(
+                "app.extensions.audit_trail._is_audit_persistence_enabled",
+                return_value=False,
+            ):
+                record_entity_delete(
+                    entity_type="transaction",
+                    entity_id=entity_id,
+                    actor_id=None,
+                )
+
+            events = AuditEvent.query.filter_by(entity_id=entity_id).all()
+            assert events == []
+
+    def test_extra_field_stored(self, app) -> None:
+        from app.extensions.audit_trail import record_entity_delete
+
+        with app.app_context():
+            from app.extensions.database import db
+            from app.models.audit_event import AuditEvent
+
+            entity_id = str(uuid4())
+            extra_payload = json.dumps({"reason": "test", "deleted_at": "2026-04-15"})
+
+            with patch(
+                "app.extensions.audit_trail._is_audit_persistence_enabled",
+                return_value=True,
+            ):
+                record_entity_delete(
+                    entity_type="user",
+                    entity_id=entity_id,
+                    actor_id=None,
+                    extra=extra_payload,
+                )
+                db.session.commit()
+
+            event = AuditEvent.query.filter_by(entity_id=entity_id).first()
+            assert event is not None
+            assert event.extra == extra_payload
+
+
+# ── list_entity_audit_events ──────────────────────────────────────────────────
+
+
+class TestListEntityAuditEvents:
+    def test_returns_events_for_entity(self, app) -> None:
+        from app.extensions.database import db
+        from app.models.audit_event import AuditEvent
+        from app.services.audit_event_service import list_entity_audit_events
+
+        with app.app_context():
+            entity_id = str(uuid4())
+            for _ in range(3):
+                db.session.add(
+                    AuditEvent(
+                        method="SYSTEM",
+                        path="",
+                        status=0,
+                        entity_type="transaction",
+                        entity_id=entity_id,
+                        action="soft_delete",
+                    )
+                )
+            db.session.commit()
+
+            results = list_entity_audit_events("transaction", entity_id)
+            assert len(results) == 3
+
+    def test_returns_empty_for_unknown_entity(self, app) -> None:
+        from app.services.audit_event_service import list_entity_audit_events
+
+        with app.app_context():
+            results = list_entity_audit_events("transaction", str(uuid4()))
+            assert results == []
+
+    def test_limit_respected(self, app) -> None:
+        from app.extensions.database import db
+        from app.models.audit_event import AuditEvent
+        from app.services.audit_event_service import list_entity_audit_events
+
+        with app.app_context():
+            entity_id = str(uuid4())
+            for _ in range(10):
+                db.session.add(
+                    AuditEvent(
+                        method="SYSTEM",
+                        path="",
+                        status=0,
+                        entity_type="user",
+                        entity_id=entity_id,
+                        action="soft_delete",
+                    )
+                )
+            db.session.commit()
+
+            results = list_entity_audit_events("user", entity_id, limit=5)
+            assert len(results) == 5
+
+
+# ── admin audit trail endpoint ────────────────────────────────────────────────
+
+
+class TestAdminAuditTrailEndpoint:
+    def test_returns_events_for_known_entity(self, admin_client, admin_app) -> None:
+        from app.extensions.database import db
+        from app.models.audit_event import AuditEvent
+
+        with admin_app.app_context():
+            entity_id = str(uuid4())
+            db.session.add(
+                AuditEvent(
+                    method="SYSTEM",
+                    path="",
+                    status=0,
+                    entity_type="transaction",
+                    entity_id=entity_id,
+                    action="soft_delete",
+                    actor_id="user-abc",
+                )
+            )
+            db.session.commit()
+
+        with patch(
+            "app.controllers.admin.audit_trail._is_admin",
+            return_value=True,
+        ):
+            resp = admin_client.get(f"/admin/audit-trail/transaction/{entity_id}")
+
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["count"] == 1
+        assert body["events"][0]["action"] == "soft_delete"
+
+    def test_returns_400_for_unknown_entity_type(self, admin_client) -> None:
+        with patch(
+            "app.controllers.admin.audit_trail._is_admin",
+            return_value=True,
+        ):
+            resp = admin_client.get(f"/admin/audit-trail/invoice/{uuid4()}")
+
+        assert resp.status_code == 400
+        assert resp.get_json()["code"] == "INVALID_ENTITY_TYPE"
+
+    def test_returns_403_for_non_admin(self, admin_client) -> None:
+        with patch(
+            "app.controllers.admin.audit_trail._is_admin",
+            return_value=False,
+        ):
+            resp = admin_client.get(f"/admin/audit-trail/transaction/{uuid4()}")
+
+        assert resp.status_code == 403
+
+    def test_returns_empty_list_for_entity_with_no_events(self, admin_client) -> None:
+        with patch(
+            "app.controllers.admin.audit_trail._is_admin",
+            return_value=True,
+        ):
+            resp = admin_client.get(f"/admin/audit-trail/user/{uuid4()}")
+
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["count"] == 0
+        assert body["events"] == []


### PR DESCRIPTION
## Summary

- Adds `entity_type`, `entity_id`, `action`, `actor_id`, `extra` nullable columns to `AuditEvent` — backward compatible with existing HTTP-level rows
- Migration `hd1052_audit_entity_fields` adds the columns + composite index `ix_audit_events_entity (entity_type, entity_id)`
- `record_entity_delete(entity_type, entity_id, actor_id, extra)` function in `audit_trail.py` — persists a `soft_delete` audit event when `AUDIT_PERSISTENCE_ENABLED=true`
- Hooked into `TransactionLedgerService.delete_transaction()` and `DeleteMeResource.delete()` (user LGPD erasure)
- New endpoint `GET /admin/audit-trail/<entity_type>/<entity_id>` — admin-only, returns all audit events for an entity (newest first, `?limit=` up to 500)
- `list_entity_audit_events()` and updated `serialize_audit_event()` in `audit_event_service.py`
- 10 tests covering persistence, no-op when disabled, list queries, limit enforcement, and all endpoint cases

## Test plan

- [x] `pytest tests/test_soft_delete_audit_trail.py` — 10/10 passed
- [x] Full CI quality gate: 1569 passed, 87.88% coverage
- [x] All pre-commit hooks passed (including controller-response-contract-check)

Closes #1052