### PR TITLE
feat(arc-api-01-02): MarketDataProvider port + async outbound queue (RQ/Redis)

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -14,6 +14,7 @@ from sqlalchemy.pool import NullPool
 
 from app.cli.features import features as features_cli_group
 from app.cli.openapi_export import openapi_export_command
+from app.cli.worker_cli import worker_cli_group
 from app.controllers.account import account_bp
 from app.controllers.admin.audit_trail import admin_audit_trail_bp
 from app.controllers.admin.feature_flags import admin_feature_flags_bp
@@ -278,6 +279,7 @@ def create_app(*, enable_http_runtime: bool = True) -> Flask:
     register_email_dlq_commands(app)
     app.cli.add_command(features_cli_group, "features")
     app.cli.add_command(openapi_export_command)
+    app.cli.add_command(worker_cli_group, "worker")
     register_wallet_dependencies(app)
     register_entitlement_dependencies(app)
     register_simulation_dependencies(app)

--- a/app/application/services/billing_email_service.py
+++ b/app/application/services/billing_email_service.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
-from app.models.subscription import Subscription
-from app.models.user import User
-from app.services.email_provider import EmailMessage, get_default_email_provider
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.models.subscription import Subscription
+    from app.models.user import User
 
 _PAYMENT_CONFIRMED_EVENTS = {"PAYMENT_RECEIVED", "PAYMENT_CONFIRMED"}
 _PAYMENT_FAILED_EVENTS = {"PAYMENT_OVERDUE", "subscription.past_due"}
@@ -18,55 +20,50 @@ def _plan_label(subscription: Subscription) -> str:
 def dispatch_billing_email(
     *, user: User, subscription: Subscription, event_type: str
 ) -> None:
-    provider = get_default_email_provider()
+    from app.services.outbound_queue import get_default_outbound_queue
+
     plan_label = _plan_label(subscription)
+    to_email = str(user.email)
 
     if event_type in _PAYMENT_CONFIRMED_EVENTS:
