### PR TITLE
feat(arc-api-03): correlation-ID middleware end-to-end (X-Request-ID)

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -65,6 +65,7 @@ from app.extensions.sentry import init_sentry
 from app.extensions.slow_query_log import install_slow_query_log
 from app.extensions.trial_expiry_cli import register_trial_expiry_cli
 from app.http.request_context import register_request_context_adapter
+from app.middleware.correlation_id import register_correlation_id
 from app.middleware.cors import register_cors
 from app.middleware.docs_access import register_docs_access_guard
 from app.middleware.security_headers import register_security_headers
@@ -99,6 +100,7 @@ DOCS_CLASS_REGISTRATION_FALLBACK_ENDPOINTS = {
 
 def _register_http_runtime(app: Flask) -> None:
     register_request_context_adapter(app)
+    register_correlation_id(app)
     register_http_observability(app)
     register_prometheus_middleware(app)
     register_cors(app)

--- a/app/http/request_context.py
+++ b/app/http/request_context.py
@@ -7,12 +7,16 @@ entrypoint for request metadata consumed outside HTTP adapters.
 from __future__ import annotations
 
 import os
+import re
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Literal, overload
 from uuid import uuid4
 
 from flask import Flask, Response, g, has_request_context, request
+
+# Allow only safe characters in inbound X-Request-ID to prevent log injection.
+_REQUEST_ID_SAFE_RE = re.compile(r"^[a-zA-Z0-9\-_.]{1,128}$")
 
 
 @dataclass(frozen=True)
@@ -83,8 +87,17 @@ def _build_request_context() -> RequestContext:
     )
 
 
+def _sanitize_inbound_request_id(value: str) -> str:
+    """Return value if it is safe to use as a request_id, else empty string."""
+    value = value.strip()
+    return value if _REQUEST_ID_SAFE_RE.match(value) else ""
+
+
 def bind_request_context() -> None:
-    g.request_id = uuid4().hex
+    # Honor an X-Request-ID forwarded by nginx ($request_id) or a frontend
+    # client so the same ID is traceable end-to-end.  Sanitise before storing.
+    incoming = _sanitize_inbound_request_id(request.headers.get("X-Request-ID", ""))
+    g.request_id = incoming or uuid4().hex
     g.request_context = _build_request_context()
 
 

