### PR TITLE
feat(simulations): allowlist aposentadoria + desconto-markup (#1131)

### DIFF
--- a/app/simulations/tools_registry.py
+++ b/app/simulations/tools_registry.py
@@ -58,8 +58,10 @@ TOOLS_REGISTRY: frozenset[str] = frozenset(
         "rent-vs-buy",
         "rental-yield",
         # Dia a dia
+        "aposentadoria",
         "cost-of-lifestyle",
         "currency-converter",
+        "desconto-markup",
         "emergency-fund",
         "fifty-thirty-twenty",
         "goal-simulator",

--- a/tests/test_simulations_canonical.py
+++ b/tests/test_simulations_canonical.py
@@ -74,6 +74,28 @@ def test_known_tool_id_is_accepted(client) -> None:
     assert resp.get_json()["simulation"]["tool_id"] == KNOWN_TOOL_ID
 
 
+def test_aposentadoria_tool_id_is_accepted(client) -> None:
+    token = _register_and_login(client, prefix="sim-reg-apos")
+    resp = client.post(
+        "/simulations",
+        json=_payload(tool_id="aposentadoria"),
+        headers=_auth(token),
+    )
+    assert resp.status_code == 201
+    assert resp.get_json()["simulation"]["tool_id"] == "aposentadoria"
+
+
+def test_desconto_markup_tool_id_is_accepted(client) -> None:
+    token = _register_and_login(client, prefix="sim-reg-dm")
+    resp = client.post(
+        "/simulations",
+        json=_payload(tool_id="desconto-markup"),
+        headers=_auth(token),
+    )
+    assert resp.status_code == 201
+    assert resp.get_json()["simulation"]["tool_id"] == "desconto-markup"
+
+
 # ---------------------------------------------------------------------------
 # inputs / result must be JSON objects
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Cross-repo do epic do app [#331](https://github.com/italofelipe/auraxis-app/issues/331). Adiciona `aposentadoria` e `desconto-markup` ao `TOOLS_REGISTRY` canônico para destravar `POST /simulations` aceitar essas duas tools (que já existem no web e foram portadas pro app em [italofelipe/auraxis-app#343](https://github.com/italofelipe/auraxis-app/pull/343)).

## Refs

Closes #1131

## Scope

- **`app/simulations/tools_registry.py`** — adiciona ambas no set canonico (categoria "Dia a dia", em ordem alfabética).
- **`tests/test_simulations_canonical.py`** — 2 novos testes confirmando que `POST /simulations` com `tool_id=aposentadoria` ou `desconto-markup` retorna 201.

## Quality gates

- [x] `tools-registry-parity` (DEC-196) — passou (parity OK contra `auraxis-app/features/tools/services/tools-catalog.ts` que já contém ambas via PR #343).
- [x] `ruff format` / `ruff check` — passed
- [x] `mypy` — passed
- [x] `bandit` — passed
- [x] `pytest tests/test_simulations_canonical.py -k "aposentadoria or desconto_markup or unknown_tool_id or known_tool_id"` — 4 passed
- [x] Pre-commit chain completo — passou (incluindo `tools-registry-parity`, `alembic-single-head`, `sonar-local-check`, `pip-audit`, `security-evidence`)

## Sequencing

App PR ([#343](https://github.com/italofelipe/auraxis-app/pull/343)) e este podem ser mergeados em qualquer ordem. Se este mergiar primeiro, save-simulation já funciona end-to-end no web. Se app mergiar primeiro, o cálculo+tela funcionam offline e o save passa a funcionar quando este mergiar.

## Risk

Baixo. Apenas additivo no allowlist. Sem migration, sem mudança de contrato OpenAPI (o enum é gerado dinamicamente do registry).