### PR TITLE
fix(tags): accept hex with alpha channel and normalize

### DIFF
--- a/app/controllers/tag/resources.py
+++ b/app/controllers/tag/resources.py
@@ -22,7 +22,8 @@ MISSING_NAME_MESSAGE = "Field 'name' is required"
 NAME_TOO_LONG_MESSAGE = "Field 'name' must be at most 50 characters"
 TAG_NOT_FOUND_MESSAGE = "Tag not found"
 INVALID_COLOR_MESSAGE = "Field 'color' must be a valid hex color code (e.g. #FF6B6B)"
-_HEX_COLOR_RE = re.compile(r"^#[0-9A-Fa-f]{6}$")
+# Accept #RRGGBB and #RRGGBBAA; alpha is stripped before persisting.
+_HEX_COLOR_RE = re.compile(r"^#[0-9A-Fa-f]{6}([0-9A-Fa-f]{2})?$")
 
 
 def _serialize_tag(t: Tag) -> dict[str, Any]:
@@ -38,6 +39,14 @@ def _validate_color(color: str | None) -> bool:
     if color is None:
         return True
     return bool(_HEX_COLOR_RE.match(color))
+
+
+def _normalize_color(color: str | None) -> str | None:
+    if color is None:
+        return None
+    if _HEX_COLOR_RE.match(color):
+        return color[:7]
+    return color
 
 
 @tag_bp.route("", methods=["GET"])
@@ -89,6 +98,7 @@ def create_tag() -> tuple[dict[str, Any], int]:
             message=INVALID_COLOR_MESSAGE,
             error_code="INVALID_COLOR",
         )
+    color = _normalize_color(color)
     icon = payload.get("icon") or None
 
     tag = Tag(user_id=user_id, name=name, color=color, icon=icon)
@@ -146,7 +156,7 @@ def update_tag(tag_id: UUID) -> tuple[dict[str, Any], int]:
 
     tag.name = name
     if "color" in payload:
-        tag.color = color
+        tag.color = _normalize_color(color)
     if "icon" in payload:
         tag.icon = payload.get("icon") or None
     db.session.commit()

--- a/app/schemas/tag_schema.py
+++ b/app/schemas/tag_schema.py
@@ -10,15 +10,6 @@ def _validate_hex_color(value: str) -> None:
         raise ValidationError("Color must be a valid hex color code (e.g. #FF6B6B)")
 
 
-def normalize_hex_color(value: str | None) -> str | None:
-    """Drop alpha channel: normalize #RRGGBBAA to canonical #RRGGBB."""
-    if value is None:
-        return None
-    if _HEX_COLOR_RE.match(value):
-        return value[:7]
-    return value
-
-
 class TagSchema(Schema):
     """Schema para criação e atualização de tags"""
 

--- a/app/schemas/tag_schema.py
+++ b/app/schemas/tag_schema.py
@@ -2,12 +2,21 @@ import re
 
 from marshmallow import Schema, ValidationError, fields, validate
 
-_HEX_COLOR_RE = re.compile(r"^#[0-9A-Fa-f]{6}$")
+_HEX_COLOR_RE = re.compile(r"^#[0-9A-Fa-f]{6}([0-9A-Fa-f]{2})?$")
 
 
 def _validate_hex_color(value: str) -> None:
     if value is not None and not _HEX_COLOR_RE.match(value):
         raise ValidationError("Color must be a valid hex color code (e.g. #FF6B6B)")
+
+
+def normalize_hex_color(value: str | None) -> str | None:
+    """Drop alpha channel: normalize #RRGGBBAA to canonical #RRGGBB."""
+    if value is None:
+        return None
+    if _HEX_COLOR_RE.match(value):
+        return value[:7]
+    return value
 
 
 class TagSchema(Schema):

--- a/tests/test_bloco2_models.py
+++ b/tests/test_bloco2_models.py
@@ -282,6 +282,29 @@ def test_update_tag_normalizes_alpha_hex(client) -> None:
     assert resp.get_json()["data"]["tag"]["color"] == "#9B59B6"
 
 
