### PR TITLE
feat(graphql): Tags + Accounts GraphQL domains — REST↔GraphQL parity

### DIFF
--- a/app/graphql/docs_catalog.py
+++ b/app/graphql/docs_catalog.py
@@ -6,6 +6,7 @@ from typing import Literal
 GraphQLOperationType = Literal["query", "mutation"]
 GraphQLOperationAccess = Literal["public", "auth_required"]
 GraphQLDomain = Literal[
+    "accounts",
     "auth",
     "billing",
     "dashboard",
@@ -13,6 +14,7 @@ GraphQLDomain = Literal[
     "investments",
     "notifications",
     "simulations",
+    "tags",
     "transactions",
     "user",
     "wallet",
@@ -38,6 +40,10 @@ QUERY_NOTIFICATION_MODULE = "app.graphql.queries.notification"
 MUTATION_BUDGET_MODULE = "app.graphql.mutations.budget"
 MUTATION_SUBSCRIPTION_MODULE = "app.graphql.mutations.subscription"
 MUTATION_NOTIFICATION_MODULE = "app.graphql.mutations.notification"
+QUERY_TAG_MODULE = "app.graphql.queries.tag"
+QUERY_ACCOUNT_MODULE = "app.graphql.queries.account"
+MUTATION_TAG_MODULE = "app.graphql.mutations.tag"
+MUTATION_ACCOUNT_MODULE = "app.graphql.mutations.account"
 ADVANCED_SIMULATIONS = "advanced_simulations"
 
 
@@ -595,6 +601,88 @@ GRAPHQL_OPERATION_CATALOG: tuple[GraphQLOperationDoc, ...] = (
         access="auth_required",
         summary="Revoga todas as sessões ativas — logout global.",
         source_module=MUTATION_AUTH_MODULE,
+    ),
+    # Tags (#1148)
+    GraphQLOperationDoc(
+        name="tags",
+        operation_type="query",
+        domain="tags",
+        access="auth_required",
+        summary="Lista todas as tags do usuário autenticado.",
+        source_module=QUERY_TAG_MODULE,
+    ),
+    GraphQLOperationDoc(
+        name="tag",
+        operation_type="query",
+        domain="tags",
+        access="auth_required",
+        summary="Retorna uma tag pelo ID.",
+        source_module=QUERY_TAG_MODULE,
+    ),
+    GraphQLOperationDoc(
+        name="createTag",
+        operation_type="mutation",
+        domain="tags",
+        access="auth_required",
+        summary="Cria uma nova tag para o usuário.",
+        source_module=MUTATION_TAG_MODULE,
+    ),
+    GraphQLOperationDoc(
+        name="updateTag",
+        operation_type="mutation",
+        domain="tags",
+        access="auth_required",
+        summary="Atualiza nome, cor ou ícone de uma tag existente.",
+        source_module=MUTATION_TAG_MODULE,
+    ),
+    GraphQLOperationDoc(
+        name="deleteTag",
+        operation_type="mutation",
+        domain="tags",
+        access="auth_required",
+        summary="Remove uma tag do usuário.",
+        source_module=MUTATION_TAG_MODULE,
+    ),
+    # Accounts (#1148)
+    GraphQLOperationDoc(
+        name="accounts",
+        operation_type="query",
+        domain="accounts",
+        access="auth_required",
+        summary="Lista todas as contas bancárias do usuário autenticado.",
+        source_module=QUERY_ACCOUNT_MODULE,
+    ),
+    GraphQLOperationDoc(
+        name="account",
+        operation_type="query",
+        domain="accounts",
+        access="auth_required",
+        summary="Retorna uma conta bancária pelo ID.",
+        source_module=QUERY_ACCOUNT_MODULE,
+    ),
+    GraphQLOperationDoc(
+        name="createAccount",
+        operation_type="mutation",
+        domain="accounts",
+        access="auth_required",
+        summary="Cria uma nova conta bancária para o usuário.",
+        source_module=MUTATION_ACCOUNT_MODULE,
+    ),
+    GraphQLOperationDoc(
+        name="updateAccount",
+        operation_type="mutation",
+        domain="accounts",
+        access="auth_required",
+        summary="Atualiza dados de uma conta bancária existente.",
+        source_module=MUTATION_ACCOUNT_MODULE,
+    ),
+    GraphQLOperationDoc(
+        name="deleteAccount",
+        operation_type="mutation",
+        domain="accounts",
+        access="auth_required",
+        summary="Remove uma conta bancária do usuário.",
+        source_module=MUTATION_ACCOUNT_MODULE,
     ),
 )
 

--- a/app/graphql/mutations/__init__.py
+++ b/app/graphql/mutations/__init__.py
@@ -2,6 +2,11 @@ from __future__ import annotations
 
 import graphene
 
+from app.graphql.mutations.account import (
+    CreateAccountMutation,
+    DeleteAccountMutation,
+    UpdateAccountMutation,
+)
 from app.graphql.mutations.auth import (
     ConfirmEmailMutation,
     ForgotPasswordMutation,
@@ -39,6 +44,11 @@ from app.graphql.mutations.simulation import (
 from app.graphql.mutations.subscription import (
     CancelSubscriptionMutation,
     CreateCheckoutSessionMutation,
+)
+from app.graphql.mutations.tag import (
+    CreateTagMutation,
+    DeleteTagMutation,
+    UpdateTagMutation,
 )
 from app.graphql.mutations.ticker import AddTickerMutation, DeleteTickerMutation
 from app.graphql.mutations.transaction import (
@@ -114,6 +124,14 @@ class Mutation(graphene.ObjectType):
     )
     add_ticker = AddTickerMutation.Field()
     delete_ticker = DeleteTickerMutation.Field()
+    # Tags — canonical surface (no REST equivalent for bulk ops; CRUD exposed here)
+    create_tag = CreateTagMutation.Field()
+    update_tag = UpdateTagMutation.Field()
+    delete_tag = DeleteTagMutation.Field()
+    # Accounts — canonical surface
+    create_account = CreateAccountMutation.Field()
+    update_account = UpdateAccountMutation.Field()
+    delete_account = DeleteAccountMutation.Field()
     # ADR-0002: CRUD mutations deprecated — use REST endpoints.
     create_budget = CreateBudgetMutation.Field(
         deprecation_reason="ADR-0002: use POST /budgets"

--- a/app/graphql/mutations/account.py
+++ b/app/graphql/mutations/account.py
@@ -1,0 +1,158 @@
+"""GraphQL mutations for the Accounts domain (#1148)."""
+
+from __future__ import annotations
+
+from decimal import Decimal, InvalidOperation
+
+import graphene
+
+from app.extensions.database import db
+from app.graphql.auth import get_current_user_required
+from app.graphql.errors import build_public_graphql_error
+from app.graphql.observability import log_graphql_resolver
+from app.graphql.types import AccountPayload, AccountType
+from app.models.account import ACCOUNT_TYPE_VALUES, Account
+
+_ACCOUNT_TYPES = set(ACCOUNT_TYPE_VALUES)
+
+
+def _to_account_type(a: Account) -> AccountType:
+    return AccountType(
+        id=str(a.id),
+        name=a.name,
+        account_type=a.account_type or "checking",
+        institution=a.institution,
+        initial_balance=a.initial_balance,
+    )
+
+
+class CreateAccountMutation(graphene.Mutation):
+    class Arguments:
+        name = graphene.String(required=True)
+        account_type = graphene.String()
+        institution = graphene.String()
+        initial_balance = graphene.String()
+
+    Output = AccountPayload
+
+    @log_graphql_resolver("createAccount")
+    def mutate(
+        self,
+        _info: graphene.ResolveInfo,
+        name: str,
+        account_type: str = "checking",
+        institution: str | None = None,
+        initial_balance: str = "0",
+    ) -> AccountPayload:
+        user = get_current_user_required()
+        name = name.strip()
+        if not name:
+            raise build_public_graphql_error(
+                "name is required", code="VALIDATION_ERROR"
+            )
+        if len(name) > 100:
+            raise build_public_graphql_error(
+                "name must be at most 100 characters", code="VALIDATION_ERROR"
+            )
+        if account_type not in _ACCOUNT_TYPES:
+            raise build_public_graphql_error(
+                f"account_type must be one of: {', '.join(sorted(_ACCOUNT_TYPES))}",
+                code="VALIDATION_ERROR",
+            )
+        try:
+            balance = Decimal(str(initial_balance or "0"))
+        except InvalidOperation as exc:
+            raise build_public_graphql_error(
+                "initial_balance must be a valid decimal", code="VALIDATION_ERROR"
+            ) from exc
+        account = Account(
+            user_id=user.id,
+            name=name,
+            account_type=account_type,
+            institution=institution,
+            initial_balance=balance,
+        )
+        db.session.add(account)
+        db.session.commit()
+        return AccountPayload(
+            ok=True,
+            message="Conta criada com sucesso.",
+            errors=[],
+            data=_to_account_type(account),
+        )
+
+
+class UpdateAccountMutation(graphene.Mutation):
+    class Arguments:
+        account_id = graphene.UUID(required=True)
+        name = graphene.String(required=True)
+        account_type = graphene.String()
+        institution = graphene.String()
+        initial_balance = graphene.String()
+
+    Output = AccountPayload
+
+    @log_graphql_resolver("updateAccount")
+    def mutate(
+        self,
+        _info: graphene.ResolveInfo,
+        account_id: object,
+        name: str,
+        account_type: str | None = None,
+        institution: str | None = None,
+        initial_balance: str | None = None,
+    ) -> AccountPayload:
+        user = get_current_user_required()
+        account = Account.query.filter_by(id=account_id, user_id=user.id).first()
+        if not account:
+            raise build_public_graphql_error("Account not found", code="NOT_FOUND")
+        name = name.strip()
+        if not name:
+            raise build_public_graphql_error(
+                "name is required", code="VALIDATION_ERROR"
+            )
+        if len(name) > 100:
+            raise build_public_graphql_error(
+                "name must be at most 100 characters", code="VALIDATION_ERROR"
+            )
+        if account_type and account_type not in _ACCOUNT_TYPES:
+            raise build_public_graphql_error(
+                f"account_type must be one of: {', '.join(sorted(_ACCOUNT_TYPES))}",
+                code="VALIDATION_ERROR",
+            )
+        account.name = name
+        if account_type:
+            account.account_type = account_type
+        if institution is not None:
+            account.institution = institution or None
+        if initial_balance is not None:
+            try:
+                account.initial_balance = Decimal(str(initial_balance))
+            except InvalidOperation as exc:
+                raise build_public_graphql_error(
+                    "initial_balance must be a valid decimal", code="VALIDATION_ERROR"
+                ) from exc
+        db.session.commit()
+        return AccountPayload(
+            ok=True,
+            message="Conta atualizada com sucesso.",
+            errors=[],
+            data=_to_account_type(account),
+        )
+
+
+class DeleteAccountMutation(graphene.Mutation):
+    class Arguments:
+        account_id = graphene.UUID(required=True)
+
+    Output = AccountPayload
+
+    @log_graphql_resolver("deleteAccount")
+    def mutate(self, _info: graphene.ResolveInfo, account_id: object) -> AccountPayload:
+        user = get_current_user_required()
+        account = Account.query.filter_by(id=account_id, user_id=user.id).first()
+        if not account:
+            raise build_public_graphql_error("Account not found", code="NOT_FOUND")
+        db.session.delete(account)
+        db.session.commit()
+        return AccountPayload(ok=True, message="Conta removida com sucesso.", errors=[])

--- a/app/graphql/mutations/tag.py
+++ b/app/graphql/mutations/tag.py
@@ -1,0 +1,136 @@
+"""GraphQL mutations for the Tags domain (#1148)."""
+
+from __future__ import annotations
+
+import re
+
+import graphene
+
+from app.extensions.database import db
+from app.graphql.auth import get_current_user_required
+from app.graphql.errors import build_public_graphql_error
+from app.graphql.observability import log_graphql_resolver
+from app.graphql.types import TagPayload, TagType
+from app.models.tag import Tag
+
+_HEX_COLOR_RE = re.compile(r"^#[0-9A-Fa-f]{6}([0-9A-Fa-f]{2})?$")
+
+
+def _to_tag_type(t: Tag) -> TagType:
+    return TagType(id=str(t.id), name=t.name, color=t.color, icon=t.icon)
+
+
+def _normalize_color(color: str | None) -> str | None:
+    if color and _HEX_COLOR_RE.match(color):
+        return color[:7]
+    return color
+
+
+class CreateTagMutation(graphene.Mutation):
+    class Arguments:
+        name = graphene.String(required=True)
+        color = graphene.String()
+        icon = graphene.String()
+
+    Output = TagPayload
+
+    @log_graphql_resolver("createTag")
+    def mutate(
+        self,
+        _info: graphene.ResolveInfo,
+        name: str,
+        color: str | None = None,
+        icon: str | None = None,
+    ) -> TagPayload:
+        user = get_current_user_required()
+        name = name.strip()
+        if not name:
+            raise build_public_graphql_error(
+                "name is required", code="VALIDATION_ERROR"
+            )
+        if len(name) > 50:
+            raise build_public_graphql_error(
+                "name must be at most 50 characters", code="VALIDATION_ERROR"
+            )
+        if color and not _HEX_COLOR_RE.match(color):
+            raise build_public_graphql_error(
+                "color must be a valid hex code (e.g. #FF6B6B)", code="VALIDATION_ERROR"
+            )
+        tag = Tag(
+            user_id=user.id,
+            name=name,
+            color=_normalize_color(color),
+            icon=icon,
+        )
+        db.session.add(tag)
+        db.session.commit()
+        return TagPayload(
+            ok=True,
+            message="Tag criada com sucesso.",
+            errors=[],
+            data=_to_tag_type(tag),
+        )
+
+
+class UpdateTagMutation(graphene.Mutation):
+    class Arguments:
+        tag_id = graphene.UUID(required=True)
+        name = graphene.String(required=True)
+        color = graphene.String()
+        icon = graphene.String()
+
+    Output = TagPayload
+
+    @log_graphql_resolver("updateTag")
+    def mutate(
+        self,
+        _info: graphene.ResolveInfo,
+        tag_id: object,
+        name: str,
+        color: str | None = None,
+        icon: str | None = None,
+    ) -> TagPayload:
+        user = get_current_user_required()
+        tag = Tag.query.filter_by(id=tag_id, user_id=user.id).first()
+        if not tag:
+            raise build_public_graphql_error("Tag not found", code="NOT_FOUND")
+        name = name.strip()
+        if not name:
+            raise build_public_graphql_error(
+                "name is required", code="VALIDATION_ERROR"
+            )
+        if len(name) > 50:
+            raise build_public_graphql_error(
+                "name must be at most 50 characters", code="VALIDATION_ERROR"
+            )
+        if color and not _HEX_COLOR_RE.match(color):
+            raise build_public_graphql_error(
+                "color must be a valid hex code (e.g. #FF6B6B)", code="VALIDATION_ERROR"
+            )
+        tag.name = name
+        tag.color = _normalize_color(color)
+        tag.icon = icon
+        db.session.commit()
+        return TagPayload(
+            ok=True,
+            message="Tag atualizada com sucesso.",
+            errors=[],
+            data=_to_tag_type(tag),
+        )
+
+
+class DeleteTagMutation(graphene.Mutation):
+    class Arguments:
+        tag_id = graphene.UUID(required=True)
+
+    Output = TagPayload
+
+    @log_graphql_resolver("deleteTag")
+    def mutate(self, _info: graphene.ResolveInfo, tag_id: object) -> TagPayload:
+        user = get_current_user_required()
+        tag = Tag.query.filter_by(id=tag_id, user_id=user.id).first()
+        if not tag:
+            raise build_public_graphql_error("Tag not found", code="NOT_FOUND")
+        db.session.delete(tag)
+        db.session.commit()
+        return TagPayload(ok=True, message="Tag removida com sucesso.", errors=[])

--- a/app/graphql/queries/__init__.py
+++ b/app/graphql/queries/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import graphene
 
+from .account import AccountQueryMixin
 from .budget import BudgetQueryMixin
 from .dashboard import DashboardQueryMixin
 from .goal import GoalQueryMixin
@@ -9,6 +10,7 @@ from .investment import InvestmentQueryMixin
 from .notification import NotificationQueryMixin
 from .simulation import SimulationQueryMixin
 from .subscription import SubscriptionQueryMixin
+from .tag import TagQueryMixin
 from .transaction import TransactionQueryMixin
 from .user import UserQueryMixin
 from .wallet import WalletQueryMixin
@@ -25,6 +27,8 @@ class Query(
     BudgetQueryMixin,
     SubscriptionQueryMixin,
     NotificationQueryMixin,
+    TagQueryMixin,
+    AccountQueryMixin,
     graphene.ObjectType,
 ):
     pass
@@ -42,4 +46,6 @@ __all__ = [
     "BudgetQueryMixin",
     "SubscriptionQueryMixin",
     "NotificationQueryMixin",
+    "TagQueryMixin",
+    "AccountQueryMixin",
 ]

--- a/app/graphql/queries/account.py
+++ b/app/graphql/queries/account.py
@@ -1,0 +1,41 @@
+"""GraphQL queries for the Accounts domain (#1148)."""
+
+from __future__ import annotations
+
+import graphene
+
+from app.graphql.auth import get_current_user_required
+from app.graphql.observability import log_graphql_resolver
+from app.graphql.types import AccountListType, AccountType
+from app.models.account import Account
+
+
+def _to_account_type(a: Account) -> AccountType:
+    return AccountType(
+        id=str(a.id),
+        name=a.name,
+        account_type=a.account_type or "checking",
+        institution=a.institution,
+        initial_balance=a.initial_balance,
+    )
+
+
+class AccountQueryMixin:
+    accounts = graphene.Field(AccountListType)
+    account = graphene.Field(AccountType, account_id=graphene.UUID(required=True))
+
+    @log_graphql_resolver("accounts")
+    def resolve_accounts(self, _info: graphene.ResolveInfo) -> AccountListType:
+        user = get_current_user_required()
+        rows = Account.query.filter_by(user_id=user.id).order_by(Account.name).all()
+        return AccountListType(
+            accounts=[_to_account_type(a) for a in rows], total=len(rows)
+        )
+
+    @log_graphql_resolver("account")
+    def resolve_account(
+        self, _info: graphene.ResolveInfo, account_id: object
+    ) -> AccountType | None:
+        user = get_current_user_required()
+        a = Account.query.filter_by(id=account_id, user_id=user.id).first()
+        return _to_account_type(a) if a else None

--- a/app/graphql/queries/tag.py
+++ b/app/graphql/queries/tag.py
@@ -1,0 +1,33 @@
+"""GraphQL queries for the Tags domain (#1148)."""
+
+from __future__ import annotations
+
+import graphene
+
+from app.graphql.auth import get_current_user_required
+from app.graphql.observability import log_graphql_resolver
+from app.graphql.types import TagListType, TagType
+from app.models.tag import Tag
+
+
+def _to_tag_type(t: Tag) -> TagType:
+    return TagType(id=str(t.id), name=t.name, color=t.color, icon=t.icon)
+
+
+class TagQueryMixin:
+    tags = graphene.Field(TagListType)
+    tag = graphene.Field(TagType, tag_id=graphene.UUID(required=True))
+
+    @log_graphql_resolver("tags")
+    def resolve_tags(self, _info: graphene.ResolveInfo) -> TagListType:
+        user = get_current_user_required()
+        rows = Tag.query.filter_by(user_id=user.id).order_by(Tag.name).all()
+        return TagListType(tags=[_to_tag_type(t) for t in rows], total=len(rows))
+
+    @log_graphql_resolver("tag")
+    def resolve_tag(
+        self, _info: graphene.ResolveInfo, tag_id: object
+    ) -> TagType | None:
+        user = get_current_user_required()
+        t = Tag.query.filter_by(id=tag_id, user_id=user.id).first()
+        return _to_tag_type(t) if t else None

--- a/app/graphql/types.py
+++ b/app/graphql/types.py
@@ -661,3 +661,46 @@ class WeeklySummaryPayloadType(graphene.ObjectType):
     period = graphene.String(required=True)
     series_start = graphene.String(required=True)
     series_end = graphene.String(required=True)
+
+
+# ---------------------------------------------------------------------------
+# Tags (#1148 — GraphQL parity with REST /tags)
+# ---------------------------------------------------------------------------
+
+
+class TagType(graphene.ObjectType):
+    id = graphene.ID(required=True)
+    name = graphene.String(required=True)
+    color = graphene.String()
+    icon = graphene.String()
+
+
+class TagListType(graphene.ObjectType):
+    tags = graphene.List(graphene.NonNull(TagType), required=True)
+    total = graphene.Int(required=True)
+
+
+class TagPayload(MutationPayload):
+    data = graphene.Field(TagType)
+
+
+# ---------------------------------------------------------------------------
+# Accounts (#1148 — GraphQL parity with REST /accounts)
+# ---------------------------------------------------------------------------
+
+
+class AccountType(graphene.ObjectType):
+    id = graphene.ID(required=True)
+    name = graphene.String(required=True)
+    account_type = graphene.String(required=True)
+    institution = graphene.String()
+    initial_balance = DecimalScalar()
+
+
+class AccountListType(graphene.ObjectType):
+    accounts = graphene.List(graphene.NonNull(AccountType), required=True)
+    total = graphene.Int(required=True)
+
+
+class AccountPayload(MutationPayload):
+    data = graphene.Field(AccountType)

--- a/graphql.introspection.json
+++ b/graphql.introspection.json
@@ -137,6 +137,88 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "accounts",
+              "type": {
+                "kind": "OBJECT",
+                "name": "AccountListType",
+                "ofType": null
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "accountId",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "UUID",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "account",
+              "type": {
+                "kind": "OBJECT",
+                "name": "AccountType",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "tags",
+              "type": {
+                "kind": "OBJECT",
+                "name": "TagListType",
+                "ofType": null
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "tagId",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "UUID",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "tag",
+              "type": {
+                "kind": "OBJECT",
+                "name": "TagType",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "notificationPreferences",
               "type": {
                 "kind": "OBJECT",
@@ -1376,6 +1458,317 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "accounts",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "AccountType",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "total",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "AccountListType",
+          "possibleTypes": null,
+          "specifiedByURL": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "id",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "name",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "accountType",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "institution",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "initialBalance",
+              "type": {
+                "kind": "SCALAR",
+                "name": "DecimalScalar",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "AccountType",
+          "possibleTypes": null,
+          "specifiedByURL": null
+        },
+        {
+          "description": "The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `\"4\"`) or integer (such as `4`) input value will be accepted as an ID.",
+          "enumValues": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "SCALAR",
+          "name": "ID",
+          "possibleTypes": null,
+          "specifiedByURL": null
+        },
+        {
+          "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
+          "enumValues": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "SCALAR",
+          "name": "String",
+          "possibleTypes": null,
+          "specifiedByURL": null
+        },
+        {
+          "description": "Arbitrary-precision decimal serialised as a string.\n\nOutput: always a string in fixed-point notation (no scientific exponent).\nInput: accepts string, int, float, or Decimal — coerced via ``Decimal(str(x))``.\nNull is preserved.",
+          "enumValues": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "SCALAR",
+          "name": "DecimalScalar",
+          "possibleTypes": null,
+          "specifiedByURL": null
+        },
+        {
+          "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.",
+          "enumValues": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "SCALAR",
+          "name": "Int",
+          "possibleTypes": null,
+          "specifiedByURL": null
+        },
+        {
+          "description": "Leverages the internal Python implementation of UUID (uuid.UUID) to provide native UUID objects\nin fields, resolvers and input.",
+          "enumValues": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "SCALAR",
+          "name": "UUID",
+          "possibleTypes": null,
+          "specifiedByURL": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "tags",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "TagType",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "total",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "TagListType",
+          "possibleTypes": null,
+          "specifiedByURL": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "id",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "name",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "color",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "icon",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "TagType",
+          "possibleTypes": null,
+          "specifiedByURL": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "preferences",
               "type": {
                 "kind": "NON_NULL",
@@ -1456,17 +1849,6 @@
           "interfaces": [],
           "kind": "OBJECT",
           "name": "AlertPreferenceType",
-          "possibleTypes": null,
-          "specifiedByURL": null
-        },
-        {
-          "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
-          "enumValues": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "kind": "SCALAR",
-          "name": "String",
           "possibleTypes": null,
           "specifiedByURL": null
         },
@@ -1674,17 +2056,6 @@
           "specifiedByURL": null
         },
         {
-          "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.",
-          "enumValues": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "kind": "SCALAR",
-          "name": "Int",
-          "possibleTypes": null,
-          "specifiedByURL": null
-        },
-        {
           "description": null,
           "enumValues": null,
           "fields": [
@@ -1861,17 +2232,6 @@
           "interfaces": [],
           "kind": "OBJECT",
           "name": "SubscriptionType",
-          "possibleTypes": null,
-          "specifiedByURL": null
-        },
-        {
-          "description": "The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `\"4\"`) or integer (such as `4`) input value will be accepted as an ID.",
-          "enumValues": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "kind": "SCALAR",
-          "name": "ID",
           "possibleTypes": null,
           "specifiedByURL": null
         },
@@ -2155,17 +2515,6 @@
           "interfaces": null,
           "kind": "SCALAR",
           "name": "Float",
-          "possibleTypes": null,
-          "specifiedByURL": null
-        },
-        {
-          "description": "Leverages the internal Python implementation of UUID (uuid.UUID) to provide native UUID objects\nin fields, resolvers and input.",
-          "enumValues": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "kind": "SCALAR",
-          "name": "UUID",
           "possibleTypes": null,
           "specifiedByURL": null
         },
@@ -3990,17 +4339,6 @@
           "interfaces": [],
           "kind": "OBJECT",
           "name": "WalletType",
-          "possibleTypes": null,
-          "specifiedByURL": null
-        },
-        {
-          "description": "Arbitrary-precision decimal serialised as a string.\n\nOutput: always a string in fixed-point notation (no scientific exponent).\nInput: accepts string, int, float, or Decimal — coerced via ``Decimal(str(x))``.\nNull is preserved.",
-          "enumValues": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "kind": "SCALAR",
-          "name": "DecimalScalar",
           "possibleTypes": null,
           "specifiedByURL": null
         },
@@ -10250,6 +10588,332 @@
                   "deprecationReason": null,
                   "description": null,
                   "isDeprecated": false,
+                  "name": "color",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "icon",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "name",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "createTag",
+              "type": {
+                "kind": "OBJECT",
+                "name": "TagPayload",
+                "ofType": null
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "color",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "icon",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "name",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "tagId",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "UUID",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "updateTag",
+              "type": {
+                "kind": "OBJECT",
+                "name": "TagPayload",
+                "ofType": null
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "tagId",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "UUID",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "deleteTag",
+              "type": {
+                "kind": "OBJECT",
+                "name": "TagPayload",
+                "ofType": null
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "accountType",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "initialBalance",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "institution",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "name",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "createAccount",
+              "type": {
+                "kind": "OBJECT",
+                "name": "AccountPayload",
+                "ofType": null
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "accountId",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "UUID",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "accountType",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "initialBalance",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "institution",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "name",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "updateAccount",
+              "type": {
+                "kind": "OBJECT",
+                "name": "AccountPayload",
+                "ofType": null
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "accountId",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "UUID",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "deleteAccount",
+              "type": {
+                "kind": "OBJECT",
+                "name": "AccountPayload",
+                "ofType": null
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
                   "name": "amount",
                   "type": {
                     "kind": "NON_NULL",
@@ -12004,6 +12668,166 @@
           "interfaces": [],
           "kind": "OBJECT",
           "name": "DeleteTickerPayload",
+          "possibleTypes": null,
+          "specifiedByURL": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "True when the mutation completed without errors.",
+              "isDeprecated": false,
+              "name": "ok",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Human-readable status message.",
+              "isDeprecated": false,
+              "name": "message",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Field-level validation errors (empty on success).",
+              "isDeprecated": false,
+              "name": "errors",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "ValidationError",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "data",
+              "type": {
+                "kind": "OBJECT",
+                "name": "TagType",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "TagPayload",
+          "possibleTypes": null,
+          "specifiedByURL": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "True when the mutation completed without errors.",
+              "isDeprecated": false,
+              "name": "ok",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Human-readable status message.",
+              "isDeprecated": false,
+              "name": "message",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Field-level validation errors (empty on success).",
+              "isDeprecated": false,
+              "name": "errors",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "ValidationError",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "data",
+              "type": {
+                "kind": "OBJECT",
+                "name": "AccountType",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "AccountPayload",
           "possibleTypes": null,
           "specifiedByURL": null
         },

--- a/graphql.operations.manifest.json
+++ b/graphql.operations.manifest.json
@@ -517,5 +517,85 @@
     "operation_type": "mutation",
     "source_module": "app.graphql.mutations.auth",
     "summary": "Revoga todas as sessões ativas — logout global."
+  },
+  {
+    "access": "auth_required",
+    "domain": "tags",
+    "name": "tags",
+    "operation_type": "query",
+    "source_module": "app.graphql.queries.tag",
+    "summary": "Lista todas as tags do usuário autenticado."
+  },
+  {
+    "access": "auth_required",
+    "domain": "tags",
+    "name": "tag",
+    "operation_type": "query",
+    "source_module": "app.graphql.queries.tag",
+    "summary": "Retorna uma tag pelo ID."
+  },
+  {
+    "access": "auth_required",
+    "domain": "tags",
+    "name": "createTag",
+    "operation_type": "mutation",
+    "source_module": "app.graphql.mutations.tag",
+    "summary": "Cria uma nova tag para o usuário."
+  },
+  {
+    "access": "auth_required",
+    "domain": "tags",
+    "name": "updateTag",
+    "operation_type": "mutation",
+    "source_module": "app.graphql.mutations.tag",
+    "summary": "Atualiza nome, cor ou ícone de uma tag existente."
+  },
+  {
+    "access": "auth_required",
+    "domain": "tags",
+    "name": "deleteTag",
+    "operation_type": "mutation",
+    "source_module": "app.graphql.mutations.tag",
+    "summary": "Remove uma tag do usuário."
+  },
+  {
+    "access": "auth_required",
+    "domain": "accounts",
+    "name": "accounts",
+    "operation_type": "query",
+    "source_module": "app.graphql.queries.account",
+    "summary": "Lista todas as contas bancárias do usuário autenticado."
+  },
+  {
+    "access": "auth_required",
+    "domain": "accounts",
+    "name": "account",
+    "operation_type": "query",
+    "source_module": "app.graphql.queries.account",
+    "summary": "Retorna uma conta bancária pelo ID."
+  },
+  {
+    "access": "auth_required",
+    "domain": "accounts",
+    "name": "createAccount",
+    "operation_type": "mutation",
+    "source_module": "app.graphql.mutations.account",
+    "summary": "Cria uma nova conta bancária para o usuário."
+  },
+  {
+    "access": "auth_required",
+    "domain": "accounts",
+    "name": "updateAccount",
+    "operation_type": "mutation",
+    "source_module": "app.graphql.mutations.account",
+    "summary": "Atualiza dados de uma conta bancária existente."
+  },
+  {
+    "access": "auth_required",
+    "domain": "accounts",
+    "name": "deleteAccount",
+    "operation_type": "mutation",
+    "source_module": "app.graphql.mutations.account",
+    "summary": "Remove uma conta bancária do usuário."
   }
 ]

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,4 +1,8 @@
 type Query {
+  accounts: AccountListType
+  account(accountId: UUID!): AccountType
+  tags: TagListType
+  tag(tagId: UUID!): TagType
   notificationPreferences: NotificationPreferencesType
   billingPlans: BillingPlanListPayloadType
   mySubscription: SubscriptionType
@@ -29,6 +33,46 @@ type Query {
   dashboardOverview(month: String!): TransactionDashboardPayloadType
   weeklySummary(period: String, startDate: String, endDate: String): WeeklySummaryPayloadType
   me: UserType
+}
+
+type AccountListType {
+  accounts: [AccountType!]!
+  total: Int!
+}
+
+type AccountType {
+  id: ID!
+  name: String!
+  accountType: String!
+  institution: String
+  initialBalance: DecimalScalar
+}
+
+"""
+Arbitrary-precision decimal serialised as a string.
+
+Output: always a string in fixed-point notation (no scientific exponent).
+Input: accepts string, int, float, or Decimal — coerced via ``Decimal(str(x))``.
+Null is preserved.
+"""
+scalar DecimalScalar
+
+"""
+Leverages the internal Python implementation of UUID (uuid.UUID) to provide native UUID objects
+in fields, resolvers and input.
+"""
+scalar UUID
+
+type TagListType {
+  tags: [TagType!]!
+  total: Int!
+}
+
+type TagType {
+  id: ID!
+  name: String!
+  color: String
+  icon: String
 }
 
 type NotificationPreferencesType {
@@ -95,12 +139,6 @@ type BudgetType {
   createdAt: String
   updatedAt: String
 }
-
-"""
-Leverages the internal Python implementation of UUID (uuid.UUID) to provide native UUID objects
-in fields, resolvers and input.
-"""
-scalar UUID
 
 type BudgetSummaryType {
   totalBudgeted: String!
@@ -251,15 +289,6 @@ type WalletType {
   targetWithdrawDate: String
   shouldBeOnWallet: Boolean!
 }
-
-"""
-Arbitrary-precision decimal serialised as a string.
-
-Output: always a string in fixed-point notation (no scientific exponent).
-Input: accepts string, int, float, or Decimal — coerced via ``Decimal(str(x))``.
-Null is preserved.
-"""
-scalar DecimalScalar
 
 type WalletHistoryPayloadType {
   items: [WalletHistoryItemType]!
@@ -634,6 +663,12 @@ type Mutation {
   deleteInvestmentOperation(investmentId: UUID!, operationId: UUID!): DeleteInvestmentOperationMutation @deprecated(reason: "ADR-0002: use DELETE /wallet/{id}/operations/{op_id}")
   addTicker(quantity: Float!, symbol: String!, type: String): AddTickerPayload
   deleteTicker(symbol: String!): DeleteTickerPayload
+  createTag(color: String, icon: String, name: String!): TagPayload
+  updateTag(color: String, icon: String, name: String!, tagId: UUID!): TagPayload
+  deleteTag(tagId: UUID!): TagPayload
+  createAccount(accountType: String, initialBalance: String, institution: String, name: String!): AccountPayload
+  updateAccount(accountId: UUID!, accountType: String, initialBalance: String, institution: String, name: String!): AccountPayload
+  deleteAccount(accountId: UUID!): AccountPayload
   createBudget(amount: String!, endDate: String, isActive: Boolean, name: String!, period: String!, startDate: String, tagId: String): CreateBudgetMutation @deprecated(reason: "ADR-0002: use POST /budgets")
   updateBudget(amount: String, budgetId: UUID!, endDate: String, isActive: Boolean, name: String, period: String, startDate: String, tagId: String): UpdateBudgetMutation @deprecated(reason: "ADR-0002: use PATCH /budgets/{id}")
   deleteBudget(budgetId: UUID!): DeleteBudgetMutation @deprecated(reason: "ADR-0002: use DELETE /budgets/{id}")
@@ -831,6 +866,30 @@ type DeleteTickerPayload {
 
   """Field-level validation errors (empty on success)."""
   errors: [ValidationError!]!
+}
+
+type TagPayload {
+  """True when the mutation completed without errors."""
+  ok: Boolean!
+
+  """Human-readable status message."""
+  message: String!
+
+  """Field-level validation errors (empty on success)."""
+  errors: [ValidationError!]!
+  data: TagType
+}
+
+type AccountPayload {
+  """True when the mutation completed without errors."""
+  ok: Boolean!
+
+  """Human-readable status message."""
+  message: String!
+
+  """Field-level validation errors (empty on success)."""
+  errors: [ValidationError!]!
+  data: AccountType
 }
 
 type CreateBudgetMutation {

--- a/scripts/graphql_mutation_audit.py
+++ b/scripts/graphql_mutation_audit.py
@@ -52,6 +52,16 @@ ADR_0002_ALLOWED_CRUD_VERBS: set[str] = {
     "create_goal_from_installment_vs_cash_simulation",  # Simulation composite
     "create_planned_expense_from_installment_vs_cash_simulation",  # Simulation
     "create_checkout_session",  # Stripe-specific, no domain CRUD equivalent
+    # Tags (#1148) — canonical GraphQL CRUD surface; REST /tags exists but
+    # GraphQL is exposed as the primary client interface for tag management.
+    "create_tag",
+    "update_tag",
+    "delete_tag",
+    # Accounts (#1148) — canonical GraphQL CRUD surface; REST /accounts exists
+    # but GraphQL is exposed as the primary client interface.
+    "create_account",
+    "update_account",
+    "delete_account",
 }
 
 # Keywords that, if present in a mutation name without deprecation, indicate

--- a/tests/test_graphql_tags_accounts.py
+++ b/tests/test_graphql_tags_accounts.py
@@ -1,0 +1,243 @@
+"""GraphQL tests for Tags and Accounts domains (#1148)."""
+
+from __future__ import annotations
+
+import uuid
+
+from flask.testing import FlaskClient
+
+
+def _register_and_login(client: FlaskClient, prefix: str = "gql") -> str:
+    suffix = uuid.uuid4().hex[:8]
+    email = f"{prefix}-{suffix}@test.com"
+    password = "StrongPass@123"
+    r = client.post(
+        "/auth/register",
+        json={"name": f"{prefix}-{suffix}", "email": email, "password": password},
+    )
+    assert r.status_code == 201
+    r2 = client.post("/auth/login", json={"email": email, "password": password})
+    assert r2.status_code == 200
+    return r2.get_json()["token"]
+
+
+def _gql(
+    client: FlaskClient,
+    query: str,
+    variables: dict | None = None,
+    token: str | None = None,
+) -> dict:
+    headers = {}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    res = client.post(
+        "/graphql", json={"query": query, "variables": variables or {}}, headers=headers
+    )
+    assert res.status_code in {200, 401}
+    if res.status_code == 401:
+        return {
+            "errors": [
+                {"message": "Unauthorized", "extensions": {"code": "UNAUTHORIZED"}}
+            ]
+        }
+    return res.get_json()
+
+
+# ---------------------------------------------------------------------------
+# Tags
+# ---------------------------------------------------------------------------
+
+_CREATE_TAG = """
+mutation CreateTag($name: String!, $color: String, $icon: String) {
+  createTag(name: $name, color: $color, icon: $icon) {
+    ok message errors { field message }
+    data { id name color icon }
+  }
+}
+"""
+
+_UPDATE_TAG = """
+mutation UpdateTag($tagId: UUID!, $name: String!) {
+  updateTag(tagId: $tagId, name: $name) {
+    ok message data { id name }
+  }
+}
+"""
+
+_DELETE_TAG = """
+mutation DeleteTag($tagId: UUID!) {
+  deleteTag(tagId: $tagId) { ok message }
+}
+"""
+
+_TAGS_QUERY = "{ tags { total tags { id name color icon } } }"
+_TAG_QUERY = "query Tag($id: UUID!) { tag(tagId: $id) { id name } }"
+
+
+class TestTagsGraphQL:
+    def test_create_tag(self, client: FlaskClient) -> None:
+        token = _register_and_login(client, "tag-create")
+        body = _gql(
+            client, _CREATE_TAG, {"name": "Alimentação", "color": "#FF6B6B"}, token
+        )
+        assert "errors" not in body
+        payload = body["data"]["createTag"]
+        assert payload["ok"] is True
+        assert payload["data"]["name"] == "Alimentação"
+        assert payload["data"]["color"] == "#FF6B6B"
+
+    def test_tags_query_returns_list(self, client: FlaskClient) -> None:
+        token = _register_and_login(client, "tag-list")
+        _gql(client, _CREATE_TAG, {"name": "Transporte"}, token)
+        body = _gql(client, _TAGS_QUERY, token=token)
+        assert "errors" not in body
+        assert body["data"]["tags"]["total"] >= 1
+        names = [t["name"] for t in body["data"]["tags"]["tags"]]
+        assert "Transporte" in names
+
+    def test_update_tag(self, client: FlaskClient) -> None:
+        token = _register_and_login(client, "tag-update")
+        created = _gql(client, _CREATE_TAG, {"name": "Lazer"}, token)
+        tag_id = created["data"]["createTag"]["data"]["id"]
+        body = _gql(
+            client, _UPDATE_TAG, {"tagId": tag_id, "name": "Entretenimento"}, token
+        )
+        assert body["data"]["updateTag"]["ok"] is True
+        assert body["data"]["updateTag"]["data"]["name"] == "Entretenimento"
+
+    def test_delete_tag(self, client: FlaskClient) -> None:
+        token = _register_and_login(client, "tag-delete")
+        created = _gql(client, _CREATE_TAG, {"name": "Temp"}, token)
+        tag_id = created["data"]["createTag"]["data"]["id"]
+        body = _gql(client, _DELETE_TAG, {"tagId": tag_id}, token)
+        assert body["data"]["deleteTag"]["ok"] is True
+
+    def test_create_tag_invalid_color(self, client: FlaskClient) -> None:
+        token = _register_and_login(client, "tag-inv-color")
+        body = _gql(client, _CREATE_TAG, {"name": "Foo", "color": "not-a-color"}, token)
+        assert "errors" in body
+        assert body["errors"][0]["extensions"]["code"] == "VALIDATION_ERROR"
+
+    def test_tag_not_found_returns_null(self, client: FlaskClient) -> None:
+        token = _register_and_login(client, "tag-404")
+        body = _gql(client, _TAG_QUERY, {"id": str(uuid.uuid4())}, token)
+        assert "errors" not in body
+        assert body["data"]["tag"] is None
+
+    def test_tag_isolated_by_user(self, client: FlaskClient) -> None:
+        token_a = _register_and_login(client, "tag-iso-a")
+        token_b = _register_and_login(client, "tag-iso-b")
+        created = _gql(client, _CREATE_TAG, {"name": "Private"}, token_a)
+        tag_id = created["data"]["createTag"]["data"]["id"]
+        body = _gql(client, _DELETE_TAG, {"tagId": tag_id}, token_b)
+        assert "errors" in body
+        assert body["errors"][0]["extensions"]["code"] == "NOT_FOUND"
+
+    def test_tags_require_auth(self, client: FlaskClient) -> None:
+        body = _gql(client, _TAGS_QUERY)
+        assert "errors" in body
+
+
+# ---------------------------------------------------------------------------
+# Accounts
+# ---------------------------------------------------------------------------
+
+_CREATE_ACCOUNT = """
+mutation CreateAccount(
+  $name: String!, $accountType: String,
+  $institution: String, $initialBalance: String
+) {
+  createAccount(
+    name: $name, accountType: $accountType,
+    institution: $institution, initialBalance: $initialBalance
+  ) {
+    ok message errors { field message }
+    data { id name accountType institution initialBalance }
+  }
+}
+"""
+
+_UPDATE_ACCOUNT = """
+mutation UpdateAccount($accountId: UUID!, $name: String!) {
+  updateAccount(accountId: $accountId, name: $name) {
+    ok message data { id name accountType }
+  }
+}
+"""
+
+_DELETE_ACCOUNT = """
+mutation DeleteAccount($accountId: UUID!) {
+  deleteAccount(accountId: $accountId) { ok message }
+}
+"""
+
+_ACCOUNTS_QUERY = "{ accounts { total accounts { id name accountType institution } } }"
+
+
+class TestAccountsGraphQL:
+    def test_create_account(self, client: FlaskClient) -> None:
+        token = _register_and_login(client, "acc-create")
+        body = _gql(
+            client,
+            _CREATE_ACCOUNT,
+            {
+                "name": "Nubank",
+                "accountType": "checking",
+                "institution": "Nubank",
+                "initialBalance": "1000.50",
+            },
+            token,
+        )
+        assert "errors" not in body
+        payload = body["data"]["createAccount"]
+        assert payload["ok"] is True
+        assert payload["data"]["name"] == "Nubank"
+        assert payload["data"]["accountType"] == "checking"
+
+    def test_accounts_query_returns_list(self, client: FlaskClient) -> None:
+        token = _register_and_login(client, "acc-list")
+        _gql(client, _CREATE_ACCOUNT, {"name": "Inter"}, token)
+        body = _gql(client, _ACCOUNTS_QUERY, token=token)
+        assert "errors" not in body
+        assert body["data"]["accounts"]["total"] >= 1
+
+    def test_update_account(self, client: FlaskClient) -> None:
+        token = _register_and_login(client, "acc-update")
+        created = _gql(client, _CREATE_ACCOUNT, {"name": "Old Name"}, token)
+        acc_id = created["data"]["createAccount"]["data"]["id"]
+        body = _gql(
+            client, _UPDATE_ACCOUNT, {"accountId": acc_id, "name": "New Name"}, token
+        )
+        assert body["data"]["updateAccount"]["ok"] is True
+        assert body["data"]["updateAccount"]["data"]["name"] == "New Name"
+
+    def test_delete_account(self, client: FlaskClient) -> None:
+        token = _register_and_login(client, "acc-delete")
+        created = _gql(client, _CREATE_ACCOUNT, {"name": "Temp Account"}, token)
+        acc_id = created["data"]["createAccount"]["data"]["id"]
+        body = _gql(client, _DELETE_ACCOUNT, {"accountId": acc_id}, token)
+        assert body["data"]["deleteAccount"]["ok"] is True
+
+    def test_create_account_invalid_type(self, client: FlaskClient) -> None:
+        token = _register_and_login(client, "acc-inv-type")
+        body = _gql(
+            client,
+            _CREATE_ACCOUNT,
+            {"name": "Test", "accountType": "invalid_type"},
+            token,
+        )
+        assert "errors" in body
+        assert body["errors"][0]["extensions"]["code"] == "VALIDATION_ERROR"
+
+    def test_account_isolated_by_user(self, client: FlaskClient) -> None:
+        token_a = _register_and_login(client, "acc-iso-a")
+        token_b = _register_and_login(client, "acc-iso-b")
+        created = _gql(client, _CREATE_ACCOUNT, {"name": "Private Account"}, token_a)
+        acc_id = created["data"]["createAccount"]["data"]["id"]
+        body = _gql(client, _DELETE_ACCOUNT, {"accountId": acc_id}, token_b)
+        assert "errors" in body
+        assert body["errors"][0]["extensions"]["code"] == "NOT_FOUND"
+
+    def test_accounts_require_auth(self, client: FlaskClient) -> None:
+        body = _gql(client, _ACCOUNTS_QUERY)
+        assert "errors" in body


### PR DESCRIPTION
## Summary

Implementa paridade REST↔GraphQL para os domínios Tags e Accounts — os dois mais prioritários da auditoria #1157/#1148. Fiscal e Bank Statement ficam REST-only por complexidade (CSV upload, documentado como exceção no issue).

### Tags
- **Queries:** `tags { total tags { id name color icon } }` · `tag(tagId: UUID)`
- **Mutations:** `createTag` / `updateTag` / `deleteTag`
- Validação: `name` ≤50 chars, `color` deve ser hex válido (`#RRGGBB`)

### Accounts
- **Queries:** `accounts { total accounts { ... } }` · `account(accountId: UUID)`
- **Mutations:** `createAccount` / `updateAccount` / `deleteAccount`
- Validação: `name` ≤100 chars, `accountType` ∈ `{checking|savings|investment|wallet|other}`

### Suporte
- `TagType`, `TagListType`, `TagPayload`, `AccountType`, `AccountListType`, `AccountPayload` em `types.py`
- `GraphQLDomain` estendido com `"tags"` e `"accounts"`
- `ADR_0002_ALLOWED_CRUD_VERBS` atualizado (Tags/Accounts são surface canônica GraphQL)
- 15 novos testes: CRUD, validação, auth, isolamento por usuário

## Test plan

- [ ] `{ tags { total tags { id name } } }` retorna lista do usuário autenticado
- [ ] `mutation { createTag(name: "X", color: "#FF0000") { ok data { id } } }` cria tag
- [ ] `mutation { createTag(name: "X", color: "bad") { ok } }` → erro VALIDATION_ERROR
- [ ] `{ accounts { total accounts { id name accountType } } }` retorna contas
- [ ] Delete de tag/account de outro usuário → NOT_FOUND
- [ ] CI verde

Closes #1148