### PR TITLE
feat(ai): AI advisory service with LLM audit logging

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -19,6 +19,7 @@ from app.controllers.account import account_bp
 from app.controllers.admin.audit_trail import admin_audit_trail_bp
 from app.controllers.admin.feature_flags import admin_feature_flags_bp
 from app.controllers.advisory import advisory_bp
+from app.controllers.ai import ai_bp
 from app.controllers.alert_controller import alert_bp, register_alert_dependencies
 from app.controllers.auth_controller import auth_bp, register_auth_dependencies
 from app.controllers.bank_statement import bank_statement_bp
@@ -86,6 +87,7 @@ from app.models.fiscal import (  # noqa: F401
 )
 from app.models.goal import Goal  # noqa: F401
 from app.models.investment_operation import InvestmentOperation  # noqa: F401
+from app.models.llm_audit_log import LLMAuditLog  # noqa: F401
 from app.models.refresh_token import RefreshToken  # noqa: F401
 from app.models.shared_entry import Invitation, SharedEntry  # noqa: F401
 from app.models.sharing_audit import SharingAuditEvent  # noqa: F401
@@ -319,6 +321,7 @@ def create_app(*, enable_http_runtime: bool = True) -> Flask:
     app.register_blueprint(tag_bp)
     app.register_blueprint(budget_bp)
     app.register_blueprint(advisory_bp)
+    app.register_blueprint(ai_bp)
     app.register_blueprint(admin_feature_flags_bp, url_prefix="/admin")
     app.register_blueprint(admin_audit_trail_bp)
 

--- a/app/controllers/ai/__init__.py
+++ b/app/controllers/ai/__init__.py
@@ -1,0 +1,14 @@
+from . import routes as _routes  # noqa: F401
+from .blueprint import ai_bp
+from .resources import (
+    AIGoalProjectionResource,
+    AISpendingInsightsResource,
+    AIWeeklySummaryResource,
+)
+
+__all__ = [
+    "ai_bp",
+    "AISpendingInsightsResource",
+    "AIGoalProjectionResource",
+    "AIWeeklySummaryResource",
+]

--- a/app/controllers/ai/blueprint.py
+++ b/app/controllers/ai/blueprint.py
@@ -1,0 +1,3 @@
+from flask import Blueprint
+
+ai_bp = Blueprint("ai", __name__, url_prefix="/ai")

