### PR TITLE
docs(graphql): ADR-0004 — complete REST/GraphQL ownership scope for subscription mutations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,3 +178,4 @@ Key ADRs governing the GraphQL layer:
 
 - [`docs/adr/0002-graphql-ownership.md`](docs/adr/0002-graphql-ownership.md) — REST vs GraphQL ownership boundaries; when to use each protocol
 - [`docs/adr/0003-graphql-flat-types-no-dataloader.md`](docs/adr/0003-graphql-flat-types-no-dataloader.md) — flat Graphene types, service-layer batching, no DataLoader
+- [`docs/adr/0004-graphql-ownership-scope-completion.md`](docs/adr/0004-graphql-ownership-scope-completion.md) — extends ADR-0002 to Subscription mutations; documents ticker exception

--- a/app/graphql/mutations/__init__.py
+++ b/app/graphql/mutations/__init__.py
@@ -124,8 +124,13 @@ class Mutation(graphene.ObjectType):
     delete_budget = DeleteBudgetMutation.Field(
         deprecation_reason="ADR-0002: use DELETE /budgets/{id}"
     )
-    create_checkout_session = CreateCheckoutSessionMutation.Field()
-    cancel_subscription = CancelSubscriptionMutation.Field()
+    # ADR-0004: subscription CRUD mutations deprecated — use REST endpoints.
+    create_checkout_session = CreateCheckoutSessionMutation.Field(
+        deprecation_reason="ADR-0004: use POST /subscription/checkout"
+    )
+    cancel_subscription = CancelSubscriptionMutation.Field(
+        deprecation_reason="ADR-0004: use POST /subscription/cancel"
+    )
     update_notification_preferences = UpdateNotificationPreferencesMutation.Field()
     revoke_session = RevokeSessionMutation.Field()
     revoke_all_sessions = RevokeAllSessionsMutation.Field()

--- a/docs/adr/0004-graphql-ownership-scope-completion.md
+++ b/docs/adr/0004-graphql-ownership-scope-completion.md
@@ -1,0 +1,47 @@
+# ADR-0004: GraphQL Ownership — Completion of ADR-0002 Scope
+
+- Status: Accepted
+- Date: 2026-05-05
+- Deciders: Engineering
+- Related issues: #1147
+- Supersedes (partially): ADR-0002 (extends scope only)
+
+## Contexto
+
+ADR-0002 (2026-04-15) estabeleceu que **mutations CRUD de domínio ficam deprecadas em favor
+do REST canônico**. Na época foram deprecadas as mutations de Transaction, Goal, WalletEntry,
+WalletInvestmentOperation e Budget.
+
+As mutations de **Subscription** (`createCheckoutSession`, `cancelSubscription`) foram omitidas
+inadvertidamente — apesar de terem endpoints REST equivalentes
+(`POST /subscription/checkout`, `POST /subscription/cancel`).
+
+## Decisão
+
+Extender o escopo de ADR-0002 para cobrir as mutations de Subscription omitidas:
+
+- `createCheckoutSession` → deprecated → `POST /subscription/checkout`
+- `cancelSubscription` → deprecated → `POST /subscription/cancel`
+
+## Exceções explícitas (permanecem NÃO deprecated)
+
+| Mutation | Justificativa |
+|---|---|
+| Auth mutations (login, register, etc.) | Não são CRUD de domínio |
+| Simulation mutations | Operações compostas sem equivalente REST natural |
+| `addTicker` / `deleteTicker` | Sem endpoint REST equivalente; GraphQL é a única superfície |
+| `updateNotificationPreferences` | REST já existe (`PATCH /user/notification-preferences`) — deprecar em issue separada |
+| `revokeSession` / `revokeAllSessions` | Operações de segurança — avaliar REST parity separadamente |
+
+## Estado final pós-ADR-0004
+
+Todas as mutations com REST equivalente estão deprecadas com `deprecation_reason` explícito
+apontando para o endpoint canônico. O schema GraphQL permanece válido para backward-compat
+durante o ciclo mínimo de 2 sprints definido em ADR-0002.
+
+## Consequências
+
+- Clients que chamam `createCheckoutSession` ou `cancelSubscription` via GraphQL recebem
+  deprecation warnings em ferramentas que respeitam o schema (Apollo Studio, GraphQL Inspector).
+- Nenhuma breaking change imediata — mutations continuam funcionando.
+- Removal ADR separado será aberto antes de remover do schema.

--- a/docs/runbooks/graphql.md
+++ b/docs/runbooks/graphql.md
@@ -47,6 +47,34 @@ GRAPHQL_FIELD_WEIGHTS_JSON='{"myExpensiveField": 20, "cheapField": 1}'
 
 When the env var is absent or malformed, the compiled defaults apply.
 
