### PR TITLE
security(nginx): unify header baseline across 3 variants (SEC-AUD-10)

### DIFF
--- a/deploy/nginx/default.alb_dual.conf
+++ b/deploy/nginx/default.alb_dual.conf
@@ -30,12 +30,30 @@ server {
     ssl_session_cache shared:SSL:10m;
     ssl_session_timeout 1d;
 
-    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-    add_header X-Frame-Options "SAMEORIGIN" always;
+    client_max_body_size 10m;
+
+    # Hide server identity — strip upstream (gunicorn) Server header so clients
+    # never see backend technology info, and suppress nginx version from error pages.
+    server_tokens off;
+    proxy_hide_header Server;
+    proxy_hide_header X-Powered-By;
+
+    # Consolidate HSTS in one place: nginx is the canonical source.
+    # proxy_hide_header strips Flask's own HSTS to prevent the duplicate
+    # "Strict-Transport-Security Multiple Header Entries" ZAP finding [10035].
+    proxy_hide_header Strict-Transport-Security;
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
+
+    # SEC-AUD-10 — Unified security-header baseline. The three nginx variants
+    # (default.conf, default.tls.conf, default.alb_dual.conf) must emit the
+    # same values. Permissions-Policy matches the CloudFront response-headers
+    # policy applied to app.auraxis.com.br (SEC-AUD-05). X-XSS-Protection is
+    # intentionally absent — deprecated and ignored by modern browsers.
+    add_header X-Frame-Options "DENY" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-
-    client_max_body_size 10m;
+    add_header Permissions-Policy "geolocation=(), microphone=(), camera=(), payment=(), usb=(), accelerometer=()" always;
+    add_header Content-Security-Policy "default-src 'none'; frame-ancestors 'none'" always;
 
     location / {
         proxy_pass http://web:8000;

--- a/deploy/nginx/default.conf
+++ b/deploy/nginx/default.conf
@@ -18,12 +18,15 @@ server {
     proxy_hide_header Strict-Transport-Security;
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
 
-    # Security headers
+    # SEC-AUD-10 — Unified security-header baseline. The three nginx variants
+    # (default.conf, default.tls.conf, default.alb_dual.conf) must emit the
+    # same values. Permissions-Policy matches the CloudFront response-headers
+    # policy applied to app.auraxis.com.br (SEC-AUD-05). X-XSS-Protection is
+    # intentionally absent — deprecated and ignored by modern browsers.
     add_header X-Frame-Options "DENY" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header X-XSS-Protection "1; mode=block" always;
-    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+    add_header Permissions-Policy "geolocation=(), microphone=(), camera=(), payment=(), usb=(), accelerometer=()" always;
     add_header Content-Security-Policy "default-src 'none'; frame-ancestors 'none'" always;
 
     location /.well-known/acme-challenge/ {

--- a/deploy/nginx/default.tls.conf
+++ b/deploy/nginx/default.tls.conf
@@ -23,12 +23,30 @@ server {
     ssl_session_cache shared:SSL:10m;
     ssl_session_timeout 1d;
 
-    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-    add_header X-Frame-Options "SAMEORIGIN" always;
+    client_max_body_size 10m;
+
+    # Hide server identity — strip upstream (gunicorn) Server header so clients
+    # never see backend technology info, and suppress nginx version from error pages.
+    server_tokens off;
+    proxy_hide_header Server;
+    proxy_hide_header X-Powered-By;
+
+    # Consolidate HSTS in one place: nginx is the canonical source.
+    # proxy_hide_header strips Flask's own HSTS to prevent the duplicate
+    # "Strict-Transport-Security Multiple Header Entries" ZAP finding [10035].
+    proxy_hide_header Strict-Transport-Security;
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
+
+    # SEC-AUD-10 — Unified security-header baseline. The three nginx variants
+    # (default.conf, default.tls.conf, default.alb_dual.conf) must emit the
+    # same values. Permissions-Policy matches the CloudFront response-headers
+    # policy applied to app.auraxis.com.br (SEC-AUD-05). X-XSS-Protection is
+    # intentionally absent — deprecated and ignored by modern browsers.
+    add_header X-Frame-Options "DENY" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-
-    client_max_body_size 10m;
+    add_header Permissions-Policy "geolocation=(), microphone=(), camera=(), payment=(), usb=(), accelerometer=()" always;
+    add_header Content-Security-Policy "default-src 'none'; frame-ancestors 'none'" always;
 
     location / {
         proxy_pass http://web:8000;

--- a/docs/runbooks/nginx-headers.md
+++ b/docs/runbooks/nginx-headers.md
@@ -1,0 +1,103 @@
+# Nginx security headers — unified baseline
+
+Canonical reference for the security headers emitted by every nginx variant
+in this repo. Use this document as the source of truth when auditing drift
+between the three `deploy/nginx/*.conf` files.
+
+> Last applied: 2026-04-22 — SEC-AUD-10 (#626).
+
+## Scope
+
+Three nginx variants live in `deploy/nginx/`:
+
+| File | Deployment |
+|---|---|
+| `default.conf` | ALB → nginx (plain HTTP, TLS terminated at ALB) |
+| `default.tls.conf` | Legacy EC2 with Let's Encrypt cert on the box |
+| `default.alb_dual.conf` | Dual-listen variant for the EC2-behind-ALB transition |
+
+`default.http.conf` and `default.alb.conf` are HTTP-only redirects to
+HTTPS and do not emit security headers — traffic is terminated by one of
+the variants above before reaching the app.
+
+All three variants that proxy traffic to `http://web:8000` MUST emit the
+same security-header set. Divergence is the bug.
+
+## Canonical header set
+
+```nginx
+# Server identity
+server_tokens off;
+proxy_hide_header Server;
+proxy_hide_header X-Powered-By;
+
+# HSTS — canonical source is nginx; strip Flask's HSTS to avoid duplicates.
+proxy_hide_header Strict-Transport-Security;
+add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
+
+# Core security baseline
+add_header X-Frame-Options "DENY" always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+add_header Permissions-Policy "geolocation=(), microphone=(), camera=(), payment=(), usb=(), accelerometer=()" always;
+add_header Content-Security-Policy "default-src 'none'; frame-ancestors 'none'" always;
+```
+
+### Per-header rationale
+
+- **HSTS 2y + preload**: matches the CloudFront policy for the web app and
+  prepares for a future hstspreload.org submission (SEC-AUD-02).
+- **`proxy_hide_header Strict-Transport-Security`**: Flask's
+  `app/middleware/security_headers.py` also emits HSTS. Without this
+  directive ZAP reports `10035 Strict-Transport-Security Multiple Header
+  Entries`.
+- **X-Frame-Options: DENY**: the API never serves a page intended to be
+  framed. `SAMEORIGIN` was historical and matched nothing real.
+- **Permissions-Policy**: value is byte-identical to the CloudFront
+  response-headers policy on `app.auraxis.com.br` (SEC-AUD-05) so the
+  web and API report the same capabilities baseline.
+- **CSP `default-src 'none'; frame-ancestors 'none'`**: the API returns
+  JSON; no scripts, no styles, no frames. The strictest possible policy.
+- **X-XSS-Protection**: intentionally NOT emitted. Deprecated and ignored
+  by modern browsers; the header only risks misbehavior in legacy UAs.
+
+## Drift audit
+
+After a deploy, confirm the live response matches the baseline:
+
+```bash
+curl -sI https://api.auraxis.com.br/healthz | \
+  grep -Ei '^(strict-transport-security|x-frame-options|x-content-type-options|referrer-policy|permissions-policy|content-security-policy|server|x-powered-by):'
+```
+
+Expected output:
+
+```
+strict-transport-security: max-age=63072000; includeSubDomains; preload
+x-frame-options: DENY
+x-content-type-options: nosniff
+referrer-policy: strict-origin-when-cross-origin
+permissions-policy: geolocation=(), microphone=(), camera=(), payment=(), usb=(), accelerometer=()
+content-security-policy: default-src 'none'; frame-ancestors 'none'
+```
+
+`server` and `x-powered-by` MUST be absent.
+
+## Changing the baseline
+
+1. Update all three variants in the same commit — grep first to confirm:
+   ```bash
+   grep -l 'Strict-Transport-Security\|Permissions-Policy\|Content-Security-Policy' deploy/nginx/default*.conf
+   ```
+2. Update this document.
+3. If the change affects the web app's posture, mirror it in:
+   - `infra/web/main.tf` (`aws_cloudfront_response_headers_policy.web_security`)
+   - `repos/auraxis-web/app/core/security/csp.ts`
+   - `app/middleware/security_headers.py`
+
+## References
+
+- Audit that produced this change: `.context/reports/historical/security_audit_2026-04-22.md`
+- Issue: [#626 SEC-AUD-10](https://github.com/italofelipe/auraxis-api/issues/626)
+- CloudFront parity: SEC-AUD-05 / `infra/web/main.tf`
+- Flask middleware: `app/middleware/security_headers.py`


### PR DESCRIPTION
## Summary
- Aligns `default.conf`, `default.tls.conf`, and `default.alb_dual.conf` to a single security-header baseline so the API emits identical headers regardless of deploy variant.
- Upgrades HSTS to `max-age=63072000; includeSubDomains; preload` on every variant + strips Flask's upstream HSTS to eliminate the ZAP `10035` duplicate-header finding.
- Extends Permissions-Policy to byte-identical parity with the CloudFront policy on `app.auraxis.com.br` (SEC-AUD-05): adds `payment`, `usb`, `accelerometer`.
- Removes deprecated `X-XSS-Protection` everywhere; tightens `X-Frame-Options` from `SAMEORIGIN` to `DENY`.
- Adds `docs/runbooks/nginx-headers.md` as canonical reference + drift-audit procedure.

Closes #626.

## Test plan
- [ ] CI green (quality + tests + security workflows)
- [ ] Post-deploy: `curl -sI https://api.auraxis.com.br/healthz` shows exactly the baseline in `docs/runbooks/nginx-headers.md`
- [ ] No duplicate `Strict-Transport-Security` header (ZAP 10035 cleared)
- [ ] `Server` and `X-Powered-By` response headers absent