### PR TITLE
feat(dx): P1 DX initiatives from PR #1174 post-mortem

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,6 +55,11 @@ repos:
     language: system
     pass_filenames: false
     files: app/controllers/
+  - id: migration-pattern-check
+    name: Migration anti-pattern check (INI-2)
+    entry: python3 scripts/check_migration_patterns.py
+    language: system
+    files: ^migrations/versions/.*\.py$
   - id: alembic-single-head-check
     name: alembic-single-head-check
     entry: python3 scripts/alembic_single_head_check.py
@@ -68,9 +73,10 @@ repos:
     files: (app/simulations/tools_registry\.py|tools-catalog\.ts)
   - id: mypy
     name: mypy
-    entry: scripts/python_tool.sh mypy --no-incremental app
+    entry: scripts/python_tool.sh mypy app
     language: system
     pass_filenames: false
+    files: \.(py)$
   - id: sonar-local-check
     name: sonar-local-check
     entry: scripts/sonar_local_check.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,6 +172,61 @@ scripts/repo_bin.sh pytest -m "not schemathesis" --cov=app --cov-fail-under=85
 | `../ai_squad/` | CrewAI multi-agent system (platform-level workspace) |
 | `docs/` | Runbooks, ADRs, security docs |
 
+## Migration Conventions (PostgreSQL)
+
+> Origem: post-mortem PR #1174. Violações causam falhas silenciosas em SQLite e explosões no CI PostgreSQL.
+
+### Enums — usar `native_enum=False` por padrão
+
+```python
+# ✅ Correto — VARCHAR + CHECK constraint, sem CREATE TYPE, sem risco de idempotência
+transport = db.Column(
+    db.Enum(PushTransport, name="push_transport", native_enum=False),
+    nullable=False
+)
+
+# ⚠️  Só usar native_enum=True se houver razão explícita (ex: performance de JOIN)
+#     + migration testada com scripts/test_migrations_local.sh
+```
+
+**Por quê:** `native_enum=True` (default SQLAlchemy) registra DDL listener na metadata.
+Quando `flask db upgrade` executa e Alembic chama `context.configure(target_metadata=...)`,
+esse listener emite `CREATE TYPE` **antes** da migration rodar. A migration tenta criar o mesmo
+tipo → `ERROR: type already exists` → bootstrap do CI falha em loop.
+
+### Antes de fazer push com nova migration
+
+```bash
+bash scripts/test_migrations_local.sh   # sobe postgres:16 efêmero, aplica up + down
+```
+
+O pre-commit hook `migration-pattern-check` também bloqueia padrões proibidos:
+
+| Padrão detectado | Alternativa |
+|---|---|
+| `op.execute("CREATE TYPE ...")` sem verificação | `native_enum=False` ou check em `pg_type` |
+| `op.get_bind()` | `op.get_context().connection` |
+| `ENUM(...).create(op.get_bind())` | `native_enum=False` |
+| `server_default=gen_random_uuid()` | `default=uuid.uuid4` no modelo |
+
+### Endpoints com validação customizada Marshmallow
+
+Ao criar endpoint com `@validates_schema` ou validação condicional por tipo,
+adicionar ENRICHMENT em `scripts/openapi_to_postman.py` **na mesma PR**:
+
+```python
+"POST /meu/endpoint": {
+    "test_lines": [
+        "pm.test('Meu endpoint — expected 200 or 400', function () {",
+        "  pm.expect(pm.response.code).to.be.oneOf([200, 400]);",
+        "});",
+    ],
+},
+```
+
+Sem ENRICHMENT, o Newman smoke test vai falhar porque o body auto-gerado pelo schema
+não passa na validação customizada.
+
 ## GraphQL Architecture Decisions
 
 Key ADRs governing the GraphQL layer:

