### PR TITLE
security(auth): gated CSRF double-submit for refresh cookie

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -85,9 +85,18 @@ class Config:
         and not _read_bool_env("FLASK_TESTING", False),
     )
     JWT_COOKIE_SAMESITE = os.getenv("JWT_COOKIE_SAMESITE", "Lax")
-    # CSRF protection for cookie-based JWTs is deferred to a follow-up issue
-    # (double-submit token + per-request header). Keep disabled for now.
-    JWT_COOKIE_CSRF_PROTECT = False
+    # SEC-AUD-03 — Double-submit CSRF token for the refresh cookie.
+    # Gated behind AURAXIS_CSRF_ENFORCE so web/app clients can migrate first:
+    # while OFF, the CSRF cookie is NOT set and refresh works without the header
+    # (backward-compatible). Once all clients read the CSRF cookie and forward
+    # it as X-CSRF-TOKEN on /auth/refresh, flip the flag in prod to enforce.
+    JWT_COOKIE_CSRF_PROTECT = _read_bool_env("AURAXIS_CSRF_ENFORCE", False)
+    JWT_CSRF_CHECK_FORM = False
+    JWT_ACCESS_CSRF_HEADER_NAME = "X-CSRF-TOKEN"
+    JWT_REFRESH_CSRF_HEADER_NAME = "X-CSRF-TOKEN"
+    JWT_ACCESS_CSRF_COOKIE_NAME = "auraxis_csrf_access"
+    JWT_REFRESH_CSRF_COOKIE_NAME = "auraxis_csrf_refresh"
+    JWT_CSRF_IN_COOKIES = True
     # SEC-1 — close dual-mode: when True, login/refresh responses stop echoing
     # refresh_token in the JSON body; clients must rely on the httpOnly cookie.
     # Keep False until legacy clients have migrated. Header X-Refresh-Cookie-Only

