### PR TITLE
refactor(graphql): split security.py into focused modules + fix CLAUDE.md docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 You are an AI software engineer working on the **Auraxis** project — a personal
 financial management platform built with Flask, SQLAlchemy, Marshmallow,
-GraphQL (Ariadne), and PostgreSQL.
+GraphQL (Graphene 3), and PostgreSQL.
 
 You operate independently from the CrewAI multi-agent system in `../ai_squad/`,
 but share the same knowledge base (`.context/`) and tracking system (`TASKS.md`).
@@ -171,3 +171,10 @@ scripts/repo_bin.sh pytest -m "not schemathesis" --cov=app --cov-fail-under=85
 | `.context/` | AI knowledge base (SDD + agentic workflows) |
 | `../ai_squad/` | CrewAI multi-agent system (platform-level workspace) |
 | `docs/` | Runbooks, ADRs, security docs |
+
+## GraphQL Architecture Decisions
+
+Key ADRs governing the GraphQL layer:
+
+- [`docs/adr/0002-graphql-ownership.md`](docs/adr/0002-graphql-ownership.md) — REST vs GraphQL ownership boundaries; when to use each protocol
+- [`docs/adr/0003-graphql-flat-types-no-dataloader.md`](docs/adr/0003-graphql-flat-types-no-dataloader.md) — flat Graphene types, service-layer batching, no DataLoader

--- a/app/graphql/CLAUDE.md
+++ b/app/graphql/CLAUDE.md
@@ -1,0 +1,57 @@
+# CLAUDE.md — GraphQL Module
+
+## Stack
+
+GraphQL is implemented with **Graphene 3** (not Ariadne). Entry point: `app/graphql/schema.py`.
+
+## Auth policy — mandatory for every new resolver
+
+Every new mutation and non-public query **must** call `get_current_user_required()` as its first
+line, or be added to the explicit public allowlist in `app/graphql/authorization.py`.
+
+There is a parameterized regression test (`tests/test_graphql_auth_everywhere.py`) that
+enumerates all mutations and queries at runtime and asserts that any operation not in the
+allowlist requires auth. A new resolver that bypasses this will cause CI to fail.
+
+Adding to the allowlist requires a deliberate review comment explaining why the operation is public.
+
+## Module layout
+
+```
+app/graphql/
+  complexity/
+    __init__.py
+    analyzer.py      — AST traversal: depth, complexity, fragment resolution
+    policy.py        — GraphQLSecurityPolicy + env loaders + GraphQLSecurityViolation
+  mutations/         — one file per domain (transaction, goal, wallet, ...)
+  queries/           — one file per domain
+  auth.py            — get_current_user_required / get_current_user_optional
+  authorization.py   — GraphQLAuthorizationPolicy + enforce_graphql_authorization
+  decorators.py      — (planned) @resolver_with_user_context, @graphql_error_adapter
+  enums.py           — WalletAssetClassEnum and other domain enums
+  errors.py          — build_public_graphql_error, PUBLIC_GRAPHQL_ERROR_CODES
+  introspection_policy.py — enforce_introspection_policy
+  observability.py   — log_graphql_resolver decorator
+  scalars.py         — DecimalScalar
+  security.py        — thin facade: analyze_graphql_query + re-exports
+  schema.py          — Schema assembly
+  types.py           — shared output types (payload types, pagination)
+```
+
+## Resolver conventions
+
+1. Call `get_current_user_required()` first (or add to allowlist with justification).
+2. Instantiate the service: `service = XxxService.with_defaults(user.id)`.
+3. Wrap service calls in `try/except` and convert domain exceptions via `build_public_graphql_error`.
+4. Return a typed payload object — never a raw dict.
+
+## Complexity limits (env-configurable)
+
+| Env var | Default | Purpose |
+|---------|---------|---------|
+| `GRAPHQL_MAX_QUERY_BYTES` | 20 000 | Request size guard |
+| `GRAPHQL_MAX_DEPTH` | 8 | AST nesting depth |
+| `GRAPHQL_MAX_COMPLEXITY` | 300 | Weighted field count |
+| `GRAPHQL_MAX_OPERATIONS` | 3 | Operations per document |
+| `GRAPHQL_MAX_LIST_MULTIPLIER` | 50 | Multiplier for list fields |
+| `GRAPHQL_ALLOW_INTROSPECTION` | false (prod) | Enable schema introspection |

