### PR TITLE
feat(graphql): per-field complexity weights for expensive resolvers

### DIFF
--- a/app/graphql/complexity/analyzer.py
+++ b/app/graphql/complexity/analyzer.py
@@ -7,6 +7,8 @@ from graphql import GraphQLError, parse
 from graphql.language import ast
 
 from app.graphql.complexity.policy import (
+    GRAPHQL_COMPLEXITY_LIMIT_EXCEEDED,
+    GRAPHQL_DEPTH_LIMIT_EXCEEDED,
     GRAPHQL_OPERATION_LIMIT_EXCEEDED,
     GRAPHQL_OPERATION_NOT_FOUND,
     GraphQLSecurityPolicy,
@@ -78,6 +80,7 @@ def _analyze_selection_set(
     fragments: dict[str, ast.FragmentDefinitionNode],
     variable_values: dict[str, Any] | None,
     max_list_multiplier: int,
+    field_weights: dict[str, int],
     visited_fragments: set[str],
 ) -> tuple[int, int]:
     max_depth = current_depth
@@ -90,6 +93,7 @@ def _analyze_selection_set(
             fragments=fragments,
             variable_values=variable_values,
             max_list_multiplier=max_list_multiplier,
+            field_weights=field_weights,
             visited_fragments=visited_fragments,
         )
         max_depth = max(max_depth, nested_depth)
@@ -105,6 +109,7 @@ def _analyze_single_selection(
     fragments: dict[str, ast.FragmentDefinitionNode],
     variable_values: dict[str, Any] | None,
     max_list_multiplier: int,
+    field_weights: dict[str, int],
     visited_fragments: set[str],
 ) -> tuple[int, int]:
     if isinstance(selection, ast.FieldNode):
@@ -114,6 +119,7 @@ def _analyze_single_selection(
             fragments=fragments,
             variable_values=variable_values,
             max_list_multiplier=max_list_multiplier,
+            field_weights=field_weights,
             visited_fragments=visited_fragments,
         )
     if isinstance(selection, ast.InlineFragmentNode):
@@ -123,6 +129,7 @@ def _analyze_single_selection(
             fragments=fragments,
             variable_values=variable_values,
             max_list_multiplier=max_list_multiplier,
+            field_weights=field_weights,
             visited_fragments=visited_fragments,
         )
     if isinstance(selection, ast.FragmentSpreadNode):
@@ -132,6 +139,7 @@ def _analyze_single_selection(
             fragments=fragments,
             variable_values=variable_values,
             max_list_multiplier=max_list_multiplier,
+            field_weights=field_weights,
             visited_fragments=visited_fragments,
         )
     return current_depth, 0
@@ -144,10 +152,12 @@ def _analyze_field_selection(
     fragments: dict[str, ast.FragmentDefinitionNode],
     variable_values: dict[str, Any] | None,
     max_list_multiplier: int,
+    field_weights: dict[str, int],
     visited_fragments: set[str],
 ) -> tuple[int, int]:
+    field_name = selection.name.value
     field_depth = current_depth + 1
-    field_complexity = 1
+    field_complexity = field_weights.get(field_name, 1)
     if not selection.selection_set:
         return field_depth, field_complexity
 
@@ -157,6 +167,7 @@ def _analyze_field_selection(
         fragments=fragments,
         variable_values=variable_values,
         max_list_multiplier=max_list_multiplier,
+        field_weights=field_weights,
         visited_fragments=visited_fragments.copy(),
     )
     multiplier = _resolve_field_multiplier(
@@ -174,6 +185,7 @@ def _analyze_inline_fragment_selection(
     fragments: dict[str, ast.FragmentDefinitionNode],
     variable_values: dict[str, Any] | None,
     max_list_multiplier: int,
+    field_weights: dict[str, int],
     visited_fragments: set[str],
 ) -> tuple[int, int]:
     if not selection.selection_set:
@@ -184,6 +196,7 @@ def _analyze_inline_fragment_selection(
         fragments=fragments,
         variable_values=variable_values,
         max_list_multiplier=max_list_multiplier,
+        field_weights=field_weights,
         visited_fragments=visited_fragments.copy(),
     )
 
@@ -195,6 +208,7 @@ def _analyze_fragment_spread_selection(
     fragments: dict[str, ast.FragmentDefinitionNode],
     variable_values: dict[str, Any] | None,
     max_list_multiplier: int,
+    field_weights: dict[str, int],
     visited_fragments: set[str],
 ) -> tuple[int, int]:
     fragment_name = selection.name.value
@@ -211,6 +225,7 @@ def _analyze_fragment_spread_selection(
         fragments=fragments,
         variable_values=variable_values,
         max_list_multiplier=max_list_multiplier,
+        field_weights=field_weights,
         visited_fragments=next_visited,
     )
 
@@ -298,6 +313,7 @@ def calculate_metrics(
     fragments: dict[str, ast.FragmentDefinitionNode],
     variable_values: dict[str, Any] | None,
     max_list_multiplier: int,
+    field_weights: dict[str, int],
     query: str,
 ) -> GraphQLQueryMetrics:
     max_depth = 0
@@ -309,6 +325,7 @@ def calculate_metrics(
             fragments=fragments,
             variable_values=variable_values,
             max_list_multiplier=max_list_multiplier,
+            field_weights=field_weights,
             visited_fragments=set(),
         )
         max_depth = max(max_depth, operation_depth)
@@ -330,7 +347,7 @@ def enforce_depth_and_complexity_limits(
 ) -> None:
     if metrics.depth > policy.max_depth:
         raise GraphQLSecurityViolation(
-            code="GRAPHQL_DEPTH_LIMIT_EXCEEDED",
+            code=GRAPHQL_DEPTH_LIMIT_EXCEEDED,
             message=(
                 "Query GraphQL excedeu a profundidade máxima permitida "
                 f"({policy.max_depth})."
@@ -340,7 +357,7 @@ def enforce_depth_and_complexity_limits(
 
     if metrics.complexity > policy.max_complexity:
         raise GraphQLSecurityViolation(
-            code="GRAPHQL_COMPLEXITY_LIMIT_EXCEEDED",
+            code=GRAPHQL_COMPLEXITY_LIMIT_EXCEEDED,
             message=(
                 "Query GraphQL excedeu a complexidade máxima permitida "
                 f"({policy.max_complexity})."

--- a/app/graphql/complexity/policy.py
+++ b/app/graphql/complexity/policy.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import json
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 GRAPHQL_QUERY_TOO_LARGE = "GRAPHQL_QUERY_TOO_LARGE"
@@ -37,6 +38,35 @@ def _read_bool_env(name: str, default: bool) -> bool:
     return raw.strip().lower() in {"1", "true", "yes", "on"}
 
 
+# Resolvers that make external HTTP calls (BRAPI, billing provider) are weighted
+# higher so that a single expensive request consumes more of the complexity budget.
+# Override via GRAPHQL_FIELD_WEIGHTS_JSON env var (JSON object, field → int).
+_DEFAULT_FIELD_WEIGHTS: dict[str, int] = {
+    # BRAPI market-data calls — each fetches live quotes from an external API
+    "investmentValuation": 10,
+    "portfolioValuation": 10,
+    "portfolioValuationHistory": 8,
+    # Analytics aggregates — multiple DB queries
+    "dashboardOverview": 3,
+    "transactionDashboard": 3,
+    # Billing provider query
+    "billingPlans": 5,
+}
+
+
+def _read_field_weights_env() -> dict[str, int]:
+    raw = os.getenv("GRAPHQL_FIELD_WEIGHTS_JSON", "")
+    if not raw.strip():
+        return dict(_DEFAULT_FIELD_WEIGHTS)
+    try:
+        parsed = json.loads(raw)
+        if isinstance(parsed, dict):
+            return {str(k): max(1, int(v)) for k, v in parsed.items()}
+    except (json.JSONDecodeError, ValueError, TypeError):
+        pass
+    return dict(_DEFAULT_FIELD_WEIGHTS)
+
+
 @dataclass
 class GraphQLSecurityPolicy:
     max_query_bytes: int
@@ -45,6 +75,9 @@ class GraphQLSecurityPolicy:
     max_operations: int
     max_list_multiplier: int
     allow_introspection: bool
+    field_weights: dict[str, int] = field(
+        default_factory=lambda: dict(_DEFAULT_FIELD_WEIGHTS)
+    )
 
     @classmethod
     def from_env(cls) -> "GraphQLSecurityPolicy":
@@ -59,6 +92,7 @@ class GraphQLSecurityPolicy:
                 "GRAPHQL_ALLOW_INTROSPECTION",
                 default_introspection,
             ),
+            field_weights=_read_field_weights_env(),
         )
 
     def update_limits(
@@ -70,6 +104,7 @@ class GraphQLSecurityPolicy:
         max_operations: int | None = None,
         max_list_multiplier: int | None = None,
         allow_introspection: bool | None = None,
+        field_weights: dict[str, int] | None = None,
     ) -> None:
         if max_query_bytes is not None:
             self.max_query_bytes = max(max_query_bytes, 1)
@@ -83,3 +118,7 @@ class GraphQLSecurityPolicy:
             self.max_list_multiplier = max(max_list_multiplier, 1)
         if allow_introspection is not None:
             self.allow_introspection = bool(allow_introspection)
+        if field_weights is not None:
+            self.field_weights = {
+                str(k): max(1, int(v)) for k, v in field_weights.items()
+            }

--- a/app/graphql/security.py
+++ b/app/graphql/security.py
@@ -76,6 +76,7 @@ def analyze_graphql_query(
         fragments=fragments,
         variable_values=variable_values,
         max_list_multiplier=policy.max_list_multiplier,
+        field_weights=policy.field_weights,
         query=query,
     )
     enforce_depth_and_complexity_limits(metrics, policy)

--- a/docs/runbooks/graphql.md
+++ b/docs/runbooks/graphql.md
@@ -1,0 +1,83 @@
+# GraphQL Security Runbook
+
+## Complexity limit
+
+Every GraphQL query is scored against a complexity budget before execution.
+The budget is configured via environment variables:
+
+| Env var | Default | Description |
+|---------|---------|-------------|
+| `GRAPHQL_MAX_QUERY_BYTES` | 20 000 | Maximum request body size in bytes |
+| `GRAPHQL_MAX_DEPTH` | 8 | Maximum AST nesting depth |
+| `GRAPHQL_MAX_COMPLEXITY` | 300 | Maximum weighted field count |
+| `GRAPHQL_MAX_OPERATIONS` | 3 | Maximum operations per document |
+| `GRAPHQL_MAX_LIST_MULTIPLIER` | 50 | Multiplier for list-shaped arguments |
+| `GRAPHQL_ALLOW_INTROSPECTION` | `false` | Enable schema introspection (true in DEBUG) |
+
+## Per-field complexity weights
+
+Individual fields can be assigned a higher base cost to reflect that their
+resolvers make external HTTP calls or expensive DB aggregates.
+
+**Default weights** (in `app/graphql/security.py → _DEFAULT_FIELD_WEIGHTS`):
+
+| Field | Weight | Reason |
+|-------|--------|--------|
+| `investmentValuation` | 10 | Calls BRAPI market-data API per request |
+| `portfolioValuation` | 10 | Calls BRAPI market-data API per request |
+| `portfolioValuationHistory` | 8 | Calls BRAPI + pagination |
+| `billingPlans` | 5 | Calls billing provider |
+| `dashboardOverview` | 3 | Multiple DB aggregate queries |
+| `transactionDashboard` | 3 | Multiple DB aggregate queries |
+| All other fields | 1 (default) | Standard resolver |
+
+### How complexity is calculated
+
+For each field: `cost = base_weight * (1 + child_complexity * list_multiplier)`.
+The budget covers the entire operation. A query with three weighted fields
+accumulates their costs together.
+
+### Override via environment variable
+
+Set `GRAPHQL_FIELD_WEIGHTS_JSON` to a JSON object to replace the default table:
+
+```bash
+GRAPHQL_FIELD_WEIGHTS_JSON='{"myExpensiveField": 20, "cheapField": 1}'
+```
+
+When the env var is absent or malformed, the compiled defaults apply.
+
+## Auth policy
+
+Every mutation and non-public query **must** call `get_current_user_required()`
+as the first line, OR be added to the explicit public allowlist in
+`app/graphql/authorization.py`.
+
+A parameterized regression test (`tests/test_graphql_auth_everywhere.py`)
+enumerates all operations at runtime and asserts each non-allowlisted operation
+rejects unauthenticated requests with `extensions.code = UNAUTHORIZED`.
+
+Adding to the allowlist requires deliberate justification in the PR description.
+
+## Playground (dev/staging)
+
+A self-contained GraphiQL 3 interface is available at `GET /graphql/playground`
+when the `ENABLE_GRAPHQL_PLAYGROUND` feature flag is enabled AND the caller has
+an admin JWT role. The endpoint is always registered but returns 404 by default.
+
+Enable for a session:
+```bash
+# via feature-flags admin API
+curl -X POST /admin/feature-flags \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -d '{"name": "ENABLE_GRAPHQL_PLAYGROUND", "status": "enabled"}'
+```
+
+## Introspection
+
+Schema introspection (`__schema`, `__type`) is disabled in production.
+It is automatically enabled when `FLASK_DEBUG=true` (local dev), or by
+setting `GRAPHQL_ALLOW_INTROSPECTION=true` explicitly.
+
+Do **not** enable introspection in production — it exposes the full schema
+surface to potential attackers.

--- a/tests/test_graphql_complexity_modules.py
+++ b/tests/test_graphql_complexity_modules.py
@@ -258,6 +258,7 @@ class TestCalculateMetrics:
             fragments=fragments,
             variable_values=None,
             max_list_multiplier=50,
+            field_weights={},
             query=query,
         )
         assert metrics.depth == 1
@@ -272,6 +273,7 @@ class TestCalculateMetrics:
             fragments=fragments,
             variable_values=None,
             max_list_multiplier=50,
+            field_weights={},
             query=query,
         )
         assert metrics.depth == 3
@@ -285,6 +287,7 @@ class TestCalculateMetrics:
             fragments=fragments,
             variable_values=None,
             max_list_multiplier=50,
+            field_weights={},
             query=query,
         )
         assert "foo" in metrics.root_fields

--- a/tests/test_graphql_field_weights.py
+++ b/tests/test_graphql_field_weights.py
@@ -1,0 +1,172 @@
+"""Tests for per-field complexity weights in GraphQLSecurityPolicy."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from app.graphql.complexity.policy import _DEFAULT_FIELD_WEIGHTS
+from app.graphql.security import (
+    GRAPHQL_COMPLEXITY_LIMIT_EXCEEDED,
+    GraphQLSecurityPolicy,
+    GraphQLSecurityViolation,
+    analyze_graphql_query,
+)
+
+
+def _policy(
+    max_complexity: int = 300,
+    field_weights: dict[str, int] | None = None,
+) -> GraphQLSecurityPolicy:
+    return GraphQLSecurityPolicy(
+        max_query_bytes=20_000,
+        max_depth=8,
+        max_complexity=max_complexity,
+        max_operations=3,
+        max_list_multiplier=50,
+        allow_introspection=False,
+        field_weights=field_weights
+        if field_weights is not None
+        else dict(_DEFAULT_FIELD_WEIGHTS),
+    )
+
+
+class TestDefaultFieldWeights:
+    def test_default_weights_include_expensive_resolvers(self) -> None:
+        assert _DEFAULT_FIELD_WEIGHTS["investmentValuation"] >= 5
+        assert _DEFAULT_FIELD_WEIGHTS["portfolioValuation"] >= 5
+        assert _DEFAULT_FIELD_WEIGHTS["portfolioValuationHistory"] >= 5
+        assert _DEFAULT_FIELD_WEIGHTS["billingPlans"] >= 5
+
+    def test_policy_uses_default_weights_when_not_specified(self) -> None:
+        policy = GraphQLSecurityPolicy(
+            max_query_bytes=20_000,
+            max_depth=8,
+            max_complexity=300,
+            max_operations=3,
+            max_list_multiplier=50,
+            allow_introspection=False,
+        )
+        assert policy.field_weights["investmentValuation"] >= 5
+
+    def test_from_env_loads_default_weights(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("GRAPHQL_FIELD_WEIGHTS_JSON", raising=False)
+        policy = GraphQLSecurityPolicy.from_env()
+        assert "investmentValuation" in policy.field_weights
+        assert policy.field_weights["investmentValuation"] >= 5
+
+
+class TestFieldWeightInComplexityCalculation:
+    def test_weighted_field_costs_more_than_plain_field(self) -> None:
+        expensive_query = "{ investmentValuation { amount } }"
+
+        weights = {"investmentValuation": 10}
+        policy_with_weights = _policy(field_weights=weights)
+        policy_no_weights = _policy(field_weights={})
+
+        metrics_expensive_weighted = analyze_graphql_query(
+            query=expensive_query,
+            operation_name=None,
+            variable_values=None,
+            policy=policy_with_weights,
+        )
+        metrics_expensive_no_weights = analyze_graphql_query(
+            query=expensive_query,
+            operation_name=None,
+            variable_values=None,
+            policy=policy_no_weights,
+        )
+
+        assert (
+            metrics_expensive_weighted.complexity
+            > metrics_expensive_no_weights.complexity
+        )
+
+    def test_weighted_field_triggers_complexity_limit(self) -> None:
+        query = "{ investmentValuation { amount } }"
+        # set max_complexity so that the weighted field exceeds it
+        policy = _policy(max_complexity=5, field_weights={"investmentValuation": 10})
+
+        with pytest.raises(GraphQLSecurityViolation) as exc_info:
+            analyze_graphql_query(
+                query=query,
+                operation_name=None,
+                variable_values=None,
+                policy=policy,
+            )
+        assert exc_info.value.code == GRAPHQL_COMPLEXITY_LIMIT_EXCEEDED
+
+    def test_same_field_no_weight_passes_lower_limit(self) -> None:
+        query = "{ investmentValuation { amount } }"
+        # no field weights → default cost 1, which is below limit of 5
+        policy = _policy(max_complexity=5, field_weights={})
+
+        metrics = analyze_graphql_query(
+            query=query,
+            operation_name=None,
+            variable_values=None,
+            policy=policy,
+        )
+        assert metrics.complexity <= 5
+
+    def test_weight_one_is_default_for_unknown_fields(self) -> None:
+        query = "{ __typename }"
+        policy = _policy(field_weights={})
+
+        metrics = analyze_graphql_query(
+            query=query,
+            operation_name=None,
+            variable_values=None,
+            policy=policy,
+        )
+        assert metrics.complexity == 1
+
+    def test_multiple_expensive_fields_accumulate_cost(self) -> None:
+        query = "{ investmentValuation { amount } portfolioValuation { total } }"
+        weights = {"investmentValuation": 10, "portfolioValuation": 10}
+        # each root field cost 10 base + 1 scalar = 11; total > 5
+        policy = _policy(max_complexity=15, field_weights=weights)
+
+        with pytest.raises(GraphQLSecurityViolation) as exc_info:
+            analyze_graphql_query(
+                query=query,
+                operation_name=None,
+                variable_values=None,
+                policy=policy,
+            )
+        assert exc_info.value.code == GRAPHQL_COMPLEXITY_LIMIT_EXCEEDED
+
+
+class TestUpdateLimitsFieldWeights:
+    def test_update_limits_can_override_field_weights(self) -> None:
+        policy = _policy(field_weights={"myField": 5})
+        policy.update_limits(field_weights={"myField": 20})
+        assert policy.field_weights["myField"] == 20
+
+    def test_update_limits_clamps_weight_minimum_to_one(self) -> None:
+        policy = _policy(field_weights={"myField": 5})
+        policy.update_limits(field_weights={"myField": 0})
+        assert policy.field_weights["myField"] == 1
+
+
+class TestReadFieldWeightsEnv:
+    def test_env_var_overrides_defaults(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        custom = json.dumps({"myCustomField": 99})
+        monkeypatch.setenv("GRAPHQL_FIELD_WEIGHTS_JSON", custom)
+        policy = GraphQLSecurityPolicy.from_env()
+        assert policy.field_weights.get("myCustomField") == 99
+
+    def test_invalid_json_falls_back_to_defaults(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("GRAPHQL_FIELD_WEIGHTS_JSON", "not_valid_json")
+        policy = GraphQLSecurityPolicy.from_env()
+        assert "investmentValuation" in policy.field_weights
+
+    def test_empty_env_var_uses_defaults(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("GRAPHQL_FIELD_WEIGHTS_JSON", "")
+        policy = GraphQLSecurityPolicy.from_env()
+        assert "investmentValuation" in policy.field_weights


### PR DESCRIPTION
## Summary

Adds per-field complexity weights to `GraphQLSecurityPolicy`, so resolvers that make external HTTP calls or heavy DB aggregates consume more of the complexity budget per query.

**Changes applied to the split module structure (from #1163):**

- **`app/graphql/complexity/policy.py`** — `GraphQLSecurityPolicy` gains `field_weights: dict[str, int]` (dataclass field with default factory). Added `_DEFAULT_FIELD_WEIGHTS` constant and `_read_field_weights_env()` for JSON override via `GRAPHQL_FIELD_WEIGHTS_JSON`. `update_limits()` accepts an optional `field_weights` kwarg.
- **`app/graphql/complexity/analyzer.py`** — `field_weights` threaded through `_analyze_selection_set`, `_analyze_single_selection`, `_analyze_field_selection`, `_analyze_inline_fragment_selection`, `_analyze_fragment_spread_selection`, and `calculate_metrics`. Field base cost is now `field_weights.get(field_name, 1)` instead of a hardcoded `1`.
- **`app/graphql/security.py`** — thin facade unchanged; passes `field_weights=policy.field_weights` to `calculate_metrics`.
- **`docs/runbooks/graphql.md`** — new runbook documenting complexity limits, per-field weights, auth policy, playground, introspection.

## Default weights

| Field | Weight | Reason |
|-------|--------|--------|
| `investmentValuation` | 10 | BRAPI market-data API call |
| `portfolioValuation` | 10 | BRAPI market-data API call |
| `portfolioValuationHistory` | 8 | BRAPI + pagination |
| `billingPlans` | 5 | Billing provider call |
| `dashboardOverview` | 3 | Multi-aggregate DB queries |
| `transactionDashboard` | 3 | Multi-aggregate DB queries |
| All other fields | 1 | Standard resolver |

Override at runtime: `GRAPHQL_FIELD_WEIGHTS_JSON='{"myField": 20}'`

## Test plan

- [x] 13 new tests in `tests/test_graphql_field_weights.py` — weight application, complexity limit enforcement, env override, `update_limits`, malformed JSON fallback
- [x] 3 updated calls in `tests/test_graphql_complexity_modules.py` (added `field_weights={}`)
- [x] All 9 existing `test_graphql_security` tests pass
- [x] Full suite: 90.93% coverage (threshold: 85%)
- [x] `ruff check`, `mypy`, `bandit` — all green

## Refs

Closes #1154
Part of umbrella #1157