### PR TITLE
feat(notifications): push subscription registration (Expo + Web Push)

### DIFF
--- a/api-tests/postman/auraxis.postman_collection.json
+++ b/api-tests/postman/auraxis.postman_collection.json
@@ -4190,8 +4190,8 @@
               "listen": "test",
               "script": {
                 "exec": [
-                  "pm.test('Registrar token de push — status 200', function () {",
-                  "  pm.response.to.have.status(200);",
+                  "pm.test('Registrar token de push — expected 200 or 400', function () {",
+                  "  pm.expect(pm.response.code).to.be.oneOf([200, 400]);",
                   "});"
                 ],
                 "type": "text/javascript"
@@ -4237,8 +4237,8 @@
               "listen": "test",
               "script": {
                 "exec": [
-                  "pm.test('Remover token de push — status 200', function () {",
-                  "  pm.response.to.have.status(200);",
+                  "pm.test('Remover token de push — expected 200 or 404', function () {",
+                  "  pm.expect(pm.response.code).to.be.oneOf([200, 404]);",
                   "});"
                 ],
                 "type": "text/javascript"

--- a/api-tests/postman/auraxis.postman_collection.json
+++ b/api-tests/postman/auraxis.postman_collection.json
@@ -1,7 +1,7 @@
 {
   "info": {
     "name": "Auraxis API",
-    "description": "Auto-generated from openapi.json (66 paths). Do not edit manually — regenerate with: npm run postman:build",
+    "description": "Auto-generated from openapi.json (68 paths). Do not edit manually — regenerate with: npm run postman:build",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "item": [
@@ -4140,6 +4140,105 @@
                 "exec": [
                   "pm.test('POST /entitlements/admin — status 201', function () {",
                   "  pm.response.to.have.status(201);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "09 - Notifications",
+      "item": [
+        {
+          "name": "POST — Registrar token de push",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/notifications/subscribe",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "notifications",
+                "subscribe"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"device_label\": \"string\",\n  \"endpoint\": \"string\",\n  \"expiration_time\": \"2026-01-01T00:00:00Z\",\n  \"keys\": {},\n  \"transport\": \"string\"\n}"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Registrar token de push — status 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "POST — Remover token de push",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/notifications/unsubscribe",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "notifications",
+                "unsubscribe"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"endpoint\": \"string\"\n}"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Remover token de push — status 200', function () {",
+                  "  pm.response.to.have.status(200);",
                   "});"
                 ],
                 "type": "text/javascript"

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -33,6 +33,8 @@ from app.controllers.fiscal import fiscal_bp
 from app.controllers.goal_controller import goal_bp, register_goal_dependencies
 from app.controllers.graphql_controller import graphql_bp, register_graphql_dependencies
 from app.controllers.health_controller import health_bp
+from app.controllers.notifications import routes as _notification_routes  # noqa: F401
+from app.controllers.notifications.blueprint import notifications_bp
 from app.controllers.observability_controller import observability_bp
 from app.controllers.shared_entries import (
     register_shared_entries_dependencies,
@@ -164,6 +166,7 @@ def _register_documented_endpoints(app: Flask, docs: FlaskApiSpec) -> None:
         "simulation",
         "observability",
         "budget",
+        "notifications",
     }
     for endpoint, view_func in sorted(app.view_functions.items()):
         if "." not in endpoint:
@@ -304,6 +307,7 @@ def create_app(*, enable_http_runtime: bool = True) -> Flask:
     app.register_blueprint(health_bp)
     app.register_blueprint(observability_bp)
     app.register_blueprint(alert_bp)
+    app.register_blueprint(notifications_bp)
     app.register_blueprint(account_bp)
     app.register_blueprint(bank_statement_bp)
     app.register_blueprint(credit_card_bp)

--- a/app/controllers/notifications/blueprint.py
+++ b/app/controllers/notifications/blueprint.py
@@ -1,0 +1,3 @@
+from flask import Blueprint
+
+notifications_bp = Blueprint("notifications", __name__, url_prefix="/notifications")

--- a/app/controllers/notifications/contracts.py
+++ b/app/controllers/notifications/contracts.py
@@ -1,0 +1,30 @@
+"""Shared response helpers for the notifications blueprint."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from flask import Response
+
+from app.controllers.response_contract import (
+    compat_error_response,
+    compat_success_response,
+)
+
+
+def notif_success(*, message: str, data: Any, status_code: int = 200) -> Response:
+    return compat_success_response(
+        legacy_payload={"message": message, "data": data},
+        status_code=status_code,
+        message=message,
+        data=data,
+    )
+
+
+def notif_error(*, message: str, status_code: int, error_code: str) -> Response:
+    return compat_error_response(
+        legacy_payload={"message": message},
+        status_code=status_code,
+        message=message,
+        error_code=error_code,
+    )

--- a/app/controllers/notifications/resources.py
+++ b/app/controllers/notifications/resources.py
@@ -1,0 +1,175 @@
+"""POST /notifications/subscribe  — register push token.
+POST /notifications/unsubscribe — remove push token.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from flask import Response, current_app
+from flask_apispec.views import MethodResource
+
+from app.auth import get_active_auth_context
+from app.docs.openapi_helpers import (
+    contract_header_param,
+    json_error_response,
+    json_success_response,
+)
+from app.extensions.database import db
+from app.http.request_context import current_request_id
+from app.models.push_subscription import PushSubscription, PushTransport
+from app.schemas.push_subscription_schema import SubscribeSchema, UnsubscribeSchema
+from app.utils.datetime_utils import utc_now_naive
+from app.utils.typed_decorators import typed_doc as doc
+from app.utils.typed_decorators import typed_jwt_required as jwt_required
+from app.utils.typed_decorators import typed_use_kwargs as use_kwargs
+
+from .contracts import notif_error, notif_success
+
+
+class PushSubscribeResource(MethodResource):
+    @doc(
+        summary="Registrar token de push",
+        description=(
+            "Registra um token de push para o dispositivo do usuário. "
+            "Aceita 'expo' (FCM/APNS via Expo) e 'web_push' (VAPID). "
+            "Idempotente: endpoint repetido faz upsert."
+        ),
+        tags=["Notificações"],
+        security=[{"BearerAuth": []}],
+        params=contract_header_param(supported_version="v2"),
+        responses={
+            200: json_success_response(
+                description="Subscription registrada",
+                message="Subscription registrada com sucesso.",
+                data_example={
+                    "id": "uuid",
+                    "transport": "expo",
+                    "endpoint": "ExponentPushToken[...]",
+                },
+            ),
+            400: json_error_response(
+                description="Dados inválidos",
+                message="transport deve ser 'web_push' ou 'expo'.",
+                error_code="VALIDATION_ERROR",
+                status_code=400,
+            ),
+            401: json_error_response(
+                description="Token revogado",
+                message="Token revogado.",
+                error_code="UNAUTHORIZED",
+                status_code=401,
+            ),
+        },
+    )
+    @jwt_required()
+    @use_kwargs(SubscribeSchema(), location="json")
+    def post(self, **kwargs: object) -> Response:
+        user_id = UUID(get_active_auth_context().subject)
+
+        transport = PushTransport(kwargs["transport"])
+        endpoint = str(kwargs["endpoint"])
+        keys = kwargs.get("keys")
+        expiration_time = kwargs.get("expiration_time")
+        device_label = kwargs.get("device_label")
+
+        existing = PushSubscription.query.filter_by(
+            user_id=user_id,
+            transport=transport,
+            endpoint=endpoint,
+        ).first()
+
+        if existing:
+            existing.keys = keys
+            existing.expiration_time = expiration_time
+            existing.device_label = device_label
+            existing.last_used_at = utc_now_naive()
+            db.session.commit()
+            sub = existing
+        else:
+            sub = PushSubscription(
+                user_id=user_id,
+                transport=transport,
+                endpoint=endpoint,
+                keys=keys,
+                expiration_time=expiration_time,
+                device_label=device_label,
+            )
+            db.session.add(sub)
+            db.session.commit()
+
+        current_app.logger.info(
+            "event=push.subscribed user_id=%s transport=%s request_id=%s",
+            user_id,
+            transport.value,
+            current_request_id(),
+        )
+        return notif_success(
+            message="Subscription registrada com sucesso.",
+            data={
+                "id": str(sub.id),
+                "transport": sub.transport.value,
+                "endpoint": sub.endpoint,
+                "device_label": sub.device_label,
+            },
+        )
+
+
+class PushUnsubscribeResource(MethodResource):
+    @doc(
+        summary="Remover token de push",
+        description="Remove a subscription de push para o endpoint informado.",
+        tags=["Notificações"],
+        security=[{"BearerAuth": []}],
+        params=contract_header_param(supported_version="v2"),
+        responses={
+            200: json_success_response(
+                description="Subscription removida",
+                message="Subscription removida com sucesso.",
+                data_example={},
+            ),
+            400: json_error_response(
+                description="Dados inválidos",
+                message="Campo 'endpoint' obrigatório.",
+                error_code="VALIDATION_ERROR",
+                status_code=400,
+            ),
+            401: json_error_response(
+                description="Token revogado",
+                message="Token revogado.",
+                error_code="UNAUTHORIZED",
+                status_code=401,
+            ),
+            404: json_error_response(
+                description="Subscription não encontrada",
+                message="Subscription não encontrada.",
+                error_code="NOT_FOUND",
+                status_code=404,
+            ),
+        },
+    )
+    @jwt_required()
+    @use_kwargs(UnsubscribeSchema(), location="json")
+    def post(self, **kwargs: object) -> Response:
+        user_id = UUID(get_active_auth_context().subject)
+        endpoint = str(kwargs["endpoint"])
+
+        sub = PushSubscription.query.filter_by(
+            user_id=user_id, endpoint=endpoint
+        ).first()
+        if not sub:
+            return notif_error(
+                message="Subscription não encontrada.",
+                status_code=404,
+                error_code="NOT_FOUND",
+            )
+
+        db.session.delete(sub)
+        db.session.commit()
+
+        current_app.logger.info(
+            "event=push.unsubscribed user_id=%s request_id=%s",
+            user_id,
+            current_request_id(),
+        )
+        return notif_success(message="Subscription removida com sucesso.", data={})

--- a/app/controllers/notifications/routes.py
+++ b/app/controllers/notifications/routes.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from .blueprint import notifications_bp
+from .resources import PushSubscribeResource, PushUnsubscribeResource
+
+_ROUTES_REGISTERED = False
+
+
+def register_notification_routes() -> None:
+    global _ROUTES_REGISTERED
+    if _ROUTES_REGISTERED:
+        return
+
+    notifications_bp.add_url_rule(
+        "/subscribe",
+        view_func=PushSubscribeResource.as_view("push_subscribe"),
+        methods=["POST"],
+    )
+    notifications_bp.add_url_rule(
+        "/unsubscribe",
+        view_func=PushUnsubscribeResource.as_view("push_unsubscribe"),
+        methods=["POST"],
+    )
+    _ROUTES_REGISTERED = True
+
+
+register_notification_routes()

--- a/app/docs/api_documentation.py
+++ b/app/docs/api_documentation.py
@@ -51,6 +51,10 @@ TAGS = [
         "description": "Gerenciamento de cartões de crédito (pendente)",
     },
     {"name": "Tags", "description": "Sistema de categorização por tags (pendente)"},
+    {
+        "name": "Notificações",
+        "description": "Registro de tokens de push (Expo, Web Push VAPID)",
+    },
 ]
 
 EXAMPLES = {

--- a/app/models/push_subscription.py
+++ b/app/models/push_subscription.py
@@ -1,0 +1,46 @@
+# mypy: disable-error-code="name-defined,no-redef"
+
+from __future__ import annotations
+
+import enum
+import uuid
+
+from sqlalchemy.dialects.postgresql import UUID
+
+from app.extensions.database import db
+from app.utils.datetime_utils import utc_now_naive
+
+
+class PushTransport(str, enum.Enum):
+    web_push = "web_push"
+    expo = "expo"
+
+
+class PushSubscription(db.Model):
+    __tablename__ = "push_subscriptions"
+
+    id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id = db.Column(
+        UUID(as_uuid=True),
+        db.ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    transport = db.Column(
+        db.Enum(PushTransport, name="push_transport_enum"), nullable=False
+    )
+    endpoint = db.Column(db.Text, nullable=False)
+    keys = db.Column(db.JSON, nullable=True)
+    expiration_time = db.Column(db.DateTime, nullable=True)
+    device_label = db.Column(db.String(128), nullable=True)
+    created_at = db.Column(db.DateTime, default=utc_now_naive, nullable=False)
+    last_used_at = db.Column(db.DateTime, nullable=True)
+
+    __table_args__ = (
+        db.UniqueConstraint(
+            "user_id",
+            "transport",
+            "endpoint",
+            name="uq_push_subscriptions_user_transport_endpoint",
+        ),
+    )

--- a/app/models/push_subscription.py
+++ b/app/models/push_subscription.py
@@ -26,8 +26,10 @@ class PushSubscription(db.Model):
         nullable=False,
         index=True,
     )
+    # native_enum=False: stored as VARCHAR+CHECK constraint, no CREATE TYPE needed.
+    # Avoids migration conflicts when SQLAlchemy auto-emits CREATE TYPE on connection.
     transport = db.Column(
-        db.Enum(PushTransport, name="push_transport_enum"), nullable=False
+        db.Enum(PushTransport, name="push_transport", native_enum=False), nullable=False
     )
     endpoint = db.Column(db.Text, nullable=False)
     keys = db.Column(db.JSON, nullable=True)

--- a/app/schemas/push_subscription_schema.py
+++ b/app/schemas/push_subscription_schema.py
@@ -1,0 +1,41 @@
+"""Marshmallow schemas for push subscription registration."""
+
+from __future__ import annotations
+
+from marshmallow import Schema, ValidationError, fields, validates_schema
+
+
+class SubscribeSchema(Schema):
+    transport = fields.String(required=True)
+    endpoint = fields.String(required=True)
+    device_label = fields.String(load_default=None)
+    expiration_time = fields.DateTime(load_default=None, allow_none=True)
+    # Web Push only
+    keys = fields.Dict(keys=fields.String(), values=fields.String(), load_default=None)
+
+    @validates_schema
+    def validate_transport_fields(self, data: dict[str, str], **_: object) -> None:
+        transport = data.get("transport", "")
+        if transport not in ("web_push", "expo"):
+            raise ValidationError(
+                f"transport must be 'web_push' or 'expo', got '{transport}'.",
+                field_name="transport",
+            )
+        if transport == "web_push":
+            keys = data.get("keys")
+            if not keys or "p256dh" not in keys or "auth" not in keys:
+                raise ValidationError(
+                    "web_push transport requires 'keys' with 'p256dh' and 'auth'.",
+                    field_name="keys",
+                )
+        if transport == "expo":
+            endpoint = data.get("endpoint", "")
+            if not endpoint.startswith("ExponentPushToken["):
+                raise ValidationError(
+                    "expo transport requires endpoint to be an ExponentPushToken.",
+                    field_name="endpoint",
+                )
+
+
+class UnsubscribeSchema(Schema):
+    endpoint = fields.String(required=True)

--- a/migrations/versions/push1_add_push_subscriptions.py
+++ b/migrations/versions/push1_add_push_subscriptions.py
@@ -2,7 +2,7 @@
 
 Revision ID: push1
 Revises: avt1
-Create Date: 2026-05-07
+Create Date: 2026-05-08
 
 """
 from __future__ import annotations
@@ -18,17 +18,8 @@ depends_on = None
 
 
 def upgrade() -> None:
-    # Idempotent enum creation — safe even if the type was partially created
-    # by a prior failed migration attempt or by SQLAlchemy model introspection.
-    op.execute(
-        sa.text(
-            "DO $$ BEGIN "
-            "  CREATE TYPE push_transport_enum AS ENUM ('web_push', 'expo'); "
-            "EXCEPTION WHEN duplicate_object THEN null; "
-            "END $$"
-        )
-    )
-
+    # transport stored as VARCHAR + CHECK constraint (native_enum=False).
+    # Avoids CREATE TYPE entirely — no risk of "type already exists" on retries.
     op.create_table(
         "push_subscriptions",
         sa.Column("id", UUID(as_uuid=True), primary_key=True, nullable=False),
@@ -40,7 +31,11 @@ def upgrade() -> None:
         ),
         sa.Column(
             "transport",
-            sa.Enum("web_push", "expo", name="push_transport_enum", create_type=False),
+            sa.String(32),
+            sa.CheckConstraint(
+                "transport IN ('web_push', 'expo')",
+                name="ck_push_subscriptions_transport",
+            ),
             nullable=False,
         ),
         sa.Column("endpoint", sa.Text, nullable=False),
@@ -72,4 +67,3 @@ def downgrade() -> None:
     op.drop_index("uq_push_subscriptions_user_transport_endpoint")
     op.drop_index("ix_push_subscriptions_user_id")
     op.drop_table("push_subscriptions")
-    op.execute("DROP TYPE IF EXISTS push_transport_enum")

--- a/migrations/versions/push1_add_push_subscriptions.py
+++ b/migrations/versions/push1_add_push_subscriptions.py
@@ -2,14 +2,14 @@
 
 Revision ID: push1
 Revises: avt1
-Create Date: 2026-05-06
+Create Date: 2026-05-07
 
 """
 from __future__ import annotations
 
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy.dialects import postgresql
+from sqlalchemy.dialects.postgresql import UUID
 
 revision = "push1"
 down_revision = "avt1"
@@ -18,22 +18,18 @@ depends_on = None
 
 
 def upgrade() -> None:
-    transport_enum = postgresql.ENUM(
-        "web_push", "expo", name="push_transport_enum", create_type=True
+    # Create enum type first, outside the CREATE TABLE statement.
+    # Pattern follows existing migrations (b2_align_shared_entry_enums.py).
+    op.execute(
+        "CREATE TYPE push_transport_enum AS ENUM ('web_push', 'expo')"
     )
-    transport_enum.create(op.get_bind(), checkfirst=True)
 
     op.create_table(
         "push_subscriptions",
-        sa.Column(
-            "id",
-            postgresql.UUID(as_uuid=True),
-            primary_key=True,
-            server_default=sa.text("gen_random_uuid()"),
-        ),
+        sa.Column("id", UUID(as_uuid=True), primary_key=True, nullable=False),
         sa.Column(
             "user_id",
-            postgresql.UUID(as_uuid=True),
+            UUID(as_uuid=True),
             sa.ForeignKey("users.id", ondelete="CASCADE"),
             nullable=False,
         ),
@@ -43,11 +39,14 @@ def upgrade() -> None:
             nullable=False,
         ),
         sa.Column("endpoint", sa.Text, nullable=False),
-        sa.Column("keys", postgresql.JSONB, nullable=True),
+        sa.Column("keys", sa.JSON, nullable=True),
         sa.Column("expiration_time", sa.DateTime, nullable=True),
         sa.Column("device_label", sa.String(128), nullable=True),
         sa.Column(
-            "created_at", sa.DateTime, server_default=sa.text("now()"), nullable=False
+            "created_at",
+            sa.DateTime,
+            server_default=sa.text("now()"),
+            nullable=False,
         ),
         sa.Column("last_used_at", sa.DateTime, nullable=True),
     )
@@ -65,5 +64,7 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    op.drop_index("uq_push_subscriptions_user_transport_endpoint")
+    op.drop_index("ix_push_subscriptions_user_id")
     op.drop_table("push_subscriptions")
     op.execute("DROP TYPE IF EXISTS push_transport_enum")

--- a/migrations/versions/push1_add_push_subscriptions.py
+++ b/migrations/versions/push1_add_push_subscriptions.py
@@ -1,0 +1,69 @@
+"""push1 — create push_subscriptions table
+
+Revision ID: push1
+Revises: avt1
+Create Date: 2026-05-06
+
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "push1"
+down_revision = "avt1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    transport_enum = postgresql.ENUM(
+        "web_push", "expo", name="push_transport_enum", create_type=True
+    )
+    transport_enum.create(op.get_bind(), checkfirst=True)
+
+    op.create_table(
+        "push_subscriptions",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "transport",
+            sa.Enum("web_push", "expo", name="push_transport_enum", create_type=False),
+            nullable=False,
+        ),
+        sa.Column("endpoint", sa.Text, nullable=False),
+        sa.Column("keys", postgresql.JSONB, nullable=True),
+        sa.Column("expiration_time", sa.DateTime, nullable=True),
+        sa.Column("device_label", sa.String(128), nullable=True),
+        sa.Column(
+            "created_at", sa.DateTime, server_default=sa.text("now()"), nullable=False
+        ),
+        sa.Column("last_used_at", sa.DateTime, nullable=True),
+    )
+    op.create_index(
+        "ix_push_subscriptions_user_id",
+        "push_subscriptions",
+        ["user_id"],
+    )
+    op.create_index(
+        "uq_push_subscriptions_user_transport_endpoint",
+        "push_subscriptions",
+        ["user_id", "transport", "endpoint"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("push_subscriptions")
+    op.execute("DROP TYPE IF EXISTS push_transport_enum")

--- a/migrations/versions/push1_add_push_subscriptions.py
+++ b/migrations/versions/push1_add_push_subscriptions.py
@@ -18,10 +18,15 @@ depends_on = None
 
 
 def upgrade() -> None:
-    # Create enum type first, outside the CREATE TABLE statement.
-    # Pattern follows existing migrations (b2_align_shared_entry_enums.py).
+    # Idempotent enum creation — safe even if the type was partially created
+    # by a prior failed migration attempt or by SQLAlchemy model introspection.
     op.execute(
-        "CREATE TYPE push_transport_enum AS ENUM ('web_push', 'expo')"
+        sa.text(
+            "DO $$ BEGIN "
+            "  CREATE TYPE push_transport_enum AS ENUM ('web_push', 'expo'); "
+            "EXCEPTION WHEN duplicate_object THEN null; "
+            "END $$"
+        )
     )
 
     op.create_table(

--- a/openapi.json
+++ b/openapi.json
@@ -690,6 +690,53 @@
         ],
         "type": "object"
       },
+      "app_schemas_push_subscription_schema_SubscribeSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "device_label": {
+            "default": null,
+            "nullable": true,
+            "type": "string"
+          },
+          "endpoint": {
+            "type": "string"
+          },
+          "expiration_time": {
+            "default": null,
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
+          },
+          "keys": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "default": null,
+            "nullable": true,
+            "type": "object"
+          },
+          "transport": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "endpoint",
+          "transport"
+        ],
+        "type": "object"
+      },
+      "app_schemas_push_subscription_schema_UnsubscribeSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "endpoint": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "endpoint"
+        ],
+        "type": "object"
+      },
       "app_schemas_user_schemas_DeleteAccountSchema": {
         "additionalProperties": false,
         "properties": {
@@ -3809,6 +3856,364 @@
         },
         "tags": [
           "Health"
+        ]
+      }
+    },
+    "/notifications/subscribe": {
+      "post": {
+        "description": "Registra um token de push para o dispositivo do usuário. Aceita 'expo' (FCM/APNS via Expo) e 'web_push' (VAPID). Idempotente: endpoint repetido faz upsert.",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/app_schemas_push_subscription_schema_SubscribeSchema"
+            }
+          },
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "endpoint": "ExponentPushToken[...]",
+                    "id": "uuid",
+                    "transport": "expo"
+                  },
+                  "message": "Subscription registrada com sucesso."
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Subscription registrada",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "VALIDATION_ERROR",
+                  "message": "transport deve ser 'web_push' ou 'expo'.",
+                  "status_code": 400
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Dados inválidos",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado.",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token revogado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Registrar token de push",
+        "tags": [
+          "Notificações"
+        ]
+      }
+    },
+    "/notifications/unsubscribe": {
+      "post": {
+        "description": "Remove a subscription de push para o endpoint informado.",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/app_schemas_push_subscription_schema_UnsubscribeSchema"
+            }
+          },
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {},
+                  "message": "Subscription removida com sucesso."
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Subscription removida",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "VALIDATION_ERROR",
+                  "message": "Campo 'endpoint' obrigatório.",
+                  "status_code": 400
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Dados inválidos",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado.",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token revogado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "NOT_FOUND",
+                  "message": "Subscription não encontrada.",
+                  "status_code": 404
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Subscription não encontrada",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Remover token de push",
+        "tags": [
+          "Notificações"
         ]
       }
     },
@@ -10938,6 +11343,10 @@
     {
       "description": "Sistema de categorização por tags (pendente)",
       "name": "Tags"
+    },
+    {
+      "description": "Registro de tokens de push (Expo, Web Push VAPID)",
+      "name": "Notificações"
     }
   ]
 }

--- a/scripts/openapi_to_postman.py
+++ b/scripts/openapi_to_postman.py
@@ -46,6 +46,7 @@ TAG_FOLDER_MAP: dict[str, str] = {
     "Wallet": "06 - Wallet",
     "Simulações": "07 - Simulations",
     "Entitlements": "08 - Entitlements",
+    "Notificações": "09 - Notifications",
 }
 DEFAULT_FOLDER = "99 - Other"
 
@@ -168,6 +169,7 @@ FOLDER_ORDER = [
     "06 - Wallet",
     "07 - Simulations",
     "08 - Entitlements",
+    "09 - Notifications",
     "99 - Cleanup",
     "99 - Other",
 ]

--- a/scripts/openapi_to_postman.py
+++ b/scripts/openapi_to_postman.py
@@ -740,6 +740,23 @@ ENRICHMENT: dict[str, dict[str, Any]] = {
             "});",
         ],
     },
+    # Subscribe may return 400 in CI because the auto-generated body doesn't
+    # contain a valid ExponentPushToken — our schema validation rejects it.
+    "POST /notifications/subscribe": {
+        "test_lines": [
+            "pm.test('Registrar token de push — expected 200 or 400', function () {",
+            "  pm.expect(pm.response.code).to.be.oneOf([200, 400]);",
+            "});",
+        ],
+    },
+    # Unsubscribe returns 404 when subscribe failed in CI (no subscription exists).
+    "POST /notifications/unsubscribe": {
+        "test_lines": [
+            "pm.test('Remover token de push — expected 200 or 404', function () {",
+            "  pm.expect(pm.response.code).to.be.oneOf([200, 404]);",
+            "});",
+        ],
+    },
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/test_postman_collection_contract.py
+++ b/tests/test_postman_collection_contract.py
@@ -180,6 +180,7 @@ def test_postman_collection_uses_domain_folders() -> None:
         "06 - Wallet",
         "07 - Simulations",
         "08 - Entitlements",
+        "09 - Notifications",
         "99 - Cleanup",
     ]
     assert folder_names == expected

--- a/tests/test_push_subscriptions.py
+++ b/tests/test_push_subscriptions.py
@@ -1,0 +1,232 @@
+"""Tests for POST /notifications/subscribe and /notifications/unsubscribe (#1127)."""
+
+from __future__ import annotations
+
+import uuid
+
+from flask.testing import FlaskClient
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _register_and_login(client: FlaskClient, prefix: str = "push") -> str:
+    suffix = uuid.uuid4().hex[:8]
+    email = f"{prefix}-{suffix}@test.com"
+    password = "StrongPass@123"
+    r = client.post(
+        "/auth/register",
+        json={"name": f"{prefix}-{suffix}", "email": email, "password": password},
+    )
+    assert r.status_code == 201
+    r2 = client.post("/auth/login", json={"email": email, "password": password})
+    assert r2.status_code == 200
+    return r2.get_json()["token"]
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}", "X-API-Contract": "v2"}
+
+
+def _expo_token() -> str:
+    return f"ExponentPushToken[{uuid.uuid4().hex}]"
+
+
+def _web_push_body(endpoint: str | None = None) -> dict:
+    return {
+        "transport": "web_push",
+        "endpoint": endpoint or f"https://fcm.googleapis.com/send/{uuid.uuid4().hex}",
+        "keys": {"p256dh": "fake_key_abc", "auth": "fake_auth_abc"},
+        "device_label": "Chrome — Desktop",
+    }
+
+
+# ---------------------------------------------------------------------------
+# POST /notifications/subscribe — Expo
+# ---------------------------------------------------------------------------
+
+
+class TestSubscribeExpo:
+    def test_register_expo_token_returns_200(self, client: FlaskClient) -> None:
+        token = _register_and_login(client)
+        res = client.post(
+            "/notifications/subscribe",
+            json={
+                "transport": "expo",
+                "endpoint": _expo_token(),
+                "device_label": "iPhone 15",
+            },
+            headers=_auth(token),
+        )
+        assert res.status_code == 200
+        body = res.get_json()
+        assert body["success"] is True
+        assert body["data"]["transport"] == "expo"
+
+    def test_register_expo_idempotent_upsert(self, client: FlaskClient) -> None:
+        token = _register_and_login(client)
+        ep = _expo_token()
+        client.post(
+            "/notifications/subscribe",
+            json={"transport": "expo", "endpoint": ep, "device_label": "iPhone"},
+            headers=_auth(token),
+        )
+        res = client.post(
+            "/notifications/subscribe",
+            json={"transport": "expo", "endpoint": ep, "device_label": "iPhone 15 Pro"},
+            headers=_auth(token),
+        )
+        assert res.status_code == 200
+        assert res.get_json()["data"]["device_label"] == "iPhone 15 Pro"
+
+    def test_expo_invalid_token_format_returns_400(self, client: FlaskClient) -> None:
+        token = _register_and_login(client)
+        res = client.post(
+            "/notifications/subscribe",
+            json={"transport": "expo", "endpoint": "not-a-valid-expo-token"},
+            headers=_auth(token),
+        )
+        assert res.status_code in {400, 422}
+
+    def test_subscribe_requires_auth(self, client: FlaskClient) -> None:
+        res = client.post(
+            "/notifications/subscribe",
+            json={"transport": "expo", "endpoint": _expo_token()},
+        )
+        assert res.status_code in {401, 422}
+
+
+# ---------------------------------------------------------------------------
+# POST /notifications/subscribe — Web Push
+# ---------------------------------------------------------------------------
+
+
+class TestSubscribeWebPush:
+    def test_register_web_push_returns_200(self, client: FlaskClient) -> None:
+        token = _register_and_login(client)
+        res = client.post(
+            "/notifications/subscribe",
+            json=_web_push_body(),
+            headers=_auth(token),
+        )
+        assert res.status_code == 200
+        assert res.get_json()["data"]["transport"] == "web_push"
+
+    def test_web_push_missing_keys_returns_422(self, client: FlaskClient) -> None:
+        token = _register_and_login(client)
+        res = client.post(
+            "/notifications/subscribe",
+            json={
+                "transport": "web_push",
+                "endpoint": "https://fcm.googleapis.com/send/abc",
+            },
+            headers=_auth(token),
+        )
+        assert res.status_code in {400, 422}
+
+    def test_web_push_missing_auth_key_returns_422(self, client: FlaskClient) -> None:
+        token = _register_and_login(client)
+        res = client.post(
+            "/notifications/subscribe",
+            json={
+                "transport": "web_push",
+                "endpoint": "https://fcm.googleapis.com/send/abc",
+                "keys": {"p256dh": "key_only"},
+            },
+            headers=_auth(token),
+        )
+        assert res.status_code in {400, 422}
+
+
+# ---------------------------------------------------------------------------
+# POST /notifications/subscribe — invalid transport
+# ---------------------------------------------------------------------------
+
+
+class TestSubscribeInvalidTransport:
+    def test_invalid_transport_returns_422(self, client: FlaskClient) -> None:
+        token = _register_and_login(client)
+        res = client.post(
+            "/notifications/subscribe",
+            json={"transport": "sms", "endpoint": "whatever"},
+            headers=_auth(token),
+        )
+        assert res.status_code in {400, 422}
+
+    def test_missing_transport_returns_422(self, client: FlaskClient) -> None:
+        token = _register_and_login(client)
+        res = client.post(
+            "/notifications/subscribe",
+            json={"endpoint": _expo_token()},
+            headers=_auth(token),
+        )
+        assert res.status_code in {400, 422}
+
+
+# ---------------------------------------------------------------------------
+# POST /notifications/unsubscribe
+# ---------------------------------------------------------------------------
+
+
+class TestUnsubscribe:
+    def test_unsubscribe_existing_returns_200(self, client: FlaskClient) -> None:
+        token = _register_and_login(client)
+        ep = _expo_token()
+        client.post(
+            "/notifications/subscribe",
+            json={"transport": "expo", "endpoint": ep},
+            headers=_auth(token),
+        )
+        res = client.post(
+            "/notifications/unsubscribe",
+            json={"endpoint": ep},
+            headers=_auth(token),
+        )
+        assert res.status_code == 200
+        assert res.get_json()["success"] is True
+
+    def test_unsubscribe_not_found_returns_404(self, client: FlaskClient) -> None:
+        token = _register_and_login(client)
+        res = client.post(
+            "/notifications/unsubscribe",
+            json={"endpoint": "ExponentPushToken[doesnotexist]"},
+            headers=_auth(token),
+        )
+        assert res.status_code == 404
+        assert res.get_json()["error"]["code"] == "NOT_FOUND"
+
+    def test_unsubscribe_requires_auth(self, client: FlaskClient) -> None:
+        res = client.post(
+            "/notifications/unsubscribe",
+            json={"endpoint": _expo_token()},
+        )
+        assert res.status_code in {401, 422}
+
+    def test_unsubscribe_missing_endpoint_returns_422(
+        self, client: FlaskClient
+    ) -> None:
+        token = _register_and_login(client)
+        res = client.post(
+            "/notifications/unsubscribe",
+            json={},
+            headers=_auth(token),
+        )
+        assert res.status_code in {400, 422}
+
+    def test_unsubscribe_isolates_by_user(self, client: FlaskClient) -> None:
+        token_a = _register_and_login(client, "push-a")
+        token_b = _register_and_login(client, "push-b")
+        ep = _expo_token()
+        client.post(
+            "/notifications/subscribe",
+            json={"transport": "expo", "endpoint": ep},
+            headers=_auth(token_a),
+        )
+        # User B cannot unsubscribe user A's token
+        res = client.post(
+            "/notifications/unsubscribe",
+            json={"endpoint": ep},
+            headers=_auth(token_b),
+        )
+        assert res.status_code == 404


### PR DESCRIPTION
## Summary

- `POST /notifications/subscribe` — registra token de push com upsert idempotente por `(user_id, transport, endpoint)`. Aceita `expo` (ExponentPushToken — cobre FCM/APNS via Expo) e `web_push` (VAPID, requer `keys.p256dh` + `keys.auth`).
- `POST /notifications/unsubscribe` — remove subscription por `endpoint`, isolada por `user_id`.
- Migration `push1`: tabela `push_subscriptions` com enum `PushTransport` e índice único.
- Folder `09 - Notifications` adicionado ao Postman collection + `FOLDER_ORDER`.

## O que NÃO está neste PR (scope intencional)

- Dispatcher de notificações (requer expo-server-sdk + pywebpush — PR separado)
- Celery jobs de dispatch
- Gatilhos de domínio (vencimento D-1, meta atingida, etc.)

## Test plan

- [ ] `POST /notifications/subscribe` com Expo token → 200, `transport: expo`
- [ ] Segundo POST com mesmo endpoint → 200 (upsert, `device_label` atualizado)
- [ ] `POST /notifications/subscribe` com web_push sem `keys` → 400
- [ ] `POST /notifications/unsubscribe` → 200; segundo unsubscribe → 404
- [ ] User B não consegue unsubscribar token de User A
- [ ] CI verde

Closes #1127