### PR TITLE
fix(jobs): audit-retention SSM cd bug + reminder DLQ fallback (#989 #1081)

### DIFF
--- a/.github/workflows/audit-retention-job.yml
+++ b/.github/workflows/audit-retention-job.yml
@@ -46,20 +46,89 @@ jobs:
           role-to-assume: ${{ vars.AWS_ROLE_ARN_PROD }}
           aws-region: ${{ vars.AWS_REGION }}
 
+      - name: Ensure web container is running
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+          PROD_INSTANCE_ID: ${{ vars.AURAXIS_PROD_INSTANCE_ID }}
+        run: |
+          COMMANDS='["cd /opt/auraxis",
+            "if docker compose exec -T web true 2>/dev/null; then echo web-container-ok; exit 0; fi",
+            "echo web-container-not-running -- attempting restart",
+            "docker compose up -d web",
+            "sleep 20",
+            "if docker compose exec -T web true 2>/dev/null; then echo web-container-recovered; exit 0; fi",
+            "echo FATAL: web container failed to start after restart attempt",
+            "docker compose logs --tail=50 web",
+            "exit 1"
+          ]'
+
+          COMMAND_ID=$(aws ssm send-command \
+            --region "${AWS_REGION}" \
+            --instance-ids "${PROD_INSTANCE_ID}" \
+            --document-name "AWS-RunShellScript" \
+            --parameters "commands=${COMMANDS}" \
+            --query "Command.CommandId" \
+            --output text)
+
+          echo "SSM Command ID: ${COMMAND_ID}"
+
+          for i in $(seq 1 36); do
+            STATUS=$(aws ssm get-command-invocation \
+              --region "${AWS_REGION}" \
+              --command-id "${COMMAND_ID}" \
+              --instance-id "${PROD_INSTANCE_ID}" \
+              --query "StatusDetails" \
+              --output text 2>/dev/null || echo "Pending")
+
+            echo "Attempt ${i}: ${STATUS}"
+
+            if [ "${STATUS}" = "Success" ]; then
+              echo "Container health check passed."
+              aws ssm get-command-invocation \
+                --region "${AWS_REGION}" \
+                --command-id "${COMMAND_ID}" \
+                --instance-id "${PROD_INSTANCE_ID}" \
+                --query "StandardOutputContent" \
+                --output text 2>/dev/null || true
+              exit 0
+            elif [ "${STATUS}" = "Failed" ] || [ "${STATUS}" = "Cancelled" ] || [ "${STATUS}" = "TimedOut" ]; then
+              echo "Container health check/recovery failed with status: ${STATUS}"
+              echo "--- stdout ---"
+              aws ssm get-command-invocation \
+                --region "${AWS_REGION}" \
+                --command-id "${COMMAND_ID}" \
+                --instance-id "${PROD_INSTANCE_ID}" \
+                --query "StandardOutputContent" \
+                --output text 2>/dev/null || true
+              echo "--- stderr ---"
+              aws ssm get-command-invocation \
+                --region "${AWS_REGION}" \
+                --command-id "${COMMAND_ID}" \
+                --instance-id "${PROD_INSTANCE_ID}" \
+                --query "StandardErrorContent" \
+                --output text 2>/dev/null || true
+              exit 1
+            fi
+
+            sleep 10
+          done
+
+          echo "Timed out waiting for container health check."
+          exit 1
+
       - name: Run audit retention purge via SSM
         env:
           AWS_REGION: ${{ vars.AWS_REGION }}
           PROD_INSTANCE_ID: ${{ vars.AURAXIS_PROD_INSTANCE_ID }}
           RETENTION_DAYS: ${{ github.event.inputs.retention_days || '90' }}
         run: |
