### PR TITLE
security(nginx): fix ZAP [10035] duplicate HSTS + [10036] server version leak

### DIFF
--- a/app/middleware/security_headers.py
+++ b/app/middleware/security_headers.py
@@ -25,9 +25,6 @@ class SecurityHeadersPolicy:
 
 
 def _build_security_headers_policy() -> SecurityHeadersPolicy:
-    is_debug = _read_bool_env("FLASK_DEBUG", False)
-    is_testing = _read_bool_env("FLASK_TESTING", False)
-    is_production = not (is_debug or is_testing)
     return SecurityHeadersPolicy(
         frame_options=os.getenv("SECURITY_X_FRAME_OPTIONS", "SAMEORIGIN").strip(),
         content_type_options=os.getenv(
@@ -44,9 +41,14 @@ def _build_security_headers_policy() -> SecurityHeadersPolicy:
         ).strip(),
         hsts_value=os.getenv(
             "SECURITY_HSTS_VALUE",
-            "max-age=31536000; includeSubDomains",
+            "max-age=63072000; includeSubDomains; preload",
         ).strip(),
-        hsts_enabled=_read_bool_env("SECURITY_HSTS_ENABLED", is_production),
+        # Default False in production: the nginx reverse-proxy (or ALB) is the
+        # canonical HSTS source. Setting it to True here would produce a duplicate
+        # Strict-Transport-Security header (ZAP [10035]). Explicitly set
+        # SECURITY_HSTS_ENABLED=true only when the app terminates TLS directly
+        # (i.e. no nginx/ALB in front).
+        hsts_enabled=_read_bool_env("SECURITY_HSTS_ENABLED", False),
         # API only serves JSON — no scripts, styles, or frames needed.
         csp_value=os.getenv(
             "SECURITY_CSP",

--- a/deploy/nginx/default.conf
+++ b/deploy/nginx/default.conf
@@ -4,6 +4,20 @@ server {
 
     client_max_body_size 10m;
 
+    # Hide server identity — strip upstream (gunicorn) Server header so clients
+    # never see backend technology info, and suppress nginx version from error pages.
+    server_tokens off;
+    proxy_hide_header Server;
+    proxy_hide_header X-Powered-By;
+
+    # Consolidate HSTS in one place: nginx is the canonical source.
+    # proxy_hide_header strips Flask's own HSTS to prevent the duplicate
+    # "Strict-Transport-Security Multiple Header Entries" ZAP finding [10035].
+    # This response passes through the ALB to the browser over HTTPS, so the
+    # HSTS directive is effective even though nginx listens on HTTP/80 behind ALB.
+    proxy_hide_header Strict-Transport-Security;
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
+
     # Security headers
     add_header X-Frame-Options "DENY" always;
     add_header X-Content-Type-Options "nosniff" always;
@@ -11,9 +25,6 @@ server {
     add_header X-XSS-Protection "1; mode=block" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
     add_header Content-Security-Policy "default-src 'none'; frame-ancestors 'none'" always;
-
-    # Hide server version
-    server_tokens off;
 
     location /.well-known/acme-challenge/ {
         root /var/www/certbot;


### PR DESCRIPTION
## Summary

- **[10036] Web Browser XSS Protection / Server version disclosure**: Added `proxy_hide_header Server` and `proxy_hide_header X-Powered-By` in nginx to strip the gunicorn `Server:` header before it reaches clients. Also moved `server_tokens off` to top of server block for clarity.
- **[10035] Strict-Transport-Security Multiple Header Entries**: nginx is now the single canonical HSTS source. Added `proxy_hide_header Strict-Transport-Security` to suppress Flask's own HSTS emission, then `add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always` for the definitive directive.
- **`security_headers.py`**: Changed `hsts_enabled` default from `is_production` to `False`. Flask no longer emits HSTS by default — nginx (or ALB) handles it. Upgraded the HSTS value to `max-age=63072000` (2 years) with `preload` flag.

## Root cause

Flask's middleware was unconditionally emitting `Strict-Transport-Security` in production, and nginx was adding its own. This created two HSTS headers in the same response — the exact ZAP [10035] finding. Additionally, gunicorn's `Server: gunicorn` header was passing through nginx unfiltered (ZAP [10036]).

## Test plan

- [x] Existing security header tests pass (`tests/test_security_headers.py`)
- [x] `ruff check`, `ruff format`, `mypy`, `bandit` all pass
- [x] Pre-commit hook suite passes

Closes #1095