--- a/scripts/check_migration_patterns.py
+++ b/scripts/check_migration_patterns.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""INI-2: Lint de padrões proibidos em migrations Alembic.
+
+Detecta anti-padrões que causam falhas silenciosas em SQLite mas explodem
+contra PostgreSQL real no CI — especialmente CREATE TYPE sem idempotência
+e APIs deprecated do SQLAlchemy 2.0.
+
+Docs: docs/wiki/Post-Mortem-PR1174-Bootstrap-Migration.md
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Padrões proibidos
+# ---------------------------------------------------------------------------
+
+FORBIDDEN: list[tuple[str, re.Pattern[str], str]] = [
+    (
+        "CREATE TYPE sem guarda de idempotência",
+        re.compile(r"op\.execute\([^)]*CREATE\s+TYPE\b", re.IGNORECASE | re.DOTALL),
+        (
+            "Use native_enum=False (preferido) ou verifique pg_type antes:\n"
+            "  conn = op.get_context().connection\n"
+            "  if not conn.execute(sa.text(\n"
+            '      "SELECT 1 FROM pg_type WHERE typname = :n"),\n'
+            '      {"n": "my_type"}).scalar():\n'
+            '      conn.execute(sa.text("CREATE TYPE my_type AS ENUM (...)"))\n'
+            "Ver: docs/wiki/Post-Mortem-PR1174-Bootstrap-Migration.md"
+        ),
+    ),
+    (
+        "op.get_bind() deprecated (SQLAlchemy 2.0)",
+        re.compile(r"\bop\.get_bind\(\)", re.IGNORECASE),
+        (
+            "Substitua por: conn = op.get_context().connection\n"
+            "Ou use op.execute() para DDL simples."
+        ),
+    ),
+    (
+        "postgresql.ENUM.create(op.get_bind()) — padrão antigo",
+        re.compile(
+            r"\bENUM\b.*\.create\s*\(\s*op\.get_bind\(\)",
+            re.IGNORECASE | re.DOTALL,
+        ),
+        (
+            "Use native_enum=False — evita CREATE TYPE completamente:\n"
+            "  db.Column(db.Enum(MyEnum, name='x', native_enum=False))\n"
+            "Ver: CLAUDE.md seção 'Migration Conventions'"
+        ),
+    ),
+    (
+        "gen_random_uuid() como server_default sem verificação de extensão",
+        re.compile(
+            r'server_default\s*=\s*sa\.text\(["\']gen_random_uuid\(\)["\']',
+            re.IGNORECASE,
+        ),
+        (
+            "gen_random_uuid() requer pgcrypto em PostgreSQL < 13.\n"
+            "Prefira o default Python-side: default=uuid.uuid4 no modelo.\n"
+            'Se precisar de server_default, use: sa.text("uuid_generate_v4()")\n'
+            'com op.execute("CREATE EXTENSION IF NOT EXISTS \\"uuid-ossp\\"") antes.'
+        ),
+    ),
+]
+
+
+def check_file(path: Path) -> list[str]:
+    source = path.read_text(encoding="utf-8")
+    errors: list[str] = []
+    for name, pattern, suggestion in FORBIDDEN:
+        if pattern.search(source):
+            errors.append(
+                f"\n  ✗ {name}\n"
+                f"    Arquivo: {path}\n"
+                f"    Sugestão:\n"
+                + "\n".join(f"      {line}" for line in suggestion.splitlines())
+            )
+    return errors
+
+
+def main() -> int:
+    files = [Path(f) for f in sys.argv[1:] if f.endswith(".py")]
+    if not files:
+        return 0
+
+    all_errors: list[str] = []
+    for f in files:
+        all_errors.extend(check_file(f))
+
+    if all_errors:
+        print(
+            "\n[migration-pattern-check] Padrões proibidos detectados em migrations:\n"
+            + "\n".join(all_errors)
+            + "\n\nDocumentação: docs/wiki/Post-Mortem-PR1174-Bootstrap-Migration.md\n"
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_migrations_local.sh
+++ b/scripts/test_migrations_local.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# INI-1: Migration smoke test contra PostgreSQL real (Docker).
+#
+# Sobe um postgres:16 efêmero, aplica todas as migrations (upgrade),
+# valida head único, e testa reversibilidade (downgrade base).
+# Derruba o container ao final (sucesso ou falha).
+#
+# Uso:
+#   bash scripts/test_migrations_local.sh
+#
+# Pré-requisitos: Docker, .venv ativo ou flask no PATH.
+#
+# Docs: docs/wiki/Post-Mortem-PR1174-Bootstrap-Migration.md (INI-1)
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONTAINER="auraxis-pg-migration-test"
+PG_PORT="${MIGRATION_TEST_PG_PORT:-5433}"
+PG_PASSWORD="migration_test_secret"
+PG_DB="migration_testdb"
+PG_USER="postgres"
+DATABASE_URL="postgresql://${PG_USER}:${PG_PASSWORD}@localhost:${PG_PORT}/${PG_DB}"
+
+FLASK_CMD="${FLASK_CMD:-scripts/python_tool.sh flask}"
+
+cleanup() {
+  echo "[migration-test] Removendo container ${CONTAINER}..."
+  docker rm -f "${CONTAINER}" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "[migration-test] Subindo postgres:16 em porta ${PG_PORT}..."
+docker run -d \
+  --name "${CONTAINER}" \
+  -e POSTGRES_PASSWORD="${PG_PASSWORD}" \
+  -e POSTGRES_DB="${PG_DB}" \
+  -e POSTGRES_USER="${PG_USER}" \
+  -p "${PG_PORT}:5432" \
+  --tmpfs /var/lib/postgresql/data \
+  public.ecr.aws/docker/library/postgres:16 >/dev/null
+
+echo "[migration-test] Aguardando PostgreSQL ficar pronto..."
+for i in $(seq 1 30); do
+  if docker exec "${CONTAINER}" pg_isready -U "${PG_USER}" -q 2>/dev/null; then
+    echo "[migration-test] PostgreSQL pronto."
+    break
+  fi
+  sleep 1
+  if [ "$i" -eq 30 ]; then
+    echo "[migration-test] ERRO: PostgreSQL não ficou pronto em 30s." >&2
+    exit 1
+  fi
+done
+
+cd "${ROOT_DIR}"
+
+echo "[migration-test] Aplicando migrations (upgrade head)..."
+DATABASE_URL="${DATABASE_URL}" ${FLASK_CMD} --app run db upgrade
+
+echo "[migration-test] Validando head único..."
+HEAD_COUNT=$(DATABASE_URL="${DATABASE_URL}" ${FLASK_CMD} --app run db heads 2>/dev/null | grep -c "(head)" || true)
+if [ "${HEAD_COUNT}" -ne 1 ]; then
+  echo "[migration-test] ERRO: esperado 1 head, encontrado ${HEAD_COUNT}." >&2
+  exit 1
+fi
+echo "[migration-test] Head único confirmado."
+
+echo "[migration-test] Testando reversibilidade (downgrade base)..."
+DATABASE_URL="${DATABASE_URL}" ${FLASK_CMD} --app run db downgrade base
+
+echo ""
+echo "[migration-test] ✅ Todas as migrations: upgrade ✓  head único ✓  downgrade ✓"


### PR DESCRIPTION
## Summary

Implementa as 4 iniciativas P1 derivadas do post-mortem do PR #1174 (bootstrap failure por `push_transport_enum`).

### INI-6 (#1175) — Mypy incremental no pre-commit
- Remove `--no-incremental` do hook mypy → cache incremental ativo
- Adiciona `files: \.(py)$` → mypy só roda quando arquivos `.py` mudam
- Efeito imediato: commits com 1-2 arquivos Python caem de 10-15 min → <1 min

### INI-2 (#1177) — Hook pre-commit: lint de padrões proibidos em migrations
- Novo script `scripts/check_migration_patterns.py`
- Detecta 4 anti-padrões em `migrations/versions/*.py`:
  - `CREATE TYPE` sem verificação de existência (causa: bootstrap retry loop)
  - `op.get_bind()` deprecated (SQLAlchemy 2.0)
  - `ENUM(...).create(op.get_bind())` — padrão antigo
  - `gen_random_uuid()` como server_default sem extensão garantida
- Falha em <1s com mensagem acionável e link para documentação

### INI-1 (#1176) — Migration smoke test local contra PostgreSQL real
- Novo script `scripts/test_migrations_local.sh`
- Sobe `postgres:16` efêmero via Docker, aplica `flask db upgrade`, valida head único, testa `flask db downgrade base`
- Teardown automático ao final (sucesso ou falha)

### INI-5 (#1179) — Diretiva `native_enum=False` + convenções no CLAUDE.md
- Nova seção "Migration Conventions (PostgreSQL)" no CLAUDE.md
- Documenta `native_enum=False` como padrão, links para INI-1/INI-2
- Adiciona regra de Postman ENRICHMENT para endpoints com `@validates_schema`

## Test plan

- [ ] Commit com arquivo `.py` mudado → mypy roda rápido (<2 min)
- [ ] Commit com migration com `CREATE TYPE` → `migration-pattern-check` falha com mensagem clara
- [ ] Commit com migration com `op.get_bind()` → falha com sugestão
- [ ] `bash scripts/test_migrations_local.sh` → postgres:16 sobe, migrate up, validate, migrate down
- [ ] CI verde

## Refs

- Post-mortem: `docs/wiki/Post-Mortem-PR1174-Bootstrap-Migration.md`
- Issues: #1175 #1176 #1177 #1179

Closes #1175
Closes #1176
Closes #1177
Closes #1179