--- a/app/graphql/complexity/analyzer.py
+++ b/app/graphql/complexity/analyzer.py
@@ -1,0 +1,352 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from graphql import GraphQLError, parse
+from graphql.language import ast
+
+from app.graphql.complexity.policy import (
+    GRAPHQL_OPERATION_LIMIT_EXCEEDED,
+    GRAPHQL_OPERATION_NOT_FOUND,
+    GraphQLSecurityPolicy,
+    GraphQLSecurityViolation,
+)
+
+_LIST_ARGUMENT_NAMES = {
+    "first",
+    "last",
+    "limit",
+    "perPage",
+    "per_page",
+    "pageSize",
+    "size",
+}
+
+
+@dataclass(frozen=True)
+class GraphQLQueryMetrics:
+    operation_count: int
+    depth: int
+    complexity: int
+    query_bytes: int
+    root_fields: tuple[str, ...] = ()
+
+
+def _resolve_int_value(
+    value_node: ast.ValueNode,
+    variable_values: dict[str, Any] | None,
+) -> int | None:
+    if isinstance(value_node, ast.IntValueNode):
+        try:
+            return int(value_node.value)
+        except ValueError:
+            return None
+
+    if isinstance(value_node, ast.VariableNode) and isinstance(variable_values, dict):
+        raw_value = variable_values.get(value_node.name.value)
+        if isinstance(raw_value, bool):
+            return None
+        if isinstance(raw_value, int):
+            return raw_value
+        if isinstance(raw_value, str) and raw_value.isdigit():
+            return int(raw_value)
+    return None
+
+
+def _resolve_field_multiplier(
+    field_node: ast.FieldNode,
+    variable_values: dict[str, Any] | None,
+    max_list_multiplier: int,
+) -> int:
+    for argument in field_node.arguments or []:
+        if argument.name.value not in _LIST_ARGUMENT_NAMES:
+            continue
+        resolved_value = _resolve_int_value(argument.value, variable_values)
+        if resolved_value is None:
+            continue
+        if resolved_value <= 0:
+            return 1
+        return min(resolved_value, max_list_multiplier)
+    return 1
+
+
+def _analyze_selection_set(
+    selection_set: ast.SelectionSetNode,
+    *,
+    current_depth: int,
+    fragments: dict[str, ast.FragmentDefinitionNode],
+    variable_values: dict[str, Any] | None,
+    max_list_multiplier: int,
+    visited_fragments: set[str],
+) -> tuple[int, int]:
+    max_depth = current_depth
+    complexity = 0
+
+    for selection in selection_set.selections:
+        nested_depth, nested_complexity = _analyze_single_selection(
+            selection,
+            current_depth=current_depth,
+            fragments=fragments,
+            variable_values=variable_values,
+            max_list_multiplier=max_list_multiplier,
+            visited_fragments=visited_fragments,
+        )
+        max_depth = max(max_depth, nested_depth)
+        complexity += nested_complexity
+
+    return max_depth, complexity
+
+
+def _analyze_single_selection(
+    selection: ast.SelectionNode,
+    *,
+    current_depth: int,
+    fragments: dict[str, ast.FragmentDefinitionNode],
+    variable_values: dict[str, Any] | None,
+    max_list_multiplier: int,
+    visited_fragments: set[str],
+) -> tuple[int, int]:
+    if isinstance(selection, ast.FieldNode):
+        return _analyze_field_selection(
+            selection,
+            current_depth=current_depth,
+            fragments=fragments,
+            variable_values=variable_values,
+            max_list_multiplier=max_list_multiplier,
+            visited_fragments=visited_fragments,
+        )
+    if isinstance(selection, ast.InlineFragmentNode):
+        return _analyze_inline_fragment_selection(
+            selection,
+            current_depth=current_depth,
+            fragments=fragments,
+            variable_values=variable_values,
+            max_list_multiplier=max_list_multiplier,
+            visited_fragments=visited_fragments,
+        )
+    if isinstance(selection, ast.FragmentSpreadNode):
+        return _analyze_fragment_spread_selection(
+            selection,
+            current_depth=current_depth,
+            fragments=fragments,
+            variable_values=variable_values,
+            max_list_multiplier=max_list_multiplier,
+            visited_fragments=visited_fragments,
+        )
+    return current_depth, 0
+
+
+def _analyze_field_selection(
+    selection: ast.FieldNode,
+    *,
+    current_depth: int,
+    fragments: dict[str, ast.FragmentDefinitionNode],
+    variable_values: dict[str, Any] | None,
+    max_list_multiplier: int,
+    visited_fragments: set[str],
+) -> tuple[int, int]:
+    field_depth = current_depth + 1
+    field_complexity = 1
+    if not selection.selection_set:
+        return field_depth, field_complexity
+
+    nested_depth, nested_complexity = _analyze_selection_set(
+        selection.selection_set,
+        current_depth=field_depth,
+        fragments=fragments,
+        variable_values=variable_values,
+        max_list_multiplier=max_list_multiplier,
+        visited_fragments=visited_fragments.copy(),
+    )
+    multiplier = _resolve_field_multiplier(
+        selection, variable_values, max_list_multiplier
+    )
+    field_depth = max(field_depth, nested_depth)
+    field_complexity += nested_complexity * multiplier
+    return field_depth, field_complexity
+
+
+def _analyze_inline_fragment_selection(
+    selection: ast.InlineFragmentNode,
+    *,
+    current_depth: int,
+    fragments: dict[str, ast.FragmentDefinitionNode],
+    variable_values: dict[str, Any] | None,
+    max_list_multiplier: int,
+    visited_fragments: set[str],
+) -> tuple[int, int]:
+    if not selection.selection_set:
+        return current_depth, 0
+    return _analyze_selection_set(
+        selection.selection_set,
+        current_depth=current_depth,
+        fragments=fragments,
+        variable_values=variable_values,
+        max_list_multiplier=max_list_multiplier,
+        visited_fragments=visited_fragments.copy(),
+    )
+
+
+def _analyze_fragment_spread_selection(
+    selection: ast.FragmentSpreadNode,
+    *,
+    current_depth: int,
+    fragments: dict[str, ast.FragmentDefinitionNode],
+    variable_values: dict[str, Any] | None,
+    max_list_multiplier: int,
+    visited_fragments: set[str],
+) -> tuple[int, int]:
+    fragment_name = selection.name.value
+    if fragment_name in visited_fragments:
+        return current_depth, 0
+    fragment_node = fragments.get(fragment_name)
+    if fragment_node is None:
+        return current_depth, 0
+    next_visited = visited_fragments.copy()
+    next_visited.add(fragment_name)
+    return _analyze_selection_set(
+        fragment_node.selection_set,
+        current_depth=current_depth,
+        fragments=fragments,
+        variable_values=variable_values,
+        max_list_multiplier=max_list_multiplier,
+        visited_fragments=next_visited,
+    )
+
+
+def parse_document(query: str) -> ast.DocumentNode:
+    try:
+        return parse(query)
+    except GraphQLError as exc:
+        raise GraphQLSecurityViolation(
+            code="GRAPHQL_PARSE_ERROR",
+            message=f"Query GraphQL inválida: {exc.message}",
+            details={},
+        ) from exc
+
+
+def collect_fragments_and_operations(
+    document: ast.DocumentNode,
+) -> tuple[dict[str, ast.FragmentDefinitionNode], list[ast.OperationDefinitionNode]]:
+    fragments: dict[str, ast.FragmentDefinitionNode] = {}
+    operations: list[ast.OperationDefinitionNode] = []
+    for definition in document.definitions:
+        if isinstance(definition, ast.FragmentDefinitionNode):
+            fragments[definition.name.value] = definition
+        if isinstance(definition, ast.OperationDefinitionNode):
+            operations.append(definition)
+    return fragments, operations
+
+
+def ensure_operation_count_within_limit(
+    operations: list[ast.OperationDefinitionNode],
+    policy: GraphQLSecurityPolicy,
+) -> None:
+    operation_count = len(operations)
+    if operation_count <= policy.max_operations:
+        return
+    raise GraphQLSecurityViolation(
+        code=GRAPHQL_OPERATION_LIMIT_EXCEEDED,
+        message=(
+            "Quantidade de operações GraphQL excedeu o limite permitido "
+            f"({policy.max_operations})."
+        ),
+        details={
+            "operation_count": operation_count,
+            "max_operations": policy.max_operations,
+        },
+    )
+
+
+def select_operations_to_analyze(
+    operations: list[ast.OperationDefinitionNode],
+    operation_name: str | None,
+) -> list[ast.OperationDefinitionNode]:
+    if not operation_name:
+        return operations
+
+    selected_operations = [
+        operation
+        for operation in operations
+        if operation.name and operation.name.value == operation_name
+    ]
+    if selected_operations:
+        return selected_operations
+
+    raise GraphQLSecurityViolation(
+        code=GRAPHQL_OPERATION_NOT_FOUND,
+        message=f"Operação '{operation_name}' não encontrada no documento.",
+        details={"operation_name": operation_name},
+    )
+
+
+def _collect_root_fields(
+    operations: list[ast.OperationDefinitionNode],
+) -> set[str]:
+    root_fields: set[str] = set()
+    for operation in operations:
+        for selection in operation.selection_set.selections:
+            if isinstance(selection, ast.FieldNode):
+                root_fields.add(selection.name.value)
+    return root_fields
+
+
+def calculate_metrics(
+    operations: list[ast.OperationDefinitionNode],
+    *,
+    fragments: dict[str, ast.FragmentDefinitionNode],
+    variable_values: dict[str, Any] | None,
+    max_list_multiplier: int,
+    query: str,
+) -> GraphQLQueryMetrics:
+    max_depth = 0
+    total_complexity = 0
+    for operation in operations:
+        operation_depth, operation_complexity = _analyze_selection_set(
+            operation.selection_set,
+            current_depth=0,
+            fragments=fragments,
+            variable_values=variable_values,
+            max_list_multiplier=max_list_multiplier,
+            visited_fragments=set(),
+        )
+        max_depth = max(max_depth, operation_depth)
+        total_complexity += operation_complexity
+
+    root_fields = _collect_root_fields(operations)
+    return GraphQLQueryMetrics(
+        operation_count=len(operations),
+        depth=max_depth,
+        complexity=total_complexity,
+        query_bytes=len(query.encode("utf-8")),
+        root_fields=tuple(sorted(root_fields)),
+    )
+
+
+def enforce_depth_and_complexity_limits(
+    metrics: GraphQLQueryMetrics,
+    policy: GraphQLSecurityPolicy,
+) -> None:
+    if metrics.depth > policy.max_depth:
+        raise GraphQLSecurityViolation(
+            code="GRAPHQL_DEPTH_LIMIT_EXCEEDED",
+            message=(
+                "Query GraphQL excedeu a profundidade máxima permitida "
+                f"({policy.max_depth})."
+            ),
+            details={"depth": metrics.depth, "max_depth": policy.max_depth},
+        )
+
+    if metrics.complexity > policy.max_complexity:
+        raise GraphQLSecurityViolation(
+            code="GRAPHQL_COMPLEXITY_LIMIT_EXCEEDED",
+            message=(
+                "Query GraphQL excedeu a complexidade máxima permitida "
+                f"({policy.max_complexity})."
+            ),
+            details={
+                "complexity": metrics.complexity,
+                "max_complexity": policy.max_complexity,
+            },
+        )