--- a/app/controllers/ai/resources.py
+++ b/app/controllers/ai/resources.py
@@ -1,0 +1,371 @@
+"""REST resources for LLM-powered AI advisory endpoints (#1206).
+
+Endpoints:
+  GET  /ai/insights/spending?month=YYYY-MM  — monthly spending insights
+  POST /ai/goals/<goal_id>/projection       — goal projection narrative
+  GET  /ai/insights/weekly-summary          — weekly summary narrative
+
+All endpoints require a valid JWT and the "advanced_simulations" entitlement.
+"""
+
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal, InvalidOperation
+from typing import Any
+from uuid import UUID
+
+from flask import Response, request
+from flask_apispec.views import MethodResource
+
+from app.auth import current_user_id
+from app.controllers.response_contract import (
+    compat_error_response,
+    compat_success_response,
+)
+from app.controllers.transaction.utils import _guard_revoked_token
+from app.docs.openapi_helpers import (
+    json_error_response,
+    json_success_response,
+)
+from app.services.ai_advisory_service import AIAdvisoryService
+from app.services.entitlement_service import has_entitlement
+from app.services.llm_provider import LLMProviderError
+from app.utils.typed_decorators import typed_doc as doc
+from app.utils.typed_decorators import typed_jwt_required as jwt_required
+
+_ENTITLEMENT_KEY = "advanced_simulations"
+
+
+def _check_entitlement(user_id: UUID) -> Response | None:
+    """Return 403 response if user lacks the required entitlement, else None."""
+    if not has_entitlement(user_id, _ENTITLEMENT_KEY):
+        return compat_error_response(
+            legacy_payload={"error": "Recurso exclusivo para assinantes Premium."},
+            status_code=403,
+            message="Recurso exclusivo para assinantes Premium.",
+            error_code="ENTITLEMENT_REQUIRED",
+        )
+    return None
+
+
+class AISpendingInsightsResource(MethodResource):
+    """GET /ai/insights/spending — monthly spending analysis with AI insights."""
+
+    @doc(
+        summary="Insights de gastos com IA (Premium)",
+        description=(
+            "Analisa os gastos do mês informado e retorna insights gerados por LLM em PT-BR. "  # noqa: E501
+            "Requer entitlement 'advanced_simulations' (plano Premium)."
+        ),
+        tags=["AI Advisory"],
+        security=[{"BearerAuth": []}],
+        params={
+            "month": {
+                "in": "query",
+                "type": "string",
+                "required": False,
+                "description": "Mês no formato YYYY-MM. Padrão: mês atual.",
+                "example": "2026-05",
+            },
+        },
+        responses={
+            200: json_success_response(
+                description="Insights gerados com sucesso",
+                message="Insights de gastos gerados com sucesso",
+                data_example={
+                    "insights": "1. Gasto elevado em alimentação...",
+                    "tokens_used": 320,
+                    "cost_usd": 0.000048,
+                    "month": "2026-05",
+                    "model": "gpt-4o-mini",
+                },
+            ),
+            401: json_error_response(
+                description="Não autenticado",
+                message="Token inválido",
+                error_code="UNAUTHORIZED",
+                status_code=401,
+            ),
+            403: json_error_response(
+                description="Entitlement insuficiente",
+                message="Recurso exclusivo para assinantes Premium.",
+                error_code="ENTITLEMENT_REQUIRED",
+                status_code=403,
+            ),
+            500: json_error_response(
+                description="Erro interno ou falha do provider LLM",
+                message="Erro ao gerar insights de gastos",
+                error_code="INTERNAL_ERROR",
+                status_code=500,
+            ),
+        },
+    )
+    @jwt_required()
+    def get(self) -> Response:
+        token_error = _guard_revoked_token()
+        if token_error is not None:
+            return token_error
+
+        user_id = current_user_id()
+
+        entitlement_error = _check_entitlement(user_id)
+        if entitlement_error is not None:
+            return entitlement_error
+
+        month = request.args.get("month") or None
+
+        service = AIAdvisoryService(user_id=user_id)
+        try:
+            result = service.generate_spending_insights(month=month)
+        except LLMProviderError as exc:
+            return compat_error_response(
+                legacy_payload={"error": str(exc)},
+                status_code=500,
+                message="Erro ao gerar insights de gastos",
+                error_code="INTERNAL_ERROR",
+            )
+        except Exception:
+            return compat_error_response(
+                legacy_payload={"error": "Erro interno ao gerar insights"},
+                status_code=500,
+                message="Erro interno ao gerar insights",
+                error_code="INTERNAL_ERROR",
+            )
+
+        return compat_success_response(
+            legacy_payload=result,
+            status_code=200,
+            message="Insights de gastos gerados com sucesso",
+            data=result,
+        )
+
+
+class AIGoalProjectionResource(MethodResource):
+    """POST /ai/goals/<goal_id>/projection — narrative for a goal projection."""
+
+    @doc(
+        summary="Narrativa de projeção de meta com IA (Premium)",
+        description=(
+            "Gera uma narrativa motivacional e prática para uma meta financeira específica, "  # noqa: E501
+            "combinando projeção matemática com contexto do usuário. "
+            "Requer entitlement 'advanced_simulations' (plano Premium)."
+        ),
+        tags=["AI Advisory"],
+        security=[{"BearerAuth": []}],
+        responses={
+            200: json_success_response(
+                description="Narrativa gerada com sucesso",
+                message="Narrativa de projeção gerada com sucesso",
+                data_example={
+                    "narrative": "Com base no seu plano de aportes...",
+                    "tokens_used": 450,
+                    "cost_usd": 0.000067,
+                    "projection": {"months_to_completion": 24},
+                    "model": "gpt-4o-mini",
+                },
+            ),
+            400: json_error_response(
+                description="Parâmetros inválidos",
+                message="monthly_contribution deve ser um número positivo",
+                error_code="VALIDATION_ERROR",
+                status_code=400,
+            ),
+            401: json_error_response(
+                description="Não autenticado",
+                message="Token inválido",
+                error_code="UNAUTHORIZED",
+                status_code=401,
+            ),
+            403: json_error_response(
+                description="Entitlement insuficiente",
+                message="Recurso exclusivo para assinantes Premium.",
+                error_code="ENTITLEMENT_REQUIRED",
+                status_code=403,
+            ),
+            404: json_error_response(
+                description="Meta não encontrada",
+                message="Meta não encontrada",
+                error_code="NOT_FOUND",
+                status_code=404,
+            ),
+            500: json_error_response(
+                description="Falha do provider LLM",
+                message="Erro ao gerar narrativa de projeção",
+                error_code="INTERNAL_ERROR",
+                status_code=500,
+            ),
+        },
+    )
+    @jwt_required()
+    def post(self, goal_id: str) -> Response:
+        token_error = _guard_revoked_token()
+        if token_error is not None:
+            return token_error
+
+        user_id = current_user_id()
+
+        entitlement_error = _check_entitlement(user_id)
+        if entitlement_error is not None:
+            return entitlement_error
+
+        # Parse and validate goal_id
+        try:
+            parsed_goal_id: UUID = uuid.UUID(goal_id)
+        except (ValueError, AttributeError):
+            return compat_error_response(
+                legacy_payload={"error": "goal_id inválido"},
+                status_code=400,
+                message="goal_id inválido",
+                error_code="VALIDATION_ERROR",
+            )
+
+        body: dict[str, Any] = request.get_json() or {}
+        user_context = str(body.get("user_context", ""))
+        raw_contribution = body.get("monthly_contribution")
+
+        if raw_contribution is None:
+            return compat_error_response(
+                legacy_payload={"error": "monthly_contribution é obrigatório"},
+                status_code=400,
+                message="monthly_contribution é obrigatório",
+                error_code="VALIDATION_ERROR",
+            )
+
+        try:
+            monthly_contribution = Decimal(str(raw_contribution))
+            if monthly_contribution < 0:
+                raise ValueError("negative")
+        except (InvalidOperation, ValueError):
+            return compat_error_response(
+                legacy_payload={
+                    "error": "monthly_contribution deve ser um número positivo"
+                },
+                status_code=400,
+                message="monthly_contribution deve ser um número positivo",
+                error_code="VALIDATION_ERROR",
+            )
+
+        service = AIAdvisoryService(user_id=user_id)
+        try:
+            result = service.generate_goal_projection_narrative(
+                goal_id=parsed_goal_id,
+                user_context=user_context,
+                monthly_contribution=monthly_contribution,
+            )
+        except ValueError as exc:
+            return compat_error_response(
+                legacy_payload={"error": str(exc)},
+                status_code=404,
+                message="Meta não encontrada",
+                error_code="NOT_FOUND",
+            )
+        except LLMProviderError as exc:
+            return compat_error_response(
+                legacy_payload={"error": str(exc)},
+                status_code=500,
+                message="Erro ao gerar narrativa de projeção",
+                error_code="INTERNAL_ERROR",
+            )
+        except Exception:
+            return compat_error_response(
+                legacy_payload={"error": "Erro interno"},
+                status_code=500,
+                message="Erro interno ao gerar narrativa",
+                error_code="INTERNAL_ERROR",
+            )
+
+        return compat_success_response(
+            legacy_payload=result,
+            status_code=200,
+            message="Narrativa de projeção gerada com sucesso",
+            data=result,
+        )
+
+
+class AIWeeklySummaryResource(MethodResource):
+    """GET /ai/insights/weekly-summary — AI narrative for weekly summary."""
+
+    @doc(
+        summary="Briefing semanal com IA (Premium)",
+        description=(
+            "Gera um briefing narrativo do resumo financeiro da semana atual. "
+            "Requer entitlement 'advanced_simulations' (plano Premium)."
+        ),
+        tags=["AI Advisory"],
+        security=[{"BearerAuth": []}],
+        responses={
+            200: json_success_response(
+                description="Briefing gerado com sucesso",
+                message="Briefing semanal gerado com sucesso",
+                data_example={
+                    "narrative": "Esta semana você gastou R$ 1.200...",
+                    "tokens_used": 280,
+                    "cost_usd": 0.000042,
+                    "summary": {"current_week": {}, "previous_week": {}},
+                    "model": "gpt-4o-mini",
+                },
+            ),
+            401: json_error_response(
+                description="Não autenticado",
+                message="Token inválido",
+                error_code="UNAUTHORIZED",
+                status_code=401,
+            ),
+            403: json_error_response(
+                description="Entitlement insuficiente",
+                message="Recurso exclusivo para assinantes Premium.",
+                error_code="ENTITLEMENT_REQUIRED",
+                status_code=403,
+            ),
+            500: json_error_response(
+                description="Falha do provider LLM",
+                message="Erro ao gerar briefing semanal",
+                error_code="INTERNAL_ERROR",
+                status_code=500,
+            ),
+        },
+    )
+    @jwt_required()
+    def get(self) -> Response:
+        token_error = _guard_revoked_token()
+        if token_error is not None:
+            return token_error
+
+        user_id = current_user_id()
+
+        entitlement_error = _check_entitlement(user_id)
+        if entitlement_error is not None:
+            return entitlement_error
+
+        service = AIAdvisoryService(user_id=user_id)
+        try:
+            result = service.generate_weekly_summary_narrative()
+        except LLMProviderError as exc:
+            return compat_error_response(
+                legacy_payload={"error": str(exc)},
+                status_code=500,
+                message="Erro ao gerar briefing semanal",
+                error_code="INTERNAL_ERROR",
+            )
+        except Exception:
+            return compat_error_response(
+                legacy_payload={"error": "Erro interno"},
+                status_code=500,
+                message="Erro interno ao gerar briefing semanal",
+                error_code="INTERNAL_ERROR",
+            )
+
+        return compat_success_response(
+            legacy_payload=result,
+            status_code=200,
+            message="Briefing semanal gerado com sucesso",
+            data=result,
+        )
+
+
+__all__ = [
+    "AIGoalProjectionResource",
+    "AISpendingInsightsResource",
+    "AIWeeklySummaryResource",
+]

--- a/app/controllers/ai/routes.py
+++ b/app/controllers/ai/routes.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from .blueprint import ai_bp
+from .resources import (
+    AIGoalProjectionResource,
+    AISpendingInsightsResource,
+    AIWeeklySummaryResource,
+)
+
+_ROUTES_REGISTERED = False
+
+
+def register_ai_routes() -> None:
+    global _ROUTES_REGISTERED
+    if _ROUTES_REGISTERED:
+        return
+
+    ai_bp.add_url_rule(
+        "/insights/spending",
+        view_func=AISpendingInsightsResource.as_view("ai_spending_insights"),
+        methods=["GET"],
+    )
+    ai_bp.add_url_rule(
+        "/goals/<goal_id>/projection",
+        view_func=AIGoalProjectionResource.as_view("ai_goal_projection"),
+        methods=["POST"],
+    )
+    ai_bp.add_url_rule(
+        "/insights/weekly-summary",
+        view_func=AIWeeklySummaryResource.as_view("ai_weekly_summary"),
+        methods=["GET"],
+    )
+    _ROUTES_REGISTERED = True
+
+
+register_ai_routes()

