### PR TITLE
feat(dashboard): B13 — contrato de resumo semanal com comparativo e série temporal

### DIFF
--- a/app/application/services/transaction/query_types.py
+++ b/app/application/services/transaction/query_types.py
@@ -112,6 +112,41 @@ class TransactionExpensePeriodResult(TypedDict):
     pagination: TransactionPaginationPayload
 
 
+class WeeklyPeriodTotals(TypedDict):
+    start: str
+    end: str
+    income: float
+    expense: float
+    balance: float
+    transaction_count: int
+
+
+class WeeklyComparison(TypedDict):
+    income_delta: float
+    income_delta_percent: float | None
+    expense_delta: float
+    expense_delta_percent: float | None
+    balance_delta: float
+    balance_delta_percent: float | None
+
+
+class WeeklySummarySeriesEntry(TypedDict):
+    date: str
+    income: float
+    expense: float
+    balance: float
+
+
+class WeeklySummaryResult(TypedDict):
+    current_week: WeeklyPeriodTotals
+    previous_week: WeeklyPeriodTotals
+    comparison: WeeklyComparison
+    series: list[WeeklySummarySeriesEntry]
+    period: str
+    series_start: str
+    series_end: str
+
+
 @dataclass(frozen=True)
 class TransactionQueryDependencies:
     transaction_application_service_factory: Callable[
@@ -136,4 +171,8 @@ __all__ = [
     "TransactionSummaryResult",
     "TransactionTrendsMonthEntry",
     "TransactionTrendsResult",
+    "WeeklyComparison",
+    "WeeklyPeriodTotals",
+    "WeeklySummaryResult",
+    "WeeklySummarySeriesEntry",
 ]

--- a/app/application/services/transaction_query_service.py
+++ b/app/application/services/transaction_query_service.py
@@ -30,6 +30,7 @@ from app.application.services.transaction.query_types import (
     TransactionSummaryResult,
     TransactionTrendsMonthEntry,
     TransactionTrendsResult,
+    WeeklySummaryResult,
 )
 from app.application.services.transaction_application_service import (
     TransactionApplicationService,
@@ -200,6 +201,22 @@ class TransactionQueryService:
 
     def get_survival_index(self, *, period_months: int = 3) -> SurvivalIndexResult:
         return self._analytics_service().get_survival_index(period_months=period_months)
+
+    def get_weekly_summary(
+        self,
+        *,
+        period: str = "1m",
+        start_date: date | None = None,
+        end_date: date | None = None,
+    ) -> WeeklySummaryResult:
+        from app.services.weekly_summary import compute_weekly_summary
+
+        return compute_weekly_summary(
+            user_id=self._user_id,
+            period=period,
+            start_date=start_date,
+            end_date=end_date,
+        )
 
     def _build_period_query(
         self,

--- a/app/controllers/dashboard/resources.py
+++ b/app/controllers/dashboard/resources.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from datetime import date
 from typing import Any
 
 from flask import Response, request
@@ -20,6 +21,7 @@ from app.schemas.openapi.dashboard.docs import (
     DASHBOARD_OVERVIEW_DOC,
     DASHBOARD_SURVIVAL_DOC,
     DASHBOARD_TRENDS_DOC,
+    DASHBOARD_WEEKLY_SUMMARY_DOC,
 )
 from app.services.cache_service import DASHBOARD_CACHE_TTL, get_cache_service
 from app.utils.typed_decorators import typed_doc as doc
@@ -28,6 +30,8 @@ from app.utils.typed_decorators import typed_jwt_required as jwt_required
 # Month query-param must match YYYY-MM exactly; reject anything else to prevent
 # log-injection attacks (Sonar S5145 / CWE-117).
 _MONTH_RE = re.compile(r"^\d{4}-\d{2}$")
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+_VALID_PERIODS = {"1m", "3m", "6m"}
 
 
 class DashboardOverviewResource(MethodResource):
@@ -230,8 +234,110 @@ class DashboardSurvivalIndexResource(MethodResource):
         return resp
 
 
+class DashboardWeeklySummaryResource(MethodResource):
+    @doc(**DASHBOARD_WEEKLY_SUMMARY_DOC)
+    @jwt_required()
+    def get(self) -> Response:
+        token_error = _guard_revoked_token()
+        if token_error is not None:
+            return token_error
+
+        user_uuid = current_user_id()
+        period_raw = str(request.args.get("period", "1m")).strip()
+        start_raw = str(request.args.get("start_date", "")).strip()
+        end_raw = str(request.args.get("end_date", "")).strip()
+
+        start_date: date | None = None
+        end_date: date | None = None
+
+        _dates_msg = "start_date e end_date são obrigatórios no formato YYYY-MM-DD."
+        _period_msg = (
+            "Período inválido. Use 1m, 3m, 6m ou forneça start_date e end_date."
+        )
+        if start_raw or end_raw:
+            if not (_DATE_RE.match(start_raw) and _DATE_RE.match(end_raw)):
+                return compat_error_response(
+                    legacy_payload={"error": _dates_msg},
+                    status_code=422,
+                    message=_dates_msg,
+                    error_code="VALIDATION_ERROR",
+                )
+            try:
+                start_date = date.fromisoformat(start_raw)
+                end_date = date.fromisoformat(end_raw)
+            except ValueError:
+                return compat_error_response(
+                    legacy_payload={"error": "Data inválida."},
+                    status_code=422,
+                    message="Data inválida.",
+                    error_code="VALIDATION_ERROR",
+                )
+            if start_date > end_date:
+                _ord_msg = "start_date não pode ser posterior a end_date."
+                return compat_error_response(
+                    legacy_payload={"error": _ord_msg},
+                    status_code=422,
+                    message=_ord_msg,
+                    error_code="VALIDATION_ERROR",
+                )
+            period = "custom"
+        else:
+            if period_raw not in _VALID_PERIODS:
+                return compat_error_response(
+                    legacy_payload={"error": _period_msg},
+                    status_code=422,
+                    message=_period_msg,
+                    error_code="VALIDATION_ERROR",
+                )
+            period = period_raw
+
+        cache = get_cache_service()
+        cache_key = (
+            f"dashboard:weekly-summary:{user_uuid}:{period}:{start_raw}:{end_raw}"
+        )
+        cached = cache.get(cache_key)
+        if cached is not None:
+            resp = compat_success_response(
+                legacy_payload=cached,
+                status_code=200,
+                message="Resumo semanal calculado com sucesso",
+                data=cached,
+            )
+            resp.headers["X-Cache"] = "HIT"
+            return resp
+
+        dependencies = get_transaction_dependencies()
+        query_service = dependencies.transaction_query_service_factory(user_uuid)
+
+        try:
+            result = query_service.get_weekly_summary(
+                period=period,
+                start_date=start_date,
+                end_date=end_date,
+            )
+        except Exception:
+            return compat_error_response(
+                legacy_payload={"error": "Erro ao calcular resumo semanal"},
+                status_code=500,
+                message="Erro ao calcular resumo semanal",
+                error_code="INTERNAL_ERROR",
+            )
+
+        payload: dict[str, Any] = dict(result)
+        cache.set(cache_key, payload, ttl=DASHBOARD_CACHE_TTL)
+        resp = compat_success_response(
+            legacy_payload=payload,
+            status_code=200,
+            message="Resumo semanal calculado com sucesso",
+            data=payload,
+        )
+        resp.headers["X-Cache"] = "MISS"
+        return resp
+
+
 __all__ = [
     "DashboardOverviewResource",
     "DashboardSurvivalIndexResource",
     "DashboardTrendsResource",
+    "DashboardWeeklySummaryResource",
 ]

--- a/app/controllers/dashboard/routes.py
+++ b/app/controllers/dashboard/routes.py
@@ -5,6 +5,7 @@ from .resources import (
     DashboardOverviewResource,
     DashboardSurvivalIndexResource,
     DashboardTrendsResource,
+    DashboardWeeklySummaryResource,
 )
 
 _ROUTES_REGISTERED = False
@@ -28,6 +29,11 @@ def register_dashboard_routes() -> None:
     dashboard_bp.add_url_rule(
         "/survival-index",
         view_func=DashboardSurvivalIndexResource.as_view("survival_index"),
+        methods=["GET"],
+    )
+    dashboard_bp.add_url_rule(
+        "/weekly-summary",
+        view_func=DashboardWeeklySummaryResource.as_view("weekly_summary"),
         methods=["GET"],
     )
     _ROUTES_REGISTERED = True

--- a/app/graphql/dashboard_payloads.py
+++ b/app/graphql/dashboard_payloads.py
@@ -10,6 +10,10 @@ from app.graphql.types import (
     DashboardStatusCountsType,
     DashboardTotalsType,
     TransactionDashboardPayloadType,
+    WeeklyComparisonType,
+    WeeklyPeriodTotalsType,
+    WeeklySummaryPayloadType,
+    WeeklySummarySeriesEntryType,
 )
 
 
@@ -69,4 +73,60 @@ def build_dashboard_overview_payload(
     )
 
 
-__all__ = ["build_dashboard_overview_payload"]
+def build_weekly_summary_payload(
+    result: Mapping[str, object],
+) -> WeeklySummaryPayloadType:
+    def _period_totals(d: Mapping[str, object]) -> WeeklyPeriodTotalsType:
+        return WeeklyPeriodTotalsType(
+            start=str(d["start"]),
+            end=str(d["end"]),
+            income=float(d["income"]),  # type: ignore[arg-type]
+            expense=float(d["expense"]),  # type: ignore[arg-type]
+            balance=float(d["balance"]),  # type: ignore[arg-type]
+            transaction_count=_get_int_value(d, "transaction_count"),
+        )
+
+    cmp = cast(Mapping[str, object], result["comparison"])
+    raw_series = cast(list[dict[str, object]], result["series"])
+
+    return WeeklySummaryPayloadType(
+        current_week=_period_totals(cast(Mapping[str, object], result["current_week"])),
+        previous_week=_period_totals(
+            cast(Mapping[str, object], result["previous_week"])
+        ),
+        comparison=WeeklyComparisonType(
+            income_delta=float(cmp["income_delta"]),  # type: ignore[arg-type]
+            income_delta_percent=(
+                float(cmp["income_delta_percent"])  # type: ignore[arg-type]
+                if cmp["income_delta_percent"] is not None
+                else None
+            ),
+            expense_delta=float(cmp["expense_delta"]),  # type: ignore[arg-type]
+            expense_delta_percent=(
+                float(cmp["expense_delta_percent"])  # type: ignore[arg-type]
+                if cmp["expense_delta_percent"] is not None
+                else None
+            ),
+            balance_delta=float(cmp["balance_delta"]),  # type: ignore[arg-type]
+            balance_delta_percent=(
+                float(cmp["balance_delta_percent"])  # type: ignore[arg-type]
+                if cmp["balance_delta_percent"] is not None
+                else None
+            ),
+        ),
+        series=[
+            WeeklySummarySeriesEntryType(
+                date=str(e["date"]),
+                income=float(e["income"]),  # type: ignore[arg-type]
+                expense=float(e["expense"]),  # type: ignore[arg-type]
+                balance=float(e["balance"]),  # type: ignore[arg-type]
+            )
+            for e in raw_series
+        ],
+        period=str(result["period"]),
+        series_start=str(result["series_start"]),
+        series_end=str(result["series_end"]),
+    )
+
+
+__all__ = ["build_dashboard_overview_payload", "build_weekly_summary_payload"]

--- a/app/graphql/docs_catalog.py
+++ b/app/graphql/docs_catalog.py
@@ -86,6 +86,17 @@ GRAPHQL_OPERATION_CATALOG: tuple[GraphQLOperationDoc, ...] = (
         source_module=QUERY_DASHBOARD_MODULE,
     ),
     GraphQLOperationDoc(
+        name="weeklySummary",
+        operation_type="query",
+        domain="dashboard",
+        access="auth_required",
+        summary=(
+            "Resumo semanal: comparativo semana atual vs anterior + "
+            "série temporal para gráfico (B13)."
+        ),
+        source_module=QUERY_DASHBOARD_MODULE,
+    ),
+    GraphQLOperationDoc(
         name="transactions",
         operation_type="query",
         domain="transactions",

--- a/app/graphql/queries/dashboard.py
+++ b/app/graphql/queries/dashboard.py
@@ -7,15 +7,24 @@ from app.application.services.transaction_application_service import (
 )
 from app.application.services.transaction_query_service import TransactionQueryService
 from app.graphql.auth import get_current_user_required
-from app.graphql.dashboard_payloads import build_dashboard_overview_payload
+from app.graphql.dashboard_payloads import (
+    build_dashboard_overview_payload,
+    build_weekly_summary_payload,
+)
 from app.graphql.errors import build_public_graphql_error, to_public_graphql_code
-from app.graphql.types import TransactionDashboardPayloadType
+from app.graphql.types import TransactionDashboardPayloadType, WeeklySummaryPayloadType
 
 
 class DashboardQueryMixin:
     dashboard_overview = graphene.Field(
         TransactionDashboardPayloadType,
         month=graphene.String(required=True),
+    )
+    weekly_summary = graphene.Field(
+        WeeklySummaryPayloadType,
+        period=graphene.String(),
+        start_date=graphene.String(),
+        end_date=graphene.String(),
     )
 
     def resolve_dashboard_overview(
@@ -33,6 +42,37 @@ class DashboardQueryMixin:
                 code=to_public_graphql_code(exc.code),
             ) from exc
         return build_dashboard_overview_payload(result)
+
+    def resolve_weekly_summary(
+        self,
+        _info: graphene.ResolveInfo,
+        period: str = "1m",
+        start_date: str | None = None,
+        end_date: str | None = None,
+    ) -> WeeklySummaryPayloadType:
+        from datetime import date
+
+        user = get_current_user_required()
+        query_service = TransactionQueryService.with_defaults(user.id)
+
+        parsed_start: date | None = None
+        parsed_end: date | None = None
+        if start_date and end_date:
+            try:
+                parsed_start = date.fromisoformat(start_date)
+                parsed_end = date.fromisoformat(end_date)
+            except ValueError as exc:
+                raise build_public_graphql_error(
+                    "Data inválida. Use o formato YYYY-MM-DD.",
+                    code="VALIDATION_ERROR",
+                ) from exc
+
+        result = query_service.get_weekly_summary(
+            period=period,
+            start_date=parsed_start,
+            end_date=parsed_end,
+        )
+        return build_weekly_summary_payload(result)
 
 
 __all__ = ["DashboardQueryMixin"]

--- a/app/graphql/types.py
+++ b/app/graphql/types.py
@@ -560,3 +560,43 @@ class AlertPreferenceType(graphene.ObjectType):
 
 class NotificationPreferencesType(graphene.ObjectType):
     preferences = graphene.List(AlertPreferenceType, required=True)
+
+
+# ---------------------------------------------------------------------------
+# Weekly summary types (B13 — MVP1 Dashboard)
+# ---------------------------------------------------------------------------
+
+
+class WeeklyPeriodTotalsType(graphene.ObjectType):
+    start = graphene.String(required=True)
+    end = graphene.String(required=True)
+    income = graphene.Float(required=True)
+    expense = graphene.Float(required=True)
+    balance = graphene.Float(required=True)
+    transaction_count = graphene.Int(required=True)
+
+
+class WeeklyComparisonType(graphene.ObjectType):
+    income_delta = graphene.Float(required=True)
+    income_delta_percent = graphene.Float()
+    expense_delta = graphene.Float(required=True)
+    expense_delta_percent = graphene.Float()
+    balance_delta = graphene.Float(required=True)
+    balance_delta_percent = graphene.Float()
+
+
+class WeeklySummarySeriesEntryType(graphene.ObjectType):
+    date = graphene.String(required=True)
+    income = graphene.Float(required=True)
+    expense = graphene.Float(required=True)
+    balance = graphene.Float(required=True)
+
+
+class WeeklySummaryPayloadType(graphene.ObjectType):
+    current_week = graphene.Field(WeeklyPeriodTotalsType, required=True)
+    previous_week = graphene.Field(WeeklyPeriodTotalsType, required=True)
+    comparison = graphene.Field(WeeklyComparisonType, required=True)
+    series = graphene.List(WeeklySummarySeriesEntryType, required=True)
+    period = graphene.String(required=True)
+    series_start = graphene.String(required=True)
+    series_end = graphene.String(required=True)

--- a/app/schemas/openapi/dashboard/docs.py
+++ b/app/schemas/openapi/dashboard/docs.py
@@ -143,6 +143,105 @@ DASHBOARD_TRENDS_DOC: dict[str, Any] = {
     },
 }
 
+DASHBOARD_WEEKLY_SUMMARY_DOC: dict[str, Any] = {
+    "summary": "Resumo semanal com comparativo (semana atual vs anterior)",
+    "description": (
+        "Retorna os totais da semana atual e da semana anterior (receita, despesa, "
+        "saldo, contagem de transações pagas), o comparativo com deltas absolutos e "
+        "percentuais, e uma série temporal para alimentar gráficos. "
+        "Granularidade: diária quando period ≤ 31 dias, semanal caso contrário."
+    ),
+    "tags": ["Dashboard"],
+    "security": [{"BearerAuth": []}],
+    "params": {
+        "period": {
+            "description": "Preset de período da série: 1m (padrão), 3m, 6m",
+            "in": "query",
+            "type": "string",
+            "required": False,
+            "example": "1m",
+        },
+        "start_date": {
+            "description": "Data inicial para período customizado (YYYY-MM-DD)",
+            "in": "query",
+            "type": "string",
+            "required": False,
+            "example": "2026-03-01",
+        },
+        "end_date": {
+            "description": "Data final para período customizado (YYYY-MM-DD)",
+            "in": "query",
+            "type": "string",
+            "required": False,
+            "example": "2026-04-19",
+        },
+        **contract_header_param(supported_version="v2"),
+    },
+    "responses": {
+        200: json_success_response(
+            description="Resumo semanal calculado com sucesso",
+            message="Resumo semanal calculado com sucesso",
+            data_example={
+                "current_week": {
+                    "start": "2026-04-14",
+                    "end": "2026-04-20",
+                    "income": 2500.0,
+                    "expense": 1800.0,
+                    "balance": 700.0,
+                    "transaction_count": 8,
+                },
+                "previous_week": {
+                    "start": "2026-04-07",
+                    "end": "2026-04-13",
+                    "income": 0.0,
+                    "expense": 2100.0,
+                    "balance": -2100.0,
+                    "transaction_count": 5,
+                },
+                "comparison": {
+                    "income_delta": 2500.0,
+                    "income_delta_percent": None,
+                    "expense_delta": -300.0,
+                    "expense_delta_percent": -14.29,
+                    "balance_delta": 2800.0,
+                    "balance_delta_percent": None,
+                },
+                "series": [
+                    {
+                        "date": "2026-03-20",
+                        "income": 0.0,
+                        "expense": 200.0,
+                        "balance": -200.0,
+                    }
+                ],
+                "period": "1m",
+                "series_start": "2026-03-20",
+                "series_end": "2026-04-19",
+            },
+        ),
+        401: json_error_response(
+            description="Token inválido",
+            message="Token revogado",
+            error_code="UNAUTHORIZED",
+            status_code=401,
+        ),
+        422: json_error_response(
+            description="Parâmetro inválido",
+            message=(
+                "Período inválido. Use 1m, 3m, 6m ou forneça start_date e end_date."
+            ),
+            error_code="VALIDATION_ERROR",
+            status_code=422,
+        ),
+        500: json_error_response(
+            description="Erro interno",
+            message="Erro ao calcular resumo semanal",
+            error_code="INTERNAL_ERROR",
+            status_code=500,
+        ),
+    },
+}
+
 DASHBOARD_SURVIVAL_DOC: dict[str, Any] = {
     "summary": "Índice de sobrevivência financeira (burn rate)",
     "description": (

--- a/app/services/weekly_summary.py
+++ b/app/services/weekly_summary.py
@@ -1,0 +1,258 @@
+"""Weekly summary computation — current/previous week comparison + time series.
+
+B13: Contrato de resumo semanal com comparativo e série temporal para gráfico.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from sqlalchemy import case, func
+
+from app.extensions.database import db
+from app.models.transaction import Transaction, TransactionStatus, TransactionType
+
+if TYPE_CHECKING:
+    from app.application.services.transaction.query_types import (
+        WeeklyComparison,
+        WeeklyPeriodTotals,
+        WeeklySummaryResult,
+        WeeklySummarySeriesEntry,
+    )
+
+_VALID_PRESET_DAYS = {"1m": 30, "3m": 90, "6m": 180}
+
+
+def _week_bounds(anchor: date) -> tuple[date, date]:
+    """Return Monday–Sunday of the ISO week that contains *anchor*."""
+    start = anchor - timedelta(days=anchor.weekday())
+    return start, start + timedelta(days=6)
+
+
+def _aggregate_range(
+    *,
+    user_id: UUID,
+    start: date,
+    end: date,
+) -> tuple[float, float, int]:
+    """Return (income, expense, count) for PAID transactions in [start, end]."""
+    row = (
+        db.session.query(
+            func.coalesce(
+                func.sum(
+                    case(
+                        (
+                            Transaction.type == TransactionType.INCOME,
+                            Transaction.amount,
+                        ),
+                        else_=0,
+                    )
+                ),
+                0,
+            ).label("income"),
+            func.coalesce(
+                func.sum(
+                    case(
+                        (
+                            Transaction.type == TransactionType.EXPENSE,
+                            Transaction.amount,
+                        ),
+                        else_=0,
+                    )
+                ),
+                0,
+            ).label("expense"),
+            func.count(Transaction.id).label("tx_count"),
+        )
+        .filter(
+            Transaction.user_id == user_id,
+            Transaction.deleted.is_(False),
+            Transaction.status == TransactionStatus.PAID,
+            Transaction.due_date >= start,
+            Transaction.due_date <= end,
+        )
+        .one()
+    )
+    return float(row.income or 0), float(row.expense or 0), int(row.tx_count or 0)
+
+
+def _safe_delta_percent(current: float, previous: float) -> float | None:
+    if previous == 0:
+        return None
+    return round((current - previous) / abs(previous) * 100, 2)
+
+
+def _build_daily_series(
+    *,
+    user_id: UUID,
+    start: date,
+    end: date,
+) -> list[WeeklySummarySeriesEntry]:
+    rows = (
+        db.session.query(
+            Transaction.due_date.label("day"),
+            func.coalesce(
+                func.sum(
+                    case(
+                        (
+                            Transaction.type == TransactionType.INCOME,
+                            Transaction.amount,
+                        ),
+                        else_=0,
+                    )
+                ),
+                0,
+            ).label("income"),
+            func.coalesce(
+                func.sum(
+                    case(
+                        (
+                            Transaction.type == TransactionType.EXPENSE,
+                            Transaction.amount,
+                        ),
+                        else_=0,
+                    )
+                ),
+                0,
+            ).label("expense"),
+        )
+        .filter(
+            Transaction.user_id == user_id,
+            Transaction.deleted.is_(False),
+            Transaction.status == TransactionStatus.PAID,
+            Transaction.due_date >= start,
+            Transaction.due_date <= end,
+        )
+        .group_by(Transaction.due_date)
+        .order_by(Transaction.due_date)
+        .all()
+    )
+    index: dict[date, tuple[float, float]] = {
+        r.day: (float(r.income or 0), float(r.expense or 0)) for r in rows
+    }
+    series: list[WeeklySummarySeriesEntry] = []
+    cursor = start
+    while cursor <= end:
+        income, expense = index.get(cursor, (0.0, 0.0))
+        series.append(
+            {
+                "date": cursor.isoformat(),
+                "income": income,
+                "expense": expense,
+                "balance": round(income - expense, 2),
+            }
+        )
+        cursor += timedelta(days=1)
+    return series
+
+
+def _build_weekly_series(
+    *,
+    user_id: UUID,
+    start: date,
+    end: date,
+) -> list[WeeklySummarySeriesEntry]:
+    # Align start to Monday
+    week_start = start - timedelta(days=start.weekday())
+    series: list[WeeklySummarySeriesEntry] = []
+    cursor = week_start
+    while cursor <= end:
+        week_end = min(cursor + timedelta(days=6), end)
+        income, expense, _ = _aggregate_range(
+            user_id=user_id, start=cursor, end=week_end
+        )
+        series.append(
+            {
+                "date": cursor.isoformat(),
+                "income": income,
+                "expense": expense,
+                "balance": round(income - expense, 2),
+            }
+        )
+        cursor += timedelta(days=7)
+    return series
+
+
+def compute_weekly_summary(
+    *,
+    user_id: UUID,
+    period: str = "1m",
+    start_date: date | None = None,
+    end_date: date | None = None,
+) -> WeeklySummaryResult:
+    today = date.today()
+
+    if start_date is not None and end_date is not None:
+        series_start = start_date
+        series_end = end_date
+        period_label = "custom"
+    else:
+        days = _VALID_PRESET_DAYS.get(period, 30)
+        series_end = today
+        series_start = today - timedelta(days=days - 1)
+        period_label = period
+
+    cur_week_start, cur_week_end = _week_bounds(today)
+    prev_week_start = cur_week_start - timedelta(days=7)
+    prev_week_end = cur_week_start - timedelta(days=1)
+
+    cur_income, cur_expense, cur_count = _aggregate_range(
+        user_id=user_id, start=cur_week_start, end=cur_week_end
+    )
+    prev_income, prev_expense, prev_count = _aggregate_range(
+        user_id=user_id, start=prev_week_start, end=prev_week_end
+    )
+
+    span_days = (series_end - series_start).days + 1
+    if span_days <= 31:
+        series = _build_daily_series(
+            user_id=user_id, start=series_start, end=series_end
+        )
+    else:
+        series = _build_weekly_series(
+            user_id=user_id, start=series_start, end=series_end
+        )
+
+    current_week: WeeklyPeriodTotals = {
+        "start": cur_week_start.isoformat(),
+        "end": cur_week_end.isoformat(),
+        "income": round(cur_income, 2),
+        "expense": round(cur_expense, 2),
+        "balance": round(cur_income - cur_expense, 2),
+        "transaction_count": cur_count,
+    }
+    previous_week: WeeklyPeriodTotals = {
+        "start": prev_week_start.isoformat(),
+        "end": prev_week_end.isoformat(),
+        "income": round(prev_income, 2),
+        "expense": round(prev_expense, 2),
+        "balance": round(prev_income - prev_expense, 2),
+        "transaction_count": prev_count,
+    }
+    comparison: WeeklyComparison = {
+        "income_delta": round(cur_income - prev_income, 2),
+        "income_delta_percent": _safe_delta_percent(cur_income, prev_income),
+        "expense_delta": round(cur_expense - prev_expense, 2),
+        "expense_delta_percent": _safe_delta_percent(cur_expense, prev_expense),
+        "balance_delta": round(
+            (cur_income - cur_expense) - (prev_income - prev_expense), 2
+        ),
+        "balance_delta_percent": _safe_delta_percent(
+            cur_income - cur_expense, prev_income - prev_expense
+        ),
+    }
+
+    return {
+        "current_week": current_week,
+        "previous_week": previous_week,
+        "comparison": comparison,
+        "series": series,
+        "period": period_label,
+        "series_start": series_start.isoformat(),
+        "series_end": series_end.isoformat(),
+    }
+
+
+__all__ = ["compute_weekly_summary"]

--- a/graphql.introspection.json
+++ b/graphql.introspection.json
@@ -1196,6 +1196,55 @@
               }
             },
             {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "period",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "startDate",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "endDate",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "weeklySummary",
+              "type": {
+                "kind": "OBJECT",
+                "name": "WeeklySummaryPayloadType",
+                "ofType": null
+              }
+            },
+            {
               "args": [],
               "deprecationReason": null,
               "description": null,
@@ -6658,6 +6707,414 @@
           "interfaces": [],
           "kind": "OBJECT",
           "name": "TransactionDueCountsType",
+          "possibleTypes": null,
+          "specifiedByURL": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "currentWeek",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "WeeklyPeriodTotalsType",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "previousWeek",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "WeeklyPeriodTotalsType",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "comparison",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "WeeklyComparisonType",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "series",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "WeeklySummarySeriesEntryType",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "period",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "seriesStart",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "seriesEnd",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "WeeklySummaryPayloadType",
+          "possibleTypes": null,
+          "specifiedByURL": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "start",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "end",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "income",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "expense",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "balance",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "transactionCount",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "WeeklyPeriodTotalsType",
+          "possibleTypes": null,
+          "specifiedByURL": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "incomeDelta",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "incomeDeltaPercent",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "expenseDelta",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "expenseDeltaPercent",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "balanceDelta",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "balanceDeltaPercent",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "WeeklyComparisonType",
+          "possibleTypes": null,
+          "specifiedByURL": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "date",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "income",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "expense",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "balance",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "WeeklySummarySeriesEntryType",
           "possibleTypes": null,
           "specifiedByURL": null
         },

--- a/graphql.operations.manifest.json
+++ b/graphql.operations.manifest.json
@@ -17,6 +17,14 @@
   },
   {
     "access": "auth_required",
+    "domain": "dashboard",
+    "name": "weeklySummary",
+    "operation_type": "query",
+    "source_module": "app.graphql.queries.dashboard",
+    "summary": "Resumo semanal: comparativo semana atual vs anterior + série temporal para gráfico (B13)."
+  },
+  {
+    "access": "auth_required",
     "domain": "transactions",
     "name": "transactions",
     "operation_type": "query",

--- a/schema.graphql
+++ b/schema.graphql
@@ -25,6 +25,7 @@ type Query {
   transactionDueRange(startDate: String, endDate: String, initialDate: String @deprecated(reason: "Use startDate."), finalDate: String @deprecated(reason: "Use endDate."), page: Int = 1, perPage: Int = 10, orderBy: String = "overdue_first"): TransactionDueRangePayloadType
   transaction(transactionId: UUID!): TransactionTypeObject
   dashboardOverview(month: String!): TransactionDashboardPayloadType
+  weeklySummary(period: String, startDate: String, endDate: String): WeeklySummaryPayloadType
   me: UserType
 }
 
@@ -494,6 +495,41 @@ type TransactionDueCountsType {
   totalTransactions: Int!
   incomeTransactions: Int!
   expenseTransactions: Int!
+}
+
+type WeeklySummaryPayloadType {
+  currentWeek: WeeklyPeriodTotalsType!
+  previousWeek: WeeklyPeriodTotalsType!
+  comparison: WeeklyComparisonType!
+  series: [WeeklySummarySeriesEntryType]!
+  period: String!
+  seriesStart: String!
+  seriesEnd: String!
+}
+
+type WeeklyPeriodTotalsType {
+  start: String!
+  end: String!
+  income: Float!
+  expense: Float!
+  balance: Float!
+  transactionCount: Int!
+}
+
+type WeeklyComparisonType {
+  incomeDelta: Float!
+  incomeDeltaPercent: Float
+  expenseDelta: Float!
+  expenseDeltaPercent: Float
+  balanceDelta: Float!
+  balanceDeltaPercent: Float
+}
+
+type WeeklySummarySeriesEntryType {
+  date: String!
+  income: Float!
+  expense: Float!
+  balance: Float!
 }
 
 type UserType {

--- a/tests/test_dashboard_weekly_summary.py
+++ b/tests/test_dashboard_weekly_summary.py
@@ -1,0 +1,296 @@
+"""Tests for GET /dashboard/weekly-summary (B13)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, date, datetime
+
+import pytest
+
+
+def _register_and_login(client, prefix: str) -> str:
+    suffix = uuid.uuid4().hex[:8]
+    email = f"{prefix}-{suffix}@email.com"
+    password = "StrongPass@123"
+    resp = client.post(
+        "/auth/register",
+        json={"name": f"{prefix}-{suffix}", "email": email, "password": password},
+    )
+    assert resp.status_code == 201
+    resp = client.post("/auth/login", json={"email": email, "password": password})
+    assert resp.status_code == 200
+    return resp.get_json()["token"]
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}", "X-API-Contract": "v2"}
+
+
+def _create_paid_tx(
+    client, token: str, *, title: str, amount: str, tx_type: str, due_date: str
+) -> None:
+    resp = client.post(
+        "/transactions",
+        headers=_auth(token),
+        json={"title": title, "amount": amount, "type": tx_type, "due_date": due_date},
+    )
+    assert resp.status_code == 201, resp.get_json()
+    body = resp.get_json()
+    tx_raw = body.get("data", {}).get("transaction") or body.get("transaction")
+    tx_id = tx_raw[0]["id"] if isinstance(tx_raw, list) else tx_raw["id"]
+    paid_at = datetime.now(UTC).isoformat()
+    resp = client.patch(
+        f"/transactions/{tx_id}",
+        headers=_auth(token),
+        json={"status": "paid", "paid_at": paid_at},
+    )
+    assert resp.status_code == 200, resp.get_json()
+
+
+class TestWeeklySummaryValidation:
+    def test_requires_auth(self, client):
+        resp = client.get("/dashboard/weekly-summary")
+        assert resp.status_code == 401
+
+    def test_invalid_period_returns_422(self, client):
+        token = _register_and_login(client, "period-err")
+        resp = client.get("/dashboard/weekly-summary?period=2y", headers=_auth(token))
+        assert resp.status_code == 422
+
+    def test_custom_period_missing_end_date_returns_422(self, client):
+        token = _register_and_login(client, "custom-err")
+        resp = client.get(
+            "/dashboard/weekly-summary?start_date=2026-01-01",
+            headers=_auth(token),
+        )
+        assert resp.status_code == 422
+
+    def test_start_after_end_returns_422(self, client):
+        token = _register_and_login(client, "order-err")
+        resp = client.get(
+            "/dashboard/weekly-summary?start_date=2026-04-20&end_date=2026-04-01",
+            headers=_auth(token),
+        )
+        assert resp.status_code == 422
+
+    def test_invalid_date_format_returns_422(self, client):
+        token = _register_and_login(client, "fmt-err")
+        resp = client.get(
+            "/dashboard/weekly-summary?start_date=20260101&end_date=20260131",
+            headers=_auth(token),
+        )
+        assert resp.status_code == 422
+
+
+class TestWeeklySummaryResponse:
+    def test_default_period_returns_correct_shape(self, client):
+        token = _register_and_login(client, "shape")
+        resp = client.get("/dashboard/weekly-summary", headers=_auth(token))
+        assert resp.status_code == 200
+        data = resp.get_json()["data"]
+        assert "current_week" in data
+        assert "previous_week" in data
+        assert "comparison" in data
+        assert "series" in data
+        assert data["period"] == "1m"
+        assert "series_start" in data
+        assert "series_end" in data
+
+    def test_current_week_fields(self, client):
+        token = _register_and_login(client, "cw-fields")
+        resp = client.get("/dashboard/weekly-summary", headers=_auth(token))
+        cw = resp.get_json()["data"]["current_week"]
+        expected = ("start", "end", "income", "expense", "balance", "transaction_count")
+        for field in expected:
+            assert field in cw, f"Missing field: {field}"
+
+    def test_comparison_fields(self, client):
+        token = _register_and_login(client, "cmp-fields")
+        resp = client.get("/dashboard/weekly-summary", headers=_auth(token))
+        cmp = resp.get_json()["data"]["comparison"]
+        for field in (
+            "income_delta",
+            "income_delta_percent",
+            "expense_delta",
+            "expense_delta_percent",
+            "balance_delta",
+            "balance_delta_percent",
+        ):
+            assert field in cmp, f"Missing field: {field}"
+
+    def test_3m_period_accepted(self, client):
+        token = _register_and_login(client, "3m-period")
+        resp = client.get("/dashboard/weekly-summary?period=3m", headers=_auth(token))
+        assert resp.status_code == 200
+        assert resp.get_json()["data"]["period"] == "3m"
+
+    def test_6m_period_accepted(self, client):
+        token = _register_and_login(client, "6m-period")
+        resp = client.get("/dashboard/weekly-summary?period=6m", headers=_auth(token))
+        assert resp.status_code == 200
+        assert resp.get_json()["data"]["period"] == "6m"
+
+    def test_custom_period_accepted(self, client):
+        token = _register_and_login(client, "custom-ok")
+        resp = client.get(
+            "/dashboard/weekly-summary?start_date=2026-01-01&end_date=2026-01-31",
+            headers=_auth(token),
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()["data"]
+        assert data["period"] == "custom"
+        assert data["series_start"] == "2026-01-01"
+        assert data["series_end"] == "2026-01-31"
+
+    def test_series_daily_for_1m(self, client):
+        token = _register_and_login(client, "series-daily")
+        resp = client.get("/dashboard/weekly-summary?period=1m", headers=_auth(token))
+        assert resp.status_code == 200
+        series = resp.get_json()["data"]["series"]
+        # 1m = 30 days → 30 daily entries
+        assert len(series) == 30
+        entry = series[0]
+        for field in ("date", "income", "expense", "balance"):
+            assert field in entry
+
+    def test_series_weekly_for_3m(self, client):
+        token = _register_and_login(client, "series-weekly")
+        resp = client.get("/dashboard/weekly-summary?period=3m", headers=_auth(token))
+        assert resp.status_code == 200
+        series = resp.get_json()["data"]["series"]
+        # 3m = 90 days > 31 → weekly buckets (≈13 weeks)
+        assert len(series) > 0
+        assert len(series) < 50  # weekly buckets, not daily
+
+
+class TestWeeklySummaryWithData:
+    def test_income_reflected_in_current_week(self, client):
+        token = _register_and_login(client, "income-data")
+        today = date.today().isoformat()
+        _create_paid_tx(
+            client,
+            token,
+            title="Salário",
+            amount="3000.00",
+            tx_type="income",
+            due_date=today,
+        )
+        resp = client.get("/dashboard/weekly-summary", headers=_auth(token))
+        cw = resp.get_json()["data"]["current_week"]
+        assert cw["income"] == pytest.approx(3000.0)
+        assert cw["transaction_count"] >= 1
+
+    def test_expense_reflected_in_current_week(self, client):
+        token = _register_and_login(client, "expense-data")
+        today = date.today().isoformat()
+        _create_paid_tx(
+            client,
+            token,
+            title="Aluguel",
+            amount="1500.00",
+            tx_type="expense",
+            due_date=today,
+        )
+        resp = client.get("/dashboard/weekly-summary", headers=_auth(token))
+        cw = resp.get_json()["data"]["current_week"]
+        assert cw["expense"] == pytest.approx(1500.0)
+        assert cw["balance"] == pytest.approx(-1500.0)
+
+    def test_delta_percent_null_when_previous_zero(self, client):
+        token = _register_and_login(client, "delta-null")
+        today = date.today().isoformat()
+        _create_paid_tx(
+            client,
+            token,
+            title="Receita",
+            amount="500.00",
+            tx_type="income",
+            due_date=today,
+        )
+        resp = client.get("/dashboard/weekly-summary", headers=_auth(token))
+        cmp = resp.get_json()["data"]["comparison"]
+        # no previous week data → percent should be None
+        assert cmp["income_delta_percent"] is None
+
+    def test_series_entry_matches_transaction_date(self, client):
+        token = _register_and_login(client, "series-match")
+        today = date.today().isoformat()
+        _create_paid_tx(
+            client,
+            token,
+            title="Compra",
+            amount="200.00",
+            tx_type="expense",
+            due_date=today,
+        )
+        resp = client.get("/dashboard/weekly-summary?period=1m", headers=_auth(token))
+        series = resp.get_json()["data"]["series"]
+        today_entries = [e for e in series if e["date"] == today]
+        assert len(today_entries) == 1
+        assert today_entries[0]["expense"] == pytest.approx(200.0)
+
+
+class TestWeeklySummaryCache:
+    def test_cache_miss_header(self, client):
+        token = _register_and_login(client, "cache-miss")
+        resp = client.get("/dashboard/weekly-summary", headers=_auth(token))
+        assert resp.status_code == 200
+        assert resp.headers.get("X-Cache") == "MISS"
+
+
+class TestWeeklySummaryGraphQL:
+    _GQL = """
+    query WeeklySummary($period: String) {
+      weeklySummary(period: $period) {
+        period
+        seriesStart
+        seriesEnd
+        currentWeek {
+          start
+          end
+          income
+          expense
+          balance
+          transactionCount
+        }
+        previousWeek {
+          start
+          end
+          income
+          expense
+          balance
+          transactionCount
+        }
+        comparison {
+          incomeDelta
+          incomeDeltaPercent
+          expenseDelta
+          expenseDeltaPercent
+          balanceDelta
+          balanceDeltaPercent
+        }
+        series {
+          date
+          income
+          expense
+          balance
+        }
+      }
+    }
+    """
+
+    def test_graphql_weekly_summary_shape(self, client):
+        token = _register_and_login(client, "gql-shape")
+        resp = client.post(
+            "/graphql",
+            headers=_auth(token),
+            json={"query": self._GQL, "variables": {"period": "1m"}},
+        )
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert "errors" not in body, body.get("errors")
+        ws = body["data"]["weeklySummary"]
+        assert ws["period"] == "1m"
+        assert "currentWeek" in ws
+        assert "comparison" in ws
+        assert isinstance(ws["series"], list)

--- a/tests/test_postman_collection_contract.py
+++ b/tests/test_postman_collection_contract.py
@@ -154,8 +154,9 @@ OPENAPI_GAPS: set[tuple[str, str]] = {
     ("POST", "/bank-statements/confirm"),
     # Advisory (not yet in apispec-documented blueprints)
     ("GET", "/advisory/insights"),
-    # Dashboard survival index (not yet in apispec-documented blueprints)
+    # Dashboard routes not yet in apispec-documented blueprints
     ("GET", "/dashboard/survival-index"),
+    ("GET", "/dashboard/weekly-summary"),
     # Multi-device session management (#1028)
     ("GET", "/auth/sessions"),
     ("DELETE", "/auth/sessions"),


### PR DESCRIPTION
## Summary

- **`GET /dashboard/weekly-summary`** — novo endpoint que retorna:
  - `current_week` / `previous_week`: income, expense, balance, transaction_count da semana atual e anterior
  - `comparison`: deltas absolutos e percentuais (income_delta_percent=null quando previous=0)
  - `series`: série temporal para alimentar gráficos — granularidade diária (≤31 dias) ou semanal (>31 dias)
  - `period`: preset `1m` (default), `3m`, `6m` ou `custom` (via `start_date`+`end_date`)
- **GraphQL**: query `weeklySummary` com paridade completa ao REST
- Novo módulo `app/services/weekly_summary.py` com toda a lógica de agregação SQL
- Novos TypedDicts em `query_types.py`: `WeeklySummaryResult`, `WeeklyPeriodTotals`, `WeeklyComparison`, `WeeklySummarySeriesEntry`
- `app/graphql/types.py`: `WeeklySummaryPayloadType` + tipos filhos
- GraphQL docs catalog, schema SDL e introspection bundle regenerados

## Test plan

- [x] 19 testes integração (`test_dashboard_weekly_summary.py`): validação de parâmetros, shape da resposta, dados reais, granularidade da série, cache header, GraphQL
- [x] CI completo: 1595 passed, cobertura 91%, ruff, mypy, bandit OK

Closes #B13