### PR TITLE
refactor(graphql): resolver decorators — @resolver_with_user_context + @graphql_error_adapter

### DIFF
--- a/app/graphql/decorators.py
+++ b/app/graphql/decorators.py
@@ -1,0 +1,104 @@
+"""GraphQL resolver decorators.
+
+Two composable decorators eliminate the standard boilerplate found in ~23 resolvers:
+
+    @resolver_with_user_context(ServiceClass)
+        Gets the authenticated user from the request context, instantiates
+        ``ServiceClass.with_defaults(user_id)``, and injects the service as
+        the third positional argument (after ``self``/root and ``info``).
+
+    @graphql_error_adapter(*exception_types)
+        Catches any of the listed domain exceptions and re-raises them as
+        ``GraphQLError`` via ``build_public_graphql_error``. The exception must
+        expose ``.message`` and ``.code`` attributes (all ApplicationError
+        subclasses do).
+
+Usage (compose outermost → innermost, execution order is opposite):
+
+    @log_graphql_resolver("deleteTransaction")          # 1st: logging
+    @resolver_with_user_context(TransactionService)     # 2nd: auth + inject
+    @graphql_error_adapter(TransactionApplicationError) # 3rd: error mapping
+    def mutate(self, info, service, transaction_id):
+        service.delete_transaction(transaction_id)
+        return DeleteTransactionMutation(ok=True, message="Deleted.")
+
+The resolver body shrinks from ~8 lines to 2-3, and auth is guaranteed by
+construction rather than by convention.
+
+For resolvers with custom error-code mappings (e.g. goal/wallet presenters),
+pass ``error_fn`` with a callable that receives the exception and raises a
+``GraphQLError``:
+
+    @graphql_error_adapter(WalletApplicationError, error_fn=raise_wallet_graphql_error)
+    def mutate(self, info, service, investment_id): ...
+"""
+
+from __future__ import annotations
+
+import functools
+from typing import Any, Callable, Type, TypeVar  # noqa: UP035
+from uuid import UUID
+
+from graphql import GraphQLError
+
+from app.graphql.errors import build_public_graphql_error, to_public_graphql_code
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def resolver_with_user_context(service_class: Any) -> Callable[[F], F]:
+    """Inject an authenticated service instance into a Graphene resolver.
+
+    The wrapped resolver receives ``service`` as the third positional argument
+    (after ``root`` and ``info``). ``get_current_user_required()`` is called
+    inside the wrapper, so the resolver body can skip the auth boilerplate.
+    """
+
+    def decorator(fn: F) -> F:
+        @functools.wraps(fn)
+        def wrapper(root: Any, info: Any, *args: Any, **kwargs: Any) -> Any:
+            from app.graphql.auth import get_current_user_required
+
+            user = get_current_user_required()
+            service = service_class.with_defaults(UUID(str(user.id)))
+            return fn(root, info, service, *args, **kwargs)
+
+        return wrapper  # type: ignore[return-value]
+
+    return decorator
+
+
+def graphql_error_adapter(
+    *exception_types: Type[Exception],
+    error_fn: Callable[[Any], None] | None = None,
+) -> Callable[[F], F]:
+    """Convert domain exceptions into ``GraphQLError`` instances.
+
+    Args:
+        *exception_types: Domain exception classes to intercept.
+        error_fn: Optional callable ``(exc) -> NoReturn`` for custom code-mapping
+            (e.g. ``raise_wallet_graphql_error``). When omitted, the adapter
+            calls ``build_public_graphql_error(exc.message, code=...)``.
+    """
+    exc_tuple = tuple(exception_types)
+
+    def decorator(fn: F) -> F:
+        @functools.wraps(fn)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            try:
+                return fn(*args, **kwargs)
+            except GraphQLError:
+                raise
+            except exc_tuple as exc:
+                if error_fn is not None:
+                    error_fn(exc)
+                message = getattr(exc, "message", str(exc))
+                code = getattr(exc, "code", "VALIDATION_ERROR") or "VALIDATION_ERROR"
+                raise build_public_graphql_error(
+                    message,
+                    code=to_public_graphql_code(code),
+                ) from exc
+
+        return wrapper  # type: ignore[return-value]
+
+    return decorator

--- a/app/graphql/mutations/goal.py
+++ b/app/graphql/mutations/goal.py
@@ -10,6 +10,7 @@ from app.application.services.goal_application_service import (
     GoalApplicationService,
 )
 from app.graphql.auth import get_current_user_required