+          # cd and docker compose exec chained with && in a single command so the
+          # working directory change applies to the exec call within SSM.
           COMMAND_ID=$(aws ssm send-command \
             --region "${AWS_REGION}" \
             --instance-ids "${PROD_INSTANCE_ID}" \
             --document-name "AWS-RunShellScript" \
-            --parameters "commands=[
-              \"cd /opt/auraxis\",
-              \"AUDIT_RETENTION_DAYS=${RETENTION_DAYS} docker compose exec -T web flask audit-events purge-expired\"
-            ]" \
+            --parameters "commands=[\"cd /opt/auraxis && docker compose exec -T -e AUDIT_RETENTION_DAYS=${RETENTION_DAYS} web flask audit-events purge-expired\"]" \
             --query "Command.CommandId" \
             --output text)
 
@@ -109,6 +178,41 @@ jobs:
           echo "Timed out waiting for SSM command to complete."
           exit 1
 
+      - name: Collect diagnostics on failure
+        if: failure()
+        id: diagnostics
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+          PROD_INSTANCE_ID: ${{ vars.AURAXIS_PROD_INSTANCE_ID }}
+        run: |
+          COMMAND_ID=$(aws ssm send-command \
+            --region "${AWS_REGION}" \
+            --instance-ids "${PROD_INSTANCE_ID}" \
+            --document-name "AWS-RunShellScript" \
+            --parameters 'commands=["cd /opt/auraxis && echo === docker compose ps === && docker compose ps && echo && echo === web logs last 30 lines === && docker compose logs --tail=30 web 2>&1 || echo no logs available"]' \
+            --query "Command.CommandId" \
+            --output text 2>/dev/null || echo "UNAVAILABLE")
+
+          if [ "${COMMAND_ID}" = "UNAVAILABLE" ]; then
+            echo "diagnostics_output=SSM unavailable — cannot collect diagnostics." >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          sleep 20
+
+          DIAG=$(aws ssm get-command-invocation \
+            --region "${AWS_REGION}" \
+            --command-id "${COMMAND_ID}" \
+            --instance-id "${PROD_INSTANCE_ID}" \
+            --query "StandardOutputContent" \
+            --output text 2>/dev/null || echo "(diagnostics collection failed)")
+
+          {
+            echo "diagnostics_output<<DIAG_EOF"
+            echo "${DIAG}" | head -c 3000
+            echo "DIAG_EOF"
+          } >> "${GITHUB_OUTPUT}"
+
       - name: Notify failure via GitHub Issue
         if: failure()
         uses: actions/github-script@v7
@@ -118,6 +222,7 @@ jobs:
             const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const now = new Date().toISOString();
             const title = '🚨 [audit-retention-job] Falha na purga de audit_events';