--- a/app/middleware/correlation_id.py
+++ b/app/middleware/correlation_id.py
@@ -1,0 +1,63 @@
+"""Correlation-ID middleware — Sentry tagging and structured log injection.
+
+Builds on top of ``app.http.request_context`` (which assigns and echoes the
+request-id) to close the remaining observability gaps:
+
+1. **Sentry tag** — ``request_id`` is set on every Sentry event so backend and
+   frontend errors can be correlated by the same ID.
+2. **Log record factory** — every ``logging.LogRecord`` carries a
+   ``request_id`` attribute so formatters can include it without coupling
+   business code to Flask.
+
+Register via ``register_correlation_id(app)`` inside ``_register_http_runtime``.
+Nginx must forward ``X-Request-ID $request_id;`` so the ID originates there.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Callable
+from typing import Any
+
+from flask import Flask, g, has_request_context
+
+_NOOP_REQUEST_ID = "n/a"
+
+
+def _current_request_id() -> str:
+    if not has_request_context():
+        return _NOOP_REQUEST_ID
+    return str(getattr(g, "request_id", None) or _NOOP_REQUEST_ID)
+
+
+def _make_log_record_factory(
+    original: Callable[..., logging.LogRecord],
+) -> Callable[..., logging.LogRecord]:
+    def _factory(*args: Any, **kwargs: Any) -> logging.LogRecord:
+        record = original(*args, **kwargs)
+        record.request_id = _current_request_id()
+        return record
+
+    return _factory
+
+
+def _inject_sentry_tag(request_id: str) -> None:
+    if not os.getenv("SENTRY_DSN", "").strip():
+        return
+    try:
+        import sentry_sdk
+
+        sentry_sdk.set_tag("request_id", request_id)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def register_correlation_id(app: Flask) -> None:
+    """Wire up Sentry tagging and log-record injection for every request."""
+    original_factory = logging.getLogRecordFactory()
+    logging.setLogRecordFactory(_make_log_record_factory(original_factory))
+
+    @app.before_request
+    def _tag_sentry() -> None:
+        _inject_sentry_tag(_current_request_id())

--- a/deploy/nginx/default.alb.conf
+++ b/deploy/nginx/default.alb.conf
@@ -13,6 +13,7 @@ server {
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-Port $http_x_forwarded_port;
         proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+        proxy_set_header X-Request-ID $request_id;
         proxy_set_header Connection "";
     }
 }

--- a/deploy/nginx/default.alb_dual.conf
+++ b/deploy/nginx/default.alb_dual.conf
@@ -13,6 +13,7 @@ server {
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-Port $http_x_forwarded_port;
         proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+        proxy_set_header X-Request-ID $request_id;
         proxy_set_header Connection "";
     }
 }
@@ -43,6 +44,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Request-ID $request_id;
         proxy_set_header Connection "";
     }
 }

--- a/deploy/nginx/default.conf
+++ b/deploy/nginx/default.conf
@@ -26,6 +26,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Request-ID $request_id;
         proxy_set_header Connection "";
         proxy_connect_timeout 5s;
         proxy_read_timeout 5s;
@@ -39,6 +40,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Request-ID $request_id;
         proxy_set_header Connection "";
         proxy_connect_timeout 10s;
         proxy_send_timeout 60s;

--- a/deploy/nginx/default.http.conf
+++ b/deploy/nginx/default.http.conf
@@ -15,6 +15,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Request-ID $request_id;
         proxy_set_header Connection "";
     }
 }

--- a/deploy/nginx/default.tls.conf
+++ b/deploy/nginx/default.tls.conf
@@ -37,6 +37,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Request-ID $request_id;
         proxy_set_header Connection "";
     }
 }

--- a/tests/middleware/test_correlation_id.py
+++ b/tests/middleware/test_correlation_id.py
@@ -1,0 +1,67 @@
+"""Tests for ARC-API-03 — Correlation-ID middleware.
+
+Verifies:
+- X-Request-Id is present on every response.
+- A valid inbound X-Request-ID is echoed back unchanged.
+- An invalid / oversized inbound value is ignored and a fresh ID is generated.
+- The Sentry tag injection path is exercised without a real DSN.
+- The log-record factory injects a ``request_id`` attribute.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+_UUID_HEX_RE = re.compile(r"^[a-f0-9]{32}$")
+_REQUEST_ID_HEADER = "X-Request-Id"
+
+
+class TestCorrelationIdResponseHeader:
+    def test_response_always_has_request_id(self, client) -> None:
+        resp = client.get("/healthz")
+        assert _REQUEST_ID_HEADER in resp.headers
+
+    def test_valid_inbound_id_echoed(self, client) -> None:
+        custom_id = "abc123-my-trace"
+        resp = client.get("/healthz", headers={"X-Request-ID": custom_id})
+        assert resp.headers[_REQUEST_ID_HEADER] == custom_id
+
+    def test_invalid_inbound_id_replaced(self, client) -> None:
+        # Space + exclamation mark fail the safe-chars regex — should be replaced.
+        resp = client.get("/healthz", headers={"X-Request-ID": "bad value!"})
+        generated = resp.headers[_REQUEST_ID_HEADER]
+        assert _UUID_HEX_RE.match(generated), f"Expected hex UUID, got {generated!r}"
+
+    def test_oversized_inbound_id_replaced(self, client) -> None:
+        resp = client.get("/healthz", headers={"X-Request-ID": "a" * 200})
+        generated = resp.headers[_REQUEST_ID_HEADER]
+        assert _UUID_HEX_RE.match(generated), f"Expected hex UUID, got {generated!r}"
+
+    def test_missing_inbound_id_generates_uuid(self, client) -> None:
+        resp = client.get("/healthz")
+        generated = resp.headers[_REQUEST_ID_HEADER]
+        assert _UUID_HEX_RE.match(generated), f"Expected hex UUID, got {generated!r}"
+
+
+class TestCorrelationIdLogFactory:
+    def test_log_record_carries_request_id(self, app) -> None:
+        captured: list[logging.LogRecord] = []
+
+        class _Capture(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                captured.append(record)
+
+        handler = _Capture()
+        logger = logging.getLogger("test_correlation_id")
+        logger.addHandler(handler)
+        logger.setLevel(logging.DEBUG)
+
+        with app.test_client() as client:
+            client.get("/healthz")
+            logger.info("probe")
+
+        logger.removeHandler(handler)
+        assert captured, "No log records captured"
+        record = captured[-1]
+        assert hasattr(record, "request_id")


### PR DESCRIPTION
Closes #1084

## Summary

- **`request_context.py`**: `bind_request_context()` now honours an inbound `X-Request-ID` header (forwarded by nginx via `$request_id` or set by the frontend). Values are sanitised (safe-chars regex, max 128 chars) to prevent log injection; invalid or absent values fall back to a fresh `uuid4().hex`.
- **`app/middleware/correlation_id.py`** (new): Sentry tag injection (`request_id` tag on every event) + `LogRecord` factory so every log line carries `request_id` without coupling business code to Flask.
- **`app/__init__.py`**: `register_correlation_id` wired into `_register_http_runtime`.
- **`deploy/nginx/*.conf`**: `proxy_set_header X-Request-ID $request_id;` added to all 5 nginx variants (default, tls, http, alb, alb_dual).
- **`tests/middleware/test_correlation_id.py`**: 6 test cases covering echo, sanitisation, UUID fallback, and log-record factory.

## Test plan

- [ ] `curl -I https://api.auraxis.com.br/healthz` returns `X-Request-Id` header.
- [ ] Send `X-Request-ID: my-trace-123` → response echoes same ID.
- [ ] All CI gates green.