### PR TITLE
ci(security): add Secret Scan (TruffleHog) for parity with web/app (SEC-AUD-12)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,27 @@ jobs:
         with:
           args: detect --source . --verbose --redact --config .gitleaks.toml
 
+  # SEC-AUD-12 — TruffleHog complements Gitleaks by validating that
+  # detected secrets are *active* against each provider's API. Parity
+  # with auraxis-web and auraxis-app, which already run both scanners.
+  secret-scan-trufflehog:
+    name: Secret Scan (TruffleHog)
+    runs-on: ubuntu-latest
+    needs: quality
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Run TruffleHog
+        uses: trufflesecurity/trufflehog@main
+        with:
+          path: ./
+          base: ${{ github.event.repository.default_branch }}
+          head: HEAD
+          extra_args: --only-verified
+
   dependency-review:
     name: Dependency Review (PR gate)
     if: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
## Summary

Closes italofelipe/auraxis-platform#628.

Adds a \`Secret Scan (TruffleHog)\` job to \`auraxis-api/.github/workflows/ci.yml\` mirroring the exact block already running in \`auraxis-web\` and \`auraxis-app\`. TruffleHog complements Gitleaks by *validating that detected secrets are active* against each provider's API (AWS, GitHub, Stripe, etc) — a regex match that Gitleaks finds can be confirmed to be a live credential before rotation.

## Changes

- \`.github/workflows/ci.yml\` — new \`secret-scan-trufflehog\` job with \`--only-verified\`, runs against the PR diff (\`default_branch..HEAD\`).

## Test plan

- [x] Locally ran pre-push gates (pip-audit, mypy, etc) — all green.
- [ ] CI renders the new check name.
- [ ] CI run does not regress or add false-positives on the current tree.

## Follow-up

Once we see one clean CI run on this PR, promote \`Secret Scan (TruffleHog)\` to a required context in \`italofelipe/auraxis-api/master\` branch protection via \`gh api PUT\` and update \`docs/governance/branch-protection.md\` to list it.