### PR TITLE
docs(agent): elevate api to 95% agent maturity

### DIFF
--- a/.claude/hooks/pre-tool-use.py
+++ b/.claude/hooks/pre-tool-use.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""auraxis-api pre-tool-use hook — Python/Flask/SQLAlchemy safety guards."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_ENV_FILE_RE = re.compile(r"(^|/)\.env(?:\.(?!example$)[\w.-]+)?$")
+_SENSITIVE = ("secrets.", "credentials.")
+_INFRA_FILES = ("docker-compose", "Dockerfile", "run.py", "pyproject.toml")
+_MIGRATION_PATTERNS = (
+    "native_enum=True",
+    "op.get_bind()",
+    'op.execute("CREATE TYPE',
+    "ENUM(",
+    "gen_random_uuid()",
+)
+_CONTRACT_PATHS = (
+    "app/models/",
+    "app/schemas/",
+    "openapi.json",
+    "schema.graphql",
+    "app/graphql/schema",
+)
+_COVERAGE_CONFIGS = ("pyproject.toml", ".coveragerc", "setup.cfg")
+
+_HARD_BLOCKS = [
+    (
+        r"git add \.(\s|$)",
+        "BLOQUEADO: 'git add .' proibido. Use: git add <arquivo>",
+    ),
+    (r"git add -A(\s|$)", "BLOQUEADO: 'git add -A' proibido."),
+    (r"git add --all(\s|$)", "BLOQUEADO: 'git add --all' proibido."),
+    (r"git push --force", "BLOQUEADO: push --force requer aprovacao humana."),
+    (r"git push -f(\s|$)", "BLOQUEADO: push -f requer aprovacao humana."),
+    (r"git commit --no-verify", "BLOQUEADO: --no-verify pula quality gates."),
+    (r"git commit -n(\s|$)", "BLOQUEADO: -n pula quality gates."),
+    (
+        r"git push\s+(\S+\s+)?(main|master)(\s|$)",
+        "BLOQUEADO: push direto para main/master. Use PR.",
+    ),
+    (r"DROP TABLE", "BLOQUEADO: DROP TABLE requer aprovacao humana."),
+    (r"DROP DATABASE", "BLOQUEADO: DROP DATABASE requer aprovacao humana."),
+    (
+        r"flask db downgrade",
+        "BLOQUEADO: downgrade de migration requer aprovacao humana.",
+    ),
+]
+
+_SOFT_WARNS = [
+    (r"git reset --hard", "AVISO: git reset --hard e destrutivo."),
+    (r"rm -rf", "AVISO: rm -rf e destrutivo."),
+    (
+        r"flask db upgrade",
+        "AVISO: flask db upgrade modifica o banco."
+        " Confirme que scripts/test_migrations_local.sh passou.",
+    ),
+    (r"alembic upgrade", "AVISO: alembic upgrade modifica o banco."),
+    (
+        r"docker-compose.*down",
+        "AVISO: docker-compose down pode destruir dados locais.",
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    try:
+        data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        sys.exit(0)
+    tool_name = data.get("tool_name", "")
+    tool_input = data.get("tool_input", {})
+    if tool_name == "Bash":
+        _check_bash(tool_input.get("command", ""))
+    elif tool_name in ("Write", "Edit"):
+        content = tool_input.get("content", "") or tool_input.get("new_string", "")
+        _check_file_write(tool_input.get("file_path", ""), content=content)
+
+
+# ---------------------------------------------------------------------------
+# Bash guard
+# ---------------------------------------------------------------------------
+
+
+def _check_bash(command: str) -> None:
+    for pattern, msg in _HARD_BLOCKS:
+        if re.search(pattern, command):
+            print(msg, file=sys.stderr)
+            sys.exit(2)
+    for pattern, msg in _SOFT_WARNS:
+        if re.search(pattern, command):
+            print(msg, file=sys.stderr)
+
+
+# ---------------------------------------------------------------------------
+# File-write guards (split to keep each helper under complexity limit)
+# ---------------------------------------------------------------------------
+
+
+def _check_secrets(file_path: str) -> None:
+    for s in _SENSITIVE:
+        if s in file_path:
+            print(
+                f"BLOQUEADO: escrita em '{file_path}' proibida (secrets).",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+    if _ENV_FILE_RE.search(file_path):
+        print(
+            f"BLOQUEADO: escrita em '{file_path}' proibida (.env).",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+
+def _check_infra(file_path: str) -> None:
+    for infra in _INFRA_FILES:
+        if infra in file_path:
+            print(
+                f"AVISO: editando arquivo de infra '{file_path}'."
+                " Requer aprovacao humana explicita.",
+                file=sys.stderr,
+            )
+
+
+def _check_migration(file_path: str, content: str) -> None:
+    if "migrations/" not in file_path or not content:
+        return
+    for pattern in _MIGRATION_PATTERNS:
+        if pattern in content:
+            print(
+                f"AVISO: padrao problematico '{pattern}' em migration.\n"
+                "Veja CLAUDE.md 'Migration Conventions' — use native_enum=False"
+                " e teste com scripts/test_migrations_local.sh",
+                file=sys.stderr,
+            )
+
+
+def _check_contract(file_path: str) -> None:
+    for cp in _CONTRACT_PATHS:
+        if cp in file_path:
+            print(
+                f"AVISO: editando fonte de contrato '{file_path}'.\n"
+                "Atualize o snapshot OpenAPI e valide consumers"
+                " (auraxis-web, auraxis-app).",
+                file=sys.stderr,
+            )
+            return
+
+
+def _check_coverage_config(file_path: str) -> None:
+    for cc in _COVERAGE_CONFIGS:
+        if file_path.endswith(cc):
+            print(
+                f"AVISO: editando config de qualidade '{file_path}'."
+                " Threshold minimo: 85%.",
+                file=sys.stderr,
+            )
+
+
+def _check_file_write(file_path: str, content: str = "") -> None:
+    _check_secrets(file_path)
+    _check_infra(file_path)
+    _check_migration(file_path, content)
+    _check_contract(file_path)
+    _check_coverage_config(file_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 .claude/hooks/pre-tool-use.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,3 +231,28 @@ Key ADRs governing the GraphQL layer:
 - [`docs/adr/0002-graphql-ownership.md`](docs/adr/0002-graphql-ownership.md) — REST vs GraphQL ownership boundaries; when to use each protocol
 - [`docs/adr/0003-graphql-flat-types-no-dataloader.md`](docs/adr/0003-graphql-flat-types-no-dataloader.md) — flat Graphene types, service-layer batching, no DataLoader
 - [`docs/adr/0004-graphql-ownership-scope-completion.md`](docs/adr/0004-graphql-ownership-scope-completion.md) — extends ADR-0002 to Subscription mutations; documents ticker exception
+
+## Mapa de dominios disponíveis
+
+Use esta tabela antes de criar qualquer novo controller, service ou model.
+**Verifique primeiro se o dominio ja existe — evite duplicar logica.**
+
+| Dominio | Controllers | Services principais | Models |
+|---------|-------------|---------------------|--------|
+| auth | `auth_controller` | `auth_security_policy_service`, `login_identity_service`, `session_service`, `email_confirmation_service`, `password_reset_service`, `password_verification_service` | `User`, `RefreshToken` |
+| transactions | `transaction_controller` | `transaction_application_service`, `transaction_ledger_service`, `transaction_query_service`, `transaction_reminder_service` | `Transaction`, `Tag`, `SharedEntry` |
+| goals | `goal_controller` | `goal_application_service` | `Goal` |
+| wallet | `wallet_controller` | `wallet_application_service`, `investment_application_service` | `WalletEntry`, `UserTicker`, `InvestmentOperation` |
+| budget | `budget/` (subpkg) | — | `BudgetEnvelope` |
+| simulation | `simulation_controller` | `simulation_application_service`, `installment_vs_cash_application_service`, `installment_vs_cash_bridge_service` | `Simulation` |
+| subscription | `subscription_controller` | `entitlement_application_service`, `billing_email_service` | `Subscription`, `Entitlement` |
+| alerts | `alert_controller` | — | `Alert` |
+| user | `user_controller` | `user_profile_service`, `authenticated_user_context_service`, `authenticated_user_bootstrap_service` | `User`, `Account` |
+| advisory | — | `advisory_service` | — |
+| fiscal | `fiscal/` (subpkg) | — | `Fiscal` |
+| credit_card | `credit_card/` (subpkg) | — | `CreditCard` |
+| dashboard | `dashboard/` (subpkg) | — | — |
+| observability | `observability_controller` | — | `AuditEvent`, `WebhookEvent` |
+
+**Antes de criar um novo service**: consulte `app/application/services/CLAUDE.md`.
+**Antes de criar um novo controller**: consulte `app/controllers/CLAUDE.md`.

--- a/app/application/services/CLAUDE.md
+++ b/app/application/services/CLAUDE.md
@@ -1,0 +1,82 @@
+# CLAUDE.md — `app/application/services/*`
+
+Camada de logica de negocio do auraxis-api. Services sao stateless e orquestram
+models, schemas e repositorios.
+
+## Regras
+
+- Services sao funcoes puras ou metodos de classe estaticos/classmethods
+- Nunca acoplam HTTP (sem `request`, `jsonify`) — isso fica nos controllers
+- Nunca acoplam ao banco diretamente com SQL raw — usam models SQLAlchemy
+- Toda operacao de escrita deve ser transacional (`db.session.commit()` ao final)
+- Erros de negocio levantam excecoes do tipo `AppError` (nunca `HTTPException`)
+- Services nao conhecem o protocolo (REST ou GraphQL) que os chamou
+
+## Padrao canonico
+
+```python
+# app/application/services/<domain>_service.py
+from app.models.<domain> import <Domain>
+from app.extensions import db
+from app.errors import AppError
+
+class <Domain>Service:
+    @classmethod
+    def create(cls, user_id: int, data: dict) -> <Domain>:
+        # validacoes de negocio
+        existing = <Domain>.query.filter_by(user_id=user_id).first()
+        if existing:
+            raise AppError("already_exists", 409)
+        # criacao do model
+        entity = <Domain>(user_id=user_id, **data)
+        db.session.add(entity)
+        db.session.commit()
+        return entity
+```
+
+## Services existentes
+
+| Service | Responsabilidade |
+|---|---|
+| `auth_security_policy_service.py` | Politicas de seguranca de autenticacao |
+| `authenticated_user_bootstrap_service.py` | Bootstrap do contexto de usuario autenticado |
+| `authenticated_user_context_service.py` | Contexto de usuario por request |
+| `billing_email_service.py` | Emails transacionais de cobranca |
+| `email_confirmation_service.py` | Confirmacao de email por token |
+| `entitlement_application_service.py` | Logica de entitlements por plano |
+| `goal_application_service.py` | Metas financeiras e contribuicoes |
+| `installment_vs_cash_application_service.py` | Comparativo parcelado vs avista |
+| `installment_vs_cash_bridge_service.py` | Bridge para dados de simulacao |
+| `investment_application_service.py` | Operacoes de investimento |
+| `login_identity_service.py` | Verificacao de identidade no login |
+| `password_reset_service.py` | Fluxo de reset de senha |
+| `password_verification_service.py` | Verificacao de senha atual |
+| `public_error_mapper_service.py` | Mapeamento de erros internos para publicos |
+| `session_service.py` | Gestao de sessoes e refresh tokens |
+| `simulation_application_service.py` | Simulacoes financeiras |
+| `transaction_application_service.py` | CRUD de transacoes |
+| `transaction_ledger_service.py` | Contabilidade do ledger |
+| `transaction_query_service.py` | Queries complexas de transacoes |
+| `transaction_reminder_service.py` | Lembretes de transacao recorrente |
+| `user_profile_service.py` | Atualizacao de perfil de usuario |
+| `wallet_application_service.py` | Carteira e ativos de investimento |
+| `advisory_service.py` | Recomendacoes e insights financeiros |
+
+## Antes de criar um novo service
+
+1. Verifique se ja existe um service para o dominio na tabela acima
+2. Prefira estender o service existente com novo metodo ao inves de criar duplicata
+3. Se o service existente ficaria grande demais (>300 linhas), divida com sufixo semantico:
+   - `_query_service` para operacoes de leitura pesada
+   - `_application_service` para orchestracao de casos de uso
+   - `_ledger_service` para contabilidade/calculo
+
+## Testes
+
+Unit tests em `tests/unit/services/` — mockam o banco com fixtures pytest:
+
+```bash
+pytest tests/unit/services/test_<domain>_service.py -v
+```
+
+Cobertura minima: 85% (obrigatoria para merge).

--- a/app/controllers/CLAUDE.md
+++ b/app/controllers/CLAUDE.md
@@ -1,0 +1,74 @@
+# CLAUDE.md — `app/controllers/*`
+
+Camada REST do auraxis-api. Cada controller e um adapter que:
+1. Valida a request com Marshmallow schema
+2. Chama o service da camada de aplicacao
+3. Serializa a response
+
+## Estrutura canonica por controller
+
+```python
+# app/controllers/<domain>_controller.py
+from flask import Blueprint, request, jsonify
+from app.schemas.<domain>_schema import <Domain>Schema
+from app.application.services.<domain>_service import <Domain>Service
+
+bp = Blueprint('<domain>', __name__)
+
+@bp.route('/<domain>', methods=['POST'])
+@require_auth   # sempre aplicar auth
+def create_<domain>():
+    data = <Domain>Schema().load(request.json)  # valida + deserializa
+    result = <Domain>Service.create(data)        # logica de negocio
+    return jsonify(<Domain>Schema().dump(result)), 201
+```
+
+## Regras
+
+- Controllers nao contem logica de negocio — apenas orchestracao HTTP
+- Toda validacao via Marshmallow schemas (em `app/schemas/`)
+- Toda logica de negocio em `app/application/services/`
+- Autenticacao via decorator `@require_auth` (sempre)
+- Erros de dominio → HTTP errors via `AppError` hierarchy
+- Response format padrao: use `response_contract.py` para envelope consistente
+
+## Controllers existentes
+
+| Controller | Dominio | Blueprint prefix |
+|---|---|---|
+| `auth_controller.py` | Auth/sessao | `/auth` |
+| `user_controller.py` | Perfil de usuario | `/user` |
+| `transaction_controller.py` | Transacoes financeiras | `/transactions` |
+| `goal_controller.py` | Metas financeiras | `/goals` |
+| `wallet_controller.py` | Carteira/investimentos | `/wallet` |
+| `subscription_controller.py` | Assinatura/billing | `/subscription` |
+| `budget_controller.py` (em `budget/`) | Orcamentos por envelope | `/budget` |
+| `alert_controller.py` | Alertas e notificacoes | `/alerts` |
+| `graphql_controller.py` | Endpoint GraphQL unificado | `/graphql` |
+| `health_controller.py` | Healthcheck da API | `/health` |
+| `simulation_controller.py` | Simulacoes financeiras | `/simulation` |
+| `observability_controller.py` | Metricas e tracing | `/observability` |
+
+## REST vs GraphQL
+
+Decisao governada por `docs/adr/0002-graphql-ownership.md`:
+
+- **REST**: operacoes de escrita (POST, PUT, PATCH, DELETE) e endpoints publicos
+- **GraphQL**: queries complexas, dados relacionados em uma unica request
+- Todo endpoint REST deve ter equivalente GraphQL quando for query de dados
+
+## O que perguntar antes (nao agir autonomamente)
+
+- Adicionar novo endpoint que mude contratos REST (impacta consumers auraxis-web e auraxis-app)
+- Modificar formato de response de endpoint existente (quebra contratos)
+- Adicionar novo decorator de auth ou middleware global
+
+## Testes
+
+Todo controller deve ter testes de integracao em `tests/integration/`:
+
+```bash
+pytest tests/integration/test_<domain>_controller.py -v
+```
+
+Cobertura minima: 85% (obrigatoria para merge).


### PR DESCRIPTION
## Summary

Elevates auraxis-api to 95% maturity for autonomous agent coding sessions.

- **.claude/hooks/pre-tool-use.py**: safety guards wired into Claude Code's PreToolUse hook — blocks destructive bash operations (git add ., force push, direct push to main/master, flask db downgrade), warns on migration anti-patterns (native_enum=True, op.get_bind(), gen_random_uuid()), warns on infra file edits (Dockerfile, docker-compose, pyproject.toml), and emits contract-drift reminders when editing models/schemas/graphql sources
- **.claude/settings.json**: wires the PreToolUse hook so it activates automatically in every Claude Code session on this repo
- **app/controllers/CLAUDE.md**: documents the REST controller contract (structure, rules, full inventory of 12 controllers, REST vs GraphQL ownership boundaries, test conventions)
- **app/application/services/CLAUDE.md**: documents service layer rules (stateless pattern, no HTTP coupling, transactional writes, full inventory of 23 existing services, guidance on when to extend vs create)
- **CLAUDE.md domain map**: adds a cross-reference table of all 15 domains (auth, transactions, goals, wallet, budget, simulation, subscription, alerts, user, advisory, fiscal, credit_card, dashboard, observability) with their controllers, services, and models — preventing accidental duplication

## Test plan

- [x] All pre-commit hooks pass: ruff check, ruff format, mypy, bandit, repo-hygiene, graphql-auth-config, alembic-single-head, sonar, pip-audit
- [x] No product code modified — only documentation and hook infrastructure
- [x] Hook is pure Python stdlib (no external deps) — works in any venv state