### PR TITLE
feat(quality): n+1 query gate + hypothesis property tests + REST contract doc (#1027 #1054 #1087)

### DIFF
--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -1,0 +1,177 @@
+# Auraxis API Response Contract
+
+Reference specification for all JSON responses served by the Auraxis REST API.
+
+---
+
+## 1. Versioning
+
+The response format is negotiated via request header:
+
+| Header | Value | Behaviour |
+|--------|-------|-----------|
+| `X-API-Contract` | `v2` | Returns structured `{"success", "message", "data", "meta"}` envelope |
+| `X-API-Contract` | `v3` | Same envelope as v2 (reserved for future extension) |
+| *(absent)* | — | Legacy format — raw dict, varies per endpoint |
+
+Clients should always send `X-API-Contract: v2` to receive the canonical
+envelope.
+
+---
+
+## 2. Success Envelope
+
+```json
+{
+  "success": true,
+  "message": "Human-readable success message",
+  "data": { ... },
+  "meta": {
+    "page": 1,
+    "per_page": 20,
+    "total": 85,
+    "pages": 5
+  }
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `success` | `boolean` | yes | Always `true` for 2xx responses |
+| `message` | `string` | yes | Localised confirmation message |
+| `data` | `object \| array \| null` | yes | Domain payload (see section 5) |
+| `meta` | `object` | no | Non-domain metadata (pagination, correlation IDs, etc.) |
+
+---
+
+## 3. Error Envelope
+
+HTTP 4xx and 5xx responses return:
+
+```json
+{
+  "success": false,
+  "message": "Human-readable error description",
+  "error": {
+    "code": "MACHINE_READABLE_CODE",
+    "details": { ... }
+  }
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `success` | `boolean` | Always `false` |
+| `message` | `string` | Error description for display |
+| `error.code` | `string` | Machine-readable code (UPPER_SNAKE_CASE) |
+| `error.details` | `object` | Optional validation messages or extra context |
+
+### Common error codes
+
+| Code | HTTP status | Meaning |
+|------|-------------|---------|
+| `VALIDATION_ERROR` | 400 | Payload failed schema validation |
+| `BAD_REQUEST` | 400 | Malformed request |
+| `UNAUTHORIZED` | 401 | Missing or invalid authentication |
+| `FORBIDDEN` | 403 | Authenticated but lacks permission |
+| `NOT_FOUND` | 404 | Resource not found |
+| `CONFLICT` | 409 | State conflict (e.g. duplicate) |
+| `INTERNAL_ERROR` | 500 | Unhandled server error |
+
+---
+
+## 4. Field Naming Convention
+
+All JSON keys use **snake_case** throughout (request bodies and response
+payloads).
+
+```json
+{ "due_date": "2026-04-19", "installment_count": 12 }
+```
+
+Date values follow ISO 8601: `YYYY-MM-DD`.
+Datetime values follow ISO 8601 with UTC suffix: `2026-04-19T14:30:00`.
+Monetary amounts are serialised as **strings** with two decimal places to
+preserve precision: `"1234.56"`.
+
+---
+
+## 5. Pagination
+
+List endpoints accept query-string parameters and include pagination metadata
+inside `meta`:
+
+### Request parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `page` | `1` | 1-based page number |
+| `per_page` | `20` | Page size (max 100) |
+
+### Response `meta` keys
+
+```json
+{
+  "meta": {
+    "total": 85,
+    "page": 1,
+    "per_page": 20,
+    "pages": 5
+  }
+}
+```
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `total` | `integer` | Total number of records across all pages |
+| `page` | `integer` | Current page number |
+| `per_page` | `integer` | Number of items per page |
+| `pages` | `integer` | Total number of pages |
+
+---
+
+## 6. Controller Implementation Reference
+
+Controllers use helpers from `app/controllers/response_contract.py`:
+
+```python
+from app.controllers.response_contract import (
+    compat_success_response,
+    compat_error_response,
+    compat_success_tuple,
+    compat_error_tuple,
+)
+```
+
+`compat_*` functions return the legacy payload when no `X-API-Contract`
+header is present, and the structured envelope when `v2`/`v3` is requested.
+This allows incremental migration without breaking existing clients.
+
+---
+
+## 7. Deprecation Headers
+
+Endpoints scheduled for removal include the following HTTP headers:
+
+| Header | Example | Meaning |
+|--------|---------|---------|
+| `Deprecation` | `true` | Endpoint is deprecated |
+| `Sunset` | `Tue, 30 Jun 2026 23:59:59 GMT` | Removal date |
+| `X-Auraxis-Successor-Endpoint` | `/api/v2/transactions` | Replacement URL |
+| `X-Auraxis-Successor-Method` | `GET` | HTTP method of replacement |
+
+---
+
+## 8. Sensitive Field Filtering
+
+The following field names are automatically stripped from response payloads
+in all environments:
+
+- `password`
+- `password_hash`
+- `secret`
+- `secret_key`
+- `jwt_secret_key`
+
+This filtering is applied inside `success_payload()` in
+`app/utils/response_builder.py`.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,4 @@ pydantic>=2.0
 schemathesis==3.39.16
 types-requests==2.33.0.20260402
 types-python-dateutil==2.9.0.20260408
+hypothesis==6.131.15

--- a/tests/api/test_query_counts.py
+++ b/tests/api/test_query_counts.py
@@ -1,0 +1,149 @@
+"""API-level query count assertions (#1054).
+
+Verifies that list endpoints stay within a bounded SQL query count when
+fetching N rows — i.e., they do NOT exhibit N+1 behaviour.
+
+The ``query_counter`` fixture (defined in tests/conftest.py) counts every
+SQL statement fired against the SQLAlchemy engine.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date, timedelta
+from decimal import Decimal
+
+from app.extensions.database import db
+from app.models.account import Account
+from app.models.goal import Goal
+from app.models.tag import Tag
+from app.models.transaction import Transaction, TransactionStatus, TransactionType
+from app.models.user import User
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_user() -> User:
+    user = User(
+        id=uuid.uuid4(),
+        name="QC Test User",
+        email=f"qc-{uuid.uuid4().hex[:8]}@test.com",
+        password="hash",
+    )
+    db.session.add(user)
+    db.session.flush()
+    return user
+
+
+def _make_tag(user: User) -> Tag:
+    tag = Tag(user_id=user.id, name=f"Tag-{uuid.uuid4().hex[:6]}", color="#AABBCC")
+    db.session.add(tag)
+    db.session.flush()
+    return tag
+
+
+def _make_account(user: User) -> Account:
+    account = Account(
+        user_id=user.id,
+        name=f"Acc-{uuid.uuid4().hex[:6]}",
+        initial_balance=Decimal("100.00"),
+    )
+    db.session.add(account)
+    db.session.flush()
+    return account
+
+
+# ---------------------------------------------------------------------------
+# Transaction list — selectinload on tag / account / credit_card
+# ---------------------------------------------------------------------------
+
+
+def test_transaction_list_bounded_queries(
+    app: object, query_counter: dict[str, int]
+) -> None:
+    """Transaction list for 10 rows must fire ≤ 5 queries (not 1+3*N)."""
+    from app.application.services.transaction_ledger_service import (
+        TransactionLedgerService,
+    )
+
+    with app.app_context():  # type: ignore[union-attr]
+        user = _make_user()
+        tag = _make_tag(user)
+        account = _make_account(user)
+
+        for i in range(10):
+            tx = Transaction(
+                user_id=user.id,
+                title=f"Tx-{i}",
+                amount=Decimal("25.00"),
+                type=TransactionType.EXPENSE,
+                status=TransactionStatus.PENDING,
+                due_date=date.today() + timedelta(days=i),
+                tag_id=tag.id,
+                account_id=account.id,
+            )
+            db.session.add(tx)
+        db.session.commit()
+
+        service = TransactionLedgerService.with_defaults(user_id=user.id)
+
+        # Reset counter AFTER setup so only the service call counts.
+        query_counter["n"] = 0
+
+        result = service.get_active_transactions(
+            page=1,
+            per_page=10,
+            transaction_type=None,
+            status=None,
+            start_date=None,
+            end_date=None,
+            tag_id=None,
+            account_id=None,
+            credit_card_id=None,
+        )
+
+    assert len(result["items"]) == 10, "Expected 10 transaction items in result"
+    assert query_counter["n"] <= 5, (
+        f"Transaction list issued {query_counter['n']} queries for 10 rows — "
+        "suspected N+1.  Expected ≤ 5 (COUNT + main SELECT + up to 3 selectinloads)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Goals list — no lazy relationships, should be ≤ 2 queries
+# ---------------------------------------------------------------------------
+
+
+def test_goal_list_bounded_queries(app: object, query_counter: dict[str, int]) -> None:
+    """Goal list for 10 rows must fire ≤ 5 queries (Goal has no lazy relations)."""
+    from app.services.goal_service import GoalService
+
+    with app.app_context():  # type: ignore[union-attr]
+        user = _make_user()
+
+        for i in range(10):
+            goal = Goal(
+                user_id=user.id,
+                title=f"Goal-{i}",
+                target_amount=Decimal("1000.00"),
+                current_amount=Decimal("0.00"),
+                priority=3,
+                status="active",
+            )
+            db.session.add(goal)
+        db.session.commit()
+
+        service = GoalService(user_id=user.id)
+
+        query_counter["n"] = 0
+
+        goals, pagination = service.list_goals(page=1, per_page=10)
+
+    assert len(goals) == 10, "Expected 10 goals in result"
+    assert pagination["total"] >= 10
+    assert query_counter["n"] <= 5, (
+        f"Goal list issued {query_counter['n']} queries for 10 rows — "
+        "expected ≤ 5 (SELECT + optional COUNT)."
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import os
 import sys
 from pathlib import Path
-from typing import Generator
+from typing import Any, Generator
 
 import pytest
 from sqlalchemy.orm import close_all_sessions
@@ -95,3 +95,44 @@ def clear_investment_service_cache() -> Generator[None, None, None]:
 def cleanup_sqlalchemy_sessions() -> Generator[None, None, None]:
     yield
     close_all_sessions()
+
+
+@pytest.fixture
+def query_counter(app: Any) -> Generator[dict[str, int], None, None]:
+    """SQLAlchemy query counter fixture.
+
+    Attaches an event listener to the engine that increments a counter for
+    every SQL statement executed.  Yields a dict with key ``"n"`` so tests
+    can assert ``counts["n"] <= threshold``.
+
+    Usage::
+
+        def test_foo(app, query_counter):
+            with app.app_context():
+                query_counter["n"] = 0  # reset if needed
+                do_something()
+                assert query_counter["n"] <= 5
+    """
+    from sqlalchemy import event
+
+    from app.extensions.database import db
+
+    counts: dict[str, int] = {"n": 0}
+
+    def _before_cursor_execute(
+        conn: Any,
+        cursor: Any,
+        statement: Any,
+        parameters: Any,
+        context: Any,
+        executemany: Any,
+    ) -> None:
+        counts["n"] += 1
+
+    with app.app_context():
+        event.listen(db.engine, "before_cursor_execute", _before_cursor_execute)
+
+    yield counts
+
+    with app.app_context():
+        event.remove(db.engine, "before_cursor_execute", _before_cursor_execute)

--- a/tests/property/test_goal_projection_props.py
+++ b/tests/property/test_goal_projection_props.py
@@ -1,0 +1,235 @@
+"""Property-based tests for goal projection math (#1087).
+
+Verifies mathematical invariants in GoalProjectionService and the underlying
+compound-interest helpers.  All functions under test are pure (no DB I/O) when
+using a mock ``portfolio_rate_provider``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date
+from decimal import Decimal
+
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from app.services.goal_projection_service import (
+    GoalProjectionService,
+    _months_to_reach_goal_compound,
+    _suggested_monthly_contribution,
+)
+
+# ---------------------------------------------------------------------------
+# Strategy helpers
+# ---------------------------------------------------------------------------
+
+# Monetary amounts: 100.00 – 100 000.00
+_money = st.decimals(
+    min_value=Decimal("100.00"),
+    max_value=Decimal("100000.00"),
+    places=2,
+    allow_nan=False,
+    allow_infinity=False,
+)
+
+# Monthly contribution: 50.00 – 5 000.00
+_contribution = st.decimals(
+    min_value=Decimal("50.00"),
+    max_value=Decimal("5000.00"),
+    places=2,
+    allow_nan=False,
+    allow_infinity=False,
+)
+
+# Monthly return rate: 0.1 % – 2.0 % (realistic for BRL fixed income)
+_monthly_rate = st.decimals(
+    min_value=Decimal("0.001"),
+    max_value=Decimal("0.020"),
+    places=6,
+    allow_nan=False,
+    allow_infinity=False,
+)
+
+
+# ---------------------------------------------------------------------------
+# Property 1: Monotonicity — higher monthly contribution → fewer months to goal
+# ---------------------------------------------------------------------------
+
+
+@given(
+    current=_money,
+    additional=_money,
+    monthly_rate=_monthly_rate,
+    low_contribution=_contribution,
+)
+@settings(
+    derandomize=True,
+    max_examples=50,
+    suppress_health_check=[HealthCheck.too_slow],
+)
+def test_higher_contribution_means_fewer_months(
+    current: Decimal,
+    additional: Decimal,
+    monthly_rate: Decimal,
+    low_contribution: Decimal,
+) -> None:
+    """Doubling the monthly contribution must not increase months-to-goal."""
+    # Ensure target > current so there is work to do
+    target = current + additional
+
+    high_contribution = low_contribution * Decimal("2")
+
+    months_low = _months_to_reach_goal_compound(
+        current=current,
+        target=target,
+        monthly_contribution=low_contribution,
+        monthly_rate=monthly_rate,
+    )
+    months_high = _months_to_reach_goal_compound(
+        current=current,
+        target=target,
+        monthly_contribution=high_contribution,
+        monthly_rate=monthly_rate,
+    )
+
+    # Both must be reachable for the monotonicity claim to hold
+    if months_low is None or months_high is None:
+        return
+
+    assert months_high <= months_low, (
+        f"Higher contribution ({high_contribution}) yielded more months "
+        f"({months_high}) than lower contribution ({low_contribution}) → "
+        f"({months_low}). Monotonicity violation."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Property 2: months_to_goal is always >= 1 for valid positive inputs
+# ---------------------------------------------------------------------------
+
+
+@given(
+    current=_money,
+    additional=_money,
+    contribution=_contribution,
+    monthly_rate=_monthly_rate,
+)
+@settings(
+    derandomize=True,
+    max_examples=50,
+    suppress_health_check=[HealthCheck.too_slow],
+)
+def test_months_to_goal_at_least_one(
+    current: Decimal,
+    additional: Decimal,
+    contribution: Decimal,
+    monthly_rate: Decimal,
+) -> None:
+    """When target > current and contribution > 0, months_to_goal is ≥ 1."""
+    target = current + additional  # always > current
+
+    months = _months_to_reach_goal_compound(
+        current=current,
+        target=target,
+        monthly_contribution=contribution,
+        monthly_rate=monthly_rate,
+    )
+
+    if months is not None:
+        assert months >= 1, (
+            f"months_to_goal={months} for current={current}, target={target}, "
+            f"contribution={contribution} — must be ≥ 1 when remaining > 0"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Property 3: suggested_monthly_contribution is non-negative
+# ---------------------------------------------------------------------------
+
+
+@given(
+    current=_money,
+    additional=_money,
+    months_to_deadline=st.integers(min_value=1, max_value=360),
+    monthly_rate=_monthly_rate,
+)
+@settings(
+    derandomize=True,
+    max_examples=50,
+    suppress_health_check=[HealthCheck.too_slow],
+)
+def test_suggested_contribution_non_negative(
+    current: Decimal,
+    additional: Decimal,
+    months_to_deadline: int,
+    monthly_rate: Decimal,
+) -> None:
+    """suggested_monthly_contribution is always ≥ 0 for valid inputs."""
+    target = current + additional  # always > current
+
+    suggested = _suggested_monthly_contribution(
+        current=current,
+        target=target,
+        months_to_deadline=months_to_deadline,
+        monthly_rate=monthly_rate,
+    )
+
+    assert suggested >= Decimal("0"), (
+        f"suggested_monthly_contribution={suggested} is negative for "
+        f"current={current}, target={target}, months={months_to_deadline}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Property 4: GoalProjectionService.project() returns self-consistent result
+#   on_track=True requires months_to_completion <= months_until_deadline
+# ---------------------------------------------------------------------------
+
+
+@given(
+    current=_money,
+    additional=_money,
+    contribution=_contribution,
+    monthly_rate=_monthly_rate,
+    months_deadline=st.integers(min_value=6, max_value=120),
+)
+@settings(
+    derandomize=True,
+    max_examples=50,
+    suppress_health_check=[HealthCheck.too_slow],
+)
+def test_projection_on_track_consistency(
+    current: Decimal,
+    additional: Decimal,
+    contribution: Decimal,
+    monthly_rate: Decimal,
+    months_deadline: int,
+) -> None:
+    """on_track=True implies months_to_completion <= months_until_deadline."""
+    target = current + additional
+    today = date.today()
+    from dateutil.relativedelta import relativedelta
+
+    target_date = today + relativedelta(months=months_deadline)
+
+    service = GoalProjectionService(
+        monthly_contribution=contribution,
+        today_provider=lambda: today,
+        portfolio_rate_provider=lambda uid: monthly_rate,
+    )
+    projection = service.project(
+        goal_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        current_amount=current,
+        target_amount=target,
+        target_date=target_date,
+    )
+
+    if projection.on_track and projection.months_to_completion is not None:
+        assert projection.months_until_deadline is not None
+        assert projection.months_to_completion <= projection.months_until_deadline, (
+            f"on_track=True but months_to_completion "
+            f"({projection.months_to_completion}) "
+            f"> months_until_deadline ({projection.months_until_deadline})"
+        )

--- a/tests/property/test_installment_vs_cash_props.py
+++ b/tests/property/test_installment_vs_cash_props.py
@@ -1,0 +1,165 @@
+"""Property-based tests for InstallmentVsCashService (#1087).
+
+Uses Hypothesis to verify mathematical invariants that must hold for all
+valid inputs.  The service is pure (no DB I/O), so no Flask app context is
+needed.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from app.services.installment_vs_cash_service import InstallmentVsCashService
+from app.services.installment_vs_cash_types import InstallmentVsCashCalculationInput
+
+# ---------------------------------------------------------------------------
+# Strategy helpers
+# ---------------------------------------------------------------------------
+
+# Positive monetary amounts in BRL: 10.00 – 50 000.00
+_money = st.decimals(
+    min_value=Decimal("10.00"),
+    max_value=Decimal("50000.00"),
+    places=2,
+    allow_nan=False,
+    allow_infinity=False,
+)
+
+# Installment counts: 2–48 (realistic consumer credit range)
+_installment_count = st.integers(min_value=2, max_value=48)
+
+# Annual inflation / opportunity rate: 1.00 – 30.00 %
+_annual_rate_pct = st.decimals(
+    min_value=Decimal("1.00"),
+    max_value=Decimal("30.00"),
+    places=2,
+    allow_nan=False,
+    allow_infinity=False,
+)
+
+# First payment delay in days: 0–90
+_delay_days = st.integers(min_value=0, max_value=90)
+
+
+def _build_service() -> InstallmentVsCashService:
+    return InstallmentVsCashService(
+        default_opportunity_rate_annual_percent=Decimal("13.75"),
+    )
+
+
+@st.composite
+def _calculation_input(draw: st.DrawFn) -> InstallmentVsCashCalculationInput:
+    """Produce a valid InstallmentVsCashCalculationInput via Hypothesis draw."""
+    cash_price = draw(_money)
+    installment_count = draw(_installment_count)
+    # installment_total >= cash_price (installments are always >= cash price)
+    # use a multiplier 1.00 – 1.50 to introduce realistic fees
+    multiplier = draw(
+        st.decimals(
+            min_value=Decimal("1.00"),
+            max_value=Decimal("1.50"),
+            places=4,
+            allow_nan=False,
+            allow_infinity=False,
+        )
+    )
+    installment_total = (cash_price * multiplier).quantize(Decimal("0.01"))
+
+    inflation_rate = draw(_annual_rate_pct)
+    opportunity_rate = draw(_annual_rate_pct)
+    first_payment_delay_days = draw(_delay_days)
+
+    payload: InstallmentVsCashCalculationInput = {
+        "cash_price": str(cash_price),
+        "installment_count": installment_count,
+        "installment_total": str(installment_total),
+        "inflation_rate_annual": str(inflation_rate),
+        "fees_enabled": False,
+        "fees_upfront": "0.00",
+        "first_payment_delay_days": first_payment_delay_days,
+        "opportunity_rate_type": "manual",
+        "opportunity_rate_annual": str(opportunity_rate),
+        "scenario_label": None,
+    }
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Property 1: nominal total conservation
+#   inputs.installment_total == sum(schedule[i].amount for all i)
+# ---------------------------------------------------------------------------
+
+
+@given(payload=_calculation_input())
+@settings(
+    derandomize=True,
+    max_examples=50,
+    suppress_health_check=[HealthCheck.too_slow],
+)
+def test_installment_nominal_total_conservation(
+    payload: InstallmentVsCashCalculationInput,
+) -> None:
+    """Sum of schedule amounts equals the declared installment_total."""
+    service = _build_service()
+    calc = service.calculate(payload)
+
+    schedule = calc.result["schedule"]
+    schedule_sum = sum(Decimal(item["amount"]) for item in schedule)
+    declared_total = Decimal(calc.inputs["installment_total"])
+
+    # Allow ±0.02 BRL for rounding distribution across installments
+    diff = abs(schedule_sum - declared_total)
+    assert diff <= Decimal("0.02"), (
+        f"Schedule sum {schedule_sum} deviates from declared total "
+        f"{declared_total} by {diff} (threshold 0.02)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Property 2: recommendation is a valid enum value
+# ---------------------------------------------------------------------------
+
+
+@given(payload=_calculation_input())
+@settings(
+    derandomize=True,
+    max_examples=50,
+    suppress_health_check=[HealthCheck.too_slow],
+)
+def test_recommendation_is_valid_option(
+    payload: InstallmentVsCashCalculationInput,
+) -> None:
+    """recommended_option is always one of the three valid literals."""
+    valid_options = {"cash", "installment", "equivalent"}
+    service = _build_service()
+    calc = service.calculate(payload)
+
+    recommendation = calc.result["recommended_option"]
+    assert recommendation in valid_options, (
+        f"recommended_option {recommendation!r} is not in {valid_options}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Property 3: present value of installments is always positive
+# ---------------------------------------------------------------------------
+
+
+@given(payload=_calculation_input())
+@settings(
+    derandomize=True,
+    max_examples=50,
+    suppress_health_check=[HealthCheck.too_slow],
+)
+def test_installment_present_value_is_positive(
+    payload: InstallmentVsCashCalculationInput,
+) -> None:
+    """installment_present_value is always > 0 when inputs are positive."""
+    service = _build_service()
+    calc = service.calculate(payload)
+
+    pv = Decimal(calc.result["comparison"]["installment_present_value"])
+    assert pv > Decimal("0"), f"installment_present_value must be positive, got {pv}"


### PR DESCRIPTION
## Summary

- **#1054 — N+1 query gate**: `query_counter` pytest fixture via SQLAlchemy event listener + `tests/api/test_query_counts.py` asserting transaction list and goal list stay ≤5 queries. (Serializer uses FK columns only — no selectinload needed; budget already uses `joinedload(Budget.tag)`.)
- **#1087 — Hypothesis property testing**: `hypothesis` added to `requirements-dev.txt`; `tests/property/` with tests for `installment_vs_cash_service` (conservation, valid enum, positive PV) and `goal_projection_service` (monotonicity, months≥1, non-negative contribution, on_track correctness). All use `@settings(derandomize=True, max_examples=50)`.
- **#1027 — REST contract doc**: All business controllers already use `response_contract.py`. Created `docs/api-contract.md` documenting envelope format, versioning header (`X-API-Contract`), error codes, snake_case convention, pagination params, and deprecation strategy.

## Test plan

- [x] 1545 tests passed, coverage 89.19% (≥85%)
- [x] `bash scripts/run_ci_quality_local.sh --local` — green
- [x] Pre-commit: ruff, mypy, bandit, alembic-single-head — all passed