### PR TITLE
feat(entitlements): add focus_mode to premium plan

### DIFF
--- a/app/config/plan_features.py
+++ b/app/config/plan_features.py
@@ -13,6 +13,7 @@ PLAN_FEATURES: dict[str, list[str]] = {
         "advanced_simulations",
         "export_pdf",
         "shared_entries",
+        "focus_mode",
     ],
     "trial": [
         "basic_simulations",
@@ -20,6 +21,7 @@ PLAN_FEATURES: dict[str, list[str]] = {
         "advanced_simulations",
         "export_pdf",
         "shared_entries",
+        "focus_mode",
     ],
 }
 

--- a/docs/entitlement-matrix.md
+++ b/docs/entitlement-matrix.md
@@ -30,6 +30,7 @@ matching entry here.
 | `export_pdf` | Premium, Trial | Downgrade to Free / cancellation |
 | `advanced_simulations` | Premium, Trial | Downgrade to Free / cancellation |
 | `shared_entries` | Premium, Trial | Downgrade to Free / cancellation |
+| `focus_mode` | Premium, Trial | Downgrade to Free / cancellation |
 | `basic_simulations` | Free, Premium, Trial | Never |
 | `wallet_read` | Free, Premium, Trial | Never |
 


### PR DESCRIPTION
## Summary

Adds the `focus_mode` entitlement to the premium + trial plans so the Focus Mode page shipping in auraxis-web can unlock for premium users while free users see the paywall teaser.

Companion to auraxis-web PR italofelipe/auraxis-web#775 (Closes auraxis-web #551, #552).

## Changes

- `app/config/plan_features.py` — add `focus_mode` to `premium` and `trial` lists (`PREMIUM_FEATURES` frozenset picks it up automatically via dict-driven derivation)
- `docs/entitlement-matrix.md` — document the `focus_mode` row (scope: Premium, Trial; revocation: downgrade to Free / cancellation)

No new endpoints, `@require_entitlement` decorators or feature flags. The web client already calls `/entitlements/check?feature=focus_mode` through `PaywallGate`, which returns `locked` today; once this merges it flips to `unlocked` for premium/trial.

## Test plan

- [x] `bash scripts/run_ci_quality_local.sh --local` — 1603 passed, 1 skipped, coverage 91% (above 85% threshold)
- [x] ruff + mypy + bandit + sonar + alembic-single-head all pass
- [x] Dynamic entitlement tests (`test_entitlement_matrix.py`, `test_billing.py`, `test_j12_entitlement_enforcement.py`) pick up the new feature_key automatically — no test edits required