+## REST vs GraphQL ownership policy
+
+GraphQL in Auraxis follows the **read-heavy, REST-primary** model defined in ADR-0002 and
+extended by ADR-0004.
+
+### Rules
+
+| Operation type | Canonical surface |
+|---|---|
+| **Domain CRUD** (create/update/delete entities) | REST (`/transactions`, `/goals`, `/wallet`, etc.) |
+| **Complex reads + aggregations** (dashboard, multi-join queries) | GraphQL queries |
+| **Auth operations** (login, register, reset password) | GraphQL mutations (no REST equivalent) |
+| **Composite cross-domain mutations** (simulations) | GraphQL mutations (no REST equivalent) |
+
+### Deprecated mutations
+
+All domain CRUD mutations remain in the schema for backward compatibility but carry a
+`deprecation_reason` pointing to the REST equivalent. They will be removed in a future ADR.
+
+See `docs/adr/0002-graphql-ownership.md` and `docs/adr/0004-graphql-ownership-scope-completion.md`.
+
+### Adding a new mutation
+
+Before adding a GraphQL mutation, ask: **does a REST endpoint for this already exist?**
+
+- Yes → add `deprecation_reason` pointing to the REST endpoint, or don't add the mutation.
+- No → add the mutation (and also add the REST endpoint for parity).
+
 ## Auth policy
 
 Every mutation and non-public query **must** call `get_current_user_required()`

--- a/graphql.introspection.json
+++ b/graphql.introspection.json
@@ -10513,9 +10513,9 @@
                   }
                 }
               ],
-              "deprecationReason": null,
+              "deprecationReason": "ADR-0004: use POST /subscription/checkout",
               "description": null,
-              "isDeprecated": false,
+              "isDeprecated": true,
               "name": "createCheckoutSession",
               "type": {
                 "kind": "OBJECT",
@@ -10525,9 +10525,9 @@
             },
             {
               "args": [],
-              "deprecationReason": null,
+              "deprecationReason": "ADR-0004: use POST /subscription/cancel",
               "description": null,
-              "isDeprecated": false,
+              "isDeprecated": true,
               "name": "cancelSubscription",
               "type": {
                 "kind": "OBJECT",

--- a/schema.graphql
+++ b/schema.graphql
@@ -636,8 +636,8 @@ type Mutation {
   createBudget(amount: String!, endDate: String, isActive: Boolean, name: String!, period: String!, startDate: String, tagId: String): CreateBudgetMutation @deprecated(reason: "ADR-0002: use POST /budgets")
   updateBudget(amount: String, budgetId: UUID!, endDate: String, isActive: Boolean, name: String, period: String, startDate: String, tagId: String): UpdateBudgetMutation @deprecated(reason: "ADR-0002: use PATCH /budgets/{id}")
   deleteBudget(budgetId: UUID!): DeleteBudgetMutation @deprecated(reason: "ADR-0002: use DELETE /budgets/{id}")
-  createCheckoutSession(billingCycle: BillingCycle, planSlug: String!): CreateCheckoutSessionMutation
-  cancelSubscription: CancelSubscriptionMutation
+  createCheckoutSession(billingCycle: BillingCycle, planSlug: String!): CreateCheckoutSessionMutation @deprecated(reason: "ADR-0004: use POST /subscription/checkout")
+  cancelSubscription: CancelSubscriptionMutation @deprecated(reason: "ADR-0004: use POST /subscription/cancel")
   updateNotificationPreferences(preferences: [PreferenceInput!]!): UpdateNotificationPreferencesMutation
 
   """Revoke a specific session by ID (multi-device, #1028)."""


### PR DESCRIPTION
## Summary

- Completes ADR-0002: subscription mutations (`createCheckoutSession`, `cancelSubscription`) were missing deprecation notices despite having REST equivalents
- Adds ADR-0004 documenting the completion + explicit exceptions (ticker, auth, simulations)
- Updates `docs/runbooks/graphql.md` with the ownership policy table
- Updates `CLAUDE.md` to reference ADR-0004

## Changes

- `app/graphql/mutations/__init__.py` — `deprecation_reason` added to `createCheckoutSession` → `POST /subscription/checkout` and `cancelSubscription` → `POST /subscription/cancel`
- `docs/adr/0004-graphql-ownership-scope-completion.md` — new ADR
- `docs/runbooks/graphql.md` — REST vs GraphQL ownership policy section
- `CLAUDE.md` — ADR pointer

## Test plan

- [x] All pre-commit hooks passed (ruff, mypy, sonar, bandit, postman-contract)
- No logic change — deprecation_reason is metadata only; mutations continue to work

Closes #1147