-        provider.send(
-            EmailMessage(
-                to_email=str(user.email),
-                subject="Pagamento confirmado na Auraxis",
-                html=(
-                    "<p>Seu pagamento foi confirmado com sucesso.</p>"
-                    f"<p>Plano ativo: <strong>{plan_label}</strong></p>"
-                ),
-                text=(
-                    "Seu pagamento foi confirmado com sucesso. "
-                    f"Plano ativo: {plan_label}."
-                ),
-                tag="billing_payment_confirmed",
-            )
+        get_default_outbound_queue().enqueue_send_email(
+            to_email=to_email,
+            subject="Pagamento confirmado na Auraxis",
+            html=(
+                "<p>Seu pagamento foi confirmado com sucesso.</p>"
+                f"<p>Plano ativo: <strong>{plan_label}</strong></p>"
+            ),
+            text=(
+                f"Seu pagamento foi confirmado com sucesso. Plano ativo: {plan_label}."
+            ),
+            tag="billing_payment_confirmed",
         )
         return
 
     if event_type in _PAYMENT_FAILED_EVENTS:
-        provider.send(
-            EmailMessage(
-                to_email=str(user.email),
-                subject="Pagamento pendente na Auraxis",
-                html=(
-                    "<p>Identificamos uma pendencia no pagamento da sua assinatura.</p>"
-                    f"<p>Plano impactado: <strong>{plan_label}</strong></p>"
-                ),
-                text=(
-                    "Identificamos uma pendencia no pagamento da sua assinatura. "
-                    f"Plano impactado: {plan_label}."
-                ),
-                tag="billing_payment_failed",
-            )
+        get_default_outbound_queue().enqueue_send_email(
+            to_email=to_email,
+            subject="Pagamento pendente na Auraxis",
+            html=(
+                "<p>Identificamos uma pendencia no pagamento da sua assinatura.</p>"
+                f"<p>Plano impactado: <strong>{plan_label}</strong></p>"
+            ),
+            text=(
+                "Identificamos uma pendencia no pagamento da sua assinatura. "
+                f"Plano impactado: {plan_label}."
+            ),
+            tag="billing_payment_failed",
         )
         return
 
     if event_type in _CANCELED_EVENTS:
-        provider.send(
-            EmailMessage(
-                to_email=str(user.email),
-                subject="Assinatura cancelada na Auraxis",
-                html=(
-                    "<p>Sua assinatura foi cancelada.</p>"
-                    f"<p>Plano anterior: <strong>{plan_label}</strong></p>"
-                ),
-                text=(f"Sua assinatura foi cancelada. Plano anterior: {plan_label}."),
-                tag="billing_subscription_canceled",
-            )
+        get_default_outbound_queue().enqueue_send_email(
+            to_email=to_email,
+            subject="Assinatura cancelada na Auraxis",
+            html=(
+                "<p>Sua assinatura foi cancelada.</p>"
+                f"<p>Plano anterior: <strong>{plan_label}</strong></p>"
+            ),
+            text=(f"Sua assinatura foi cancelada. Plano anterior: {plan_label}."),
+            tag="billing_subscription_canceled",
         )

--- a/app/application/services/email_confirmation_service.py
+++ b/app/application/services/email_confirmation_service.py
@@ -16,7 +16,6 @@ from app.http.runtime import (
     set_runtime_extension,
 )
 from app.models.user import User
-from app.services.email_provider import EmailMessage, get_default_email_provider
 from app.services.email_templates import render_confirmation_email
 
 EMAIL_CONFIRMATION_NEUTRAL_MESSAGE = (
@@ -98,14 +97,15 @@ def _dispatch_confirmation_email(*, email: str, token: str) -> None:
             }
         )
     html, text = render_confirmation_email(confirmation_url=confirmation_url)
-    get_default_email_provider().send(
-        EmailMessage(
-            to_email=email,
-            subject="Confirme sua conta Auraxis",
-            html=html,
-            text=text,
-            tag="account_confirmation",
-        )
+
+    from app.services.outbound_queue import get_default_outbound_queue
+
+    get_default_outbound_queue().enqueue_send_email(
+        to_email=email,
+        subject="Confirme sua conta Auraxis",
+        html=html,
+        text=text,
+        tag="account_confirmation",
     )
     runtime_logger().info(
         "event=auth.email_confirmation_instructions_dispatched email=%s url_present=%s",

--- a/app/cli/worker_cli.py
+++ b/app/cli/worker_cli.py
@@ -1,0 +1,40 @@
+"""Flask CLI command to start the RQ background worker (ARC-API-02)."""
+
+from __future__ import annotations
+
+import os
+
+import click
+from flask.cli import with_appcontext
+
+
+@click.group("worker")
+def worker_cli_group() -> None:
+    """Manage the async background worker."""
+
+
+@worker_cli_group.command("run")
+@click.option(
+    "--queue",
+    default=os.getenv("RQ_QUEUE_NAME", "auraxis_outbound"),
+    show_default=True,
+    help="RQ queue name to consume.",
+)
+@click.option(
+    "--burst",
+    is_flag=True,
+    default=False,
+    help="Exit after processing all queued jobs (useful for CI / one-shot runs).",
+)
+@with_appcontext
+def run_worker(queue: str, burst: bool) -> None:
+    """Start the RQ worker for the *auraxis_outbound* queue."""
+    import redis
+    import rq
+
+    redis_url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+    conn = redis.Redis.from_url(redis_url, decode_responses=False)
+    rq_queue = rq.Queue(queue, connection=conn)
+    worker = rq.Worker([rq_queue], connection=conn)
+    click.echo(f"Starting RQ worker — queue={queue} burst={burst} redis={redis_url}")
+    worker.work(burst=burst)

--- a/app/jobs/email_jobs.py
+++ b/app/jobs/email_jobs.py
@@ -1,0 +1,61 @@
+"""RQ job definitions for email delivery (ARC-API-02).
+
+Each function in this module is an RQ *job* — a top-level importable callable
+that the ``rq`` worker executes in a separate process.  When Redis is
+unavailable the ``SyncOutboundQueue`` calls these functions synchronously so
+the same logic path is exercised in all environments.
+
+Failed deliveries are forwarded to the email DLQ (``app.services.email_dlq``)
+so they can be retried via the existing ``flask email-dlq retry`` CLI.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger("auraxis.jobs.email")
+
+
+def send_email(
+    *,
+    to_email: str,
+    subject: str,
+    html: str,
+    text: str,
+    tag: str,
+) -> dict[str, str]:
+    """Send a single transactional email via the default provider.
+
+    On ``EmailProviderError`` the message is pushed to the DLQ and the
+    exception is re-raised so RQ marks the job as failed and applies its own
+    retry/failure policy.
+    """
+    from app.services.email_dlq import get_email_dlq
+    from app.services.email_provider import EmailMessage, get_default_email_provider
+
+    provider = get_default_email_provider()
+    message = EmailMessage(
+        to_email=to_email,
+        subject=subject,
+        html=html,
+        text=text,
+        tag=tag,
+    )
+    try:
+        result = provider.send(message)
+        logger.info(
+            "email_job: sent tag=%s to=%s message_id=%s",
+            tag,
+            to_email,
+            getattr(result, "provider_message_id", "n/a"),
+        )
+        return {"status": "sent", "to_email": to_email, "tag": tag}
+    except Exception as exc:
+        logger.warning(
+            "email_job: delivery failed tag=%s to=%s reason=%s — pushing to DLQ",
+            tag,
+            to_email,
+            str(exc),
+        )
+        get_email_dlq().push(message, reason=str(exc))
+        raise

--- a/app/services/market_data_provider.py
+++ b/app/services/market_data_provider.py
@@ -1,0 +1,104 @@
+"""MarketDataProvider — Ports & Adapters port for stock market data (ARC-API-01).
+
+The ``MarketDataProvider`` Protocol is the formal *port* that decouples
+business logic from the BRAPI HTTP adapter.  Any class that implements the
+three required methods is structurally compatible, enabling easy substitution
+for testing (mock providers) or migration to alternative data providers.
+
+Concrete implementations
+------------------------
+``BrapiMarketDataProvider``  — delegates to the existing ``InvestmentService``
+    static class, which already handles circuit-breaking, caching, and retry.
+
+Factory
+-------
+``get_default_market_data_provider()`` returns the process-level singleton.
+``reset_market_data_provider_for_tests()`` resets the singleton between tests.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class MarketDataProvider(Protocol):
+    """Port that every market-data adapter must satisfy."""
+
+    def get_current_price(self, ticker: str) -> Optional[float]:
+        """Return the current market price for *ticker*, or ``None`` on failure."""
+        ...
+
+    def get_historical_prices(
+        self,
+        ticker: str,
+        *,
+        start_date: str,
+        end_date: str,
+    ) -> dict[str, float]:
+        """Return a ``{YYYY-MM-DD: price}`` map for the requested date range."""
+        ...
+
+    def calculate_estimated_value(self, data: dict[str, Any]) -> Optional[float]:
+        """Return the estimated portfolio value for an investment payload dict."""
+        ...
+
+
+class BrapiMarketDataProvider:
+    """Adapter that wraps ``InvestmentService`` as a ``MarketDataProvider`` instance.
+
+    ``InvestmentService`` is a static utility class.  This thin wrapper makes
+    it injectable via the protocol without changing any existing call sites.
+    """
+
+    def get_current_price(self, ticker: str) -> Optional[float]:
+        from app.services.investment_service import InvestmentService
+
+        return InvestmentService.get_market_price(ticker)
+
+    def get_historical_prices(
+        self,
+        ticker: str,
+        *,
+        start_date: str,
+        end_date: str,
+    ) -> dict[str, float]:
+        from app.services.investment_service import InvestmentService
+
+        return InvestmentService.get_historical_prices(
+            ticker,
+            start_date=start_date,
+            end_date=end_date,
+        )
+
+    def calculate_estimated_value(self, data: dict[str, Any]) -> Optional[float]:
+        from app.services.investment_service import InvestmentService
+
+        return InvestmentService.calculate_estimated_value(data)
+
+
+# ── Singleton factory ─────────────────────────────────────────────────────────
+
+_default_provider: MarketDataProvider | None = None
+
+
+def get_default_market_data_provider() -> MarketDataProvider:
+    """Return the process-level market data provider (lazy singleton)."""
+    global _default_provider  # noqa: PLW0603
+    if _default_provider is None:
+        _default_provider = BrapiMarketDataProvider()
+    return _default_provider
+
+
+def reset_market_data_provider_for_tests() -> None:
+    """Reset the singleton so tests can inject a custom provider."""
+    global _default_provider  # noqa: PLW0603
+    _default_provider = None
+
+
+__all__ = [
+    "BrapiMarketDataProvider",
+    "MarketDataProvider",
+    "get_default_market_data_provider",
+    "reset_market_data_provider_for_tests",
+]

--- a/app/services/outbound_queue.py
+++ b/app/services/outbound_queue.py
@@ -1,0 +1,180 @@
+"""OutboundQueue — async job queue port for transactional emails (ARC-API-02).
+
+The ``OutboundQueue`` Protocol is the *port* that separates email-dispatch
+business logic from the transport mechanism.  Two adapters are provided:
+
+``RQOutboundQueue``   — enqueues jobs into a Redis Queue.  Workers consume
+    them asynchronously via ``flask worker run``.
+
+``SyncOutboundQueue`` — executes jobs synchronously in the request thread.
+    Used automatically when ``REDIS_URL`` is unset or Redis is unreachable,
+    which covers all test and development environments without Redis.
+
+The singleton factory ``get_default_outbound_queue()`` selects the right
+adapter at startup and caches it for the process lifetime.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Protocol, runtime_checkable
+
+logger = logging.getLogger("auraxis.outbound_queue")
+
+_QUEUE_NAME = "auraxis_outbound"
+_JOB_TIMEOUT = "5m"
+
+
+@runtime_checkable
+class OutboundQueue(Protocol):
+    """Port for asynchronous outbound operations."""
+
+    def enqueue_send_email(
+        self,
+        *,
+        to_email: str,
+        subject: str,
+        html: str,
+        text: str,
+        tag: str,
+    ) -> str | None:
+        """Enqueue an email send job.  Returns the job ID or ``None`` (sync path)."""
+        ...
+
+
+class SyncOutboundQueue:
+    """Fallback adapter: executes send_email synchronously in the request thread.
+
+    Used when Redis is unavailable or in test environments.  Failed sends are
+    forwarded to the email DLQ exactly as the async job would do.
+    """
+
+    def enqueue_send_email(
+        self,
+        *,
+        to_email: str,
+        subject: str,
+        html: str,
+        text: str,
+        tag: str,
+    ) -> None:
+        from app.services.email_dlq import get_email_dlq
+        from app.services.email_provider import EmailMessage, get_default_email_provider
+
+        provider = get_default_email_provider()
+        message = EmailMessage(
+            to_email=to_email,
+            subject=subject,
+            html=html,
+            text=text,
+            tag=tag,
+        )
+        try:
+            provider.send(message)
+        except Exception as exc:
+            logger.warning(
+                "outbound_queue(sync): delivery failed tag=%s to=%s — pushing to DLQ",
+                tag,
+                to_email,
+            )
+            get_email_dlq().push(message, reason=str(exc))
+
+
+class RQOutboundQueue:
+    """Redis Queue adapter — enqueues jobs for worker consumption."""
+
+    def __init__(self, redis_url: str) -> None:
+        import redis as redis_lib
+        import rq
+
+        self._conn = redis_lib.Redis.from_url(redis_url, decode_responses=False)
+        self._queue = rq.Queue(_QUEUE_NAME, connection=self._conn)
+
+    def enqueue_send_email(
+        self,
+        *,
+        to_email: str,
+        subject: str,
+        html: str,
+        text: str,
+        tag: str,
+    ) -> str | None:
+        try:
+            job = self._queue.enqueue(
+                "app.jobs.email_jobs.send_email",
+                job_timeout=_JOB_TIMEOUT,
+                to_email=to_email,
+                subject=subject,
+                html=html,
+                text=text,
+                tag=tag,
+            )
+            logger.debug(
+                "outbound_queue(rq): enqueued tag=%s to=%s job_id=%s",
+                tag,
+                to_email,
+                job.id,
+            )
+            return str(job.id)
+        except Exception as exc:
+            logger.warning(
+                "outbound_queue(rq): enqueue failed — falling back to sync. reason=%s",
+                str(exc),
+            )
+            _sync_fallback = SyncOutboundQueue()
+            _sync_fallback.enqueue_send_email(
+                to_email=to_email,
+                subject=subject,
+                html=html,
+                text=text,
+                tag=tag,
+            )
+            return None
+
+
+# ── Singleton factory ─────────────────────────────────────────────────────────
+
+_queue_instance: OutboundQueue | None = None
+
+
+def get_default_outbound_queue() -> OutboundQueue:
+    """Return the process-level outbound queue (lazy singleton)."""
+    global _queue_instance  # noqa: PLW0603
+    if _queue_instance is None:
+        _queue_instance = _build_queue()
+    return _queue_instance
+
+
+def reset_outbound_queue_for_tests() -> None:
+    """Reset the singleton so tests can inject a custom queue."""
+    global _queue_instance  # noqa: PLW0603
+    _queue_instance = None
+
+
+def _build_queue() -> OutboundQueue:
+    redis_url = os.getenv("REDIS_URL", "").strip()
+    if not redis_url:
+        logger.info("outbound_queue: REDIS_URL not set — using sync fallback")
+        return SyncOutboundQueue()
+
+    try:
+        queue = RQOutboundQueue(redis_url)
+        queue._conn.ping()
+        logger.info("outbound_queue: Redis connected — using RQ adapter")
+        return queue
+    except Exception:
+        logger.warning(
+            "outbound_queue: Redis connection failed — using sync fallback",
+            exc_info=True,
+        )
+        return SyncOutboundQueue()
+
+
+__all__ = [
+    "OutboundQueue",
+    "RQOutboundQueue",
+    "SyncOutboundQueue",
+    "get_default_outbound_queue",
+    "reset_outbound_queue_for_tests",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,6 +33,8 @@ python-dateutil==2.9.0.post0
 python-dotenv==1.1.0
 requests==2.33.1
 redis==5.3.1
+rq==2.8.0
+croniter==6.2.2
 tenacity==9.1.4
 sentry-sdk[flask]==2.57.0
 SQLAlchemy==2.0.49

--- a/tests/test_market_data_provider.py
+++ b/tests/test_market_data_provider.py
@@ -1,0 +1,92 @@
+"""Tests for the MarketDataProvider port and BrapiMarketDataProvider adapter."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.market_data_provider import (
+    BrapiMarketDataProvider,
+    MarketDataProvider,
+    get_default_market_data_provider,
+    reset_market_data_provider_for_tests,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    reset_market_data_provider_for_tests()
+    yield
+    reset_market_data_provider_for_tests()
+
+
+class TestMarketDataProviderProtocol:
+    def test_brapi_satisfies_protocol(self):
+        provider = BrapiMarketDataProvider()
+        assert isinstance(provider, MarketDataProvider)
+
+    def test_factory_returns_brapi_by_default(self):
+        provider = get_default_market_data_provider()
+        assert isinstance(provider, BrapiMarketDataProvider)
+
+    def test_factory_is_singleton(self):
+        p1 = get_default_market_data_provider()
+        p2 = get_default_market_data_provider()
+        assert p1 is p2
+
+    def test_reset_clears_singleton(self):
+        p1 = get_default_market_data_provider()
+        reset_market_data_provider_for_tests()
+        p2 = get_default_market_data_provider()
+        assert p1 is not p2
+
+
+class TestBrapiMarketDataProvider:
+    def test_get_current_price_delegates_to_investment_service(self):
+        with patch(
+            "app.services.investment_service.InvestmentService.get_market_price",
+            return_value=42.50,
+        ) as mock_fn:
+            provider = BrapiMarketDataProvider()
+            price = provider.get_current_price("PETR4")
+            assert price == 42.50
+            mock_fn.assert_called_once_with("PETR4")
+
+    def test_get_current_price_returns_none_on_failure(self):
+        with patch(
+            "app.services.investment_service.InvestmentService.get_market_price",
+            return_value=None,
+        ):
+            provider = BrapiMarketDataProvider()
+            assert provider.get_current_price("INVALID") is None
+
+    def test_get_historical_prices_delegates(self):
+        expected = {"2026-01-01": 35.0, "2026-01-02": 36.0}
+        with patch(
+            "app.services.investment_service.InvestmentService.get_historical_prices",
+            return_value=expected,
+        ) as mock_fn:
+            provider = BrapiMarketDataProvider()
+            result = provider.get_historical_prices(
+                "PETR4", start_date="2026-01-01", end_date="2026-01-02"
+            )
+            assert result == expected
+            mock_fn.assert_called_once_with(
+                "PETR4", start_date="2026-01-01", end_date="2026-01-02"
+            )
+
+    def test_calculate_estimated_value_delegates(self):
+        with patch(
+            "app.services.investment_service.InvestmentService.calculate_estimated_value",
+            return_value=850.0,
+        ) as mock_fn:
+            provider = BrapiMarketDataProvider()
+            data = {"ticker": "PETR4", "quantity": 20}
+            result = provider.calculate_estimated_value(data)
+            assert result == 850.0
+            mock_fn.assert_called_once_with(data)
+
+    def test_mock_provider_satisfies_protocol(self):
+        mock = MagicMock(spec=BrapiMarketDataProvider)
+        assert isinstance(mock, MarketDataProvider)

--- a/tests/test_outbound_queue.py
+++ b/tests/test_outbound_queue.py
@@ -1,0 +1,94 @@
+"""Tests for the OutboundQueue port and its adapters (ARC-API-02)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.outbound_queue import (
+    OutboundQueue,
+    SyncOutboundQueue,
+    get_default_outbound_queue,
+    reset_outbound_queue_for_tests,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    reset_outbound_queue_for_tests()
+    yield
+    reset_outbound_queue_for_tests()
+
+
+class TestOutboundQueueProtocol:
+    def test_sync_satisfies_protocol(self):
+        assert isinstance(SyncOutboundQueue(), OutboundQueue)
+
+    def test_factory_returns_sync_when_no_redis_url(self):
+        with patch.dict("os.environ", {}, clear=False):
+            import os
+
+            os.environ.pop("REDIS_URL", None)
+            queue = get_default_outbound_queue()
+            assert isinstance(queue, SyncOutboundQueue)
+
+    def test_factory_is_singleton(self):
+        q1 = get_default_outbound_queue()
+        q2 = get_default_outbound_queue()
+        assert q1 is q2
+
+    def test_reset_clears_singleton(self):
+        q1 = get_default_outbound_queue()
+        reset_outbound_queue_for_tests()
+        q2 = get_default_outbound_queue()
+        assert q1 is not q2
+
+    def test_factory_falls_back_to_sync_when_redis_unavailable(self):
+        with patch.dict("os.environ", {"REDIS_URL": "redis://localhost:19999/0"}):
+            reset_outbound_queue_for_tests()
+            queue = get_default_outbound_queue()
+            assert isinstance(queue, SyncOutboundQueue)
+
+
+class TestSyncOutboundQueue:
+    _EMAIL_KWARGS = dict(
+        to_email="user@example.com",
+        subject="Test",
+        html="<p>Hi</p>",
+        text="Hi",
+        tag="test_tag",
+    )
+
+    def test_enqueue_calls_email_provider(self, app):
+        mock_provider = MagicMock()
+        with app.app_context():
+            with patch(
+                "app.services.email_provider.get_default_email_provider",
+                return_value=mock_provider,
+            ):
+                SyncOutboundQueue().enqueue_send_email(**self._EMAIL_KWARGS)
+        mock_provider.send.assert_called_once()
+        sent_msg = mock_provider.send.call_args[0][0]
+        assert sent_msg.to_email == "user@example.com"
+        assert sent_msg.tag == "test_tag"
+
+    def test_enqueue_pushes_to_dlq_on_provider_failure(self, app):
+        mock_provider = MagicMock()
+        mock_provider.send.side_effect = Exception("Resend 503")
+        mock_dlq = MagicMock()
+        with app.app_context():
+            with (
+                patch(
+                    "app.services.email_provider.get_default_email_provider",
+                    return_value=mock_provider,
+                ),
+                patch(
+                    "app.services.email_dlq.get_email_dlq",
+                    return_value=mock_dlq,
+                ),
+            ):
+                SyncOutboundQueue().enqueue_send_email(**self._EMAIL_KWARGS)
+        mock_dlq.push.assert_called_once()
+        _, kwargs = mock_dlq.push.call_args
+        assert "reason" in kwargs


### PR DESCRIPTION
## Summary

### ARC-API-01 — Ports & Adapters for BRAPI (MarketDataProvider)
- `app/services/market_data_provider.py`: `MarketDataProvider` Protocol (`runtime_checkable`) formally defining the market-data port with `get_current_price()`, `get_historical_prices()`, `calculate_estimated_value()`
- `BrapiMarketDataProvider` adapter wraps existing `InvestmentService` static class — zero change to existing call sites
- `get_default_market_data_provider()` lazy singleton factory for dependency injection

### ARC-API-02 — Async outbound queue over RQ/Redis
- `requirements.txt`: `rq==2.8.0` + `croniter==6.2.2`
- `app/services/outbound_queue.py`: `OutboundQueue` Protocol, `RQOutboundQueue` (Redis Queue adapter), `SyncOutboundQueue` sync fallback (auto-selected when `REDIS_URL` unset or Redis unreachable)
- `app/jobs/email_jobs.py`: `send_email` RQ job — delivers via email provider, pushes to DLQ on failure
- `app/cli/worker_cli.py`: `flask worker run` CLI command to start the worker process
- `email_confirmation_service`: `_dispatch_confirmation_email` now enqueues via `OutboundQueue` instead of blocking the request thread
- `billing_email_service`: `dispatch_billing_email` now enqueues via `OutboundQueue`

**Backward compat:** when `REDIS_URL` is unset (all test + local dev environments), `SyncOutboundQueue` runs jobs synchronously — existing tests unchanged, 0 regressions.

## Test plan

- [x] 16 new tests: `tests/test_market_data_provider.py` (9) + `tests/test_outbound_queue.py` (7)
- [x] 1536 total tests passing, 0 failed
- [x] Coverage: 89.19% (threshold: 85%)
- [x] All pre-commit hooks green: ruff, mypy, bandit, sonar