### PR TITLE
feat(graphql): structured resolver logging + parameterized auth-required regression test

### DIFF
--- a/app/graphql/mutations/auth.py
+++ b/app/graphql/mutations/auth.py
@@ -38,6 +38,7 @@ from app.graphql.errors import (
     GRAPHQL_ERROR_CODE_VALIDATION,
     build_public_graphql_error,
 )
+from app.graphql.observability import log_graphql_resolver
 from app.graphql.schema_utils import _user_basic_auth_payload, _user_to_graphql_payload
 from app.graphql.types import AuthPayloadType, UserType
 from app.http.runtime import runtime_logger
@@ -188,6 +189,7 @@ class LoginMutation(graphene.Mutation):
 
     Output = AuthPayloadType
 
+    @log_graphql_resolver("login")
     def mutate(
         self,
         info: graphene.ResolveInfo,
@@ -274,6 +276,7 @@ class LogoutMutation(graphene.Mutation):
     ok = graphene.Boolean(required=True)
     message = graphene.String(required=True)
 
+    @log_graphql_resolver("logout")
     def mutate(self, info: graphene.ResolveInfo) -> "LogoutMutation":
         user = get_current_user_required()
         user_id = str(user.id)

--- a/app/graphql/mutations/goal.py
+++ b/app/graphql/mutations/goal.py
@@ -15,6 +15,7 @@ from app.graphql.goal_presenters import (
     to_goal_plan_type,
     to_goal_type_object,
 )
+from app.graphql.observability import log_graphql_resolver
 from app.graphql.types import GoalPlanType, GoalTypeObject
 
 
@@ -82,6 +83,7 @@ class DeleteGoalMutation(graphene.Mutation):
     ok = graphene.Boolean(required=True)
     message = graphene.String(required=True)
 
+    @log_graphql_resolver("deleteGoal")
     def mutate(self, info: graphene.ResolveInfo, goal_id: UUID) -> "DeleteGoalMutation":
         user = get_current_user_required()
         service = GoalApplicationService.with_defaults(UUID(str(user.id)))

--- a/app/graphql/mutations/subscription.py
+++ b/app/graphql/mutations/subscription.py
@@ -19,6 +19,7 @@ from app.graphql.errors import (
     GRAPHQL_ERROR_CODE_VALIDATION,
     build_public_graphql_error,
 )
+from app.graphql.observability import log_graphql_resolver
 from app.graphql.queries.subscription import (
     _serialize_subscription,
     _to_subscription_type,
@@ -110,6 +111,7 @@ class CancelSubscriptionMutation(graphene.Mutation):
     message = graphene.String(required=True)
     subscription = graphene.Field(SubscriptionType, required=True)
 
+    @log_graphql_resolver("cancelSubscription")
     def mutate(self, info: graphene.ResolveInfo) -> "CancelSubscriptionMutation":
         user = get_current_user_required()
         sub = get_or_create_subscription(UUID(str(user.id)))

--- a/app/graphql/mutations/transaction.py
+++ b/app/graphql/mutations/transaction.py
@@ -12,6 +12,7 @@ from app.application.services.transaction_application_service import (
 from app.controllers.transaction.utils import _build_installment_amounts
 from app.graphql.auth import get_current_user_required
 from app.graphql.errors import build_public_graphql_error, to_public_graphql_code
+from app.graphql.observability import log_graphql_resolver
 from app.graphql.types import TransactionTypeObject
 
 
@@ -76,6 +77,7 @@ class DeleteTransactionMutation(graphene.Mutation):
     ok = graphene.Boolean(required=True)
     message = graphene.String(required=True)
 
+    @log_graphql_resolver("deleteTransaction")
     def mutate(
         self, info: graphene.ResolveInfo, transaction_id: UUID
     ) -> "DeleteTransactionMutation":

--- a/app/graphql/mutations/wallet.py
+++ b/app/graphql/mutations/wallet.py
@@ -11,6 +11,7 @@ from app.application.services.wallet_application_service import (
     WalletApplicationService,
 )
 from app.graphql.auth import get_current_user_required
+from app.graphql.observability import log_graphql_resolver
 from app.graphql.types import WalletType
 from app.graphql.wallet_presenters import raise_wallet_graphql_error, to_wallet_type
 
@@ -100,6 +101,7 @@ class DeleteWalletEntryMutation(graphene.Mutation):
     ok = graphene.Boolean(required=True)
     message = graphene.String(required=True)
 
+    @log_graphql_resolver("deleteWalletEntry")
     def mutate(
         self, info: graphene.ResolveInfo, investment_id: UUID
     ) -> "DeleteWalletEntryMutation":

--- a/app/graphql/observability.py
+++ b/app/graphql/observability.py
@@ -1,0 +1,103 @@
+"""GraphQL resolver-level structured logging.
+
+The audit (2026-05-02) flagged that the GraphQL package emits **zero**
+application-level log events. Auth failures, destructive mutations, and
+slow resolvers are invisible until something goes wrong in production.
+
+This module provides a thin decorator that wraps a resolver, emitting two
+structured events:
+
+- ``graphql.resolver.ok`` on success — info level, includes the
+  operation name, the duration, and a hashed user identifier (SHA-256
+  truncated to 8 hex chars; never the raw id, never an email).
+- ``graphql.resolver.failed`` on exception — warning level, same
+  fields plus the error code from the GraphQL extensions when available.
+
+The decorator is intentionally minimal: it does not own metrics emission
+(the security middleware already counts requests/violations) and it does
+not mutate the resolver's return value. Wider rollout — every resolver,
+not just the audit-bearing ones — is tracked under #1142 / umbrella #1157.
+"""
+
+from __future__ import annotations
+
+import functools
+import hashlib
+import time
+from typing import Any, Callable, TypeVar
+
+from app.http.runtime import runtime_logger
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def _hash_user_id(value: Any) -> str | None:
+    if value is None:
+        return None
+    try:
+        digest = hashlib.sha256(str(value).encode("utf-8")).hexdigest()
+    except Exception:
+        return None
+    return digest[:8]
+
+
+def _extract_error_code(exc: BaseException) -> str | None:
+    extensions = getattr(exc, "extensions", None)
+    if isinstance(extensions, dict):
+        code = extensions.get("code")
+        if isinstance(code, str) and code:
+            return code
+    return None
+
+
+def _resolve_actor_hash() -> str | None:
+    # Imported lazily to avoid eager Flask context loading at module import
+    # time; the helper itself is tolerant of missing context.
+    from app.graphql.auth import get_current_user_optional
+
+    try:
+        user = get_current_user_optional()
+    except Exception:
+        return None
+    if user is None:
+        return None
+    return _hash_user_id(getattr(user, "id", None))
+
+
+def log_graphql_resolver(operation_name: str) -> Callable[[F], F]:
+    """Decorator wrapping a Graphene mutation/query resolver to emit a single
+    structured log event per invocation.
+
+    ``operation_name`` is the canonical event identifier — choose the
+    GraphQL field name (``deleteGoal``, ``cancelSubscription``, ...).
+    """
+
+    def decorator(fn: F) -> F:
+        @functools.wraps(fn)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            start = time.monotonic()
+            try:
+                result = fn(*args, **kwargs)
+            except BaseException as exc:
+                duration_ms = int((time.monotonic() - start) * 1000)
+                runtime_logger().warning(
+                    "graphql.resolver.failed operation=%s code=%s "
+                    "duration_ms=%d user_hash=%s",
+                    operation_name,
+                    _extract_error_code(exc) or "n/a",
+                    duration_ms,
+                    _resolve_actor_hash() or "anonymous",
+                )
+                raise
+            duration_ms = int((time.monotonic() - start) * 1000)
+            runtime_logger().info(
+                "graphql.resolver.ok operation=%s duration_ms=%d user_hash=%s",
+                operation_name,
+                duration_ms,
+                _resolve_actor_hash() or "anonymous",
+            )
+            return result
+
+        return wrapper  # type: ignore[return-value]
+
+    return decorator

--- a/app/middleware/correlation_id.py
+++ b/app/middleware/correlation_id.py
@@ -31,6 +31,9 @@ def _current_request_id() -> str:
     return str(getattr(g, "request_id", None) or _NOOP_REQUEST_ID)
 
 
+_CORRELATION_FACTORY_MARK = "_auraxis_correlation_factory"
+
+
 def _make_log_record_factory(
     original: Callable[..., logging.LogRecord],
 ) -> Callable[..., logging.LogRecord]:
@@ -39,6 +42,7 @@ def _make_log_record_factory(
         record.request_id = _current_request_id()
         return record
 
+    setattr(_factory, _CORRELATION_FACTORY_MARK, True)
     return _factory
 
 
@@ -54,9 +58,18 @@ def _inject_sentry_tag(request_id: str) -> None:
 
 
 def register_correlation_id(app: Flask) -> None:
-    """Wire up Sentry tagging and log-record injection for every request."""
+    """Wire up Sentry tagging and log-record injection for every request.
+
+    The log-record factory is wrapped exactly once per process. Calling
+    ``register_correlation_id`` multiple times (e.g. one Flask app per
+    pytest test) is safe — without the idempotency check, each call would
+    nest a new wrapper around the previous one, eventually exceeding
+    Python's recursion limit during ``logger.info`` and bringing the test
+    suite down.
+    """
     original_factory = logging.getLogRecordFactory()
-    logging.setLogRecordFactory(_make_log_record_factory(original_factory))
+    if not getattr(original_factory, _CORRELATION_FACTORY_MARK, False):
+        logging.setLogRecordFactory(_make_log_record_factory(original_factory))
 
     @app.before_request
     def _tag_sentry() -> None:

--- a/tests/test_graphql_auth_everywhere.py
+++ b/tests/test_graphql_auth_everywhere.py
@@ -1,0 +1,107 @@
+"""Regression tests asserting auth is enforced on every non-public GraphQL
+operation.
+
+The audit (2026-05-02) confirmed that every protected mutation/query calls
+``get_current_user_required()`` today — but no test pinned that contract,
+so a future mutation could regress silently. This module enumerates the
+schema at runtime and verifies the authorization gate fires for every
+mutation and every query that is not in the documented public allowlist.
+
+If a new operation needs to be public, it must be added explicitly to
+``DEFAULT_GRAPHQL_PUBLIC_QUERIES`` / ``DEFAULT_GRAPHQL_PUBLIC_MUTATIONS``.
+That keeps the allowlist auditable and forces a deliberate review of any
+unauthenticated surface.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.graphql.authorization import (
+    DEFAULT_GRAPHQL_PUBLIC_MUTATIONS,
+    DEFAULT_GRAPHQL_PUBLIC_QUERIES,
+)
+from app.graphql.mutations import Mutation
+from app.graphql.queries import Query
+
+
+def _to_camel(name: str) -> str:
+    head, *tail = name.split("_")
+    return head + "".join(part.capitalize() for part in tail)
+
+
+def _protected_mutation_field_names() -> list[str]:
+    fields = [_to_camel(name) for name in Mutation._meta.fields]
+    return sorted(set(fields) - DEFAULT_GRAPHQL_PUBLIC_MUTATIONS)
+
+
+def _protected_query_field_names() -> list[str]:
+    fields = [_to_camel(name) for name in Query._meta.fields]
+    return sorted(set(fields) - DEFAULT_GRAPHQL_PUBLIC_QUERIES)
+
+
+def _post_unauth(client: Any, query: str) -> Any:
+    return client.post("/graphql", json={"query": query})
+
+
+def _first_error_code(response: Any) -> str | None:
+    body = response.get_json() or {}
+    errors = body.get("errors") or []
+    if not errors:
+        return None
+    extensions = errors[0].get("extensions") or {}
+    code = extensions.get("code")
+    return str(code) if code is not None else None
+
+
+@pytest.mark.parametrize("mutation_name", _protected_mutation_field_names())
+def test_protected_mutation_requires_auth(client: Any, mutation_name: str) -> None:
+    """Every mutation outside ``DEFAULT_GRAPHQL_PUBLIC_MUTATIONS`` must reject
+    anonymous callers with a documented auth-required code at the
+    authorization gate (before any field-level validation)."""
+
+    query = f"mutation Probe {{ {mutation_name} {{ __typename }} }}"
+    response = _post_unauth(client, query)
+    code = _first_error_code(response)
+    assert code in {
+        "UNAUTHORIZED",
+        "GRAPHQL_AUTH_REQUIRED",
+    }, f"mutation {mutation_name} did not enforce auth — got code={code!r}"
+
+
+@pytest.mark.parametrize("query_name", _protected_query_field_names())
+def test_protected_query_requires_auth(client: Any, query_name: str) -> None:
+    """Every query outside ``DEFAULT_GRAPHQL_PUBLIC_QUERIES`` must reject
+    anonymous callers with a documented auth-required code."""
+
+    query = f"query Probe {{ {query_name} {{ __typename }} }}"
+    response = _post_unauth(client, query)
+    code = _first_error_code(response)
+    assert code in {
+        "UNAUTHORIZED",
+        "GRAPHQL_AUTH_REQUIRED",
+    }, f"query {query_name} did not enforce auth — got code={code!r}"
+
+
+def test_public_mutation_allowlist_is_intentional() -> None:
+    """Pin the allowlist so regressions surface as a test diff and require a
+    matching update to this assertion. Adding a new public mutation now
+    requires both the allowlist update AND an explicit code change here,
+    catching accidental exposure during review."""
+
+    expected = {
+        "registerUser",
+        "login",
+        "forgotPassword",
+        "resetPassword",
+        "resendConfirmationEmail",
+        "confirmEmail",
+    }
+    assert DEFAULT_GRAPHQL_PUBLIC_MUTATIONS == expected
+
+
+def test_public_query_allowlist_is_intentional() -> None:
+    expected = {"__typename", "billingPlans", "installmentVsCashCalculate"}
+    assert DEFAULT_GRAPHQL_PUBLIC_QUERIES == expected

--- a/tests/test_graphql_observability_logging.py
+++ b/tests/test_graphql_observability_logging.py
@@ -1,0 +1,126 @@
+"""Regression tests for the structured-logging decorator wired around the
+audit-bearing GraphQL resolvers (delete-shaped mutations + the auth flows).
+
+The decorator emits a single info event on success and a single warning
+event on failure, with operation name, duration, error code (when
+available), and a SHA-256 truncated user hash. PII (raw user id, email)
+must never appear in the log payload — these tests pin that invariant.
+
+Scope: unit-level coverage of the decorator's contract. Integration with
+the live Flask app is exercised indirectly by the rest of the GraphQL
+test suite (every login/delete call goes through the wrapped resolvers).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+import pytest
+
+from app.graphql.observability import _hash_user_id, log_graphql_resolver
+
+
+class TestUserIdHashing:
+    def test_hash_is_deterministic_and_truncated_to_eight_hex(self) -> None:
+        user_id = "00000000-0000-0000-0000-000000000001"
+        first = _hash_user_id(user_id)
+        second = _hash_user_id(user_id)
+        assert first == second
+        assert first is not None
+        assert re.fullmatch(r"[0-9a-f]{8}", first)
+
+    def test_distinct_inputs_produce_distinct_hashes(self) -> None:
+        a = _hash_user_id("user-a")
+        b = _hash_user_id("user-b")
+        assert a != b
+
+    def test_none_input_returns_none(self) -> None:
+        assert _hash_user_id(None) is None
+
+
+class TestDecoratorInUnitContext:
+    def test_emits_ok_event_on_success(self, caplog: pytest.LogCaptureFixture) -> None:
+        @log_graphql_resolver("probeOp")
+        def fake_resolver() -> str:
+            return "result"
+
+        with caplog.at_level(logging.INFO):
+            assert fake_resolver() == "result"
+
+        ok_events = [
+            record
+            for record in caplog.records
+            if "graphql.resolver.ok" in record.getMessage()
+        ]
+        assert ok_events, "no ok event emitted"
+        assert "operation=probeOp" in ok_events[0].getMessage()
+        assert "duration_ms=" in ok_events[0].getMessage()
+
+    def test_emits_failed_event_on_exception_and_propagates(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        @log_graphql_resolver("probeFail")
+        def fake_resolver() -> None:
+            raise ValueError("boom")
+
+        with caplog.at_level(logging.WARNING):
+            with pytest.raises(ValueError):
+                fake_resolver()
+
+        failed_events = [
+            record
+            for record in caplog.records
+            if "graphql.resolver.failed" in record.getMessage()
+        ]
+        assert failed_events, "no failed event emitted"
+        assert "operation=probeFail" in failed_events[0].getMessage()
+
+
+class TestLogPayloadHygiene:
+    """The log payload must never contain raw PII or secrets."""
+
+    def test_payload_uses_user_hash_not_raw_id(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        @log_graphql_resolver("probeHash")
+        def fake_resolver() -> None:
+            return None
+
+        with caplog.at_level(logging.INFO):
+            fake_resolver()
+
+        events = [
+            record
+            for record in caplog.records
+            if "graphql.resolver.ok" in record.getMessage()
+        ]
+        assert events
+        payload = events[0].getMessage()
+        # user_hash field is always present (even when no user is in
+        # context, falls back to "anonymous").
+        assert (
+            "user_hash=anonymous" in payload
+            or re.search(r"user_hash=[0-9a-f]{8}", payload) is not None
+        )
+
+    def test_failed_event_carries_extension_code(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        from graphql import GraphQLError
+
+        @log_graphql_resolver("probeCode")
+        def fake_resolver() -> None:
+            raise GraphQLError("denied", extensions={"code": "FORBIDDEN"})
+
+        with caplog.at_level(logging.WARNING):
+            with pytest.raises(GraphQLError):
+                fake_resolver()
+
+        events = [
+            record
+            for record in caplog.records
+            if "graphql.resolver.failed" in record.getMessage()
+        ]
+        assert events
+        assert "code=FORBIDDEN" in events[0].getMessage()


### PR DESCRIPTION
Closes #1142, #1145.
Part of umbrella #1157.

## Summary

Two audit gaps closed with minimum-surface changes plus a small adjacent fix the rest of the observability rollout depends on:

1. **Structured logging decorator** wired around the audit-bearing resolvers (delete-shaped mutations + the auth flows). Wider rollout to every resolver, plus per-operation timing histograms, stays tracked in #1142 / umbrella #1157.
2. **Parameterized auth-required test** enumerating `Mutation._meta.fields` and `Query._meta.fields` at runtime, asserting every operation outside the documented public allowlist enforces auth. Allowlists pinned by dedicated tests so accidental exposure surfaces as a diff.
3. **Adjacent fix** in `correlation_id.py`: the log-record factory was wrapped unconditionally on every app construction; with ~1660 tests the recursion blew the Python stack during `logger.info`. Wrapper now self-marks and `register_correlation_id` skips re-wrapping.

## What changed

- **`app/graphql/observability.py`** (new) — `log_graphql_resolver(operation_name)` decorator emitting `graphql.resolver.ok` (info) on success and `graphql.resolver.failed` (warning) on exception. Payload: operation name, `duration_ms`, error code from `exc.extensions[\"code\"]` when available, SHA-256 truncated user hash. Raw ids / emails / passwords never logged.
- **Mutations wired**: `deleteTransaction`, `deleteGoal`, `deleteWalletEntry`, `cancelSubscription`, `login`, `logout`.
- **`tests/test_graphql_auth_everywhere.py`** (new) — 58 parametrized cases.
- **`tests/test_graphql_observability_logging.py`** (new) — 7 unit specs covering the decorator's contract.
- **`app/middleware/correlation_id.py`** — sentinel-based idempotency for the log-record factory wrap.

## Test plan

- [x] 58 parametrized auth-required cases (all non-public mutations + queries).
- [x] 7 unit specs for the decorator (hash determinism, ok/failed shape, error-code propagation, hygiene).
- [x] \`bash scripts/run_ci_quality_local.sh --local\` — green: 1685 passed, 91.02% coverage, all gates.

## Risk

Low. Logging is additive; the decorator never mutates the resolver's return value. The correlation_id idempotency check is conservative (only skips when the sentinel is set).

## Refs

- Audit report: \`auraxis-platform/.context/reports/historical/graphql_audit_2026-05-02.md\` §4
- Umbrella tracker: #1157