### PR TITLE
feat(audit): record entity-delete audit events for goals, wallet, subscriptions

### DIFF
--- a/app/application/services/wallet_application_service.py
+++ b/app/application/services/wallet_application_service.py
@@ -198,12 +198,19 @@ class WalletApplicationService:
             "Você não tem permissão para deletar este investimento."
         ),
     ) -> None:
+        from app.extensions.audit_trail import record_entity_delete
+
         investment = self._get_owned_wallet(
             investment_id,
             forbidden_message=forbidden_message,
         )
         try:
             db.session.delete(investment)
+            record_entity_delete(
+                entity_type="wallet",
+                entity_id=str(investment_id),
+                actor_id=str(self._user_id),
+            )
             db.session.commit()
         except Exception as exc:
             db.session.rollback()

--- a/app/services/goal_service.py
+++ b/app/services/goal_service.py
@@ -107,8 +107,15 @@ class GoalService:
         return goal
 
     def delete_goal(self, goal_id: UUID) -> None:
+        from app.extensions.audit_trail import record_entity_delete
+
         goal = self.get_goal(goal_id)
         db.session.delete(goal)
+        record_entity_delete(
+            entity_type="goal",
+            entity_id=str(goal_id),
+            actor_id=str(self.user_id),
+        )
         db.session.commit()
 
     def serialize(self, goal: Goal) -> dict[str, Any]:

--- a/app/services/subscription_service.py
+++ b/app/services/subscription_service.py
@@ -170,10 +170,12 @@ def cancel_subscription(
     If the subscription has no provider ID the status is set to CANCELED locally
     without making a provider call.
     """
+    from app.extensions.audit_trail import record_entity_delete
+
     if subscription.provider_subscription_id:
         provider.cancel_subscription(subscription.provider_subscription_id)
 
-    return apply_subscription_snapshot(
+    snapshot = apply_subscription_snapshot(
         subscription,
         {
             "status": SubscriptionStatus.CANCELED.value,
@@ -186,3 +188,9 @@ def cancel_subscription(
             ),
         },
     )
+    record_entity_delete(
+        entity_type="subscription",
+        entity_id=str(snapshot.id),
+        actor_id=str(snapshot.user_id),
+    )
+    return snapshot

--- a/tests/test_audit_log_destructive_ops.py
+++ b/tests/test_audit_log_destructive_ops.py
@@ -1,0 +1,234 @@
+"""Audit-log coverage for destructive operations across REST + GraphQL.
+
+The GraphQL audit (2026-05-02) flagged that delete-shaped mutations had no
+audit trail. The infrastructure (``audit_events`` table +
+``record_entity_delete``) already exists from #1052; this PR wires the
+remaining domains (goal, wallet, subscription) and pins the contract with
+regression tests covering both transports.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import patch
+from uuid import UUID
+
+import pytest
+
+from app.extensions.database import db
+from app.models.audit_event import AuditEvent
+from app.models.user import User
+
+
+@pytest.fixture(autouse=True)
+def _enable_audit_persistence():
+    """Audit persistence defaults to off in tests; force-enable it for the
+    full lifecycle of these specs so the wiring is exercised end-to-end."""
+
+    with patch(
+        "app.extensions.audit_trail._is_audit_persistence_enabled",
+        return_value=True,
+    ):
+        yield
+
+
+def _graphql(
+    client: Any,
+    query: str,
+    variables: dict[str, Any] | None = None,
+    token: str | None = None,
+) -> Any:
+    headers: dict[str, str] = {}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return client.post(
+        "/graphql",
+        json={"query": query, "variables": variables or {}},
+        headers=headers,
+    )
+
+
+def _register_and_login(client: Any, prefix: str) -> tuple[str, str]:
+    suffix = uuid.uuid4().hex[:8]
+    email = f"{prefix}-{suffix}@email.com"
+    password = "StrongPass@123"
+    register = _graphql(
+        client,
+        """
+        mutation Register($name: String!, $email: String!, $password: String!) {
+          registerUser(name: $name, email: $email, password: $password) { message }
+        }
+        """,
+        {"name": f"{prefix}-{suffix}", "email": email, "password": password},
+    )
+    assert register.status_code == 200
+    assert "errors" not in register.get_json()
+
+    login = _graphql(
+        client,
+        """
+        mutation Login($email: String!, $password: String!) {
+          login(email: $email, password: $password) { token }
+        }
+        """,
+        {"email": email, "password": password},
+    )
+    body = login.get_json()
+    return str(body["data"]["login"]["token"]), email
+
+
+def _audit_events_for(user_id: UUID, entity_type: str) -> list[AuditEvent]:
+    rows = (
+        AuditEvent.query.filter_by(
+            actor_id=str(user_id),
+            entity_type=entity_type,
+            action="soft_delete",
+        )
+        .order_by(AuditEvent.created_at.desc())
+        .all()
+    )
+    return list(rows)
+
+
+def _user_id_by_email(app: Any, email: str) -> UUID:
+    with app.app_context():
+        user = User.query.filter_by(email=email).first()
+        assert user is not None
+        return UUID(str(user.id))
+
+
+def test_graphql_delete_goal_records_audit_event(client: Any, app: Any) -> None:
+    token, email = _register_and_login(client, "audit-goal")
+    user_id = _user_id_by_email(app, email)
+
+    create = _graphql(
+        client,
+        """
+        mutation { createGoal(title: "Audit", targetAmount: "1000.00") {
+            goal { id }
+        } }
+        """,
+        token=token,
+    )
+    body = create.get_json()
+    assert "errors" not in body, body
+    goal_id = body["data"]["createGoal"]["goal"]["id"]
+
+    delete = _graphql(
+        client,
+        """
+        mutation D($goalId: UUID!) { deleteGoal(goalId: $goalId) { ok } }
+        """,
+        {"goalId": goal_id},
+        token=token,
+    )
+    assert "errors" not in delete.get_json(), delete.get_json()
+
+    with app.app_context():
+        events = _audit_events_for(user_id, "goal")
+        assert len(events) == 1
+        assert events[0].entity_id == goal_id
+
+
+def test_graphql_delete_wallet_entry_records_audit_event(client: Any, app: Any) -> None:
+    token, email = _register_and_login(client, "audit-wallet")
+    user_id = _user_id_by_email(app, email)
+
+    create = _graphql(
+        client,
+        """
+        mutation { addWalletEntry(
+            name: "Custom",
+            value: 100,
+            assetClass: "custom",
+            registerDate: "2026-01-01",
+            shouldBeOnWallet: true
+        ) { item { id } } }
+        """,
+        token=token,
+    )
+    body = create.get_json()
+    assert "errors" not in body, body
+    investment_id = body["data"]["addWalletEntry"]["item"]["id"]
+
+    delete = _graphql(
+        client,
+        """
+        mutation D($investmentId: UUID!) {
+          deleteWalletEntry(investmentId: $investmentId) { ok }
+        }
+        """,
+        {"investmentId": investment_id},
+        token=token,
+    )
+    assert "errors" not in delete.get_json(), delete.get_json()
+
+    with app.app_context():
+        events = _audit_events_for(user_id, "wallet")
+        assert len(events) == 1
+        assert events[0].entity_id == investment_id
+
+
+def test_rest_delete_goal_records_audit_event(client: Any, app: Any) -> None:
+    """The audit must fire from the REST controller too — the service layer
+    is the canonical recording site so both transports stay aligned."""
+
+    suffix = uuid.uuid4().hex[:8]
+    email = f"audit-goal-rest-{suffix}@email.com"
+    password = "StrongPass@123"
+    register = client.post(
+        "/auth/register",
+        json={
+            "name": f"audit-goal-rest-{suffix}",
+            "email": email,
+            "password": password,
+        },
+    )
+    assert register.status_code == 201
+    login = client.post("/auth/login", json={"email": email, "password": password})
+    token = login.get_json()["token"]
+    user_id = _user_id_by_email(app, email)
+
+    create = client.post(
+        "/goals",
+        headers={"Authorization": f"Bearer {token}", "X-API-Contract": "v2"},
+        json={"title": "REST audit", "target_amount": "1000.00"},
+    )
+    assert create.status_code == 201, create.get_json()
+    goal_id = create.get_json()["data"]["goal"]["id"]
+
+    delete = client.delete(
+        f"/goals/{goal_id}",
+        headers={"Authorization": f"Bearer {token}", "X-API-Contract": "v2"},
+    )
+    assert delete.status_code in {200, 204}, delete.get_json()
+
+    with app.app_context():
+        events = _audit_events_for(user_id, "goal")
+        assert len(events) == 1
+        assert events[0].entity_id == goal_id
+
+
+def test_audit_event_not_recorded_when_unauthenticated(client: Any, app: Any) -> None:
+    """Auth-failure paths must not leak audit rows — the audit row is the
+    success witness, not an attempt log."""
+
+    delete = _graphql(
+        client,
+        """
+        mutation D($goalId: UUID!) { deleteGoal(goalId: $goalId) { ok } }
+        """,
+        {"goalId": str(uuid.uuid4())},
+    )
+    body = delete.get_json()
+    assert "errors" in body
+    with app.app_context():
+        # No goal_id matched, no actor — the event count for any actor for
+        # entity_type="goal" should remain zero.
+        rows = (
+            db.session.query(AuditEvent)
+            .filter_by(entity_type="goal", action="soft_delete")
+            .all()
+        )
+        assert rows == []


### PR DESCRIPTION
Closes #1141.
Part of umbrella #1157.

## Summary

GraphQL audit (2026-05-02) flagged destructive mutations as missing entity-level audit trail. `delete_transaction` already emits via `record_entity_delete` (#1052); this PR fills the same gap for **goals**, **wallet entries**, and **subscription cancellations**.

Reuses existing `audit_events` table and `record_entity_delete` helper — no new schema, no new service.

## What changed

- `GoalService.delete_goal` — emits `soft_delete` event with `entity_type=\"goal\"` before flushing.
- `WalletApplicationService.delete_entry` — emits `entity_type=\"wallet\"` before commit; rolls back with the delete on failure.
- `subscription_service.cancel_subscription` — emits `entity_type=\"subscription\"` after the status snapshot, capturing both provider-initiated and pure-local cancellations.

All three calls go through the existing `AUDIT_PERSISTENCE_ENABLED` gate, so persistence stays opt-in until the rollout flag flips.

## Test plan

- [x] New `tests/test_audit_log_destructive_ops.py` with autouse fixture enabling persistence:
  - GraphQL `deleteGoal` records exactly one audit row keyed by actor + entity id.
  - GraphQL `deleteWalletEntry` records the same shape.
  - REST `DELETE /goals/<id>` records an event — pinning the contract that the service layer is the canonical emitter for both transports.
  - Unauthenticated `deleteGoal` does *not* leak an audit row.
- [x] \`bash scripts/run_ci_quality_local.sh --local\` — green: 1624 passed, 91.02% coverage, all gates.

## Out of scope (tracked under #1157)

- Audit on non-destructive mutations (create/update).
- Idempotency keys for repeated delete attempts.
- LGPD reporting/exports on top of the audit table.

## Refs

- Audit report: \`auraxis-platform/.context/reports/historical/graphql_audit_2026-05-02.md\` §2
- Original audit infrastructure: PR/issue #1052