### PR TITLE
fix(graphql): replace Float with DecimalScalar on monetary fields, paginate tickers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,7 +148,7 @@ scripts/repo_bin.sh pytest -m "not schemathesis" --cov=app --cov-fail-under=85
 | Backend | Python 3.13, Flask |
 | ORM | SQLAlchemy with Flask-SQLAlchemy |
 | Serialization | Marshmallow Schemas |
-| API | GraphQL (Ariadne) + REST (Flask controllers) |
+| API | GraphQL (Graphene 3) + REST (Flask controllers) |
 | Migrations | Alembic via Flask-Migrate |
 | Tests | Pytest (85% coverage minimum) |
 | Database | PostgreSQL |

--- a/app/graphql/mutations/auth.py
+++ b/app/graphql/mutations/auth.py
@@ -38,6 +38,7 @@ from app.graphql.errors import (
     GRAPHQL_ERROR_CODE_VALIDATION,
     build_public_graphql_error,
 )
+from app.graphql.scalars import DecimalScalar
 from app.graphql.schema_utils import _user_basic_auth_payload, _user_to_graphql_payload
 from app.graphql.types import AuthPayloadType, UserType
 from app.http.runtime import runtime_logger
@@ -377,12 +378,12 @@ class UpdateUserProfileMutation(graphene.Mutation):
     class Arguments:
         gender = graphene.String()
         birth_date = graphene.String()
-        monthly_income = graphene.Float()
-        monthly_income_net = graphene.Float()
-        net_worth = graphene.Float()
-        monthly_expenses = graphene.Float()
-        initial_investment = graphene.Float()
-        monthly_investment = graphene.Float()
+        monthly_income = DecimalScalar()
+        monthly_income_net = DecimalScalar()
+        net_worth = DecimalScalar()
+        monthly_expenses = DecimalScalar()
+        initial_investment = DecimalScalar()
+        monthly_investment = DecimalScalar()
         investment_goal_date = graphene.String()
         state_uf = graphene.String()
         occupation = graphene.String()

--- a/app/graphql/mutations/wallet.py
+++ b/app/graphql/mutations/wallet.py
@@ -11,6 +11,7 @@ from app.application.services.wallet_application_service import (
     WalletApplicationService,
 )
 from app.graphql.auth import get_current_user_required
+from app.graphql.scalars import DecimalScalar
 from app.graphql.types import WalletType
 from app.graphql.wallet_presenters import raise_wallet_graphql_error, to_wallet_type
 
@@ -18,11 +19,11 @@ from app.graphql.wallet_presenters import raise_wallet_graphql_error, to_wallet_
 class AddWalletEntryMutation(graphene.Mutation):
     class Arguments:
         name = graphene.String(required=True)
-        value = graphene.Float()
+        value = DecimalScalar()
         ticker = graphene.String()
         quantity = graphene.Int()
         asset_class = graphene.String()
-        annual_rate = graphene.Float()
+        annual_rate = DecimalScalar()
         register_date = graphene.String()
         target_withdraw_date = graphene.String()
         should_be_on_wallet = graphene.Boolean(required=True)
@@ -56,11 +57,11 @@ class UpdateWalletEntryMutation(graphene.Mutation):
     class Arguments:
         investment_id = graphene.UUID(required=True)
         name = graphene.String()
-        value = graphene.Float()
+        value = DecimalScalar()
         ticker = graphene.String()
         quantity = graphene.Int()
         asset_class = graphene.String()
-        annual_rate = graphene.Float()
+        annual_rate = DecimalScalar()
         register_date = graphene.String()
         target_withdraw_date = graphene.String()
         should_be_on_wallet = graphene.Boolean()

--- a/app/graphql/queries/wallet.py
+++ b/app/graphql/queries/wallet.py
@@ -13,6 +13,7 @@ from app.graphql.queries.common import paginate
 from app.graphql.schema_utils import _validate_pagination_values
 from app.graphql.types import (
     PaginationType,
+    TickerListPayloadType,
     TickerType,
     WalletHistoryPayloadType,
     WalletListPayloadType,
@@ -37,7 +38,11 @@ class WalletQueryMixin:
         page=graphene.Int(default_value=1),
         per_page=graphene.Int(default_value=5),
     )
-    tickers = graphene.List(TickerType)
+    tickers = graphene.Field(
+        TickerListPayloadType,
+        page=graphene.Int(default_value=1),
+        per_page=graphene.Int(default_value=50),
+    )
 
     def resolve_wallet_entries(
         self, _info: graphene.ResolveInfo, page: int, per_page: int
@@ -96,15 +101,33 @@ class WalletQueryMixin:
             ),
         )
 
-    def resolve_tickers(self, _info: graphene.ResolveInfo) -> list[TickerType]:
+    def resolve_tickers(
+        self,
+        _info: graphene.ResolveInfo,
+        page: int = 1,
+        per_page: int = 50,
+    ) -> TickerListPayloadType:
+        _validate_pagination_values(page, per_page)
         user = get_current_user_required()
