### PR TITLE
security(audit): S5145 — sanitize entity_id before logging

### DIFF
--- a/app/extensions/audit_trail.py
+++ b/app/extensions/audit_trail.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import re
 from typing import Any
 
 from flask import Flask, Response, current_app
@@ -17,6 +18,19 @@ DEFAULT_AUDIT_PATH_PREFIXES = (
     "/wallet",
     "/graphql",
 )
+
+
+# Allow-list for log-safe entity IDs (S5145 / CWE-117).
+# Only UUID-format strings pass through; anything else is redacted so
+# user-controlled data never reaches the logger verbatim.
+_SAFE_ID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+
+
+def _safe_log_id(value: str) -> str:
+    return value if _SAFE_ID_RE.match(value) else "[redacted]"
 
 
 def _is_audit_trail_enabled() -> bool:
@@ -143,7 +157,7 @@ def record_entity_delete(
         current_app.logger.exception(
             "audit_entity_delete_failed entity_type=%s entity_id=%s",
             entity_type,
-            entity_id,
+            _safe_log_id(entity_id),
         )
 
 


### PR DESCRIPTION
## Summary

- Adds `_SAFE_ID_RE` UUID allow-list regex and `_safe_log_id()` helper in `app/extensions/audit_trail.py`
- `record_entity_delete()` exception handler now calls `_safe_log_id(entity_id)` instead of logging raw user-controlled data
- Fixes Sonar S5145 / CWE-117 log injection: taint flow `transaction_id → delete_transaction → record_entity_delete → logger.exception`
- Non-UUID values are redacted as `[redacted]`; valid UUIDs pass through unchanged

## Test plan

- [ ] All 47 audit trail tests pass (`pytest tests/test_audit_trail.py`)
- [ ] `ruff check`, `ruff format`, `mypy`, `bandit` all clean
- [ ] Sonar local check passes (pre-commit hook)
- [ ] Verify `_safe_log_id` returns `[redacted]` for non-UUID input in unit test
- [ ] Verify valid UUID passes through unchanged

Closes #1095

🤖 Generated with [Claude Code](https://claude.com/claude-code)