--- a/app/models/llm_audit_log.py
+++ b/app/models/llm_audit_log.py
@@ -1,0 +1,52 @@
+# mypy: disable-error-code=name-defined
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from sqlalchemy.dialects.postgresql import UUID
+
+from app.extensions.database import db
+from app.utils.datetime_utils import utc_now_naive
+
+
+class LLMAuditLog(db.Model):
+    """Audit log for every LLM call made on behalf of a user.
+
+    Stores prompt, response, token usage, cost estimate, and latency so that
+    costs can be tracked, abuse detected, and model behaviour audited over time.
+    """
+
+    __tablename__ = "llm_audit_logs"
+
+    id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    user_id = db.Column(
+        UUID(as_uuid=True),
+        db.ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    # Which advisory endpoint triggered this call.
+    # Examples: "spending_insights", "goal_projection", "weekly_summary"
+    endpoint = db.Column(db.String(100), nullable=False)
+    model = db.Column(db.String(80), nullable=False)
+    prompt = db.Column(db.Text, nullable=False)
+    response_text = db.Column(db.Text, nullable=False)
+    prompt_tokens = db.Column(db.Integer, nullable=False, default=0)
+    completion_tokens = db.Column(db.Integer, nullable=False, default=0)
+    total_tokens = db.Column(db.Integer, nullable=False, default=0)
+    estimated_cost_usd = db.Column(db.Numeric(10, 8), nullable=False, default=0)
+    latency_ms = db.Column(db.Integer, nullable=False, default=0)
+    created_at = db.Column(db.DateTime, default=utc_now_naive, nullable=False)
+
+    __table_args__ = (
+        db.Index("ix_llm_audit_logs_user_id", "user_id"),
+        db.Index("ix_llm_audit_logs_created_at", "created_at"),
+        db.Index("ix_llm_audit_logs_endpoint", "endpoint"),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<LLMAuditLog id={self.id} user_id={self.user_id} "
+            f"endpoint={self.endpoint!r} model={self.model!r} "
+            f"total_tokens={self.total_tokens}>"
+        )

--- a/app/services/ai_advisory_service.py
+++ b/app/services/ai_advisory_service.py
@@ -1,0 +1,428 @@
+"""AI Advisory Service — central service for LLM-powered financial analysis.
+
+Provides three advisory capabilities:
+  1. generate_spending_insights  — monthly spending analysis in PT-BR
+  2. generate_goal_projection_narrative — narrative for a specific goal projection
+  3. generate_weekly_summary_narrative — narrative for weekly summary data
+
+All calls are logged to LLMAuditLog for cost tracking and auditability.
+
+Required env vars (configure in .env — never set here):
+  - LLM_PROVIDER: "openai" | "claude" | "stub"
+  - OPENAI_API_KEY: required when LLM_PROVIDER=openai
+  - ANTHROPIC_API_KEY: required when LLM_PROVIDER=claude
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from calendar import monthrange
+from datetime import date
+from decimal import Decimal
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import case, func
+
+from app.extensions.database import db
+from app.models.goal import Goal
+from app.models.llm_audit_log import LLMAuditLog
+from app.models.transaction import Transaction, TransactionStatus, TransactionType
+from app.services.goal_projection_service import GoalProjectionService
+from app.services.llm_provider import LLMProvider, LLMProviderError, get_llm_provider
+from app.services.weekly_summary import compute_weekly_summary
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _safe_float(value: object) -> float:
+    try:
+        return float(value or 0)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _log_llm_call(
+    *,
+    user_id: UUID,
+    endpoint: str,
+    prompt: str,
+    llm_response: Any,
+) -> None:
+    """Persist an LLMAuditLog row for every LLM call. Swallows exceptions so
+    that audit failures never break the advisory flow."""
+    try:
+        log_row = LLMAuditLog(
+            user_id=user_id,
+            endpoint=endpoint,
+            model=llm_response.model,
+            prompt=prompt,
+            response_text=llm_response.content,
+            prompt_tokens=llm_response.prompt_tokens,
+            completion_tokens=llm_response.completion_tokens,
+            total_tokens=llm_response.total_tokens,
+            estimated_cost_usd=llm_response.estimated_cost_usd,
+            latency_ms=llm_response.latency_ms,
+        )
+        db.session.add(log_row)
+        db.session.commit()
+    except Exception as exc:
+        log.warning(
+            "ai_advisory.audit_log_failed user=%s endpoint=%s error=%s",
+            user_id,
+            endpoint,
+            exc,
+        )
+        db.session.rollback()
+
+
+# ---------------------------------------------------------------------------
+# Service
+# ---------------------------------------------------------------------------
+
+
+class AIAdvisoryService:
+    """Central service for LLM-powered financial insights.
+
+    Instantiate with a user_id. The provider defaults to whatever is
+    configured in LLM_PROVIDER env var (stub in tests, openai in prod).
+    """
+
+    def __init__(
+        self,
+        user_id: UUID,
+        llm_provider: LLMProvider | None = None,
+    ) -> None:
+        self._user_id = user_id
+        self._provider = llm_provider or get_llm_provider()
+
+    # ------------------------------------------------------------------
+    # 1. Spending insights
+    # ------------------------------------------------------------------
+
+    def generate_spending_insights(self, month: str | None = None) -> dict[str, Any]:
+        """Analyse spending for the given month and return AI-generated insights.
+
+        Args:
+            month: "YYYY-MM" string. Defaults to the current calendar month.
+
+        Returns:
+            {"insights": str, "tokens_used": int, "cost_usd": float,
+             "month": "YYYY-MM", "model": str}
+        """
+        today = date.today()
+        if month:
+            year, mon = int(month[:4]), int(month[5:7])
+        else:
+            year, mon = today.year, today.month
+
+        start = date(year, mon, 1)
+        end = date(year, mon, monthrange(year, mon)[1])
+
+        snapshot = self._build_spending_snapshot(start=start, end=end)
+        prompt = _build_spending_prompt(snapshot, month_label=f"{year}-{mon:02d}")
+
+        try:
+            llm_resp = self._provider.generate_with_usage(prompt)
+        except LLMProviderError as exc:
+            log.warning(
+                "ai_advisory.spending_insights.llm_error user=%s error=%s",
+                self._user_id,
+                exc,
+            )
+            raise
+
+        _log_llm_call(
+            user_id=self._user_id,
+            endpoint="spending_insights",
+            prompt=prompt,
+            llm_response=llm_resp,
+        )
+
+        return {
+            "insights": llm_resp.content,
+            "tokens_used": llm_resp.total_tokens,
+            "cost_usd": llm_resp.estimated_cost_usd,
+            "month": f"{year}-{mon:02d}",
+            "model": llm_resp.model,
+        }
+
+    def _build_spending_snapshot(self, *, start: date, end: date) -> dict[str, Any]:
+        """Build a spending summary dict for the given date range."""
+        row = (
+            db.session.query(
+                func.coalesce(
+                    func.sum(
+                        case(
+                            (
+                                Transaction.type == TransactionType.EXPENSE,
+                                Transaction.amount,
+                            ),
+                            else_=0,
+                        )
+                    ),
+                    0,
+                ).label("total_expense"),
+                func.coalesce(
+                    func.sum(
+                        case(
+                            (
+                                Transaction.type == TransactionType.INCOME,
+                                Transaction.amount,
+                            ),
+                            else_=0,
+                        )
+                    ),
+                    0,
+                ).label("total_income"),
+                func.count(Transaction.id).label("tx_count"),
+            )
+            .filter(
+                Transaction.user_id == self._user_id,
+                Transaction.deleted.is_(False),
+                Transaction.status == TransactionStatus.PAID,
+                Transaction.due_date >= start,
+                Transaction.due_date <= end,
+            )
+            .one()
+        )
+
+        # Top expense categories (tags)
+        category_rows = (
+            db.session.query(
+                Transaction.description.label("description"),
+                func.sum(Transaction.amount).label("total"),
+            )
+            .filter(
+                Transaction.user_id == self._user_id,
+                Transaction.deleted.is_(False),
+                Transaction.type == TransactionType.EXPENSE,
+                Transaction.status == TransactionStatus.PAID,
+                Transaction.due_date >= start,
+                Transaction.due_date <= end,
+            )
+            .group_by(Transaction.description)
+            .order_by(func.sum(Transaction.amount).desc())
+            .limit(5)
+            .all()
+        )
+
+        top_expenses = [
+            {
+                "description": r.description or "Sem descrição",
+                "total": _safe_float(r.total),
+            }
+            for r in category_rows
+        ]
+
+        total_expense = _safe_float(row.total_expense)
+        total_income = _safe_float(row.total_income)
+        balance = round(total_income - total_expense, 2)
+        savings_rate = (
+            round((total_income - total_expense) / total_income * 100, 1)
+            if total_income > 0
+            else 0.0
+        )
+
+        return {
+            "period_start": start.isoformat(),
+            "period_end": end.isoformat(),
+            "total_expense": round(total_expense, 2),
+            "total_income": round(total_income, 2),
+            "balance": balance,
+            "savings_rate_pct": savings_rate,
+            "transaction_count": int(row.tx_count or 0),
+            "top_expenses": top_expenses,
+        }
+
+    # ------------------------------------------------------------------
+    # 2. Goal projection narrative
+    # ------------------------------------------------------------------
+
+    def generate_goal_projection_narrative(
+        self,
+        goal_id: UUID,
+        user_context: str,
+        monthly_contribution: Decimal,
+    ) -> dict[str, Any]:
+        """Generate a narrative for the given goal's projection.
+
+        Args:
+            goal_id: UUID of the Goal record.
+            user_context: Free-text context from the user (motivations, constraints).
+            monthly_contribution: Planned monthly contribution in BRL.
+
+        Returns:
+            {"narrative": str, "tokens_used": int, "cost_usd": float,
+             "projection": dict, "model": str}
+
+        Raises:
+            ValueError: When goal is not found or doesn't belong to the user.
+            LLMProviderError: On provider failure.
+        """
+        goal: Goal | None = Goal.query.filter_by(
+            id=goal_id, user_id=self._user_id
+        ).first()
+        if goal is None:
+            raise ValueError(f"Goal {goal_id} not found for user {self._user_id}")
+
+        projection_service = GoalProjectionService(
+            monthly_contribution=monthly_contribution
+        )
+        projection = projection_service.project(
+            goal_id=goal.id,
+            user_id=self._user_id,
+            current_amount=Decimal(str(goal.current_amount or 0)),
+            target_amount=Decimal(str(goal.target_amount or 0)),
+            target_date=goal.target_date,
+        )
+        projection_data = projection_service.serialize(projection)
+
+        prompt = _build_goal_projection_prompt(
+            goal_title=str(goal.title),
+            projection=projection_data,
+            user_context=user_context,
+            monthly_contribution=monthly_contribution,
+        )
+
+        try:
+            llm_resp = self._provider.generate_with_usage(prompt)
+        except LLMProviderError as exc:
+            log.warning(
+                "ai_advisory.goal_projection.llm_error user=%s goal=%s error=%s",
+                self._user_id,
+                goal_id,
+                exc,
+            )
+            raise
+
+        _log_llm_call(
+            user_id=self._user_id,
+            endpoint="goal_projection",
+            prompt=prompt,
+            llm_response=llm_resp,
+        )
+
+        return {
+            "narrative": llm_resp.content,
+            "tokens_used": llm_resp.total_tokens,
+            "cost_usd": llm_resp.estimated_cost_usd,
+            "projection": projection_data,
+            "model": llm_resp.model,
+        }
+
+    # ------------------------------------------------------------------
+    # 3. Weekly summary narrative
+    # ------------------------------------------------------------------
+
+    def generate_weekly_summary_narrative(self) -> dict[str, Any]:
+        """Generate a narrative for the current week's financial summary.
+
+        Returns:
+            {"narrative": str, "tokens_used": int, "cost_usd": float,
+             "summary": dict, "model": str}
+
+        Raises:
+            LLMProviderError: On provider failure.
+        """
+        summary = compute_weekly_summary(user_id=self._user_id)
+        prompt = _build_weekly_summary_prompt(summary)
+
+        try:
+            llm_resp = self._provider.generate_with_usage(prompt)
+        except LLMProviderError as exc:
+            log.warning(
+                "ai_advisory.weekly_summary.llm_error user=%s error=%s",
+                self._user_id,
+                exc,
+            )
+            raise
+
+        _log_llm_call(
+            user_id=self._user_id,
+            endpoint="weekly_summary",
+            prompt=prompt,
+            llm_response=llm_resp,
+        )
+
+        return {
+            "narrative": llm_resp.content,
+            "tokens_used": llm_resp.total_tokens,
+            "cost_usd": llm_resp.estimated_cost_usd,
+            "summary": summary,
+            "model": llm_resp.model,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Prompt builders
+# ---------------------------------------------------------------------------
+
+
+def _build_spending_prompt(snapshot: dict[str, Any], month_label: str) -> str:
+    context = json.dumps(snapshot, ensure_ascii=False, default=str)
+    return (
+        f"Você é um consultor financeiro pessoal. Analise os dados de gastos de {month_label} "  # noqa: E501
+        "abaixo e gere 3 insights práticos e personalizados em português brasileiro. "
+        "Para cada insight, identifique o tipo (gasto_elevado, oportunidade_economia, "
+        "saude_financeira, alerta_orcamento, padrao_gasto), um título curto e "
+        "uma recomendação específica e acionável.\n\n"
+        f"Dados financeiros do período:\n{context}\n\n"
+        "Retorne um JSON array no formato:\n"
+        '[{"type": "...", "title": "...", "message": "..."}]'
+    )
+
+
+def _build_goal_projection_prompt(
+    *,
+    goal_title: str,
+    projection: dict[str, Any],
+    user_context: str,
+    monthly_contribution: Decimal,
+) -> str:
+    proj_json = json.dumps(projection, ensure_ascii=False, default=str)
+    return (
+        f"Você é um consultor financeiro pessoal. O usuário tem uma meta financeira "
+        f"chamada '{goal_title}' e planeja contribuir R$ {monthly_contribution:.2f}/mês.\n\n"  # noqa: E501
+        f"Contexto do usuário: {user_context}\n\n"
+        f"Projeção matemática calculada:\n{proj_json}\n\n"
+        "Com base nesses dados, gere uma narrativa motivacional e prática em português "
+        "brasileiro (máximo 200 palavras) que:\n"
+        "1. Explique claramente quando a meta será alcançada\n"
+        "2. Diga se o usuário está no caminho certo ou precisa ajustar\n"
+        "3. Ofereça 1-2 recomendações específicas e acionáveis\n"
+        "4. Use tom encorajador mas realista\n\n"
+        "Retorne apenas o texto da narrativa, sem JSON."
+    )
+
+
+def _build_weekly_summary_prompt(summary: Any) -> str:
+    context = json.dumps(
+        {
+            "semana_atual": summary.get("current_week"),
+            "semana_anterior": summary.get("previous_week"),
+            "comparativo": summary.get("comparison"),
+        },
+        ensure_ascii=False,
+        default=str,
+    )
+    return (
+        "Você é um consultor financeiro pessoal. Analise o resumo financeiro semanal "
+        "abaixo e gere um briefing conciso em português brasileiro (máximo 150 palavras) que:\n"  # noqa: E501
+        "1. Destaque o desempenho desta semana vs. semana anterior\n"
+        "2. Aponte o ponto mais crítico (gasto ou renda) que merece atenção\n"
+        "3. Termine com uma dica prática para a próxima semana\n\n"
+        f"Dados do resumo semanal:\n{context}\n\n"
+        "Retorne apenas o texto do briefing, sem JSON."
+    )
+
+
+__all__ = [
+    "AIAdvisoryService",
+]

--- a/app/services/llm_provider.py
+++ b/app/services/llm_provider.py
@@ -4,16 +4,52 @@ Provider pattern: configure via LLM_PROVIDER env var.
   - "stub"   (default) — rule-based insights, no external calls
   - "openai" — OpenAI chat completions (requires OPENAI_API_KEY)
   - "claude" — Anthropic Messages API (requires ANTHROPIC_API_KEY)
+
+Required env vars (do NOT set here — configure in .env):
+  - LLM_PROVIDER: "openai" | "claude" | "stub"
+  - OPENAI_API_KEY: required when LLM_PROVIDER=openai
+  - ANTHROPIC_API_KEY: required when LLM_PROVIDER=claude
 """
 
 from __future__ import annotations
 
 import os
+import time
+from dataclasses import dataclass
 from typing import Protocol, runtime_checkable
 
 
 class LLMProviderError(Exception):
     """Raised when the LLM provider fails."""
+
+
+@dataclass
+class LLMResponse:
+    """Structured response from an LLM provider, including usage metadata."""
+
+    content: str
+    prompt_tokens: int
+    completion_tokens: int
+    total_tokens: int
+    model: str
+    latency_ms: int
+
+    @property
+    def estimated_cost_usd(self) -> float:
+        """Estimate cost in USD based on token counts and model pricing.
+
+        Prices per 1M tokens (input_price, output_price).
+        Falls back to conservative defaults for unknown models.
+        """
+        _PRICES: dict[str, tuple[float, float]] = {
+            "gpt-4o-mini": (0.15, 0.60),
+            "gpt-4.1-mini": (0.40, 1.60),
+            "claude-haiku-4-5-20251001": (0.25, 1.25),
+        }
+        input_price, output_price = _PRICES.get(self.model, (0.002, 0.008))
+        return (
+            self.prompt_tokens * input_price + self.completion_tokens * output_price
+        ) / 1_000_000
 
 
 @runtime_checkable
@@ -22,16 +58,33 @@ class LLMProvider(Protocol):
         """Generate a response for *prompt*. Raises LLMProviderError on failure."""
         ...
 
+    def generate_with_usage(self, prompt: str) -> LLMResponse:
+        """Generate a response and return structured usage data."""
+        ...
+
 
 class StubLLMProvider:
     """Canned response — useful for testing and environments without API keys."""
 
+    _STUB_MODEL = "stub"
+    _STUB_CONTENT = (
+        "Com base nos seus dados financeiros, identifiquei os seguintes insights: "
+        "1. Gastos discricionários >30% das despesas — revise esses valores. "
+        "2. Você tem metas ativas que podem estar em risco caso o ritmo de gastos atual continue. "  # noqa: E501
+        "3. Há uma oportunidade de economia de até 15% caso reduza gastos variáveis nos próximos 60 dias."  # noqa: E501
+    )
+
     def generate(self, prompt: str) -> str:  # noqa: ARG002
-        return (  # noqa: E501
-            "Com base nos seus dados financeiros, identifiquei os seguintes insights: "
-            "1. Gastos discricionários >30% das despesas — revise esses valores. "  # noqa: E501
-            "2. Você tem metas ativas que podem estar em risco caso o ritmo de gastos atual continue. "  # noqa: E501
-            "3. Há uma oportunidade de economia de até 15% caso reduza gastos variáveis nos próximos 60 dias."  # noqa: E501
+        return self._STUB_CONTENT
+
+    def generate_with_usage(self, prompt: str) -> LLMResponse:  # noqa: ARG002
+        return LLMResponse(
+            content=self._STUB_CONTENT,
+            prompt_tokens=150,
+            completion_tokens=80,
+            total_tokens=230,
+            model=self._STUB_MODEL,
+            latency_ms=0,
         )
 
 
@@ -45,10 +98,14 @@ class OpenAILLMProvider:
         self._model = os.getenv("OPENAI_ADVISORY_MODEL", "gpt-4o-mini")
 
     def generate(self, prompt: str) -> str:
+        return self.generate_with_usage(prompt).content
+
+    def generate_with_usage(self, prompt: str) -> LLMResponse:
         if not self._api_key:
             raise LLMProviderError("OPENAI_API_KEY is not configured.")
         import requests  # lazy import to keep startup fast
 
+        start = time.monotonic()
         try:
             resp = requests.post(
                 self._BASE_URL,
@@ -65,7 +122,18 @@ class OpenAILLMProvider:
                 timeout=20,
             )
             resp.raise_for_status()
-            return str(resp.json()["choices"][0]["message"]["content"])
+            latency_ms = int((time.monotonic() - start) * 1000)
+            data = resp.json()
+            usage = data.get("usage", {})
+            content = str(data["choices"][0]["message"]["content"])
+            return LLMResponse(
+                content=content,
+                prompt_tokens=int(usage.get("prompt_tokens", 0)),
+                completion_tokens=int(usage.get("completion_tokens", 0)),
+                total_tokens=int(usage.get("total_tokens", 0)),
+                model=str(data.get("model", self._model)),
+                latency_ms=latency_ms,
+            )
         except Exception as exc:
             raise LLMProviderError(f"OpenAI call failed: {exc}") from exc
 
@@ -80,10 +148,14 @@ class ClaudeLLMProvider:
         self._model = os.getenv("ANTHROPIC_ADVISORY_MODEL", "claude-haiku-4-5-20251001")
 
     def generate(self, prompt: str) -> str:
+        return self.generate_with_usage(prompt).content
+
+    def generate_with_usage(self, prompt: str) -> LLMResponse:
         if not self._api_key:
             raise LLMProviderError("ANTHROPIC_API_KEY is not configured.")
         import requests
 
+        start = time.monotonic()
         try:
             resp = requests.post(
                 self._BASE_URL,
@@ -100,7 +172,19 @@ class ClaudeLLMProvider:
                 timeout=20,
             )
             resp.raise_for_status()
-            return str(resp.json()["content"][0]["text"])
+            latency_ms = int((time.monotonic() - start) * 1000)
+            data = resp.json()
+            usage = data.get("usage", {})
+            content = str(data["content"][0]["text"])
+            return LLMResponse(
+                content=content,
+                prompt_tokens=int(usage.get("input_tokens", 0)),
+                completion_tokens=int(usage.get("output_tokens", 0)),
+                total_tokens=int(usage.get("input_tokens", 0))
+                + int(usage.get("output_tokens", 0)),
+                model=str(data.get("model", self._model)),
+                latency_ms=latency_ms,
+            )
         except Exception as exc:
             raise LLMProviderError(f"Claude call failed: {exc}") from exc
 
@@ -119,6 +203,7 @@ __all__ = [
     "ClaudeLLMProvider",
     "LLMProvider",
     "LLMProviderError",
+    "LLMResponse",
     "OpenAILLMProvider",
     "StubLLMProvider",
     "get_llm_provider",

--- a/migrations/versions/ai1_add_llm_audit_logs.py
+++ b/migrations/versions/ai1_add_llm_audit_logs.py
@@ -1,0 +1,64 @@
+"""ai1 — create llm_audit_logs table
+
+Revision ID: ai1
+Revises: push1
+Create Date: 2026-05-10
+
+Stores every LLM call made on behalf of a user:
+prompt, response, token usage, cost estimate, and latency.
+No native enums — all string columns with CHECK constraints or plain text.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = "ai1"
+down_revision = "push1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "llm_audit_logs",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column(
+            "user_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("endpoint", sa.String(100), nullable=False),
+        sa.Column("model", sa.String(80), nullable=False),
+        sa.Column("prompt", sa.Text, nullable=False),
+        sa.Column("response_text", sa.Text, nullable=False),
+        sa.Column("prompt_tokens", sa.Integer, nullable=False, server_default="0"),
+        sa.Column("completion_tokens", sa.Integer, nullable=False, server_default="0"),
+        sa.Column("total_tokens", sa.Integer, nullable=False, server_default="0"),
+        sa.Column(
+            "estimated_cost_usd",
+            sa.Numeric(10, 8),
+            nullable=False,
+            server_default="0",
+        ),
+        sa.Column("latency_ms", sa.Integer, nullable=False, server_default="0"),
+        sa.Column(
+            "created_at",
+            sa.DateTime,
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+    )
+    op.create_index("ix_llm_audit_logs_user_id", "llm_audit_logs", ["user_id"])
+    op.create_index("ix_llm_audit_logs_created_at", "llm_audit_logs", ["created_at"])
+    op.create_index("ix_llm_audit_logs_endpoint", "llm_audit_logs", ["endpoint"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_llm_audit_logs_endpoint")
+    op.drop_index("ix_llm_audit_logs_created_at")
+    op.drop_index("ix_llm_audit_logs_user_id")
+    op.drop_table("llm_audit_logs")

--- a/tests/test_ai_advisory_service.py
+++ b/tests/test_ai_advisory_service.py
@@ -1,0 +1,585 @@
+"""Tests for AIAdvisoryService and AI advisory controller endpoints (#1206).
+
+Coverage areas:
+- LLMResponse dataclass and estimated_cost_usd property
+- StubLLMProvider.generate_with_usage()
+- AIAdvisoryService.generate_spending_insights()
+- AIAdvisoryService.generate_goal_projection_narrative()
+- AIAdvisoryService.generate_weekly_summary_narrative()
+- LLMAuditLog persistence
+- Entitlement gate (premium required)
+- GET /ai/insights/spending — auth, entitlement, happy path
+- POST /ai/goals/<goal_id>/projection — auth, entitlement, validation, happy path
+- GET /ai/insights/weekly-summary — auth, entitlement, happy path
+- LLMProviderError propagation
+- Goal not found raises ValueError → 404
+"""
+
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.llm_provider import LLMProviderError, LLMResponse, StubLLMProvider
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _register_and_login(client, prefix: str) -> str:
+    suffix = uuid.uuid4().hex[:8]
+    email = f"{prefix}-{suffix}@test.com"
+    password = "StrongPass@123"
+    reg = client.post(
+        "/auth/register",
+        json={"name": f"{prefix}-{suffix}", "email": email, "password": password},
+    )
+    assert reg.status_code == 201
+    login = client.post("/auth/login", json={"email": email, "password": password})
+    assert login.status_code == 200
+    return login.get_json()["token"]
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _grant_entitlement(app, user_id: uuid.UUID, feature_key: str) -> None:
+    """Grant an entitlement directly in the DB for test setup."""
+    with app.app_context():
+        from app.extensions.database import db
+        from app.models.entitlement import Entitlement, EntitlementSource
+
+        ent = Entitlement(
+            user_id=user_id,
+            feature_key=feature_key,
+            source=EntitlementSource.MANUAL,
+            expires_at=None,
+        )
+        db.session.add(ent)
+        db.session.commit()
+
+
+def _revoke_premium_entitlements(app, user_id: uuid.UUID) -> None:
+    """Revoke all premium-only entitlements so user is effectively on free plan."""
+    with app.app_context():
+        from app.services.entitlement_service import deactivate_premium
+
+        deactivate_premium(user_id)
+
+
+def _get_current_user_id(app, token: str) -> uuid.UUID:
+    """Extract user UUID from the JWT token."""
+    with app.app_context():
+        from flask_jwt_extended import decode_token
+
+        decoded = decode_token(token)
+        return uuid.UUID(decoded["sub"])
+
+
+# ---------------------------------------------------------------------------
+# LLMResponse tests
+# ---------------------------------------------------------------------------
+
+
+class TestLLMResponse:
+    def test_known_model_cost(self) -> None:
+        resp = LLMResponse(
+            content="test",
+            prompt_tokens=1_000_000,
+            completion_tokens=1_000_000,
+            total_tokens=2_000_000,
+            model="gpt-4o-mini",
+            latency_ms=100,
+        )
+        # 1M prompt * 0.15 + 1M completion * 0.60 = 0.75
+        assert abs(resp.estimated_cost_usd - 0.75) < 1e-6
+
+    def test_unknown_model_fallback_cost(self) -> None:
+        resp = LLMResponse(
+            content="test",
+            prompt_tokens=1_000_000,
+            completion_tokens=1_000_000,
+            total_tokens=2_000_000,
+            model="unknown-model",
+            latency_ms=50,
+        )
+        # fallback: 0.002 + 0.008 = 0.010
+        assert abs(resp.estimated_cost_usd - 0.010) < 1e-6
+
+    def test_zero_tokens_zero_cost(self) -> None:
+        resp = LLMResponse(
+            content="",
+            prompt_tokens=0,
+            completion_tokens=0,
+            total_tokens=0,
+            model="gpt-4o-mini",
+            latency_ms=0,
+        )
+        assert resp.estimated_cost_usd == 0.0
+
+    def test_claude_model_cost(self) -> None:
+        resp = LLMResponse(
+            content="ok",
+            prompt_tokens=1_000_000,
+            completion_tokens=1_000_000,
+            total_tokens=2_000_000,
+            model="claude-haiku-4-5-20251001",
+            latency_ms=200,
+        )
+        # 1M * 0.25 + 1M * 1.25 = 1.50
+        assert abs(resp.estimated_cost_usd - 1.50) < 1e-6
+
+
+# ---------------------------------------------------------------------------
+# StubLLMProvider tests
+# ---------------------------------------------------------------------------
+
+
+class TestStubLLMProvider:
+    def test_generate_returns_string(self) -> None:
+        provider = StubLLMProvider()
+        result = provider.generate("any prompt")
+        assert isinstance(result, str)
+        assert len(result) > 10
+
+    def test_generate_with_usage_returns_llm_response(self) -> None:
+        provider = StubLLMProvider()
+        result = provider.generate_with_usage("any prompt")
+        assert isinstance(result, LLMResponse)
+        assert result.content == provider.generate("any prompt")
+        assert result.model == "stub"
+        assert result.total_tokens > 0
+        assert result.latency_ms == 0
+
+    def test_generate_and_generate_with_usage_content_match(self) -> None:
+        provider = StubLLMProvider()
+        assert provider.generate("x") == provider.generate_with_usage("x").content
+
+
+# ---------------------------------------------------------------------------
+# AIAdvisoryService unit tests (mocked provider)
+# ---------------------------------------------------------------------------
+
+
+class TestAIAdvisoryServiceSpendingInsights:
+    def test_generate_spending_insights_returns_expected_keys(self, app) -> None:
+        with app.app_context():
+            user_id = uuid.uuid4()
+            provider = StubLLMProvider()
+            from app.services.ai_advisory_service import AIAdvisoryService
+
+            service = AIAdvisoryService(user_id=user_id, llm_provider=provider)
+            result = service.generate_spending_insights()
+            assert "insights" in result
+            assert "tokens_used" in result
+            assert "cost_usd" in result
+            assert "month" in result
+            assert "model" in result
+
+    def test_generate_spending_insights_with_explicit_month(self, app) -> None:
+        with app.app_context():
+            user_id = uuid.uuid4()
+            provider = StubLLMProvider()
+            from app.services.ai_advisory_service import AIAdvisoryService
+
+            service = AIAdvisoryService(user_id=user_id, llm_provider=provider)
+            result = service.generate_spending_insights(month="2026-01")
+            assert result["month"] == "2026-01"
+
+    def test_llm_provider_error_propagates(self, app) -> None:
+        with app.app_context():
+            user_id = uuid.uuid4()
+            broken = MagicMock()
+            broken.generate_with_usage.side_effect = LLMProviderError("fail")
+
+            from app.services.ai_advisory_service import AIAdvisoryService
+
+            service = AIAdvisoryService(user_id=user_id, llm_provider=broken)
+            with pytest.raises(LLMProviderError):
+                service.generate_spending_insights()
+
+    def test_audit_log_created_on_success(self, app) -> None:
+        with app.app_context():
+            user_id = uuid.uuid4()
+            provider = StubLLMProvider()
+            from app.models.llm_audit_log import LLMAuditLog
+            from app.services.ai_advisory_service import AIAdvisoryService
+
+            service = AIAdvisoryService(user_id=user_id, llm_provider=provider)
+            service.generate_spending_insights()
+
+            log_row = LLMAuditLog.query.filter_by(
+                user_id=user_id, endpoint="spending_insights"
+            ).first()
+            assert log_row is not None
+            assert log_row.model == "stub"
+            assert log_row.total_tokens > 0
+
+
+class TestAIAdvisoryServiceGoalProjection:
+    def _create_goal(self, app, user_id: uuid.UUID) -> uuid.UUID:
+        with app.app_context():
+            from app.extensions.database import db
+            from app.models.goal import Goal
+
+            goal = Goal(
+                user_id=user_id,
+                title="Viagem Europa",
+                target_amount=Decimal("15000.00"),
+                current_amount=Decimal("3000.00"),
+                status="active",
+            )
+            db.session.add(goal)
+            db.session.commit()
+            return goal.id  # type: ignore[return-value]
+
+    def test_goal_not_found_raises_value_error(self, app) -> None:
+        with app.app_context():
+            user_id = uuid.uuid4()
+            provider = StubLLMProvider()
+            from app.services.ai_advisory_service import AIAdvisoryService
+
+            service = AIAdvisoryService(user_id=user_id, llm_provider=provider)
+            with pytest.raises(ValueError, match="not found"):
+                service.generate_goal_projection_narrative(
+                    goal_id=uuid.uuid4(),
+                    user_context="Quero viajar",
+                    monthly_contribution=Decimal("500"),
+                )
+
+    def test_goal_wrong_user_raises_value_error(self, app) -> None:
+        with app.app_context():
+            owner_id = uuid.uuid4()
+            other_id = uuid.uuid4()
+            goal_id = self._create_goal(app, owner_id)
+
+            provider = StubLLMProvider()
+            from app.services.ai_advisory_service import AIAdvisoryService
+
+            service = AIAdvisoryService(user_id=other_id, llm_provider=provider)
+            with pytest.raises(ValueError, match="not found"):
+                service.generate_goal_projection_narrative(
+                    goal_id=goal_id,
+                    user_context="teste",
+                    monthly_contribution=Decimal("500"),
+                )
+
+    def test_happy_path_returns_required_keys(self, app) -> None:
+        with app.app_context():
+            user_id = uuid.uuid4()
+            goal_id = self._create_goal(app, user_id)
+            provider = StubLLMProvider()
+            from app.services.ai_advisory_service import AIAdvisoryService
+
+            service = AIAdvisoryService(user_id=user_id, llm_provider=provider)
+            result = service.generate_goal_projection_narrative(
+                goal_id=goal_id,
+                user_context="Quero viajar para Europa em 2028",
+                monthly_contribution=Decimal("500"),
+            )
+            assert "narrative" in result
+            assert "tokens_used" in result
+            assert "cost_usd" in result
+            assert "projection" in result
+            assert "model" in result
+            assert isinstance(result["projection"], dict)
+
+
+class TestAIAdvisoryServiceWeeklySummary:
+    def test_weekly_summary_returns_required_keys(self, app) -> None:
+        with app.app_context():
+            user_id = uuid.uuid4()
+            provider = StubLLMProvider()
+            from app.services.ai_advisory_service import AIAdvisoryService
+
+            service = AIAdvisoryService(user_id=user_id, llm_provider=provider)
+            result = service.generate_weekly_summary_narrative()
+            assert "narrative" in result
+            assert "tokens_used" in result
+            assert "cost_usd" in result
+            assert "summary" in result
+            assert "model" in result
+
+    def test_llm_error_propagates_in_weekly_summary(self, app) -> None:
+        with app.app_context():
+            user_id = uuid.uuid4()
+            broken = MagicMock()
+            broken.generate_with_usage.side_effect = LLMProviderError("fail")
+
+            from app.services.ai_advisory_service import AIAdvisoryService
+
+            service = AIAdvisoryService(user_id=user_id, llm_provider=broken)
+            with pytest.raises(LLMProviderError):
+                service.generate_weekly_summary_narrative()
+
+
+# ---------------------------------------------------------------------------
+# HTTP endpoint tests
+# ---------------------------------------------------------------------------
+
+
+class TestAISpendingInsightsEndpoint:
+    def test_unauthenticated_returns_401(self, client) -> None:
+        resp = client.get("/ai/insights/spending")
+        assert resp.status_code == 401
+
+    def test_authenticated_free_user_returns_403(self, app, client) -> None:
+        token = _register_and_login(client, prefix="ai-free")
+        user_id = _get_current_user_id(app, token)
+        # New registrations may get a trial; revoke premium to simulate free plan.
+        _revoke_premium_entitlements(app, user_id)
+        resp = client.get("/ai/insights/spending", headers=_auth(token))
+        assert resp.status_code == 403
+
+    def test_premium_user_returns_200(self, app, client) -> None:
+        token = _register_and_login(client, prefix="ai-prem")
+        user_id = _get_current_user_id(app, token)
+        _grant_entitlement(app, user_id, "advanced_simulations")
+
+        resp = client.get("/ai/insights/spending", headers=_auth(token))
+        assert resp.status_code == 200
+
+    def test_response_has_required_keys(self, app, client) -> None:
+        token = _register_and_login(client, prefix="ai-keys")
+        user_id = _get_current_user_id(app, token)
+        _grant_entitlement(app, user_id, "advanced_simulations")
+
+        resp = client.get("/ai/insights/spending", headers=_auth(token))
+        assert resp.status_code == 200
+        body = resp.get_json()
+        data = body.get("data") or body
+        for key in ("insights", "tokens_used", "cost_usd", "month", "model"):
+            assert key in data, f"Missing key: {key}"
+
+    def test_month_param_accepted(self, app, client) -> None:
+        token = _register_and_login(client, prefix="ai-month")
+        user_id = _get_current_user_id(app, token)
+        _grant_entitlement(app, user_id, "advanced_simulations")
+
+        resp = client.get("/ai/insights/spending?month=2026-01", headers=_auth(token))
+        assert resp.status_code == 200
+        body = resp.get_json()
+        data = body.get("data") or body
+        assert data["month"] == "2026-01"
+
+    def test_llm_error_returns_500(self, app, client) -> None:
+        token = _register_and_login(client, prefix="ai-err")
+        user_id = _get_current_user_id(app, token)
+        _grant_entitlement(app, user_id, "advanced_simulations")
+
+        with patch(
+            "app.services.ai_advisory_service.AIAdvisoryService.generate_spending_insights",
+            side_effect=LLMProviderError("provider down"),
+        ):
+            resp = client.get("/ai/insights/spending", headers=_auth(token))
+            assert resp.status_code == 500
+
+
+class TestAIGoalProjectionEndpoint:
+    def _create_goal_via_api(self, client, token: str) -> str:
+        resp = client.post(
+            "/goals",
+            json={
+                "title": "Meta Teste",
+                "target_amount": 10000,
+                "current_amount": 1000,
+                "status": "active",
+            },
+            headers=_auth(token),
+        )
+        assert resp.status_code in (200, 201)
+        data = resp.get_json()
+        # Extract goal id from response
+        goal_data = data.get("data", {}).get("goal") or data.get("goal") or {}
+        return goal_data.get("id", "")
+
+    def test_unauthenticated_returns_401(self, client) -> None:
+        resp = client.post(
+            f"/ai/goals/{uuid.uuid4()}/projection",
+            json={"monthly_contribution": 500, "user_context": "teste"},
+        )
+        assert resp.status_code == 401
+
+    def test_free_user_returns_403(self, app, client) -> None:
+        token = _register_and_login(client, prefix="ai-gfree")
+        user_id = _get_current_user_id(app, token)
+        _revoke_premium_entitlements(app, user_id)
+        goal_id = str(uuid.uuid4())
+        resp = client.post(
+            f"/ai/goals/{goal_id}/projection",
+            json={"monthly_contribution": 500, "user_context": "teste"},
+            headers=_auth(token),
+        )
+        assert resp.status_code == 403
+
+    def test_invalid_goal_id_returns_400(self, app, client) -> None:
+        token = _register_and_login(client, prefix="ai-gbad")
+        user_id = _get_current_user_id(app, token)
+        _grant_entitlement(app, user_id, "advanced_simulations")
+
+        resp = client.post(
+            "/ai/goals/not-a-uuid/projection",
+            json={"monthly_contribution": 500, "user_context": "teste"},
+            headers=_auth(token),
+        )
+        assert resp.status_code == 400
+
+    def test_missing_monthly_contribution_returns_400(self, app, client) -> None:
+        token = _register_and_login(client, prefix="ai-gnomc")
+        user_id = _get_current_user_id(app, token)
+        _grant_entitlement(app, user_id, "advanced_simulations")
+
+        resp = client.post(
+            f"/ai/goals/{uuid.uuid4()}/projection",
+            json={"user_context": "teste"},
+            headers=_auth(token),
+        )
+        assert resp.status_code == 400
+
+    def test_goal_not_found_returns_404(self, app, client) -> None:
+        token = _register_and_login(client, prefix="ai-g404")
+        user_id = _get_current_user_id(app, token)
+        _grant_entitlement(app, user_id, "advanced_simulations")
+
+        resp = client.post(
+            f"/ai/goals/{uuid.uuid4()}/projection",
+            json={"monthly_contribution": 500, "user_context": "teste"},
+            headers=_auth(token),
+        )
+        assert resp.status_code == 404
+
+    def test_happy_path_returns_200_with_narrative(self, app, client) -> None:
+        token = _register_and_login(client, prefix="ai-gok")
+        user_id = _get_current_user_id(app, token)
+        _grant_entitlement(app, user_id, "advanced_simulations")
+
+        # Create goal directly in DB
+        with app.app_context():
+            from app.extensions.database import db
+            from app.models.goal import Goal
+
+            goal = Goal(
+                user_id=user_id,
+                title="Carro Novo",
+                target_amount=Decimal("50000"),
+                current_amount=Decimal("5000"),
+                status="active",
+            )
+            db.session.add(goal)
+            db.session.commit()
+            goal_id = str(goal.id)
+
+        resp = client.post(
+            f"/ai/goals/{goal_id}/projection",
+            json={
+                "monthly_contribution": 1000,
+                "user_context": "Quero comprar um carro",
+            },
+            headers=_auth(token),
+        )
+        assert resp.status_code == 200
+        body = resp.get_json()
+        data = body.get("data") or body
+        assert "narrative" in data
+        assert "projection" in data
+
+
+class TestAIWeeklySummaryEndpoint:
+    def test_unauthenticated_returns_401(self, client) -> None:
+        resp = client.get("/ai/insights/weekly-summary")
+        assert resp.status_code == 401
+
+    def test_free_user_returns_403(self, app, client) -> None:
+        token = _register_and_login(client, prefix="ai-wfree")
+        user_id = _get_current_user_id(app, token)
+        _revoke_premium_entitlements(app, user_id)
+        resp = client.get("/ai/insights/weekly-summary", headers=_auth(token))
+        assert resp.status_code == 403
+
+    def test_premium_user_returns_200(self, app, client) -> None:
+        token = _register_and_login(client, prefix="ai-wprem")
+        user_id = _get_current_user_id(app, token)
+        _grant_entitlement(app, user_id, "advanced_simulations")
+
+        resp = client.get("/ai/insights/weekly-summary", headers=_auth(token))
+        assert resp.status_code == 200
+
+    def test_response_has_required_keys(self, app, client) -> None:
+        token = _register_and_login(client, prefix="ai-wkeys")
+        user_id = _get_current_user_id(app, token)
+        _grant_entitlement(app, user_id, "advanced_simulations")
+
+        resp = client.get("/ai/insights/weekly-summary", headers=_auth(token))
+        assert resp.status_code == 200
+        body = resp.get_json()
+        data = body.get("data") or body
+        for key in ("narrative", "tokens_used", "cost_usd", "summary", "model"):
+            assert key in data, f"Missing key: {key}"
+
+    def test_llm_error_returns_500(self, app, client) -> None:
+        token = _register_and_login(client, prefix="ai-werr")
+        user_id = _get_current_user_id(app, token)
+        _grant_entitlement(app, user_id, "advanced_simulations")
+
+        with patch(
+            "app.services.ai_advisory_service.AIAdvisoryService.generate_weekly_summary_narrative",
+            side_effect=LLMProviderError("provider down"),
+        ):
+            resp = client.get("/ai/insights/weekly-summary", headers=_auth(token))
+            assert resp.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# LLMAuditLog model tests
+# ---------------------------------------------------------------------------
+
+
+class TestLLMAuditLogModel:
+    def test_audit_log_can_be_created_and_retrieved(self, app) -> None:
+        with app.app_context():
+            from app.extensions.database import db
+            from app.models.llm_audit_log import LLMAuditLog
+
+            user_id = uuid.uuid4()
+            log_row = LLMAuditLog(
+                user_id=user_id,
+                endpoint="spending_insights",
+                model="stub",
+                prompt="test prompt",
+                response_text="test response",
+                prompt_tokens=100,
+                completion_tokens=50,
+                total_tokens=150,
+                estimated_cost_usd=0.0001,
+                latency_ms=50,
+            )
+            db.session.add(log_row)
+            db.session.commit()
+
+            retrieved = LLMAuditLog.query.filter_by(user_id=user_id).first()
+            assert retrieved is not None
+            assert retrieved.endpoint == "spending_insights"
+            assert retrieved.model == "stub"
+            assert retrieved.total_tokens == 150
+
+    def test_audit_log_repr(self, app) -> None:
+        with app.app_context():
+            from app.models.llm_audit_log import LLMAuditLog
+
+            user_id = uuid.uuid4()
+            log_row = LLMAuditLog(
+                user_id=user_id,
+                endpoint="weekly_summary",
+                model="gpt-4o-mini",
+                prompt="p",
+                response_text="r",
+                total_tokens=99,
+            )
+            r = repr(log_row)
+            assert "LLMAuditLog" in r
+            assert "weekly_summary" in r

--- a/tests/test_postman_collection_contract.py
+++ b/tests/test_postman_collection_contract.py
@@ -156,6 +156,10 @@ OPENAPI_GAPS: set[tuple[str, str]] = {
     ("POST", "/bank-statements/confirm"),
     # Advisory (not yet in apispec-documented blueprints)
     ("GET", "/advisory/insights"),
+    # AI Advisory (not yet in apispec-documented blueprints — #1206)
+    ("GET", "/ai/insights/spending"),
+    ("POST", "/ai/goals/{param}/projection"),
+    ("GET", "/ai/insights/weekly-summary"),
     # Dashboard routes not yet in apispec-documented blueprints
     ("GET", "/dashboard/survival-index"),
     ("GET", "/dashboard/weekly-summary"),


### PR DESCRIPTION
## Summary

- Adds `AIAdvisoryService` with three endpoints: spending insights, goal projection narrative, weekly summary briefing — all gated behind `advanced_simulations` entitlement (Premium)
- Enriches `LLMProvider` protocol with `generate_with_usage()` returning `LLMResponse` dataclass with token counts and `estimated_cost_usd`
- Adds `LLMAuditLog` SQLAlchemy model + Alembic migration (`ai1`) for per-call cost/latency tracking
- Creates `app/controllers/ai/` package with blueprint at `/ai`, following existing advisory/goal controller patterns
- 35 new tests covering service unit logic, entitlement gate, HTTP endpoints, and audit log persistence; total coverage 87.57%

## Test plan

- [ ] `pytest tests/test_ai_advisory_service.py -v` — all 35 tests pass
- [ ] `pytest -m "not schemathesis" --cov=app --cov-fail-under=85` — full suite passes at 87.57%
- [ ] `ruff check` + `mypy app` — no issues
- [ ] All pre-commit hooks pass (confirmed in push log)
- [ ] GET `/ai/insights/spending` returns 401 without token, 403 for free user, 200 for premium
- [ ] POST `/ai/goals/<id>/projection` returns 400 on missing contribution, 404 on bad goal ID
- [ ] GET `/ai/insights/weekly-summary` returns 403 for free user, 200 for premium

Closes #1206