+def test_tag_schema_accepts_six_and_eight_digit_hex() -> None:
+    from marshmallow import ValidationError
+
+    from app.schemas.tag_schema import TagSchema
+
+    schema = TagSchema()
+
+    # 6-digit canonical
+    schema.load({"name": "ok-6", "color": "#FF6B6B"})
+    # 8-digit with alpha
+    schema.load({"name": "ok-8", "color": "#C21717FF"})
+    # null color allowed
+    schema.load({"name": "ok-null", "color": None})
+
+    # Invalid forms still rejected
+    for bad in ("red", "#XYZ", "#12345", "#1234567"):
+        try:
+            schema.load({"name": "bad", "color": bad})
+        except ValidationError:
+            continue
+        raise AssertionError(f"expected ValidationError for color={bad!r}")
+
+
 def test_list_tags_returns_color_and_icon(client) -> None:
     token, _ = _register_and_login(client, "tag-list-color")
 

--- a/tests/test_bloco2_models.py
+++ b/tests/test_bloco2_models.py
@@ -249,6 +249,39 @@ def test_create_tag_invalid_color_returns_400(client) -> None:
     assert resp.status_code == 400
 
 
+def test_create_tag_accepts_hex_with_alpha_and_normalizes(client) -> None:
+    token, _ = _register_and_login(client, "tag-color-alpha")
+
+    resp = client.post(
+        "/tags",
+        headers=_auth(token),
+        json={"name": "Gastos fixos", "color": "#C21717FF", "icon": None},
+    )
+    assert resp.status_code == 201, resp.get_json()
+    tag = resp.get_json()["data"]["tag"]
+    assert tag["color"] == "#C21717"
+    assert tag["icon"] is None
+
+
+def test_update_tag_normalizes_alpha_hex(client) -> None:
+    token, _ = _register_and_login(client, "tag-update-alpha")
+
+    create = client.post(
+        "/tags",
+        headers=_auth(token),
+        json={"name": "Lazer", "color": "#FFEAA7"},
+    )
+    tag_id = create.get_json()["data"]["tag"]["id"]
+
+    resp = client.put(
+        f"/tags/{tag_id}",
+        headers=_auth(token),
+        json={"name": "Lazer", "color": "#9B59B6CC"},
+    )
+    assert resp.status_code == 200, resp.get_json()
+    assert resp.get_json()["data"]["tag"]["color"] == "#9B59B6"
+
+
 def test_list_tags_returns_color_and_icon(client) -> None:
     token, _ = _register_and_login(client, "tag-list-color")
 


### PR DESCRIPTION
## Summary

- Backend rejected `POST /tags` and `PUT /tags/{id}` whenever the `color` field arrived as 8-digit hex (#RRGGBBAA), responding with `INVALID_COLOR` (400). This happens because Naive UI's `NColorPicker` emits the alpha channel by default.
- Relax the regex to accept `#RRGGBB` and `#RRGGBBAA`, then drop the alpha byte before persistence so storage stays canonical 6-digit (`color` column is `String(7)`).

## Changes

- `app/schemas/tag_schema.py`: regex now allows optional `(AA)`; new `normalize_hex_color()` helper drops alpha.
- `app/controllers/tag/resources.py`: same regex + private `_normalize_color()` applied on POST and PUT before assignment.
- `tests/test_bloco2_models.py`: new tests verify `#C21717FF` is accepted on create and stored as `#C21717`, plus PUT path normalizes `#9B59B6CC` → `#9B59B6`.

## Coordination

- Companion fix on the web client: italofelipe/auraxis-web — disables `show-alpha` on the picker and adds `stripHexAlpha` defensively. Backend fix lands first to unblock production users immediately.

## Test plan

- [ ] CI pytest passes (8 tag tests including 2 new)
- [ ] ruff + mypy green
- [ ] After deploy, repro from the original cURL (`color: "#C21717FF"`) returns 201 and stored color is `#C21717`