+            const diagnostics = `${{ steps.diagnostics.outputs.diagnostics_output }}` || '(diagnostics unavailable)';
             const issueBody = [
               '## Audit Retention Job falhou',
               '',
@@ -139,6 +244,11 @@ jobs:
               '',
               `- Data: ${now}`,
               `- Run: ${runUrl}`,
+              '',
+              '### Diagnóstico automático',
+              '```',
+              diagnostics,
+              '```',
             ].join('\n');
             const query = [
               `repo:${context.repo.owner}/${context.repo.repo}`,

--- a/app/application/services/transaction_reminder_service.py
+++ b/app/application/services/transaction_reminder_service.py
@@ -26,6 +26,7 @@ class ReminderDispatchResult:
     scanned: int
     sent: int
     skipped: int
+    queued: int = 0
 
 
 def _start_of_day(day: date) -> datetime:
@@ -88,6 +89,7 @@ def dispatch_due_transaction_reminders(
     scanned = 0
     sent = 0
     skipped = 0
+    queued = 0
     provider = get_default_email_provider()
 
     for transaction in _eligible_transactions(target_date=target_date):
@@ -122,30 +124,43 @@ def dispatch_due_transaction_reminders(
                 f"Vence em {days_before_due} dias: {transaction.title} "
                 f"(R$ {amount_str})"
             )
-        provider.send(
-            EmailMessage(
-                to_email=str(user.email),
-                subject=subject,
-                html=email_html,
-                text=email_text,
-                tag=category,
-            )
+        message = EmailMessage(
+            to_email=str(user.email),
+            subject=subject,
+            html=email_html,
+            text=email_text,
+            tag=category,
         )
+        from app.services.email_dlq import get_email_dlq
+        from app.services.email_provider import EmailProviderError
+
+        try:
+            provider.send(message)
+            alert_status = AlertStatus.SENT
+            sent += 1
+        except EmailProviderError as exc:
+            # Push to DLQ so the message is not lost; do not propagate so the
+            # job continues processing remaining transactions and exits 0.
+            get_email_dlq().push(message, reason=str(exc))
+            alert_status = AlertStatus.PENDING
+            queued += 1
+
         db.session.add(
             Alert(
                 user_id=transaction.user_id,
                 category=category,
-                status=AlertStatus.SENT,
+                status=alert_status,
                 entity_type="transaction",
                 entity_id=transaction.id,
                 # Anchor triggered_at to reference_day so idempotency checks that
                 # filter by _start_of_day(day)//_end_of_day(day) always match,
                 # even when the caller passes a synthetic `today` (e.g. in tests).
                 triggered_at=_start_of_day(reference_day),
-                sent_at=utc_now_naive(),
+                sent_at=utc_now_naive() if alert_status == AlertStatus.SENT else None,
             )
         )
-        sent += 1
 
     db.session.commit()
-    return ReminderDispatchResult(scanned=scanned, sent=sent, skipped=skipped)
+    return ReminderDispatchResult(
+        scanned=scanned, sent=sent, skipped=skipped, queued=queued
+    )

--- a/app/application/services/transaction_reminder_service.py
+++ b/app/application/services/transaction_reminder_service.py
@@ -69,6 +69,12 @@ def _serialize_amount(value: Decimal | float | int | object) -> str:
         return str(value)
 
 
+def _build_subject(*, days_before_due: int, title: str, amount_str: str) -> str:
+    if days_before_due == 1:
+        return f"Amanhã vence: {title} (R$ {amount_str})"
+    return f"Vence em {days_before_due} dias: {title} (R$ {amount_str})"
+
+
 def _send_or_queue(message: EmailMessage) -> AlertStatus:
     """Send email; push to DLQ on failure. Returns the resulting alert status."""
     try:
@@ -131,13 +137,11 @@ def dispatch_due_transaction_reminders(
             amount_formatted=amount_str,
             days_before_due=days_before_due,
         )
-        if days_before_due == 1:
-            subject = f"Amanhã vence: {transaction.title} (R$ {amount_str})"
-        else:
-            subject = (
-                f"Vence em {days_before_due} dias: {transaction.title} "
-                f"(R$ {amount_str})"
-            )
+        subject = _build_subject(
+            days_before_due=days_before_due,
+            title=transaction.title,
+            amount_str=amount_str,
+        )
         alert_status = _send_or_queue(
             EmailMessage(
                 to_email=str(user.email),
@@ -149,8 +153,10 @@ def dispatch_due_transaction_reminders(
         )
         if alert_status == AlertStatus.SENT:
             sent += 1
+            sent_at = utc_now_naive()
         else:
             queued += 1
+            sent_at = None
 
         db.session.add(
             Alert(
@@ -163,7 +169,7 @@ def dispatch_due_transaction_reminders(
                 # filter by _start_of_day(day)//_end_of_day(day) always match,
                 # even when the caller passes a synthetic `today` (e.g. in tests).
                 triggered_at=_start_of_day(reference_day),
-                sent_at=utc_now_naive() if alert_status == AlertStatus.SENT else None,
+                sent_at=sent_at,
             )
         )
 

--- a/app/application/services/transaction_reminder_service.py
+++ b/app/application/services/transaction_reminder_service.py
@@ -11,7 +11,12 @@ from app.models.alert import Alert, AlertStatus
 from app.models.transaction import Transaction, TransactionStatus
 from app.models.user import User
 from app.services.alert_service import _is_dispatch_allowed
-from app.services.email_provider import EmailMessage, get_default_email_provider
+from app.services.email_dlq import get_email_dlq
+from app.services.email_provider import (
+    EmailMessage,
+    EmailProviderError,
+    get_default_email_provider,
+)
 from app.services.email_templates.base import render_due_soon_email
 from app.utils.datetime_utils import utc_now_naive
 
@@ -64,6 +69,16 @@ def _serialize_amount(value: Decimal | float | int | object) -> str:
         return str(value)
 
 
+def _send_or_queue(message: EmailMessage) -> AlertStatus:
+    """Send email; push to DLQ on failure. Returns the resulting alert status."""
+    try:
+        get_default_email_provider().send(message)
+        return AlertStatus.SENT
+    except EmailProviderError as exc:
+        get_email_dlq().push(message, reason=str(exc))
+        return AlertStatus.PENDING
+
+
 def _eligible_transactions(*, target_date: date) -> Sequence[Transaction]:
     return cast(
         Sequence[Transaction],
@@ -90,7 +105,6 @@ def dispatch_due_transaction_reminders(
     sent = 0
     skipped = 0
     queued = 0
-    provider = get_default_email_provider()
 
     for transaction in _eligible_transactions(target_date=target_date):
         scanned += 1
@@ -124,25 +138,18 @@ def dispatch_due_transaction_reminders(
                 f"Vence em {days_before_due} dias: {transaction.title} "
                 f"(R$ {amount_str})"
             )
-        message = EmailMessage(
-            to_email=str(user.email),
-            subject=subject,
-            html=email_html,
-            text=email_text,
-            tag=category,
+        alert_status = _send_or_queue(
+            EmailMessage(
+                to_email=str(user.email),
+                subject=subject,
+                html=email_html,
+                text=email_text,
+                tag=category,
+            )
         )
-        from app.services.email_dlq import get_email_dlq
-        from app.services.email_provider import EmailProviderError
-
-        try:
-            provider.send(message)
-            alert_status = AlertStatus.SENT
+        if alert_status == AlertStatus.SENT:
             sent += 1
-        except EmailProviderError as exc:
-            # Push to DLQ so the message is not lost; do not propagate so the
-            # job continues processing remaining transactions and exits 0.
-            get_email_dlq().push(message, reason=str(exc))
-            alert_status = AlertStatus.PENDING
+        else:
             queued += 1
 
         db.session.add(

--- a/app/extensions/reminders_cli.py
+++ b/app/extensions/reminders_cli.py
@@ -36,7 +36,6 @@ def dispatch_due_soon(ctx: click.Context, dry_run: bool) -> None:
     from app.application.services.transaction_reminder_service import (
         dispatch_due_transaction_reminders,
     )
-    from app.services.email_provider import EmailProviderError
 
     exit_code = 0
     for window in (7, 1):
@@ -44,14 +43,9 @@ def dispatch_due_soon(ctx: click.Context, dry_run: bool) -> None:
             result = dispatch_due_transaction_reminders(days_before_due=window)
             click.echo(
                 f"{window}-day reminders: "
-                f"scanned={result.scanned} sent={result.sent} skipped={result.skipped}"
+                f"scanned={result.scanned} sent={result.sent} "
+                f"skipped={result.skipped} queued={result.queued}"
             )
-        except EmailProviderError as exc:
-            click.echo(
-                f"ERROR {window}-day reminders: email provider failed — {exc}",
-                err=True,
-            )
-            exit_code = 1
         except Exception as exc:  # noqa: BLE001
             click.echo(
                 f"ERROR {window}-day reminders: unexpected failure — {exc}",

--- a/tests/test_reminders_cli.py
+++ b/tests/test_reminders_cli.py
@@ -77,7 +77,9 @@ def test_dispatch_due_soon_email_provider_error_queues_to_dlq_and_exits_zero(
             mock.patch(
                 "app.application.services.transaction_reminder_service.get_default_email_provider"
             ) as mock_provider_factory,
-            mock.patch("app.services.email_dlq.get_email_dlq") as mock_dlq_factory,
+            mock.patch(
+                "app.application.services.transaction_reminder_service.get_email_dlq"
+            ) as mock_dlq_factory,
         ):
             mock_provider = mock.MagicMock()
             mock_provider.send.side_effect = EmailProviderError(

--- a/tests/test_reminders_cli.py
+++ b/tests/test_reminders_cli.py
@@ -62,25 +62,32 @@ def test_dispatch_due_soon_sends_reminders(app) -> None:
         assert len(outbox) >= 1
 
 
-def test_dispatch_due_soon_email_provider_error_exits_nonzero(app) -> None:
-    """If the email provider raises EmailProviderError the CLI exits 1,
-    logs the error to stderr, and does not abort mid-loop."""
+def test_dispatch_due_soon_email_provider_error_queues_to_dlq_and_exits_zero(
+    app,
+) -> None:
+    """EmailProviderError is caught by the service, pushed to DLQ, and the CLI
+    exits 0 with queued=N in output — the job is not considered failed."""
     import unittest.mock as mock
 
     from app.services.email_provider import EmailProviderError
 
     with app.app_context():
         runner = app.test_cli_runner()
-        with mock.patch(
-            "app.application.services.transaction_reminder_service.get_default_email_provider"
-        ) as mock_provider_factory:
+        with (
+            mock.patch(
+                "app.application.services.transaction_reminder_service.get_default_email_provider"
+            ) as mock_provider_factory,
+            mock.patch("app.services.email_dlq.get_email_dlq") as mock_dlq_factory,
+        ):
             mock_provider = mock.MagicMock()
             mock_provider.send.side_effect = EmailProviderError(
                 "RESEND_API_KEY missing"
             )
             mock_provider_factory.return_value = mock_provider
 
-            # Add a transaction so the provider is actually called
+            mock_dlq = mock.MagicMock()
+            mock_dlq_factory.return_value = mock_dlq
+
             user = User(
                 id=uuid.uuid4(),
                 name="Error Test User",
@@ -102,8 +109,9 @@ def test_dispatch_due_soon_email_provider_error_exits_nonzero(app) -> None:
 
             result = runner.invoke(args=["reminders", "dispatch-due-soon"])
 
-    assert result.exit_code == 1
-    assert "ERROR" in result.output
+    assert result.exit_code == 0
+    assert "queued=1" in result.output
+    mock_dlq.push.assert_called_once()
 
 
 def test_dispatch_due_soon_unexpected_error_exits_nonzero(app) -> None:


### PR DESCRIPTION
## Summary

- **#1081 root cause**: `audit-retention-job.yml` passava `cd /opt/auraxis` e `docker compose exec` como dois itens separados no array SSM — o `cd` não persiste entre comandos. Reescrito como um único comando `&&`-chained (igual ao reminder-job.yml). Adicionado step de container health check + diagnostics on failure que estavam ausentes.
- **#989 root cause**: `EmailProviderError` durante envio de lembretes causava `exit_code=1` no job inteiro. Agora o serviço captura o erro, envia ao Redis DLQ (sem perda de mensagem), registra o `Alert` como `PENDING` para retry tracking, e continua processando. Job sai com `queued=N` em vez de falhar.

## Changes

- `.github/workflows/audit-retention-job.yml` — container health check step, SSM command corrigido, diagnostics step, AUDIT_RETENTION_DAYS via `-e`
- `app/application/services/transaction_reminder_service.py` — DLQ fallback no send, `queued` counter, `ReminderDispatchResult.queued` field
- `app/extensions/reminders_cli.py` — imprime `queued=N`, remove `EmailProviderError` handling (agora no service)

## Test plan

- [x] `bash scripts/run_ci_quality_local.sh --local` — passou (exit 0)
- [x] pre-commit hooks passaram (ruff, mypy, bandit, alembic-single-head)
- [ ] Deploy para prod e observar próxima execução dos dois jobs (03:00 UTC audit, 07:00 UTC reminders)