+from app.graphql.decorators import graphql_error_adapter, resolver_with_user_context
 from app.graphql.enums import GoalStatusEnum, coerce_enum_kwargs
 from app.graphql.goal_presenters import (
     raise_goal_graphql_error,
@@ -87,13 +88,15 @@ class DeleteGoalMutation(graphene.Mutation):
     message = graphene.String(required=True)
 
     @log_graphql_resolver("deleteGoal")
-    def mutate(self, info: graphene.ResolveInfo, goal_id: UUID) -> "DeleteGoalMutation":
-        user = get_current_user_required()
-        service = GoalApplicationService.with_defaults(UUID(str(user.id)))
-        try:
-            service.delete_goal(goal_id)
-        except GoalApplicationError as exc:
-            raise_goal_graphql_error(exc)
+    @resolver_with_user_context(GoalApplicationService)
+    @graphql_error_adapter(GoalApplicationError, error_fn=raise_goal_graphql_error)
+    def mutate(
+        self,
+        info: graphene.ResolveInfo,
+        service: GoalApplicationService,
+        goal_id: UUID,
+    ) -> "DeleteGoalMutation":
+        service.delete_goal(goal_id)
         return DeleteGoalMutation(
             ok=True,
             message="Meta removida com sucesso",

--- a/app/graphql/mutations/transaction.py
+++ b/app/graphql/mutations/transaction.py
@@ -11,6 +11,7 @@ from app.application.services.transaction_application_service import (
 )
 from app.controllers.transaction.utils import _build_installment_amounts
 from app.graphql.auth import get_current_user_required
+from app.graphql.decorators import graphql_error_adapter, resolver_with_user_context
 from app.graphql.enums import (
     TransactionStatusEnum,
     TransactionTypeEnum,
@@ -85,18 +86,15 @@ class DeleteTransactionMutation(graphene.Mutation):
     message = graphene.String(required=True)
 
     @log_graphql_resolver("deleteTransaction")
+    @resolver_with_user_context(TransactionApplicationService)
+    @graphql_error_adapter(TransactionApplicationError)
     def mutate(
-        self, info: graphene.ResolveInfo, transaction_id: UUID
+        self,
+        info: graphene.ResolveInfo,
+        service: TransactionApplicationService,
+        transaction_id: UUID,
     ) -> "DeleteTransactionMutation":
-        user = get_current_user_required()
-        service = TransactionApplicationService.with_defaults(UUID(str(user.id)))
-        try:
-            service.delete_transaction(transaction_id)
-        except TransactionApplicationError as exc:
-            raise build_public_graphql_error(
-                exc.message,
-                code=to_public_graphql_code(exc.code),
-            ) from exc
+        service.delete_transaction(transaction_id)
         return DeleteTransactionMutation(
             ok=True, message="Transação deletada com sucesso (soft delete)."
         )

--- a/app/graphql/mutations/wallet.py
+++ b/app/graphql/mutations/wallet.py
@@ -11,6 +11,7 @@ from app.application.services.wallet_application_service import (
     WalletApplicationService,
 )
 from app.graphql.auth import get_current_user_required
+from app.graphql.decorators import graphql_error_adapter, resolver_with_user_context
 from app.graphql.enums import WalletAssetClassEnum, coerce_enum_kwargs
 from app.graphql.observability import log_graphql_resolver
 from app.graphql.scalars import DecimalScalar
@@ -106,20 +107,18 @@ class DeleteWalletEntryMutation(graphene.Mutation):
     message = graphene.String(required=True)
 
     @log_graphql_resolver("deleteWalletEntry")
+    @resolver_with_user_context(WalletApplicationService)
+    @graphql_error_adapter(WalletApplicationError, error_fn=raise_wallet_graphql_error)
     def mutate(
-        self, info: graphene.ResolveInfo, investment_id: UUID
+        self,
+        info: graphene.ResolveInfo,
+        service: WalletApplicationService,
+        investment_id: UUID,
     ) -> "DeleteWalletEntryMutation":
-        user = get_current_user_required()
-        service = WalletApplicationService.with_defaults(UUID(str(user.id)))
-        try:
-            service.delete_entry(
-                investment_id,
-                forbidden_message=(
-                    "Você não tem permissão para remover este investimento."
-                ),
-            )
-        except WalletApplicationError as exc:
-            raise_wallet_graphql_error(exc)
+        service.delete_entry(
+            investment_id,
+            forbidden_message="Você não tem permissão para remover este investimento.",
+        )
         return DeleteWalletEntryMutation(
             ok=True, message="Investimento removido com sucesso"
         )

--- a/tests/test_graphql_decorators.py
+++ b/tests/test_graphql_decorators.py
@@ -1,0 +1,222 @@
+"""Unit tests for app/graphql/decorators.py."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from graphql import GraphQLError
+
+from app.graphql.decorators import graphql_error_adapter, resolver_with_user_context
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeDomainError(Exception):
+    message: str
+    code: str
+
+
+class _FakeService:
+    def __init__(self, user_id: Any) -> None:
+        self.user_id = user_id
+
+    @classmethod
+    def with_defaults(cls, user_id: Any) -> "_FakeService":
+        return cls(user_id)
+
+    def do_thing(self, value: int) -> int:
+        return value * 2
+
+
+class _FakeUser:
+    def __init__(self) -> None:
+        self.id = "00000000-0000-0000-0000-000000000001"
+
+
+# ---------------------------------------------------------------------------
+# resolver_with_user_context
+# ---------------------------------------------------------------------------
+
+
+class TestResolverWithUserContext:
+    def test_injects_service_as_third_arg(self) -> None:
+        captured: list[Any] = []
+
+        @resolver_with_user_context(_FakeService)
+        def my_resolver(root: Any, info: Any, service: _FakeService) -> None:
+            captured.append(service)
+
+        fake_user = _FakeUser()
+        with patch(
+            "app.graphql.decorators.resolver_with_user_context.__wrapped__", create=True
+        ):
+            with patch(
+                "app.graphql.auth.get_current_user_required", return_value=fake_user
+            ):
+                my_resolver(None, MagicMock())
+
+        assert len(captured) == 1
+        assert isinstance(captured[0], _FakeService)
+
+    def test_passes_args_through(self) -> None:
+        received: list[Any] = []
+
+        @resolver_with_user_context(_FakeService)
+        def my_resolver(
+            root: Any, info: Any, service: _FakeService, x: int, y: str
+        ) -> None:
+            received.extend([x, y])
+
+        fake_user = _FakeUser()
+        with patch(
+            "app.graphql.auth.get_current_user_required", return_value=fake_user
+        ):
+            my_resolver(None, MagicMock(), 42, "hello")
+
+        assert received == [42, "hello"]
+
+    def test_raises_if_user_not_authenticated(self) -> None:
+        @resolver_with_user_context(_FakeService)
+        def my_resolver(root: Any, info: Any, service: _FakeService) -> None:
+            pass
+
+        with patch(
+            "app.graphql.auth.get_current_user_required",
+            side_effect=GraphQLError("Unauthorized"),
+        ):
+            with pytest.raises(GraphQLError):
+                my_resolver(None, MagicMock())
+
+    def test_service_user_id_is_set(self) -> None:
+        captured_service: list[_FakeService] = []
+
+        @resolver_with_user_context(_FakeService)
+        def my_resolver(root: Any, info: Any, service: _FakeService) -> None:
+            captured_service.append(service)
+
+        fake_user = _FakeUser()
+        with patch(
+            "app.graphql.auth.get_current_user_required", return_value=fake_user
+        ):
+            my_resolver(None, MagicMock())
+
+        from uuid import UUID
+
+        assert captured_service[0].user_id == UUID(fake_user.id)
+
+    def test_preserves_function_name(self) -> None:
+        @resolver_with_user_context(_FakeService)
+        def my_unique_resolver(root: Any, info: Any, service: _FakeService) -> None:
+            pass
+
+        assert my_unique_resolver.__name__ == "my_unique_resolver"
+
+
+# ---------------------------------------------------------------------------
+# graphql_error_adapter
+# ---------------------------------------------------------------------------
+
+
+class TestGraphQLErrorAdapter:
+    def test_passes_through_on_success(self) -> None:
+        @graphql_error_adapter(_FakeDomainError)
+        def my_fn() -> str:
+            return "ok"
+
+        assert my_fn() == "ok"
+
+    def test_converts_domain_exception(self) -> None:
+        @graphql_error_adapter(_FakeDomainError)
+        def my_fn() -> None:
+            raise _FakeDomainError(message="Something went wrong", code="NOT_FOUND")
+
+        with pytest.raises(GraphQLError) as exc_info:
+            my_fn()
+
+        # to_public_graphql_code maps NOT_FOUND to NOT_FOUND (known code)
+        assert exc_info.value.extensions is not None
+        assert exc_info.value.extensions.get("code") == "NOT_FOUND"
+
+    def test_unknown_code_maps_to_validation_error(self) -> None:
+        @graphql_error_adapter(_FakeDomainError)
+        def my_fn() -> None:
+            raise _FakeDomainError(message="oops", code="CUSTOM_UNKNOWN_CODE")
+
+        with pytest.raises(GraphQLError) as exc_info:
+            my_fn()
+
+        assert exc_info.value.extensions is not None
+        assert exc_info.value.extensions.get("code") == "VALIDATION_ERROR"
+
+    def test_does_not_catch_unregistered_exceptions(self) -> None:
+        @dataclass
+        class OtherError(Exception):
+            message: str
+
+        @graphql_error_adapter(_FakeDomainError)
+        def my_fn() -> None:
+            raise OtherError(message="unregistered")
+
+        with pytest.raises(OtherError):
+            my_fn()
+
+    def test_graphql_errors_pass_through_untouched(self) -> None:
+        original = GraphQLError("already a gql error")
+
+        @graphql_error_adapter(_FakeDomainError)
+        def my_fn() -> None:
+            raise original
+
+        with pytest.raises(GraphQLError) as exc_info:
+            my_fn()
+
+        assert exc_info.value is original
+
+    def test_custom_error_fn_is_called(self) -> None:
+        called_with: list[Any] = []
+
+        def my_error_fn(exc: _FakeDomainError) -> None:
+            called_with.append(exc)
+            raise GraphQLError("custom mapped error")
+
+        @graphql_error_adapter(_FakeDomainError, error_fn=my_error_fn)
+        def my_fn() -> None:
+            raise _FakeDomainError(message="domain problem", code="CONFLICT")
+
+        with pytest.raises(GraphQLError, match="custom mapped error"):
+            my_fn()
+
+        assert len(called_with) == 1
+        assert called_with[0].message == "domain problem"
+
+    def test_preserves_function_name(self) -> None:
+        @graphql_error_adapter(_FakeDomainError)
+        def my_unique_fn() -> None:
+            pass
+
+        assert my_unique_fn.__name__ == "my_unique_fn"
+
+    def test_multiple_exception_types(self) -> None:
+        @dataclass
+        class ErrorA(Exception):
+            message: str
+            code: str
+
+        @dataclass
+        class ErrorB(Exception):
+            message: str
+            code: str
+
+        @graphql_error_adapter(ErrorA, ErrorB)
+        def my_fn(exc_type: type) -> None:
+            raise exc_type(message="err", code="CONFLICT")
+
+        for exc_type in (ErrorA, ErrorB):
+            with pytest.raises(GraphQLError):
+                my_fn(exc_type)


### PR DESCRIPTION
## Summary

- **`app/graphql/decorators.py`** (new) — two composable decorators:
  - `@resolver_with_user_context(ServiceClass)`: calls `get_current_user_required()` and injects `service = ServiceClass.with_defaults(user_id)` as the third positional argument to any Graphene resolver
  - `@graphql_error_adapter(*exception_types, error_fn=None)`: catches registered domain exceptions and converts them to `GraphQLError` via `build_public_graphql_error`; accepts an optional `error_fn` for custom code-mapping (e.g. `raise_wallet_graphql_error`)
- **Pilot refactor** — 3 delete mutations use the new decorators: `deleteTransaction`, `deleteGoal`, `deleteWalletEntry`. Each `mutate` body shrinks from ~8 lines to 2 lines (service call + return).
- Full rollout to all remaining resolvers tracked as follow-up.

## Before / After

```python
# Before
def mutate(self, info, transaction_id):
    user = get_current_user_required()
    service = TransactionApplicationService.with_defaults(UUID(str(user.id)))
    try:
        service.delete_transaction(transaction_id)
    except TransactionApplicationError as exc:
        raise build_public_graphql_error(exc.message, code=...) from exc
    return DeleteTransactionMutation(ok=True, message="...")

# After
@resolver_with_user_context(TransactionApplicationService)
@graphql_error_adapter(TransactionApplicationError)
def mutate(self, info, service, transaction_id):
    service.delete_transaction(transaction_id)
    return DeleteTransactionMutation(ok=True, message="...")
```

## Test plan

- [x] 13 unit tests for both decorators (`tests/test_graphql_decorators.py`)
- [x] 58 auth-required tests still pass (decorator preserves auth enforcement)
- [x] 4 audit log tests pass (decorator preserves logging when composed with `@log_graphql_resolver`)
- [x] Full suite: 90.83% coverage (threshold: 85%)
- [x] `ruff check`, `ruff format`, `mypy`, `bandit` — all green

## Refs

Closes #1151
Part of umbrella #1157