### PR TITLE
feat(graphql): /graphql/playground — GraphiQL endpoint (feature-flagged, admin-only)

### DIFF
--- a/app/controllers/graphql/playground.py
+++ b/app/controllers/graphql/playground.py
@@ -1,0 +1,101 @@
+# ruff: noqa: E501
+"""GET /graphql/playground — embedded GraphiQL interface.
+
+Available only when the ``ENABLE_GRAPHQL_PLAYGROUND`` feature flag is enabled.
+Requires an authenticated request with the ``admin`` role.  Default: disabled.
+
+Intended for dev/staging only.  Do NOT enable in production.
+"""
+
+from __future__ import annotations
+
+from flask import Response, make_response, request
+
+from app.auth import get_active_auth_context
+from app.controllers.response_contract import compat_error_response
+from app.utils.feature_flags import is_feature_enabled
+
+_FLAG_KEY = "ENABLE_GRAPHQL_PLAYGROUND"
+
+_GRAPHIQL_HTML = """\
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>GraphiQL — Auraxis API</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/graphiql@3/graphiql.min.css" />
+  <style>
+    html, body, #graphiql {{ height: 100%; margin: 0; overflow: hidden; }}
+  </style>
+</head>
+<body>
+  <div id="graphiql">Loading GraphiQL…</div>
+  <script
+    crossorigin
+    src="https://cdn.jsdelivr.net/npm/react@18/umd/react.production.min.js"
+  ></script>
+  <script
+    crossorigin
+    src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.production.min.js"
+  ></script>
+  <script
+    crossorigin
+    src="https://cdn.jsdelivr.net/npm/graphiql@3/graphiql.min.js"
+  ></script>
+  <script>
+    const fetchURL = "{graphql_url}";
+    const fetcher = GraphiQL.createFetcher({{ url: fetchURL }});
+    ReactDOM.render(
+      React.createElement(GraphiQL, {{ fetcher: fetcher }}),
+      document.getElementById("graphiql")
+    );
+  </script>
+</body>
+</html>
+"""
+
+
+def _is_admin() -> bool:
+    try:
+        ctx = get_active_auth_context()
+        return "admin" in ctx.roles
+    except Exception:
+        return False
+
+
+def _not_found_response() -> Response:
+    return compat_error_response(
+        legacy_payload={"message": "Not Found", "success": False},
+        status_code=404,
+        message="Not Found",
+        error_code="NOT_FOUND",
+    )
+
+
+def _forbidden_response() -> Response:
+    return compat_error_response(
+        legacy_payload={"message": "Forbidden", "success": False},
+        status_code=403,
+        message="Forbidden",
+        error_code="FORBIDDEN",
+    )
+
+
+def graphql_playground() -> Response:
+    """Serve embedded GraphiQL when the feature flag is on and caller is admin."""
+    if not is_feature_enabled(_FLAG_KEY):
+        return _not_found_response()
+
+    auth_header = str(request.headers.get("Authorization", "")).strip()
+    if not auth_header.startswith("Bearer "):
+        return _forbidden_response()
+
+    if not _is_admin():
+        return _forbidden_response()
+
+    graphql_url = request.host_url.rstrip("/") + "/graphql"
+    html = _GRAPHIQL_HTML.format(graphql_url=graphql_url)
+    response = make_response(html)
+    response.content_type = "text/html; charset=utf-8"
+    return response

--- a/app/controllers/graphql/routes.py
+++ b/app/controllers/graphql/routes.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from .blueprint import graphql_bp
+from .playground import graphql_playground
 from .resources import execute_graphql
 
 _ROUTES_REGISTERED = False
@@ -14,6 +15,9 @@ def register_graphql_routes() -> None:
         return
 
     graphql_bp.add_url_rule("", view_func=execute_graphql, methods=["POST"])
+    graphql_bp.add_url_rule(
+        "/playground", view_func=graphql_playground, methods=["GET"]
+    )
     _ROUTES_REGISTERED = True
 
 

--- a/app/middleware/auth_guard.py
+++ b/app/middleware/auth_guard.py
@@ -24,6 +24,8 @@ def register_auth_guard(app: Flask) -> None:
             "resendconfirmationresource",
             "refreshtokenresource",
             "execute_graphql",
+            # Playground handles its own auth (feature flag + admin role check)
+            "graphql_playground",
             "static",
             "swaggerui.index",
             "swaggerui.static",