--- a/tests/test_auth_refresh_csrf.py
+++ b/tests/test_auth_refresh_csrf.py
@@ -1,0 +1,154 @@
+"""SEC-AUD-03 — CSRF double-submit protection for the refresh cookie.
+
+Covers the two-phase rollout gated by AURAXIS_CSRF_ENFORCE
+(exposed as the Flask config ``JWT_COOKIE_CSRF_PROTECT``):
+
+Phase 1 (flag OFF — current default, backward compatible):
+- No CSRF cookie is set on login.
+- ``POST /auth/refresh`` succeeds without ``X-CSRF-TOKEN`` header.
+
+Phase 2 (flag ON — after clients migrate):
+- Login sets the ``auraxis_csrf_refresh`` cookie (non-HttpOnly so JS can read).
+- Refresh without a matching ``X-CSRF-TOKEN`` header returns 401.
+- Refresh succeeds when the header value matches the cookie value.
+- Rotation also rotates the CSRF token.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from werkzeug.security import generate_password_hash
+
+from app.extensions.database import db
+
+REFRESH_COOKIE_NAME = "auraxis_refresh"
+CSRF_REFRESH_COOKIE_NAME = "auraxis_csrf_refresh"
+
+
+def _create_user(
+    app, *, email: str = "csrf@test.com", password: str = "Pass123!"
+) -> Any:
+    from app.models.user import User
+
+    with app.app_context():
+        user = User(
+            id=uuid.uuid4(),
+            name="CSRF Test User",
+            email=email,
+            password=generate_password_hash(password),
+        )
+        db.session.add(user)
+        db.session.commit()
+        return user.id
+
+
+def _login(client, *, email: str = "csrf@test.com", password: str = "Pass123!"):
+    return client.post(
+        "/auth/login",
+        json={"email": email, "password": password, "captcha_token": "test"},
+    )
+
+
+def _find_set_cookie(response, name: str) -> str | None:
+    for header_name, header_value in response.headers.items():
+        if header_name.lower() != "set-cookie":
+            continue
+        if header_value.split("=", 1)[0].strip() == name:
+            return header_value
+    return None
+
+
+def _cookie_value(raw: str) -> str:
+    return raw.split("=", 1)[1].split(";", 1)[0]
+
+
+# ─── Phase 1 — default OFF (backward compatible) ─────────────────────────────
+
+
+class TestCsrfDisabledByDefault:
+    def test_login_does_not_set_csrf_cookie_when_flag_off(self, app, client):
+        _create_user(app, email="csrf-off-login@test.com")
+        resp = _login(client, email="csrf-off-login@test.com")
+        assert resp.status_code == 200, resp.get_json()
+        assert _find_set_cookie(resp, CSRF_REFRESH_COOKIE_NAME) is None
+
+    def test_refresh_succeeds_without_csrf_header_when_flag_off(self, app, client):
+        _create_user(app, email="csrf-off-refresh@test.com")
+        _login(client, email="csrf-off-refresh@test.com")
+        resp = client.post("/auth/refresh")
+        assert resp.status_code == 200, resp.get_json()
+
+
+# ─── Phase 2 — enforcement ON ────────────────────────────────────────────────
+
+
+class TestCsrfEnforcementWhenEnabled:
+    def _enable_csrf(self, app) -> None:
+        app.config["JWT_COOKIE_CSRF_PROTECT"] = True
+
+    def test_login_sets_csrf_refresh_cookie(self, app, client):
+        self._enable_csrf(app)
+        _create_user(app, email="csrf-on-login@test.com")
+        resp = _login(client, email="csrf-on-login@test.com")
+        assert resp.status_code == 200, resp.get_json()
+        raw = _find_set_cookie(resp, CSRF_REFRESH_COOKIE_NAME)
+        assert raw is not None, "login must emit Set-Cookie auraxis_csrf_refresh"
+
+    def test_csrf_cookie_is_not_http_only(self, app, client):
+        """JS on the client needs to read the cookie to forward it as a header."""
+        self._enable_csrf(app)
+        _create_user(app, email="csrf-on-not-httponly@test.com")
+        resp = _login(client, email="csrf-on-not-httponly@test.com")
+        raw = _find_set_cookie(resp, CSRF_REFRESH_COOKIE_NAME) or ""
+        assert raw, "CSRF cookie must be emitted"
+        assert "HttpOnly" not in raw, "CSRF cookie must be readable by client JS"
+
+    def test_refresh_without_csrf_header_returns_401(self, app, client):
+        self._enable_csrf(app)
+        _create_user(app, email="csrf-on-missing-header@test.com")
+        _login(client, email="csrf-on-missing-header@test.com")
+        resp = client.post("/auth/refresh")
+        assert resp.status_code == 401, resp.get_json()
+
+    def test_refresh_with_matching_csrf_header_succeeds(self, app, client):
+        self._enable_csrf(app)
+        _create_user(app, email="csrf-on-matching@test.com")
+        login_resp = _login(client, email="csrf-on-matching@test.com")
+        csrf_raw = _find_set_cookie(login_resp, CSRF_REFRESH_COOKIE_NAME)
+        assert csrf_raw is not None
+        csrf_value = _cookie_value(csrf_raw)
+
+        resp = client.post("/auth/refresh", headers={"X-CSRF-TOKEN": csrf_value})
+        assert resp.status_code == 200, resp.get_json()
+
+    def test_refresh_with_wrong_csrf_header_returns_401(self, app, client):
+        self._enable_csrf(app)
+        _create_user(app, email="csrf-on-wrong@test.com")
+        _login(client, email="csrf-on-wrong@test.com")
+        resp = client.post(
+            "/auth/refresh",
+            headers={"X-CSRF-TOKEN": "tampered-value-does-not-match-cookie"},
+        )
+        assert resp.status_code == 401, resp.get_json()
+
+    def test_refresh_rotates_csrf_cookie(self, app, client):
+        self._enable_csrf(app)
+        _create_user(app, email="csrf-on-rotate@test.com")
+        login_resp = _login(client, email="csrf-on-rotate@test.com")
+        original_raw = _find_set_cookie(login_resp, CSRF_REFRESH_COOKIE_NAME)
+        assert original_raw is not None
+        original_value = _cookie_value(original_raw)
+
+        refresh_resp = client.post(
+            "/auth/refresh", headers={"X-CSRF-TOKEN": original_value}
+        )
+        assert refresh_resp.status_code == 200, refresh_resp.get_json()
+
+        rotated_raw = _find_set_cookie(refresh_resp, CSRF_REFRESH_COOKIE_NAME)
+        assert rotated_raw is not None, "refresh must rotate the CSRF cookie"
+        rotated_value = _cookie_value(rotated_raw)
+        assert rotated_value != original_value, (
+            "rotated CSRF token must differ from the original"
+        )


### PR DESCRIPTION
## Summary

Enables Flask-JWT-Extended double-submit CSRF protection for the refresh-cookie path, **gated behind `AURAXIS_CSRF_ENFORCE` (default OFF)** so web + app clients can migrate first without breaking anyone.

Ref **italofelipe/auraxis-platform#619** (SEC-AUD-03, P0).

## Why gated

Flipping `JWT_COOKIE_CSRF_PROTECT=True` directly would break every existing login/refresh flow immediately — web and app don't yet read the CSRF cookie or send the `X-CSRF-TOKEN` header. Doing it as a feature flag lets us:

1. Ship backend support now (this PR). Default behavior unchanged.
2. Migrate web + app in follow-up PRs (they can start reading + forwarding the header even while the flag is OFF — the backend just won't enforce).
3. Flip `AURAXIS_CSRF_ENFORCE=true` in prod after telemetry confirms 100% of refresh calls carry the header.

## Config changes (`config/__init__.py`)

| Key | Value |
|---|---|
| `JWT_COOKIE_CSRF_PROTECT` | `_read_bool_env("AURAXIS_CSRF_ENFORCE", False)` |
| `JWT_CSRF_CHECK_FORM` | `False` — header-only, no form field |
| `JWT_ACCESS_CSRF_HEADER_NAME` | `X-CSRF-TOKEN` |
| `JWT_REFRESH_CSRF_HEADER_NAME` | `X-CSRF-TOKEN` |
| `JWT_ACCESS_CSRF_COOKIE_NAME` | `auraxis_csrf_access` |
| `JWT_REFRESH_CSRF_COOKIE_NAME` | `auraxis_csrf_refresh` |
| `JWT_CSRF_IN_COOKIES` | `True` |

CSRF cookies are **non-HttpOnly** by design — client JS must read them and echo in the request header. The refresh JWT cookie itself remains HttpOnly.

## Behaviour matrix

| Scenario | Flag OFF (default) | Flag ON |
|---|---|---|
| Login sets `auraxis_csrf_refresh` cookie | No | Yes (non-HttpOnly) |
| `/auth/refresh` without header | 200 | 401 |
| `/auth/refresh` with wrong header value | 200 | 401 |
| `/auth/refresh` with matching header | 200 | 200 |
| Refresh rotates CSRF token | N/A | Yes |

## Tests

`tests/test_auth_refresh_csrf.py` — 8 new cases:

- `TestCsrfDisabledByDefault` (2 cases, flag off):
  - `test_login_does_not_set_csrf_cookie_when_flag_off`
  - `test_refresh_succeeds_without_csrf_header_when_flag_off`
- `TestCsrfEnforcementWhenEnabled` (6 cases, flag on via `app.config`):
  - `test_login_sets_csrf_refresh_cookie`
  - `test_csrf_cookie_is_not_http_only`
  - `test_refresh_without_csrf_header_returns_401`
  - `test_refresh_with_matching_csrf_header_succeeds`
  - `test_refresh_with_wrong_csrf_header_returns_401`
  - `test_refresh_rotates_csrf_cookie`

Existing `test_auth_refresh_cookie.py` suite (18 cases) still passes unchanged.

## Rollout plan (follow-ups)

- [ ] `auraxis-web`: read `auraxis_csrf_refresh` cookie, forward as `X-CSRF-TOKEN` header on `/auth/refresh` calls (separate PR).
- [ ] `auraxis-app`: same via Expo cookie accessor (separate PR).
- [ ] Telemetry: add dashboard tracking % of refresh calls that carry the header.
- [ ] Flip `AURAXIS_CSRF_ENFORCE=true` in prod once header coverage = 100%.

## Verification

- `pytest tests/test_auth*.py` → 53 passed
- Full suite (excluding pre-existing unrelated failures: property tests missing `hypothesis`, `test_lib_python.py` pyenv check) → all green
- `ruff check` + `mypy` clean
- Pre-push CI parity gate (incl. pip-audit, bandit, sonar-local) → all green

## Test plan

- [ ] CI green on `security/sec-aud-03-csrf-cookie-protect`
- [ ] Merge to master; default behavior unchanged
- [ ] Issue #619 updated with merge commit