--- a/app/graphql/complexity/policy.py
+++ b/app/graphql/complexity/policy.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any
+
+GRAPHQL_QUERY_TOO_LARGE = "GRAPHQL_QUERY_TOO_LARGE"
+GRAPHQL_DEPTH_LIMIT_EXCEEDED = "GRAPHQL_DEPTH_LIMIT_EXCEEDED"
+GRAPHQL_COMPLEXITY_LIMIT_EXCEEDED = "GRAPHQL_COMPLEXITY_LIMIT_EXCEEDED"
+GRAPHQL_OPERATION_LIMIT_EXCEEDED = "GRAPHQL_OPERATION_LIMIT_EXCEEDED"
+GRAPHQL_OPERATION_NOT_FOUND = "GRAPHQL_OPERATION_NOT_FOUND"
+GRAPHQL_INTROSPECTION_DISABLED = "GRAPHQL_INTROSPECTION_DISABLED"
+
+
+@dataclass(frozen=True)
+class GraphQLSecurityViolation(Exception):
+    code: str
+    message: str
+    details: dict[str, Any]
+
+
+def _read_int_env(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        parsed = int(raw)
+    except ValueError:
+        return default
+    return parsed if parsed > 0 else default
+
+
+def _read_bool_env(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+@dataclass
+class GraphQLSecurityPolicy:
+    max_query_bytes: int
+    max_depth: int
+    max_complexity: int
+    max_operations: int
+    max_list_multiplier: int
+    allow_introspection: bool
+
+    @classmethod
+    def from_env(cls) -> "GraphQLSecurityPolicy":
+        default_introspection = _read_bool_env("FLASK_DEBUG", False)
+        return cls(
+            max_query_bytes=_read_int_env("GRAPHQL_MAX_QUERY_BYTES", 20_000),
+            max_depth=_read_int_env("GRAPHQL_MAX_DEPTH", 8),
+            max_complexity=_read_int_env("GRAPHQL_MAX_COMPLEXITY", 300),
+            max_operations=_read_int_env("GRAPHQL_MAX_OPERATIONS", 3),
+            max_list_multiplier=_read_int_env("GRAPHQL_MAX_LIST_MULTIPLIER", 50),
+            allow_introspection=_read_bool_env(
+                "GRAPHQL_ALLOW_INTROSPECTION",
+                default_introspection,
+            ),
+        )
+
+    def update_limits(
+        self,
+        *,
+        max_query_bytes: int | None = None,
+        max_depth: int | None = None,
+        max_complexity: int | None = None,
+        max_operations: int | None = None,
+        max_list_multiplier: int | None = None,
+        allow_introspection: bool | None = None,
+    ) -> None:
+        if max_query_bytes is not None:
+            self.max_query_bytes = max(max_query_bytes, 1)
+        if max_depth is not None:
+            self.max_depth = max(max_depth, 1)
+        if max_complexity is not None:
+            self.max_complexity = max(max_complexity, 1)
+        if max_operations is not None:
+            self.max_operations = max(max_operations, 1)
+        if max_list_multiplier is not None:
+            self.max_list_multiplier = max(max_list_multiplier, 1)
+        if allow_introspection is not None:
+            self.allow_introspection = bool(allow_introspection)

--- a/app/graphql/introspection_policy.py
+++ b/app/graphql/introspection_policy.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from graphql.language import ast
+
+from app.graphql.complexity.policy import (
+    GRAPHQL_INTROSPECTION_DISABLED,
+    GraphQLSecurityPolicy,
+    GraphQLSecurityViolation,
+)
+
+
+def _contains_introspection_field(selection_set: ast.SelectionSetNode | None) -> bool:
+    if selection_set is None:
+        return False
+    for selection in selection_set.selections:
+        if isinstance(selection, ast.FieldNode):
+            if selection.name.value in {"__schema", "__type"}:
+                return True
+            if _contains_introspection_field(selection.selection_set):
+                return True
+        elif isinstance(selection, ast.InlineFragmentNode):
+            if _contains_introspection_field(selection.selection_set):
+                return True
+    return False
+
+
+def enforce_introspection_policy(
+    selected_operations: list[ast.OperationDefinitionNode],
+    policy: GraphQLSecurityPolicy,
+) -> None:
+    if policy.allow_introspection:
+        return
+    if any(
+        _contains_introspection_field(operation.selection_set)
+        for operation in selected_operations
+    ):
+        raise GraphQLSecurityViolation(
+            code=GRAPHQL_INTROSPECTION_DISABLED,
+            message="Introspecção GraphQL está desabilitada neste ambiente.",
+            details={},
+        )

--- a/app/graphql/security.py
+++ b/app/graphql/security.py
@@ -1,461 +1,48 @@
 from __future__ import annotations
 
-import os
-from dataclasses import dataclass
 from typing import Any
 
-from graphql import GraphQLError, parse
-from graphql.language import ast
+from app.graphql.complexity.analyzer import (
+    GraphQLQueryMetrics,
+    calculate_metrics,
+    collect_fragments_and_operations,
+    enforce_depth_and_complexity_limits,
+    ensure_operation_count_within_limit,
+    parse_document,
+    select_operations_to_analyze,
+)
+from app.graphql.complexity.policy import (
+    GRAPHQL_COMPLEXITY_LIMIT_EXCEEDED,
+    GRAPHQL_DEPTH_LIMIT_EXCEEDED,
+    GRAPHQL_INTROSPECTION_DISABLED,
+    GRAPHQL_OPERATION_LIMIT_EXCEEDED,
+    GRAPHQL_OPERATION_NOT_FOUND,
+    GRAPHQL_QUERY_TOO_LARGE,
+    GraphQLSecurityPolicy,
+    GraphQLSecurityViolation,
+)
+from app.graphql.introspection_policy import enforce_introspection_policy
 
-GRAPHQL_QUERY_TOO_LARGE = "GRAPHQL_QUERY_TOO_LARGE"
-GRAPHQL_DEPTH_LIMIT_EXCEEDED = "GRAPHQL_DEPTH_LIMIT_EXCEEDED"
-GRAPHQL_COMPLEXITY_LIMIT_EXCEEDED = "GRAPHQL_COMPLEXITY_LIMIT_EXCEEDED"
-GRAPHQL_OPERATION_LIMIT_EXCEEDED = "GRAPHQL_OPERATION_LIMIT_EXCEEDED"
-GRAPHQL_OPERATION_NOT_FOUND = "GRAPHQL_OPERATION_NOT_FOUND"
-GRAPHQL_INTROSPECTION_DISABLED = "GRAPHQL_INTROSPECTION_DISABLED"
+__all__ = [
+    "GRAPHQL_COMPLEXITY_LIMIT_EXCEEDED",
+    "GRAPHQL_DEPTH_LIMIT_EXCEEDED",
+    "GRAPHQL_INTROSPECTION_DISABLED",
+    "GRAPHQL_OPERATION_LIMIT_EXCEEDED",
+    "GRAPHQL_OPERATION_NOT_FOUND",
+    "GRAPHQL_QUERY_TOO_LARGE",
+    "GraphQLQueryMetrics",
+    "GraphQLSecurityPolicy",
+    "GraphQLSecurityViolation",
+    "analyze_graphql_query",
+]
 
-_LIST_ARGUMENT_NAMES = {
-    "first",
-    "last",
-    "limit",
-    "perPage",
-    "per_page",
-    "pageSize",
-    "size",
-}
-
-
-def _read_int_env(name: str, default: int) -> int:
-    raw = os.getenv(name)
-    if raw is None:
-        return default
-    try:
-        parsed = int(raw)
-    except ValueError:
-        return default
-    return parsed if parsed > 0 else default
-
-
-def _read_bool_env(name: str, default: bool) -> bool:
-    raw = os.getenv(name)
-    if raw is None:
-        return default
-    return raw.strip().lower() in {"1", "true", "yes", "on"}
-
-
-@dataclass
-class GraphQLSecurityPolicy:
-    max_query_bytes: int
-    max_depth: int
-    max_complexity: int
-    max_operations: int
-    max_list_multiplier: int
-    allow_introspection: bool
-
-    @classmethod
-    def from_env(cls) -> "GraphQLSecurityPolicy":
-        default_introspection = _read_bool_env("FLASK_DEBUG", False)
-        return cls(
-            max_query_bytes=_read_int_env("GRAPHQL_MAX_QUERY_BYTES", 20_000),
-            max_depth=_read_int_env("GRAPHQL_MAX_DEPTH", 8),
-            max_complexity=_read_int_env("GRAPHQL_MAX_COMPLEXITY", 300),
-            max_operations=_read_int_env("GRAPHQL_MAX_OPERATIONS", 3),
-            max_list_multiplier=_read_int_env("GRAPHQL_MAX_LIST_MULTIPLIER", 50),
-            allow_introspection=_read_bool_env(
-                "GRAPHQL_ALLOW_INTROSPECTION",
-                default_introspection,
-            ),
-        )
-
-    def update_limits(
-        self,
-        *,
-        max_query_bytes: int | None = None,
-        max_depth: int | None = None,
-        max_complexity: int | None = None,
-        max_operations: int | None = None,
-        max_list_multiplier: int | None = None,
-        allow_introspection: bool | None = None,
-    ) -> None:
-        if max_query_bytes is not None:
-            self.max_query_bytes = max(max_query_bytes, 1)
-        if max_depth is not None:
-            self.max_depth = max(max_depth, 1)
-        if max_complexity is not None:
-            self.max_complexity = max(max_complexity, 1)
-        if max_operations is not None:
-            self.max_operations = max(max_operations, 1)
-        if max_list_multiplier is not None:
-            self.max_list_multiplier = max(max_list_multiplier, 1)
-        if allow_introspection is not None:
-            self.allow_introspection = bool(allow_introspection)
-
-
-@dataclass(frozen=True)
-class GraphQLQueryMetrics:
-    operation_count: int
-    depth: int
-    complexity: int
-    query_bytes: int
-    root_fields: tuple[str, ...] = ()
-
-
-@dataclass(frozen=True)
-class GraphQLSecurityViolation(Exception):
-    code: str
-    message: str
-    details: dict[str, Any]
-
-
-def _resolve_int_value(
-    value_node: ast.ValueNode,
-    variable_values: dict[str, Any] | None,
-) -> int | None:
-    if isinstance(value_node, ast.IntValueNode):
-        try:
-            return int(value_node.value)
-        except ValueError:
-            return None
-
-    if isinstance(value_node, ast.VariableNode) and isinstance(variable_values, dict):
-        raw_value = variable_values.get(value_node.name.value)
-        if isinstance(raw_value, bool):
-            return None
-        if isinstance(raw_value, int):
-            return raw_value
-        if isinstance(raw_value, str) and raw_value.isdigit():
-            return int(raw_value)
-    return None
-
-
-def _resolve_field_multiplier(
-    field_node: ast.FieldNode,
-    variable_values: dict[str, Any] | None,
-    max_list_multiplier: int,
-) -> int:
-    for argument in field_node.arguments or []:
-        if argument.name.value not in _LIST_ARGUMENT_NAMES:
-            continue
-        resolved_value = _resolve_int_value(argument.value, variable_values)
-        if resolved_value is None:
-            continue
-        if resolved_value <= 0:
-            return 1
-        return min(resolved_value, max_list_multiplier)
-    return 1
-
-
-def _analyze_selection_set(
-    selection_set: ast.SelectionSetNode,
-    *,
-    current_depth: int,
-    fragments: dict[str, ast.FragmentDefinitionNode],
-    variable_values: dict[str, Any] | None,
-    max_list_multiplier: int,
-    visited_fragments: set[str],
-) -> tuple[int, int]:
-    max_depth = current_depth
-    complexity = 0
-
-    for selection in selection_set.selections:
-        nested_depth, nested_complexity = _analyze_single_selection(
-            selection,
-            current_depth=current_depth,
-            fragments=fragments,
-            variable_values=variable_values,
-            max_list_multiplier=max_list_multiplier,
-            visited_fragments=visited_fragments,
-        )
-        max_depth = max(max_depth, nested_depth)
-        complexity += nested_complexity
-
-    return max_depth, complexity
-
-
-def _analyze_single_selection(
-    selection: ast.SelectionNode,
-    *,
-    current_depth: int,
-    fragments: dict[str, ast.FragmentDefinitionNode],
-    variable_values: dict[str, Any] | None,
-    max_list_multiplier: int,
-    visited_fragments: set[str],
-) -> tuple[int, int]:
-    if isinstance(selection, ast.FieldNode):
-        return _analyze_field_selection(
-            selection,
-            current_depth=current_depth,
-            fragments=fragments,
-            variable_values=variable_values,
-            max_list_multiplier=max_list_multiplier,
-            visited_fragments=visited_fragments,
-        )
-    if isinstance(selection, ast.InlineFragmentNode):
-        return _analyze_inline_fragment_selection(
-            selection,
-            current_depth=current_depth,
-            fragments=fragments,
-            variable_values=variable_values,
-            max_list_multiplier=max_list_multiplier,
-            visited_fragments=visited_fragments,
-        )
-    if isinstance(selection, ast.FragmentSpreadNode):
-        return _analyze_fragment_spread_selection(
-            selection,
-            current_depth=current_depth,
-            fragments=fragments,
-            variable_values=variable_values,
-            max_list_multiplier=max_list_multiplier,
-            visited_fragments=visited_fragments,
-        )
-    return current_depth, 0
-
-
-def _analyze_field_selection(
-    selection: ast.FieldNode,
-    *,
-    current_depth: int,
-    fragments: dict[str, ast.FragmentDefinitionNode],
-    variable_values: dict[str, Any] | None,
-    max_list_multiplier: int,
-    visited_fragments: set[str],
-) -> tuple[int, int]:
-    field_depth = current_depth + 1
-    field_complexity = 1
-    if not selection.selection_set:
-        return field_depth, field_complexity
-
-    nested_depth, nested_complexity = _analyze_selection_set(
-        selection.selection_set,
-        current_depth=field_depth,
-        fragments=fragments,
-        variable_values=variable_values,
-        max_list_multiplier=max_list_multiplier,
-        visited_fragments=visited_fragments.copy(),
-    )
-    multiplier = _resolve_field_multiplier(
-        selection, variable_values, max_list_multiplier
-    )
-    field_depth = max(field_depth, nested_depth)
-    field_complexity += nested_complexity * multiplier
-    return field_depth, field_complexity
-
-
-def _analyze_inline_fragment_selection(
-    selection: ast.InlineFragmentNode,
-    *,
-    current_depth: int,
-    fragments: dict[str, ast.FragmentDefinitionNode],
-    variable_values: dict[str, Any] | None,
-    max_list_multiplier: int,
-    visited_fragments: set[str],
-) -> tuple[int, int]:
-    if not selection.selection_set:
-        return current_depth, 0
-    return _analyze_selection_set(
-        selection.selection_set,
-        current_depth=current_depth,
-        fragments=fragments,
-        variable_values=variable_values,
-        max_list_multiplier=max_list_multiplier,
-        visited_fragments=visited_fragments.copy(),
-    )
-
-
-def _analyze_fragment_spread_selection(
-    selection: ast.FragmentSpreadNode,
-    *,
-    current_depth: int,
-    fragments: dict[str, ast.FragmentDefinitionNode],
-    variable_values: dict[str, Any] | None,
-    max_list_multiplier: int,
-    visited_fragments: set[str],
-) -> tuple[int, int]:
-    fragment_name = selection.name.value
-    if fragment_name in visited_fragments:
-        return current_depth, 0
-    fragment_node = fragments.get(fragment_name)
-    if fragment_node is None:
-        return current_depth, 0
-    next_visited = visited_fragments.copy()
-    next_visited.add(fragment_name)
-    return _analyze_selection_set(
-        fragment_node.selection_set,
-        current_depth=current_depth,
-        fragments=fragments,
-        variable_values=variable_values,
-        max_list_multiplier=max_list_multiplier,
-        visited_fragments=next_visited,
-    )
-
-
-def _parse_document(query: str) -> ast.DocumentNode:
-    try:
-        return parse(query)
-    except GraphQLError as exc:
-        raise GraphQLSecurityViolation(
-            code="GRAPHQL_PARSE_ERROR",
-            message=f"Query GraphQL inválida: {exc.message}",
-            details={},
-        ) from exc
-
-
-def _collect_fragments_and_operations(
-    document: ast.DocumentNode,
-) -> tuple[dict[str, ast.FragmentDefinitionNode], list[ast.OperationDefinitionNode]]:
-    fragments: dict[str, ast.FragmentDefinitionNode] = {}
-    operations: list[ast.OperationDefinitionNode] = []
-    for definition in document.definitions:
-        if isinstance(definition, ast.FragmentDefinitionNode):
-            fragments[definition.name.value] = definition
-        if isinstance(definition, ast.OperationDefinitionNode):
-            operations.append(definition)
-    return fragments, operations
-
-
-def _ensure_operation_count_within_limit(
-    operations: list[ast.OperationDefinitionNode],
-    policy: GraphQLSecurityPolicy,
-) -> None:
-    operation_count = len(operations)
-    if operation_count <= policy.max_operations:
-        return
-    raise GraphQLSecurityViolation(
-        code=GRAPHQL_OPERATION_LIMIT_EXCEEDED,
-        message=(
-            "Quantidade de operações GraphQL excedeu o limite permitido "
-            f"({policy.max_operations})."
-        ),
-        details={
-            "operation_count": operation_count,
-            "max_operations": policy.max_operations,
-        },
-    )
-
-
-def _select_operations_to_analyze(
-    operations: list[ast.OperationDefinitionNode],
-    operation_name: str | None,
-) -> list[ast.OperationDefinitionNode]:
-    if not operation_name:
-        return operations
-
-    selected_operations = [
-        operation
-        for operation in operations
-        if operation.name and operation.name.value == operation_name
-    ]
-    if selected_operations:
-        return selected_operations
-
-    raise GraphQLSecurityViolation(
-        code=GRAPHQL_OPERATION_NOT_FOUND,
-        message=f"Operação '{operation_name}' não encontrada no documento.",
-        details={"operation_name": operation_name},
-    )
-
-
-def _calculate_metrics(
-    operations: list[ast.OperationDefinitionNode],
-    *,
-    fragments: dict[str, ast.FragmentDefinitionNode],
-    variable_values: dict[str, Any] | None,
-    max_list_multiplier: int,
-    query: str,
-) -> GraphQLQueryMetrics:
-    max_depth = 0
-    total_complexity = 0
-    for operation in operations:
-        operation_depth, operation_complexity = _analyze_selection_set(
-            operation.selection_set,
-            current_depth=0,
-            fragments=fragments,
-            variable_values=variable_values,
-            max_list_multiplier=max_list_multiplier,
-            visited_fragments=set(),
-        )
-        max_depth = max(max_depth, operation_depth)
-        total_complexity += operation_complexity
-
-    root_fields = _collect_root_fields(operations)
-    return GraphQLQueryMetrics(
-        operation_count=len(operations),
-        depth=max_depth,
-        complexity=total_complexity,
-        query_bytes=len(query.encode("utf-8")),
-        root_fields=tuple(sorted(root_fields)),
-    )
-
-
-def _collect_root_fields(
-    operations: list[ast.OperationDefinitionNode],
-) -> set[str]:
-    root_fields: set[str] = set()
-    for operation in operations:
-        for selection in operation.selection_set.selections:
-            if isinstance(selection, ast.FieldNode):
-                root_fields.add(selection.name.value)
-    return root_fields
-
-
-def _enforce_depth_and_complexity_limits(
-    metrics: GraphQLQueryMetrics,
-    policy: GraphQLSecurityPolicy,
-) -> None:
-    if metrics.depth > policy.max_depth:
-        raise GraphQLSecurityViolation(
-            code=GRAPHQL_DEPTH_LIMIT_EXCEEDED,
-            message=(
-                "Query GraphQL excedeu a profundidade máxima permitida "
-                f"({policy.max_depth})."
-            ),
-            details={"depth": metrics.depth, "max_depth": policy.max_depth},
-        )
-
-    if metrics.complexity > policy.max_complexity:
-        raise GraphQLSecurityViolation(
-            code=GRAPHQL_COMPLEXITY_LIMIT_EXCEEDED,
-            message=(
-                "Query GraphQL excedeu a complexidade máxima permitida "
-                f"({policy.max_complexity})."
-            ),
-            details={
-                "complexity": metrics.complexity,
-                "max_complexity": policy.max_complexity,
-            },
-        )
-
-
-def _contains_introspection_field(selection_set: ast.SelectionSetNode | None) -> bool:
-    if selection_set is None:
-        return False
-    for selection in selection_set.selections:
-        if isinstance(selection, ast.FieldNode):
-            if selection.name.value in {"__schema", "__type"}:
-                return True
-            if _contains_introspection_field(selection.selection_set):
-                return True
-        elif isinstance(selection, ast.InlineFragmentNode):
-            if _contains_introspection_field(selection.selection_set):
-                return True
-    return False
-
-
-def _enforce_introspection_policy(
-    selected_operations: list[ast.OperationDefinitionNode],
-    policy: GraphQLSecurityPolicy,
-) -> None:
-    if policy.allow_introspection:
-        return
-    if any(
-        _contains_introspection_field(operation.selection_set)
-        for operation in selected_operations
-    ):
-        raise GraphQLSecurityViolation(
-            code=GRAPHQL_INTROSPECTION_DISABLED,
-            message="Introspecção GraphQL está desabilitada neste ambiente.",
-            details={},
-        )
+# Private aliases kept for backwards compatibility with private imports in tests
+_parse_document = parse_document
+_collect_fragments_and_operations = collect_fragments_and_operations
+_ensure_operation_count_within_limit = ensure_operation_count_within_limit
+_select_operations_to_analyze = select_operations_to_analyze
+_enforce_depth_and_complexity_limits = enforce_depth_and_complexity_limits
+_enforce_introspection_policy = enforce_introspection_policy
 
 
 def analyze_graphql_query(
@@ -479,19 +66,19 @@ def analyze_graphql_query(
             },
         )
 
-    document = _parse_document(query)
-    fragments, operations = _collect_fragments_and_operations(document)
-    _ensure_operation_count_within_limit(operations, policy)
-    selected_operations = _select_operations_to_analyze(operations, operation_name)
-    _enforce_introspection_policy(selected_operations, policy)
-    metrics = _calculate_metrics(
+    document = parse_document(query)
+    fragments, operations = collect_fragments_and_operations(document)
+    ensure_operation_count_within_limit(operations, policy)
+    selected_operations = select_operations_to_analyze(operations, operation_name)
+    enforce_introspection_policy(selected_operations, policy)
+    metrics = calculate_metrics(
         selected_operations,
         fragments=fragments,
         variable_values=variable_values,
         max_list_multiplier=policy.max_list_multiplier,
         query=query,
     )
-    _enforce_depth_and_complexity_limits(metrics, policy)
+    enforce_depth_and_complexity_limits(metrics, policy)
     return GraphQLQueryMetrics(
         operation_count=len(operations),
         depth=metrics.depth,

--- a/tests/test_graphql_complexity_modules.py
+++ b/tests/test_graphql_complexity_modules.py
@@ -1,0 +1,388 @@
+"""Unit tests for the extracted graphql/complexity/ modules and introspection_policy."""
+
+from __future__ import annotations
+
+import pytest
+from graphql import parse
+from graphql.language import ast
+
+from app.graphql.complexity.analyzer import (
+    GraphQLQueryMetrics,
+    calculate_metrics,
+    collect_fragments_and_operations,
+    enforce_depth_and_complexity_limits,
+    ensure_operation_count_within_limit,
+    parse_document,
+    select_operations_to_analyze,
+)
+from app.graphql.complexity.policy import (
+    GRAPHQL_COMPLEXITY_LIMIT_EXCEEDED,
+    GRAPHQL_DEPTH_LIMIT_EXCEEDED,
+    GRAPHQL_INTROSPECTION_DISABLED,
+    GRAPHQL_OPERATION_LIMIT_EXCEEDED,
+    GRAPHQL_OPERATION_NOT_FOUND,
+    GraphQLSecurityPolicy,
+    GraphQLSecurityViolation,
+    _read_bool_env,
+    _read_int_env,
+)
+from app.graphql.introspection_policy import (
+    _contains_introspection_field,
+    enforce_introspection_policy,
+)
+
+# ---------------------------------------------------------------------------
+# policy.py — env helpers
+# ---------------------------------------------------------------------------
+
+
+class TestReadIntEnv:
+    def test_returns_default_when_not_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("TEST_VAR", raising=False)
+        assert _read_int_env("TEST_VAR", 42) == 42
+
+    def test_parses_valid_integer(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("TEST_VAR", "100")
+        assert _read_int_env("TEST_VAR", 42) == 100
+
+    def test_returns_default_on_invalid_value(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("TEST_VAR", "not_a_number")
+        assert _read_int_env("TEST_VAR", 42) == 42
+
+    def test_returns_default_when_zero(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("TEST_VAR", "0")
+        assert _read_int_env("TEST_VAR", 42) == 42
+
+    def test_returns_default_when_negative(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("TEST_VAR", "-5")
+        assert _read_int_env("TEST_VAR", 42) == 42
+
+
+class TestReadBoolEnv:
+    def test_returns_default_when_not_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("TEST_FLAG", raising=False)
+        assert _read_bool_env("TEST_FLAG", False) is False
+        assert _read_bool_env("TEST_FLAG", True) is True
+
+    @pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on", "True"])
+    def test_truthy_values(self, monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+        monkeypatch.setenv("TEST_FLAG", value)
+        assert _read_bool_env("TEST_FLAG", False) is True
+
+    @pytest.mark.parametrize("value", ["0", "false", "no", "off", ""])
+    def test_falsy_values(self, monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+        monkeypatch.setenv("TEST_FLAG", value)
+        assert _read_bool_env("TEST_FLAG", True) is False
+
+
+# ---------------------------------------------------------------------------
+# policy.py — GraphQLSecurityPolicy
+# ---------------------------------------------------------------------------
+
+
+class TestGraphQLSecurityPolicy:
+    def test_from_env_uses_defaults(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for var in [
+            "GRAPHQL_MAX_QUERY_BYTES",
+            "GRAPHQL_MAX_DEPTH",
+            "GRAPHQL_MAX_COMPLEXITY",
+            "GRAPHQL_MAX_OPERATIONS",
+            "GRAPHQL_MAX_LIST_MULTIPLIER",
+            "GRAPHQL_ALLOW_INTROSPECTION",
+            "FLASK_DEBUG",
+        ]:
+            monkeypatch.delenv(var, raising=False)
+        policy = GraphQLSecurityPolicy.from_env()
+        assert policy.max_query_bytes == 20_000
+        assert policy.max_depth == 8
+        assert policy.max_complexity == 300
+        assert policy.max_operations == 3
+        assert policy.max_list_multiplier == 50
+        assert policy.allow_introspection is False
+
+    def test_update_limits_clamps_minimum_to_one(self) -> None:
+        policy = GraphQLSecurityPolicy(
+            max_query_bytes=1000,
+            max_depth=5,
+            max_complexity=100,
+            max_operations=2,
+            max_list_multiplier=10,
+            allow_introspection=False,
+        )
+        policy.update_limits(max_depth=0, max_complexity=-5)
+        assert policy.max_depth == 1
+        assert policy.max_complexity == 1
+
+    def test_update_limits_sets_values(self) -> None:
+        policy = GraphQLSecurityPolicy(
+            max_query_bytes=1000,
+            max_depth=5,
+            max_complexity=100,
+            max_operations=2,
+            max_list_multiplier=10,
+            allow_introspection=False,
+        )
+        policy.update_limits(max_depth=15, allow_introspection=True)
+        assert policy.max_depth == 15
+        assert policy.allow_introspection is True
+
+
+# ---------------------------------------------------------------------------
+# analyzer.py — parse_document
+# ---------------------------------------------------------------------------
+
+
+class TestParseDocument:
+    def test_parses_valid_query(self) -> None:
+        doc = parse_document("{ __typename }")
+        assert isinstance(doc, ast.DocumentNode)
+
+    def test_raises_violation_on_invalid_query(self) -> None:
+        with pytest.raises(GraphQLSecurityViolation) as exc_info:
+            parse_document("{ invalid {{ syntax")
+        assert exc_info.value.code == "GRAPHQL_PARSE_ERROR"
+
+
+# ---------------------------------------------------------------------------
+# analyzer.py — collect_fragments_and_operations
+# ---------------------------------------------------------------------------
+
+
+class TestCollectFragmentsAndOperations:
+    def test_separates_fragments_and_operations(self) -> None:
+        doc = parse(
+            """
+            fragment F on Query { __typename }
+            query Q { __typename }
+            """
+        )
+        fragments, operations = collect_fragments_and_operations(doc)
+        assert "F" in fragments
+        assert len(operations) == 1
+
+    def test_empty_document(self) -> None:
+        doc = parse("{ __typename }")
+        fragments, operations = collect_fragments_and_operations(doc)
+        assert fragments == {}
+        assert len(operations) == 1
+
+
+# ---------------------------------------------------------------------------
+# analyzer.py — ensure_operation_count_within_limit
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureOperationCountWithinLimit:
+    def _make_policy(self, max_operations: int) -> GraphQLSecurityPolicy:
+        return GraphQLSecurityPolicy(
+            max_query_bytes=20_000,
+            max_depth=8,
+            max_complexity=300,
+            max_operations=max_operations,
+            max_list_multiplier=50,
+            allow_introspection=False,
+        )
+
+    def test_passes_when_within_limit(self) -> None:
+        doc = parse("query A { __typename } query B { __typename }")
+        _, operations = collect_fragments_and_operations(doc)
+        ensure_operation_count_within_limit(operations, self._make_policy(3))
+
+    def test_raises_when_exceeds_limit(self) -> None:
+        doc = parse(
+            "query A { __typename } query B { __typename } query C { __typename }"
+        )
+        _, operations = collect_fragments_and_operations(doc)
+        with pytest.raises(GraphQLSecurityViolation) as exc_info:
+            ensure_operation_count_within_limit(operations, self._make_policy(2))
+        assert exc_info.value.code == GRAPHQL_OPERATION_LIMIT_EXCEEDED
+
+
+# ---------------------------------------------------------------------------
+# analyzer.py — select_operations_to_analyze
+# ---------------------------------------------------------------------------
+
+
+class TestSelectOperationsToAnalyze:
+    def test_returns_all_when_no_name(self) -> None:
+        doc = parse("query A { __typename } query B { __typename }")
+        _, operations = collect_fragments_and_operations(doc)
+        selected = select_operations_to_analyze(operations, None)
+        assert len(selected) == 2
+
+    def test_selects_by_name(self) -> None:
+        doc = parse("query A { __typename } query B { __typename }")
+        _, operations = collect_fragments_and_operations(doc)
+        selected = select_operations_to_analyze(operations, "A")
+        assert len(selected) == 1
+        assert selected[0].name and selected[0].name.value == "A"
+
+    def test_raises_when_name_not_found(self) -> None:
+        doc = parse("query A { __typename }")
+        _, operations = collect_fragments_and_operations(doc)
+        with pytest.raises(GraphQLSecurityViolation) as exc_info:
+            select_operations_to_analyze(operations, "Z")
+        assert exc_info.value.code == GRAPHQL_OPERATION_NOT_FOUND
+
+
+# ---------------------------------------------------------------------------
+# analyzer.py — calculate_metrics
+# ---------------------------------------------------------------------------
+
+
+class TestCalculateMetrics:
+    def _policy_kwargs(self) -> dict:
+        return dict(
+            max_query_bytes=20_000,
+            max_depth=8,
+            max_complexity=300,
+            max_operations=3,
+            max_list_multiplier=50,
+            allow_introspection=False,
+        )
+
+    def test_flat_query_depth_one(self) -> None:
+        query = "{ __typename }"
+        doc = parse(query)
+        fragments, operations = collect_fragments_and_operations(doc)
+        metrics = calculate_metrics(
+            operations,
+            fragments=fragments,
+            variable_values=None,
+            max_list_multiplier=50,
+            query=query,
+        )
+        assert metrics.depth == 1
+        assert metrics.complexity >= 1
+
+    def test_nested_query_increases_depth(self) -> None:
+        query = "{ a { b { c } } }"
+        doc = parse(query)
+        fragments, operations = collect_fragments_and_operations(doc)
+        metrics = calculate_metrics(
+            operations,
+            fragments=fragments,
+            variable_values=None,
+            max_list_multiplier=50,
+            query=query,
+        )
+        assert metrics.depth == 3
+
+    def test_root_fields_captured(self) -> None:
+        query = "{ foo bar }"
+        doc = parse(query)
+        fragments, operations = collect_fragments_and_operations(doc)
+        metrics = calculate_metrics(
+            operations,
+            fragments=fragments,
+            variable_values=None,
+            max_list_multiplier=50,
+            query=query,
+        )
+        assert "foo" in metrics.root_fields
+        assert "bar" in metrics.root_fields
+
+
+# ---------------------------------------------------------------------------
+# analyzer.py — enforce_depth_and_complexity_limits
+# ---------------------------------------------------------------------------
+
+
+class TestEnforceDepthAndComplexityLimits:
+    def _policy(
+        self, max_depth: int = 8, max_complexity: int = 300
+    ) -> GraphQLSecurityPolicy:
+        return GraphQLSecurityPolicy(
+            max_query_bytes=20_000,
+            max_depth=max_depth,
+            max_complexity=max_complexity,
+            max_operations=3,
+            max_list_multiplier=50,
+            allow_introspection=False,
+        )
+
+    def test_passes_within_limits(self) -> None:
+        metrics = GraphQLQueryMetrics(
+            operation_count=1, depth=3, complexity=10, query_bytes=50
+        )
+        enforce_depth_and_complexity_limits(metrics, self._policy())
+
+    def test_raises_on_depth_exceeded(self) -> None:
+        metrics = GraphQLQueryMetrics(
+            operation_count=1, depth=9, complexity=10, query_bytes=50
+        )
+        with pytest.raises(GraphQLSecurityViolation) as exc_info:
+            enforce_depth_and_complexity_limits(metrics, self._policy(max_depth=8))
+        assert exc_info.value.code == GRAPHQL_DEPTH_LIMIT_EXCEEDED
+
+    def test_raises_on_complexity_exceeded(self) -> None:
+        metrics = GraphQLQueryMetrics(
+            operation_count=1, depth=3, complexity=301, query_bytes=50
+        )
+        with pytest.raises(GraphQLSecurityViolation) as exc_info:
+            enforce_depth_and_complexity_limits(
+                metrics, self._policy(max_complexity=300)
+            )
+        assert exc_info.value.code == GRAPHQL_COMPLEXITY_LIMIT_EXCEEDED
+
+
+# ---------------------------------------------------------------------------
+# introspection_policy.py
+# ---------------------------------------------------------------------------
+
+
+class TestContainsIntrospectionField:
+    def test_detects_schema_introspection(self) -> None:
+        doc = parse("{ __schema { types { name } } }")
+        _, operations = collect_fragments_and_operations(doc)
+        assert _contains_introspection_field(operations[0].selection_set) is True
+
+    def test_detects_type_introspection(self) -> None:
+        doc = parse('{ __type(name: "User") { name } }')
+        _, operations = collect_fragments_and_operations(doc)
+        assert _contains_introspection_field(operations[0].selection_set) is True
+
+    def test_returns_false_for_normal_query(self) -> None:
+        doc = parse("{ __typename }")
+        _, operations = collect_fragments_and_operations(doc)
+        assert _contains_introspection_field(operations[0].selection_set) is False
+
+    def test_returns_false_for_none(self) -> None:
+        assert _contains_introspection_field(None) is False
+
+
+class TestEnforceIntrospectionPolicy:
+    def _policy(self, allow: bool) -> GraphQLSecurityPolicy:
+        return GraphQLSecurityPolicy(
+            max_query_bytes=20_000,
+            max_depth=8,
+            max_complexity=300,
+            max_operations=3,
+            max_list_multiplier=50,
+            allow_introspection=allow,
+        )
+
+    def test_allows_introspection_when_enabled(self) -> None:
+        doc = parse("{ __schema { types { name } } }")
+        _, operations = collect_fragments_and_operations(doc)
+        enforce_introspection_policy(operations, self._policy(allow=True))
+
+    def test_blocks_introspection_when_disabled(self) -> None:
+        doc = parse("{ __schema { types { name } } }")
+        _, operations = collect_fragments_and_operations(doc)
+        with pytest.raises(GraphQLSecurityViolation) as exc_info:
+            enforce_introspection_policy(operations, self._policy(allow=False))
+        assert exc_info.value.code == GRAPHQL_INTROSPECTION_DISABLED
+
+    def test_passes_normal_query_when_introspection_disabled(self) -> None:
+        doc = parse("{ __typename }")
+        _, operations = collect_fragments_and_operations(doc)
+        enforce_introspection_policy(operations, self._policy(allow=False))


### PR DESCRIPTION
## Summary

- **`app/graphql/complexity/policy.py`** — `GraphQLSecurityPolicy` + `GraphQLSecurityViolation` + all security constants, extracted from security.py
- **`app/graphql/complexity/analyzer.py`** — pure AST traversal: depth/complexity calculation, `GraphQLQueryMetrics`, fragment resolution
- **`app/graphql/introspection_policy.py`** — introspection detection and enforcement, decoupled from complexity analysis
- **`app/graphql/security.py`** — thin facade: re-exports full public API unchanged, orchestrates the sub-modules in `analyze_graphql_query`
- **`tests/test_graphql_complexity_modules.py`** — 42 unit tests covering each extracted module
- **`CLAUDE.md`** + **`app/graphql/CLAUDE.md`** — fix Ariadne→Graphene 3, add ADR references, document GraphQL auth policy

## What didn't change

All existing callers (`app.controllers.graphql.resources`, `app.controllers.graphql.dependencies`, all test files) import from `app.graphql.security` and continue to work without modification — the public API is fully stable.

## Test plan

- [x] 42 new unit tests for `complexity/policy`, `complexity/analyzer`, `introspection_policy`
- [x] All existing 9 `test_graphql_security` tests pass
- [x] All existing 6 `test_graphql_introspection_production` tests pass
- [x] Full test suite: 90.89% coverage (threshold: 85%)
- [x] `ruff check`, `ruff format`, `mypy`, `bandit` — all green

## Refs

Closes #1150
Closes #1152
Part of umbrella #1157