--- a/tests/test_graphql_playground.py
+++ b/tests/test_graphql_playground.py
@@ -1,0 +1,86 @@
+"""Tests for GET /graphql/playground endpoint."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+
+def _login(client: Any, *, prefix: str = "playground-tester") -> str:
+    import uuid
+
+    suffix = uuid.uuid4().hex[:8]
+    email = f"{prefix}-{suffix}@test.com"
+    password = "StrongPass@123"
+    r = client.post(
+        "/auth/register",
+        json={"name": f"{prefix}-{suffix}", "email": email, "password": password},
+    )
+    assert r.status_code == 201
+    r2 = client.post("/auth/login", json={"email": email, "password": password})
+    assert r2.status_code == 200
+    return str(r2.get_json()["token"])
+
+
+class TestGraphQLPlayground:
+    def test_returns_404_when_flag_disabled(self, client: Any) -> None:
+        with patch(
+            "app.controllers.graphql.playground.is_feature_enabled", return_value=False
+        ):
+            response = client.get("/graphql/playground")
+        assert response.status_code == 404
+
+    def test_returns_403_when_not_authenticated(self, client: Any) -> None:
+        with patch(
+            "app.controllers.graphql.playground.is_feature_enabled", return_value=True
+        ):
+            response = client.get("/graphql/playground")
+        assert response.status_code == 403
+
+    def test_returns_403_when_not_admin(self, client: Any) -> None:
+        token = _login(client)
+        with patch(
+            "app.controllers.graphql.playground.is_feature_enabled", return_value=True
+        ):
+            with patch(
+                "app.controllers.graphql.playground._is_admin", return_value=False
+            ):
+                response = client.get(
+                    "/graphql/playground",
+                    headers={"Authorization": f"Bearer {token}"},
+                )
+        assert response.status_code == 403
+
+    def test_returns_html_when_admin_and_flag_enabled(self, client: Any) -> None:
+        token = _login(client)
+        with patch(
+            "app.controllers.graphql.playground.is_feature_enabled", return_value=True
+        ):
+            with patch(
+                "app.controllers.graphql.playground._is_admin", return_value=True
+            ):
+                response = client.get(
+                    "/graphql/playground",
+                    headers={"Authorization": f"Bearer {token}"},
+                )
+        assert response.status_code == 200
+        assert response.content_type.startswith("text/html")
+        data = response.data.decode()
+        assert "graphiql" in data.lower()
+        assert "/graphql" in data
+
+    def test_playground_html_contains_expected_elements(self, client: Any) -> None:
+        token = _login(client)
+        with patch(
+            "app.controllers.graphql.playground.is_feature_enabled", return_value=True
+        ):
+            with patch(
+                "app.controllers.graphql.playground._is_admin", return_value=True
+            ):
+                response = client.get(
+                    "/graphql/playground",
+                    headers={"Authorization": f"Bearer {token}"},
+                )
+        html = response.data.decode()
+        assert "ReactDOM" in html or "graphiql" in html.lower()
+        assert "fetchURL" in html or "url" in html.lower() or "/graphql" in html

--- a/tests/test_postman_collection_contract.py
+++ b/tests/test_postman_collection_contract.py
@@ -116,6 +116,8 @@ OPENAPI_GAPS: set[tuple[str, str]] = {
     # GraphQL
     ("GET", "/graphql"),
     ("POST", "/graphql"),
+    # GraphiQL playground — admin-only HTML UI, not a REST API contract
+    ("GET", "/graphql/playground"),
     # Reminders CLI-only (no REST route)
     # Auth email routes (confirm/resend have REST but via different path convention)
     # Recurrence


### PR DESCRIPTION
## Summary

- `GET /graphql/playground` — serves an embedded GraphiQL 3 interface for interactive schema exploration
- **Feature flag**: `ENABLE_GRAPHQL_PLAYGROUND` (default: `false`). Returns 404 when disabled.
- **Auth**: requires admin JWT role. Returns 403 for anonymous or non-admin callers.
- Self-contained: renders via CDN bundles (React 18 + GraphiQL 3), no npm build step.
- Added `graphql_playground` to auth-guard open endpoints (handles auth internally).

## Security

- Disabled by default — safe to ship in production binary without risk
- Double-gated: feature flag AND admin role required
- No query logging or schema exposure when flag is off

## Test plan

- [x] 5 tests in `tests/test_graphql_playground.py`: flag-off → 404, unauthenticated → 403, non-admin → 403, admin + flag → 200 HTML with GraphiQL content
- [x] Full suite coverage: 85%+ (unchanged)
- [x] `ruff check`, `mypy`, `bandit` — all green

## Refs

Closes #1153
Part of umbrella #1157