-        tickers = UserTicker.query.filter_by(user_id=user.id).all()
-        return [
+        base_query = UserTicker.query.filter_by(user_id=user.id)
+        total = base_query.count()
+        offset = (page - 1) * per_page
+        rows = (
+            base_query.order_by(UserTicker.symbol.asc())
+            .offset(offset)
+            .limit(per_page)
+            .all()
+        )
+        items = [
             TickerType(
                 id=str(item.id),
                 symbol=item.symbol,
                 quantity=item.quantity,
                 type=item.type,
             )
-            for item in tickers
+            for item in rows
         ]
+        return TickerListPayloadType(
+            items=items,
+            pagination=paginate(total=total, page=page, per_page=per_page),
+        )

--- a/app/graphql/scalars.py
+++ b/app/graphql/scalars.py
@@ -1,0 +1,63 @@
+"""Custom GraphQL scalars used across the auraxis-api schema.
+
+The :class:`DecimalScalar` exists because :class:`graphene.Float` collapses
+values to IEEE 754 binary floats, which silently lose precision on monetary
+amounts. The REST contract serialises monetary fields with
+``marshmallow.fields.Decimal(as_string=True)`` (see ``app/schemas/``); this
+scalar mirrors that behaviour so REST and GraphQL stay byte-equivalent.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+import graphene
+from graphql import GraphQLError
+from graphql.language.ast import FloatValueNode, IntValueNode, StringValueNode
+
+
+def _to_decimal(value: Any) -> Decimal:
+    if isinstance(value, Decimal):
+        return value
+    if isinstance(value, bool):
+        # bool is a subclass of int — be explicit and reject it.
+        raise GraphQLError("DecimalScalar does not accept boolean values.")
+    if isinstance(value, (int, float, str)):
+        try:
+            return Decimal(str(value))
+        except InvalidOperation as exc:
+            raise GraphQLError(f"Invalid decimal value: {value!r}") from exc
+    raise GraphQLError(
+        f"DecimalScalar cannot coerce value of type {type(value).__name__}."
+    )
+
+
+class DecimalScalar(graphene.Scalar):
+    """Arbitrary-precision decimal serialised as a string.
+
+    Output: always a string in fixed-point notation (no scientific exponent).
+    Input: accepts string, int, float, or Decimal — coerced via ``Decimal(str(x))``.
+    Null is preserved.
+    """
+
+    @staticmethod
+    def serialize(value: Any) -> str | None:
+        if value is None:
+            return None
+        return format(_to_decimal(value), "f")
+
+    @staticmethod
+    def parse_value(value: Any) -> Decimal | None:
+        if value is None:
+            return None
+        return _to_decimal(value)
+
+    @staticmethod
+    def parse_literal(node: Any, _variables: Any = None) -> Decimal | None:
+        if isinstance(node, (StringValueNode, IntValueNode, FloatValueNode)):
+            try:
+                return Decimal(node.value)
+            except InvalidOperation as exc:
+                raise GraphQLError(f"Invalid decimal literal: {node.value!r}") from exc
+        raise GraphQLError("DecimalScalar literal must be a string, int, or float.")

--- a/app/graphql/types.py
+++ b/app/graphql/types.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import graphene
 
+from app.graphql.scalars import DecimalScalar
+
 
 class UserType(graphene.ObjectType):
     id = graphene.ID(required=True)
@@ -9,12 +11,12 @@ class UserType(graphene.ObjectType):
     email = graphene.String(required=True)
     gender = graphene.String()
     birth_date = graphene.String()
-    monthly_income = graphene.Float()
-    monthly_income_net = graphene.Float()
-    net_worth = graphene.Float()
-    monthly_expenses = graphene.Float()
-    initial_investment = graphene.Float()
-    monthly_investment = graphene.Float()
+    monthly_income = DecimalScalar()
+    monthly_income_net = DecimalScalar()
+    net_worth = DecimalScalar()
+    monthly_expenses = DecimalScalar()
+    initial_investment = DecimalScalar()
+    monthly_investment = DecimalScalar()
     investment_goal_date = graphene.String()
     state_uf = graphene.String()
     occupation = graphene.String()
@@ -73,8 +75,8 @@ class TransactionListPayloadType(graphene.ObjectType):
 
 class TransactionSummaryPayloadType(graphene.ObjectType):
     month = graphene.String(required=True)
-    income_total = graphene.Float(required=True)
-    expense_total = graphene.Float(required=True)
+    income_total = DecimalScalar(required=True)
+    expense_total = DecimalScalar(required=True)
     items = graphene.List(TransactionTypeObject, required=True)
     pagination = graphene.Field(PaginationType, required=True)
 
@@ -107,15 +109,15 @@ class DashboardCountsType(graphene.ObjectType):
 
 
 class DashboardTotalsType(graphene.ObjectType):
-    income_total = graphene.Float(required=True)
-    expense_total = graphene.Float(required=True)
-    balance = graphene.Float(required=True)
+    income_total = DecimalScalar(required=True)
+    expense_total = DecimalScalar(required=True)
+    balance = DecimalScalar(required=True)
 
 
 class DashboardCategoryType(graphene.ObjectType):
     tag_id = graphene.String()
     category_name = graphene.String(required=True)
-    total_amount = graphene.Float(required=True)
+    total_amount = DecimalScalar(required=True)
     transactions_count = graphene.Int(required=True)
 
 
@@ -311,20 +313,20 @@ class CreatePlannedExpenseFromInstallmentVsCashSimulationPayloadType(
 class WalletType(graphene.ObjectType):
     id = graphene.ID(required=True)
     name = graphene.String(required=True)
-    value = graphene.Float()
-    estimated_value_on_create_date = graphene.Float()
+    value = DecimalScalar()
+    estimated_value_on_create_date = DecimalScalar()
     ticker = graphene.String()
     quantity = graphene.Int()
     asset_class = graphene.String(required=True)
-    annual_rate = graphene.Float()
+    annual_rate = DecimalScalar()
     register_date = graphene.String(required=True)
     target_withdraw_date = graphene.String()
     should_be_on_wallet = graphene.Boolean(required=True)
 
 
 class WalletHistoryItemType(graphene.ObjectType):
-    original_quantity = graphene.Float()
-    original_value = graphene.Float()
+    original_quantity = DecimalScalar()
+    original_value = DecimalScalar()
     change_type = graphene.String()
     change_date = graphene.String()
 
@@ -462,6 +464,11 @@ class TickerType(graphene.ObjectType):
     type = graphene.String()
 
 
+class TickerListPayloadType(graphene.ObjectType):
+    items = graphene.List(TickerType, required=True)
+    pagination = graphene.Field(PaginationType, required=True)
+
+
 # ---------------------------------------------------------------------------
 # Budget types (H-PROD-04 / #886)
 # ---------------------------------------------------------------------------
@@ -570,26 +577,26 @@ class NotificationPreferencesType(graphene.ObjectType):
 class WeeklyPeriodTotalsType(graphene.ObjectType):
     start = graphene.String(required=True)
     end = graphene.String(required=True)
-    income = graphene.Float(required=True)
-    expense = graphene.Float(required=True)
-    balance = graphene.Float(required=True)
+    income = DecimalScalar(required=True)
+    expense = DecimalScalar(required=True)
+    balance = DecimalScalar(required=True)
     transaction_count = graphene.Int(required=True)
 
 
 class WeeklyComparisonType(graphene.ObjectType):
-    income_delta = graphene.Float(required=True)
+    income_delta = DecimalScalar(required=True)
     income_delta_percent = graphene.Float()
-    expense_delta = graphene.Float(required=True)
+    expense_delta = DecimalScalar(required=True)
     expense_delta_percent = graphene.Float()
-    balance_delta = graphene.Float(required=True)
+    balance_delta = DecimalScalar(required=True)
     balance_delta_percent = graphene.Float()
 
 
 class WeeklySummarySeriesEntryType(graphene.ObjectType):
     date = graphene.String(required=True)
-    income = graphene.Float(required=True)
-    expense = graphene.Float(required=True)
-    balance = graphene.Float(required=True)
+    income = DecimalScalar(required=True)
+    expense = DecimalScalar(required=True)
+    balance = DecimalScalar(required=True)
 
 
 class WeeklySummaryPayloadType(graphene.ObjectType):

--- a/graphql.introspection.json
+++ b/graphql.introspection.json
@@ -546,19 +546,40 @@
               }
             },
             {
-              "args": [],
+              "args": [
+                {
+                  "defaultValue": "1",
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "page",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": "50",
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "perPage",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                }
+              ],
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
               "name": "tickers",
               "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "TickerType",
-                  "ofType": null
-                }
+                "kind": "OBJECT",
+                "name": "TickerListPayloadType",
+                "ofType": null
               }
             },
             {
@@ -3852,7 +3873,7 @@
               "name": "value",
               "type": {
                 "kind": "SCALAR",
-                "name": "Float",
+                "name": "DecimalScalar",
                 "ofType": null
               }
             },
@@ -3864,7 +3885,7 @@
               "name": "estimatedValueOnCreateDate",
               "type": {
                 "kind": "SCALAR",
-                "name": "Float",
+                "name": "DecimalScalar",
                 "ofType": null
               }
             },
@@ -3916,7 +3937,7 @@
               "name": "annualRate",
               "type": {
                 "kind": "SCALAR",
-                "name": "Float",
+                "name": "DecimalScalar",
                 "ofType": null
               }
             },
@@ -3969,6 +3990,17 @@
           "interfaces": [],
           "kind": "OBJECT",
           "name": "WalletType",
+          "possibleTypes": null,
+          "specifiedByURL": null
+        },
+        {
+          "description": "Arbitrary-precision decimal serialised as a string.\n\nOutput: always a string in fixed-point notation (no scientific exponent).\nInput: accepts string, int, float, or Decimal — coerced via ``Decimal(str(x))``.\nNull is preserved.",
+          "enumValues": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "SCALAR",
+          "name": "DecimalScalar",
           "possibleTypes": null,
           "specifiedByURL": null
         },
@@ -4032,7 +4064,7 @@
               "name": "originalQuantity",
               "type": {
                 "kind": "SCALAR",
-                "name": "Float",
+                "name": "DecimalScalar",
                 "ofType": null
               }
             },
@@ -4044,7 +4076,7 @@
               "name": "originalValue",
               "type": {
                 "kind": "SCALAR",
-                "name": "Float",
+                "name": "DecimalScalar",
                 "ofType": null
               }
             },
@@ -4077,6 +4109,54 @@
           "interfaces": [],
           "kind": "OBJECT",
           "name": "WalletHistoryItemType",
+          "possibleTypes": null,
+          "specifiedByURL": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "items",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "TickerType",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "pagination",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PaginationType",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "TickerListPayloadType",
           "possibleTypes": null,
           "specifiedByURL": null
         },
@@ -6445,7 +6525,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "Float",
+                  "name": "DecimalScalar",
                   "ofType": null
                 }
               }
@@ -6461,7 +6541,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "Float",
+                  "name": "DecimalScalar",
                   "ofType": null
                 }
               }
@@ -6601,7 +6681,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "Float",
+                  "name": "DecimalScalar",
                   "ofType": null
                 }
               }
@@ -6617,7 +6697,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "Float",
+                  "name": "DecimalScalar",
                   "ofType": null
                 }
               }
@@ -6633,7 +6713,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "Float",
+                  "name": "DecimalScalar",
                   "ofType": null
                 }
               }
@@ -6909,7 +6989,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "Float",
+                  "name": "DecimalScalar",
                   "ofType": null
                 }
               }
@@ -7237,7 +7317,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "Float",
+                  "name": "DecimalScalar",
                   "ofType": null
                 }
               }
@@ -7253,7 +7333,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "Float",
+                  "name": "DecimalScalar",
                   "ofType": null
                 }
               }
@@ -7269,7 +7349,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "Float",
+                  "name": "DecimalScalar",
                   "ofType": null
                 }
               }
@@ -7313,7 +7393,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "Float",
+                  "name": "DecimalScalar",
                   "ofType": null
                 }
               }
@@ -7341,7 +7421,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "Float",
+                  "name": "DecimalScalar",
                   "ofType": null
                 }
               }
@@ -7369,7 +7449,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "Float",
+                  "name": "DecimalScalar",
                   "ofType": null
                 }
               }
@@ -7425,7 +7505,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "Float",
+                  "name": "DecimalScalar",
                   "ofType": null
                 }
               }
@@ -7441,7 +7521,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "Float",
+                  "name": "DecimalScalar",
                   "ofType": null
                 }
               }
@@ -7457,7 +7537,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "Float",
+                  "name": "DecimalScalar",
                   "ofType": null
                 }
               }
@@ -7554,7 +7634,7 @@
               "name": "monthlyIncome",
               "type": {
                 "kind": "SCALAR",
-                "name": "Float",
+                "name": "DecimalScalar",
                 "ofType": null
               }
             },
@@ -7566,7 +7646,7 @@
               "name": "monthlyIncomeNet",
               "type": {
                 "kind": "SCALAR",
-                "name": "Float",
+                "name": "DecimalScalar",
                 "ofType": null
               }
             },
@@ -7578,7 +7658,7 @@
               "name": "netWorth",
               "type": {
                 "kind": "SCALAR",
-                "name": "Float",
+                "name": "DecimalScalar",
                 "ofType": null
               }
             },
@@ -7590,7 +7670,7 @@
               "name": "monthlyExpenses",
               "type": {
                 "kind": "SCALAR",
-                "name": "Float",
+                "name": "DecimalScalar",
                 "ofType": null
               }
             },
@@ -7602,7 +7682,7 @@
               "name": "initialInvestment",
               "type": {
                 "kind": "SCALAR",
-                "name": "Float",
+                "name": "DecimalScalar",
                 "ofType": null
               }
             },
@@ -7614,7 +7694,7 @@
               "name": "monthlyInvestment",
               "type": {
                 "kind": "SCALAR",
-                "name": "Float",
+                "name": "DecimalScalar",
                 "ofType": null
               }
             },
@@ -8034,7 +8114,7 @@
                   "name": "initialInvestment",
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Float",
+                    "name": "DecimalScalar",
                     "ofType": null
                   }
                 },
@@ -8082,7 +8162,7 @@
                   "name": "monthlyExpenses",
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Float",
+                    "name": "DecimalScalar",
                     "ofType": null
                   }
                 },
@@ -8094,7 +8174,7 @@
                   "name": "monthlyIncome",
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Float",
+                    "name": "DecimalScalar",
                     "ofType": null
                   }
                 },
@@ -8106,7 +8186,7 @@
                   "name": "monthlyIncomeNet",
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Float",
+                    "name": "DecimalScalar",
                     "ofType": null
                   }
                 },
@@ -8118,7 +8198,7 @@
                   "name": "monthlyInvestment",
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Float",
+                    "name": "DecimalScalar",
                     "ofType": null
                   }
                 },
@@ -8130,7 +8210,7 @@
                   "name": "netWorth",
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Float",
+                    "name": "DecimalScalar",
                     "ofType": null
                   }
                 },
@@ -9505,7 +9585,7 @@
                   "name": "annualRate",
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Float",
+                    "name": "DecimalScalar",
                     "ofType": null
                   }
                 },
@@ -9609,7 +9689,7 @@
                   "name": "value",
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Float",
+                    "name": "DecimalScalar",
                     "ofType": null
                   }
                 }
@@ -9634,7 +9714,7 @@
                   "name": "annualRate",
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Float",
+                    "name": "DecimalScalar",
                     "ofType": null
                   }
                 },
@@ -9746,7 +9826,7 @@
                   "name": "value",
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Float",
+                    "name": "DecimalScalar",
                     "ofType": null
                   }
                 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -14,7 +14,7 @@ type Query {
   portfolioValuationHistory(startDate: String, finalDate: String): PortfolioHistoryPayloadType
   walletEntries(page: Int = 1, perPage: Int = 10): WalletListPayloadType
   walletHistory(investmentId: UUID!, page: Int = 1, perPage: Int = 5): WalletHistoryPayloadType
-  tickers: [TickerType]
+  tickers(page: Int = 1, perPage: Int = 50): TickerListPayloadType
   installmentVsCashCalculate(cashPrice: String!, installmentCount: Int!, installmentAmount: String, installmentTotal: String, firstPaymentDelayDays: Int = 30, opportunityRateType: String = "manual", opportunityRateAnnual: String, inflationRateAnnual: String!, feesEnabled: Boolean = false, feesUpfront: String = "0.00", scenarioLabel: String): InstallmentVsCashCalculationPayloadType
   simulations(page: Int = 1, perPage: Int = 20, toolId: String): SimulationListPayloadType!
   simulation(id: UUID!): SimulationType
@@ -241,16 +241,25 @@ type WalletListPayloadType {
 type WalletType {
   id: ID!
   name: String!
-  value: Float
-  estimatedValueOnCreateDate: Float
+  value: DecimalScalar
+  estimatedValueOnCreateDate: DecimalScalar
   ticker: String
   quantity: Int
   assetClass: String!
-  annualRate: Float
+  annualRate: DecimalScalar
   registerDate: String!
   targetWithdrawDate: String
   shouldBeOnWallet: Boolean!
 }
+
+"""
+Arbitrary-precision decimal serialised as a string.
+
+Output: always a string in fixed-point notation (no scientific exponent).
+Input: accepts string, int, float, or Decimal — coerced via ``Decimal(str(x))``.
+Null is preserved.
+"""
+scalar DecimalScalar
 
 type WalletHistoryPayloadType {
   items: [WalletHistoryItemType]!
@@ -258,10 +267,15 @@ type WalletHistoryPayloadType {
 }
 
 type WalletHistoryItemType {
-  originalQuantity: Float
-  originalValue: Float
+  originalQuantity: DecimalScalar
+  originalValue: DecimalScalar
   changeType: String
   changeDate: String
+}
+
+type TickerListPayloadType {
+  items: [TickerType]!
+  pagination: PaginationType!
 }
 
 type TickerType {
@@ -477,8 +491,8 @@ type TransactionTypeObject {
 
 type TransactionSummaryPayloadType {
   month: String!
-  incomeTotal: Float!
-  expenseTotal: Float!
+  incomeTotal: DecimalScalar!
+  expenseTotal: DecimalScalar!
   items: [TransactionTypeObject]!
   pagination: PaginationType!
 }
@@ -491,9 +505,9 @@ type TransactionDashboardPayloadType {
 }
 
 type DashboardTotalsType {
-  incomeTotal: Float!
-  expenseTotal: Float!
-  balance: Float!
+  incomeTotal: DecimalScalar!
+  expenseTotal: DecimalScalar!
+  balance: DecimalScalar!
 }
 
 type DashboardCountsType {
@@ -519,7 +533,7 @@ type DashboardCategoriesType {
 type DashboardCategoryType {
   tagId: String
   categoryName: String!
-  totalAmount: Float!
+  totalAmount: DecimalScalar!
   transactionsCount: Int!
 }
 
@@ -548,26 +562,26 @@ type WeeklySummaryPayloadType {
 type WeeklyPeriodTotalsType {
   start: String!
   end: String!
-  income: Float!
-  expense: Float!
-  balance: Float!
+  income: DecimalScalar!
+  expense: DecimalScalar!
+  balance: DecimalScalar!
   transactionCount: Int!
 }
 
 type WeeklyComparisonType {
-  incomeDelta: Float!
+  incomeDelta: DecimalScalar!
   incomeDeltaPercent: Float
-  expenseDelta: Float!
+  expenseDelta: DecimalScalar!
   expenseDeltaPercent: Float
-  balanceDelta: Float!
+  balanceDelta: DecimalScalar!
   balanceDeltaPercent: Float
 }
 
 type WeeklySummarySeriesEntryType {
   date: String!
-  income: Float!
-  expense: Float!
-  balance: Float!
+  income: DecimalScalar!
+  expense: DecimalScalar!
+  balance: DecimalScalar!
 }
 
 type UserType {
@@ -576,12 +590,12 @@ type UserType {
   email: String!
   gender: String
   birthDate: String
-  monthlyIncome: Float
-  monthlyIncomeNet: Float
-  netWorth: Float
-  monthlyExpenses: Float
-  initialInvestment: Float
-  monthlyInvestment: Float
+  monthlyIncome: DecimalScalar
+  monthlyIncomeNet: DecimalScalar
+  netWorth: DecimalScalar
+  monthlyExpenses: DecimalScalar
+  initialInvestment: DecimalScalar
+  monthlyInvestment: DecimalScalar
   investmentGoalDate: String
   stateUf: String
   occupation: String
@@ -600,7 +614,7 @@ type Mutation {
   resendConfirmationEmail(email: String!): AuthPayloadType
   resetPassword(newPassword: String!, token: String!): AuthPayloadType
   confirmEmail(token: String!): AuthPayloadType
-  updateUserProfile(birthDate: String, financialObjectives: String, gender: String, initialInvestment: Float, investmentGoalDate: String, investorProfile: String, investorProfileSuggested: String, monthlyExpenses: Float, monthlyIncome: Float, monthlyIncomeNet: Float, monthlyInvestment: Float, netWorth: Float, occupation: String, profileQuizScore: Int, stateUf: String, taxonomyVersion: String): UpdateUserProfileMutation
+  updateUserProfile(birthDate: String, financialObjectives: String, gender: String, initialInvestment: DecimalScalar, investmentGoalDate: String, investorProfile: String, investorProfileSuggested: String, monthlyExpenses: DecimalScalar, monthlyIncome: DecimalScalar, monthlyIncomeNet: DecimalScalar, monthlyInvestment: DecimalScalar, netWorth: DecimalScalar, occupation: String, profileQuizScore: Int, stateUf: String, taxonomyVersion: String): UpdateUserProfileMutation
   createTransaction(accountId: UUID, amount: String!, creditCardId: UUID, currency: String = "BRL", description: String, dueDate: String!, endDate: String, installmentCount: Int, isInstallment: Boolean = false, isRecurring: Boolean = false, observation: String, startDate: String, status: String = "pending", tagId: UUID, title: String!, type: String!): CreateTransactionMutation @deprecated(reason: "ADR-0002: use POST /transactions")
   updateTransaction(accountId: UUID, amount: String, creditCardId: UUID, currency: String, description: String, dueDate: String, endDate: String, installmentCount: Int, isInstallment: Boolean, isRecurring: Boolean, observation: String, paidAt: String, startDate: String, status: String, tagId: UUID, title: String, transactionId: UUID!, type: String): UpdateTransactionMutation @deprecated(reason: "ADR-0002: use PATCH /transactions/{id}")
   deleteTransaction(transactionId: UUID!): DeleteTransactionMutation @deprecated(reason: "ADR-0002: use DELETE /transactions/{id}")
@@ -611,8 +625,8 @@ type Mutation {
   saveInstallmentVsCashSimulation(cashPrice: String!, feesEnabled: Boolean = false, feesUpfront: String = "0.00", firstPaymentDelayDays: Int = 30, inflationRateAnnual: String!, installmentAmount: String, installmentCount: Int!, installmentTotal: String, opportunityRateAnnual: String, opportunityRateType: String = "manual", scenarioLabel: String): SaveInstallmentVsCashSimulationMutation
   createGoalFromInstallmentVsCashSimulation(category: String = "planned_purchase", currentAmount: String = "0.00", description: String, priority: Int = 3, selectedOption: String!, simulationId: UUID!, targetDate: String, title: String!): CreateGoalFromInstallmentVsCashSimulationMutation
   createPlannedExpenseFromInstallmentVsCashSimulation(accountId: UUID, creditCardId: UUID, currency: String = "BRL", description: String, dueDate: String, firstDueDate: String, observation: String, selectedOption: String!, simulationId: UUID!, status: String = "pending", tagId: UUID, title: String!, upfrontDueDate: String): CreatePlannedExpenseFromInstallmentVsCashSimulationMutation
-  addWalletEntry(annualRate: Float, assetClass: String, name: String!, quantity: Int, registerDate: String, shouldBeOnWallet: Boolean!, targetWithdrawDate: String, ticker: String, value: Float): AddWalletEntryMutation @deprecated(reason: "ADR-0002: use POST /wallet")
-  updateWalletEntry(annualRate: Float, assetClass: String, investmentId: UUID!, name: String, quantity: Int, registerDate: String, shouldBeOnWallet: Boolean, targetWithdrawDate: String, ticker: String, value: Float): UpdateWalletEntryMutation @deprecated(reason: "ADR-0002: use PATCH /wallet/{id}")
+  addWalletEntry(annualRate: DecimalScalar, assetClass: String, name: String!, quantity: Int, registerDate: String, shouldBeOnWallet: Boolean!, targetWithdrawDate: String, ticker: String, value: DecimalScalar): AddWalletEntryMutation @deprecated(reason: "ADR-0002: use POST /wallet")
+  updateWalletEntry(annualRate: DecimalScalar, assetClass: String, investmentId: UUID!, name: String, quantity: Int, registerDate: String, shouldBeOnWallet: Boolean, targetWithdrawDate: String, ticker: String, value: DecimalScalar): UpdateWalletEntryMutation @deprecated(reason: "ADR-0002: use PATCH /wallet/{id}")
   deleteWalletEntry(investmentId: UUID!): DeleteWalletEntryMutation @deprecated(reason: "ADR-0002: use DELETE /wallet/{id}")
   addInvestmentOperation(executedAt: String, fees: String, investmentId: UUID!, notes: String, operationType: String!, quantity: String!, unitPrice: String!): AddInvestmentOperationMutation @deprecated(reason: "ADR-0002: use POST /wallet/{id}/operations")
   updateInvestmentOperation(executedAt: String, fees: String, investmentId: UUID!, notes: String, operationId: UUID!, operationType: String, quantity: String, unitPrice: String): UpdateInvestmentOperationMutation @deprecated(reason: "ADR-0002: use PATCH /wallet/{id}/operations/{op_id}")

--- a/tests/test_graphql_api.py
+++ b/tests/test_graphql_api.py
@@ -916,9 +916,17 @@ def test_graphql_wallet_and_ticker_queries_mutations(client) -> None:
     tickers_query = """
     query Tickers {
       tickers {
-        symbol
-        quantity
-        type
+        items {
+          symbol
+          quantity
+          type
+        }
+        pagination {
+          total
+          page
+          perPage
+          pages
+        }
       }
     }
     """
@@ -926,7 +934,13 @@ def test_graphql_wallet_and_ticker_queries_mutations(client) -> None:
     assert tickers_response.status_code == 200
     tickers_body = tickers_response.get_json()
     assert "errors" not in tickers_body
-    assert len(tickers_body["data"]["tickers"]) == 1
+    tickers_payload = tickers_body["data"]["tickers"]
+    assert len(tickers_payload["items"]) == 1
+    assert tickers_payload["items"][0]["symbol"] == "PETR4"
+    assert tickers_payload["pagination"]["total"] == 1
+    assert tickers_payload["pagination"]["page"] == 1
+    assert tickers_payload["pagination"]["perPage"] == 50
+    assert tickers_payload["pagination"]["pages"] == 1
 
     delete_ticker_mutation = """
     mutation DeleteTicker {
@@ -1102,3 +1116,153 @@ def test_graphql_ticker_duplicate_and_delete_not_found(client) -> None:
     delete_missing_body = delete_missing.get_json()
     assert "errors" in delete_missing_body
     assert delete_missing_body["errors"][0]["message"] == "Ticker não encontrado"
+
+
+def test_wallet_value_round_trip_returns_string_preserving_column_scale(
+    client,
+) -> None:
+    """The DecimalScalar contract is two-fold:
+
+    1. The JSON transport returns the monetary value as a *string*, never as
+       a JSON number — preventing IEEE 754 round-trip surprises when the API
+       grows beyond the current column scale.
+    2. Whatever fits the column scale (today ``Numeric(12, 2)`` for
+       ``Wallet.value``) is preserved bit-for-bit through the response.
+    """
+
+    token = _register_and_login_graphql(client)
+    column_max_value = "9999999999.99"
+    add_mutation = """
+    mutation AddCustomWallet($value: DecimalScalar!) {
+      addWalletEntry(
+        name: "High precision",
+        value: $value,
+        assetClass: "custom",
+        registerDate: "2026-01-01",
+        shouldBeOnWallet: true
+      ) {
+        item { id name value assetClass annualRate }
+      }
+    }
+    """
+    response = _graphql(
+        client,
+        add_mutation,
+        variables={"value": column_max_value},
+        token=token,
+    )
+    assert response.status_code == 200
+    body = response.get_json()
+    assert "errors" not in body, body
+    item = body["data"]["addWalletEntry"]["item"]
+    assert isinstance(item["value"], str)
+    assert Decimal(item["value"]) == Decimal(column_max_value)
+    assert "e" not in item["value"].lower()
+    assert "E" not in item["value"]
+
+
+def test_wallet_value_supports_string_input_for_arbitrary_precision(client) -> None:
+    """Callers must be able to pass values as strings (REST-compatible) and
+    as numeric literals — both should reach the service layer as Decimal."""
+
+    token = _register_and_login_graphql(client)
+    add_mutation = """
+    mutation AddCustomWallet {
+      addWalletEntry(
+        name: "From string",
+        value: "1234.56",
+        assetClass: "custom",
+        registerDate: "2026-01-01",
+        shouldBeOnWallet: true
+      ) {
+        item { id value }
+      }
+    }
+    """
+    response = _graphql(client, add_mutation, token=token)
+    body = response.get_json()
+    assert "errors" not in body, body
+    item = body["data"]["addWalletEntry"]["item"]
+    assert item["value"] == "1234.56"
+
+
+def test_tickers_pagination_pages_and_overflow(client) -> None:
+    token = _register_and_login_graphql(client)
+    symbols = ["AAAA1", "BBBB2", "CCCC3", "DDDD4", "EEEE5"]
+    for symbol in symbols:
+        add_mutation = (
+            'mutation { addTicker(symbol: "' + symbol + '", quantity: 1, '
+            'type: "stock") { item { id } } }'
+        )
+        response = _graphql(client, add_mutation, token=token)
+        assert response.status_code == 200, response.get_json()
+        assert "errors" not in response.get_json()
+
+    paginated_query = """
+    query Tickers($page: Int!, $perPage: Int!) {
+      tickers(page: $page, perPage: $perPage) {
+        items { symbol }
+        pagination { total page perPage pages }
+      }
+    }
+    """
+    page1 = _graphql(
+        client,
+        paginated_query,
+        variables={"page": 1, "perPage": 2},
+        token=token,
+    )
+    page1_body = page1.get_json()
+    assert "errors" not in page1_body
+    assert [item["symbol"] for item in page1_body["data"]["tickers"]["items"]] == [
+        "AAAA1",
+        "BBBB2",
+    ]
+    assert page1_body["data"]["tickers"]["pagination"] == {
+        "total": 5,
+        "page": 1,
+        "perPage": 2,
+        "pages": 3,
+    }
+
+    page3 = _graphql(
+        client,
+        paginated_query,
+        variables={"page": 3, "perPage": 2},
+        token=token,
+    )
+    page3_body = page3.get_json()
+    assert "errors" not in page3_body
+    assert [item["symbol"] for item in page3_body["data"]["tickers"]["items"]] == [
+        "EEEE5",
+    ]
+
+    overflow = _graphql(
+        client,
+        paginated_query,
+        variables={"page": 99, "perPage": 2},
+        token=token,
+    )
+    overflow_body = overflow.get_json()
+    assert "errors" not in overflow_body
+    assert overflow_body["data"]["tickers"]["items"] == []
+
+    # A perPage above the resolver's hard cap (100) returns VALIDATION_ERROR.
+    # The query keeps the inner selection minimal so it stays well under the
+    # GraphQL complexity policy and exercises the resolver's own validation.
+    minimal_query = """
+    query Tickers($page: Int!, $perPage: Int!) {
+      tickers(page: $page, perPage: $perPage) {
+        pagination { total }
+      }
+    }
+    """
+    invalid = _graphql(
+        client,
+        minimal_query,
+        variables={"page": 1, "perPage": 101},
+        token=token,
+    )
+    invalid_body = invalid.get_json()
+    assert "errors" in invalid_body
+    assert invalid_body["errors"][0]["extensions"]["code"] == "VALIDATION_ERROR"

--- a/tests/test_graphql_decimal_scalar.py
+++ b/tests/test_graphql_decimal_scalar.py
@@ -1,0 +1,89 @@
+"""Regression tests for the GraphQL DecimalScalar.
+
+The scalar exists to mirror the REST contract (``Decimal(as_string=True)``) and
+to prevent silent precision loss in monetary fields. These tests pin the
+contract: round-trip without precision loss and string output regardless of
+input form.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+import pytest
+from graphql import GraphQLError
+from graphql.language.ast import FloatValueNode, IntValueNode, StringValueNode
+
+from app.graphql.scalars import DecimalScalar
+
+
+class TestDecimalScalarSerialize:
+    def test_preserves_high_precision_decimal(self) -> None:
+        value = Decimal("12345678901234.123456789")
+        assert DecimalScalar.serialize(value) == "12345678901234.123456789"
+
+    def test_preserves_value_above_one_billion(self) -> None:
+        value = Decimal("9999999999.99")
+        assert DecimalScalar.serialize(value) == "9999999999.99"
+
+    def test_serialises_integer_input_as_string(self) -> None:
+        assert DecimalScalar.serialize(42) == "42"
+
+    def test_serialises_string_input_unchanged(self) -> None:
+        assert DecimalScalar.serialize("0.10") == "0.10"
+
+    def test_returns_none_for_none_input(self) -> None:
+        assert DecimalScalar.serialize(None) is None
+
+    def test_avoids_scientific_notation(self) -> None:
+        value = Decimal("0.00000001")
+        assert DecimalScalar.serialize(value) == "0.00000001"
+
+    def test_rejects_boolean_input(self) -> None:
+        with pytest.raises(GraphQLError):
+            DecimalScalar.serialize(True)
+
+    def test_rejects_unsupported_types(self) -> None:
+        with pytest.raises(GraphQLError):
+            DecimalScalar.serialize(object())
+
+
+class TestDecimalScalarParseValue:
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("1234567.89", Decimal("1234567.89")),
+            (10, Decimal("10")),
+            (0.5, Decimal("0.5")),
+            (Decimal("99.99"), Decimal("99.99")),
+        ],
+    )
+    def test_accepts_supported_inputs(self, raw: Any, expected: Decimal) -> None:
+        assert DecimalScalar.parse_value(raw) == expected
+
+    def test_returns_none_for_none(self) -> None:
+        assert DecimalScalar.parse_value(None) is None
+
+    def test_rejects_invalid_string(self) -> None:
+        with pytest.raises(GraphQLError):
+            DecimalScalar.parse_value("not-a-number")
+
+
+class TestDecimalScalarParseLiteral:
+    @pytest.mark.parametrize(
+        "node,expected",
+        [
+            (StringValueNode(value="1234.56"), Decimal("1234.56")),
+            (IntValueNode(value="10"), Decimal("10")),
+            (FloatValueNode(value="0.10"), Decimal("0.10")),
+        ],
+    )
+    def test_accepts_string_int_and_float_literals(
+        self, node: Any, expected: Decimal
+    ) -> None:
+        assert DecimalScalar.parse_literal(node) == expected
+
+    def test_rejects_invalid_literal(self) -> None:
+        with pytest.raises(GraphQLError):
+            DecimalScalar.parse_literal(StringValueNode(value="not-a-number"))

--- a/tests/test_user_profile.py
+++ b/tests/test_user_profile.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import uuid
+from decimal import Decimal
 from typing import Any
 
 from app.application.services.user_profile_service import (
@@ -269,8 +270,8 @@ def test_graphql_update_profile_accepts_valid_investor_profile(client) -> None:
     assert user["stateUf"] == "RJ"
     assert user["occupation"] == "Arquiteto"
     assert user["financialObjectives"] == "Independência financeira"
-    assert user["monthlyIncome"] == 9500.0
-    assert user["monthlyIncomeNet"] == 9500.0
+    assert Decimal(user["monthlyIncome"]) == Decimal("9500")
+    assert Decimal(user["monthlyIncomeNet"]) == Decimal("9500")
 
 
 def test_graphql_update_profile_rejects_invalid_investor_profile(client) -> None:


### PR DESCRIPTION
Closes #1138, #1139, #1152.
Part of umbrella #1157.

## Summary

Three adjacent fixes from the GraphQL audit (`auraxis-platform/.context/reports/historical/graphql_audit_2026-05-02.md`) bundled into a single PR:

1. **Custom `DecimalScalar`** replacing `graphene.Float` on every monetary field (User profile, Wallet, Transaction summary/dashboard totals, Weekly summary). Mirrors the REST contract (Marshmallow `Decimal(as_string=True)`).
2. **`tickers` query paginated** — was the only unbounded list resolver in the schema. Now returns `TickerListPayloadType {items, pagination}` with `perPage` default 50, capped at 100.
3. **`CLAUDE.md` correction**: stack is Graphene 3, not Ariadne.

## Why

Float in JSON loses precision at the IEEE 754 boundary. The current column scale (`Numeric(12, 2)`) doesn't trigger the bug yet, but:

- A string-typed transport future-proofs the API against larger scales without a breaking change later.
- REST and GraphQL now serialise monetary values byte-identically, simplifying client SDK generation and removing a parity violation.
- Pagination on `tickers` removes a latent OOM/payload-bloat risk if a user accumulates many tickers.

## What changed

- `app/graphql/scalars.py` (new) — `DecimalScalar` with serialize/parse_value/parse_literal, rejects bool, raises GraphQLError on invalid input.
- `app/graphql/types.py` — monetary fields switched (UserType profile, TransactionSummaryPayload totals, DashboardTotals, DashboardCategory totalAmount, Wallet, WalletHistoryItem, WeeklyPeriodTotals, WeeklyComparison delta absolutes, WeeklySummarySeriesEntry). Ratio fields (`*_delta_percent`, ticker `quantity`) stay Float per REST.
- `app/graphql/mutations/auth.py`, `app/graphql/mutations/wallet.py` — input arguments use DecimalScalar.
- `app/graphql/queries/wallet.py` — `tickers` resolver paginated.
- `schema.graphql`, `graphql.introspection.json` — regenerated via `scripts/export_graphql_docs.py`.
- `CLAUDE.md` — Ariadne → Graphene 3.

## Test plan

- [x] New `tests/test_graphql_decimal_scalar.py` (13 unit tests) covering scalar contract.
- [x] `tests/test_graphql_api.py` — existing wallet/ticker round-trip updated to paginated shape; new integration tests for high-precision round-trip and string-input acceptance.
- [x] `tests/test_user_profile.py` — Decimal comparisons replacing float equality.
- [x] `bash scripts/run_ci_quality_local.sh --local` — green: 1641 passed, 91.04% coverage, all gates.

## Risk

**Breaking change for any client comparing wallet/dashboard/weekly-summary monetary values as numbers.** Web (Nuxt) and app (React Native) currently consume monetary fields without strict typing — any direct numeric comparison will need to switch to Decimal/string parsing. The `tickers` query GraphQL is **not consumed** by either client (verified via grep — they use BRAPI search, not the user-saved tickers list), so the pagination shape change is safe.

## Refs

- Audit report: `auraxis-platform/.context/reports/historical/graphql_audit_2026-05-02.md`
- Umbrella tracker: #1157