### PR TITLE
feat(notifications): gate premium em reminders + notificacao analise pronta

### DIFF
--- a/app/application/services/transaction_reminder_service.py
+++ b/app/application/services/transaction_reminder_service.py
@@ -18,7 +18,10 @@ from app.services.email_provider import (
     get_default_email_provider,
 )
 from app.services.email_templates.base import render_due_soon_email
+from app.services.entitlement_service import has_entitlement
 from app.utils.datetime_utils import utc_now_naive
+
+_EMAIL_REMINDERS_FEATURE = "email_reminders"
 
 _REMINDER_WINDOWS = {
     7: "due_soon_7_days",
@@ -123,6 +126,10 @@ def dispatch_due_transaction_reminders(
             skipped += 1
             continue
         if not _is_dispatch_allowed(transaction.user_id, category):
+            skipped += 1
+            continue
+
+        if not has_entitlement(transaction.user_id, _EMAIL_REMINDERS_FEATURE):
             skipped += 1
             continue
 

--- a/app/config/plan_features.py
+++ b/app/config/plan_features.py
@@ -14,6 +14,7 @@ PLAN_FEATURES: dict[str, list[str]] = {
         "export_pdf",
         "shared_entries",
         "focus_mode",
+        "email_reminders",
     ],
     "trial": [
         "basic_simulations",
@@ -22,6 +23,7 @@ PLAN_FEATURES: dict[str, list[str]] = {
         "export_pdf",
         "shared_entries",
         "focus_mode",
+        "email_reminders",
     ],
 }
 

--- a/app/controllers/ai/resources.py
+++ b/app/controllers/ai/resources.py
@@ -10,6 +10,7 @@ All endpoints require a valid JWT and the "advanced_simulations" entitlement.
 
 from __future__ import annotations
 
+import logging
 import uuid
 from decimal import Decimal, InvalidOperation
 from typing import Any
@@ -29,10 +30,15 @@ from app.docs.openapi_helpers import (
     json_success_response,
 )
 from app.services.ai_advisory_service import AIAdvisoryService
+from app.services.analysis_ready_notification_service import (
+    dispatch_analysis_ready_notification,
+)
 from app.services.entitlement_service import has_entitlement
 from app.services.llm_provider import LLMProviderError
 from app.utils.typed_decorators import typed_doc as doc
 from app.utils.typed_decorators import typed_jwt_required as jwt_required
+
+log = logging.getLogger(__name__)
 
 _ENTITLEMENT_KEY = "advanced_simulations"
 
@@ -356,12 +362,45 @@ class AIWeeklySummaryResource(MethodResource):
                 error_code="INTERNAL_ERROR",
             )
 
+        # Notify the user that a new analysis is ready (fire-and-forget).
+        # Truncate narrative to 280 chars for the email preview.
+        _notify_analysis_ready(
+            user_id=user_id, narrative=str(result.get("narrative", ""))
+        )
+
         return compat_success_response(
             legacy_payload=result,
             status_code=200,
             message="Briefing semanal gerado com sucesso",
             data=result,
         )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _notify_analysis_ready(*, user_id: UUID, narrative: str) -> None:
+    """Fire-and-forget: send 'analysis ready' notification to the user.
+
+    Swallows all exceptions so notification failures never break the response.
+    The notification service itself handles entitlement gating — free users
+    are silently skipped without reaching this point in practice because the
+    endpoint already requires 'advanced_simulations', but the service enforces
+    'email_reminders' independently.
+    """
+    try:
+        preview = (
+            narrative[:280].rsplit(" ", 1)[0] if len(narrative) > 280 else narrative
+        )
+        dispatch_analysis_ready_notification(
+            user_id=user_id,
+            summary_preview=preview
+            or "Sua análise financeira semanal está disponível.",  # noqa: E501
+        )
+    except Exception as exc:
+        log.warning("ai.weekly_summary.notify_failed user_id=%s error=%s", user_id, exc)
 
 
 __all__ = [

--- a/app/services/analysis_ready_notification_service.py
+++ b/app/services/analysis_ready_notification_service.py
@@ -1,0 +1,214 @@
+"""Notification service for 'AI analysis ready' events (#1207).
+
+Dispatches an email (and optionally a push notification) to a premium user
+when a new AI financial analysis is available for them to view.
+
+Usage::
+
+    from app.services.analysis_ready_notification_service import (
+        dispatch_analysis_ready_notification,
+    )
+
+    result = dispatch_analysis_ready_notification(
+        user_id=uuid,
+        summary_preview="Seus gastos com alimentação subiram 18% este mês...",
+    )
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import cast
+from uuid import UUID
+
+import requests as http_client
+
+from app.extensions.database import db
+from app.models.push_subscription import PushSubscription, PushTransport
+from app.models.user import User
+from app.services.email_provider import EmailMessage, get_default_email_provider
+from app.services.email_templates.base import render_analysis_ready_email
+from app.services.entitlement_service import has_entitlement
+
+log = logging.getLogger(__name__)
+
+_EMAIL_REMINDERS_FEATURE = "email_reminders"
+_DEFAULT_SUMMARY = (
+    "Sua análise financeira semanal está disponível. "
+    "Acesse o dashboard para ver seus insights personalizados."
+)
+_EXPO_PUSH_URL = "https://exp.host/--/api/v2/push/send"
+
+
+@dataclass(frozen=True)
+class AnalysisNotificationResult:
+    email_sent: bool
+    push_sent: bool
+    skipped_reason: str | None = None
+
+
+def dispatch_analysis_ready_notification(
+    *,
+    user_id: UUID,
+    summary_preview: str = _DEFAULT_SUMMARY,
+) -> AnalysisNotificationResult:
+    """Send 'analysis ready' notification to a premium user.
+
+    Sends an email when the user has the ``email_reminders`` entitlement.
+    Skips silently for free-tier users.
+
+    Args:
+        user_id: The user to notify.
+        summary_preview: A 1-2 sentence AI-generated preview included in the email.
+
+    Returns:
+        AnalysisNotificationResult with flags indicating what was sent.
+    """
+    if not has_entitlement(user_id, _EMAIL_REMINDERS_FEATURE):
+        log.debug(
+            "analysis_ready_notification.skipped user_id=%s reason=no_entitlement",
+            user_id,
+        )
+        return AnalysisNotificationResult(
+            email_sent=False,
+            push_sent=False,
+            skipped_reason="no_entitlement",
+        )
+
+    user = db.session.get(User, user_id)
+    if user is None:
+        log.warning(
+            "analysis_ready_notification.skipped user_id=%s reason=user_not_found",
+            user_id,
+        )
+        return AnalysisNotificationResult(
+            email_sent=False,
+            push_sent=False,
+            skipped_reason="user_not_found",
+        )
+
+    first_name = _extract_first_name(user)
+    email_sent = _send_email(
+        to_email=str(user.email),
+        first_name=first_name,
+        summary_preview=summary_preview,
+    )
+    push_sent = _send_expo_push(
+        user_id=user_id,
+        first_name=first_name,
+        summary_preview=summary_preview,
+    )
+
+    return AnalysisNotificationResult(
+        email_sent=email_sent,
+        push_sent=push_sent,
+    )
+
+
+def _extract_first_name(user: User) -> str:
+    name = getattr(user, "name", None) or getattr(user, "full_name", None) or ""
+    return str(name).split()[0] if name else "você"
+
+
+def _send_email(
+    *,
+    to_email: str,
+    first_name: str,
+    summary_preview: str,
+) -> bool:
+    """Send the analysis-ready email. Returns True on success, False on failure."""
+    try:
+        html, text = render_analysis_ready_email(
+            first_name=first_name,
+            summary_preview=summary_preview,
+        )
+        provider = get_default_email_provider()
+        provider.send(
+            EmailMessage(
+                to_email=to_email,
+                subject=f"Sua análise financeira está pronta, {first_name}!",
+                html=html,
+                text=text,
+                tag="analysis_ready",
+            )
+        )
+        log.info(
+            "analysis_ready_notification.email_sent to=%s",
+            to_email,
+        )
+        return True
+    except Exception as exc:
+        log.warning(
+            "analysis_ready_notification.email_failed to=%s error=%s",
+            to_email,
+            exc,
+        )
+        return False
+
+
+def _send_expo_push(
+    *,
+    user_id: UUID,
+    first_name: str,
+    summary_preview: str,
+) -> bool:
+    """Send Expo push notifications to all registered Expo tokens for the user.
+
+    Returns True if at least one notification was dispatched successfully.
+    Swallows individual token failures so one bad token doesn't block the rest.
+    """
+    subscriptions = cast(
+        list[PushSubscription],
+        PushSubscription.query.filter_by(
+            user_id=user_id,
+            transport=PushTransport.expo,
+        ).all(),
+    )
+    if not subscriptions:
+        return False
+
+    any_sent = False
+    for sub in subscriptions:
+        token = str(sub.endpoint)
+        if not token.startswith("ExponentPushToken["):
+            continue
+        try:
+            resp = http_client.post(
+                _EXPO_PUSH_URL,
+                json={
+                    "to": token,
+                    "title": f"Análise pronta, {first_name}!",
+                    "body": summary_preview[:200],
+                    "data": {"screen": "Dashboard"},
+                    "sound": "default",
+                    "channelId": "analysis_ready",
+                },
+                timeout=10,
+            )
+            if resp.ok:
+                any_sent = True
+                log.info(
+                    "analysis_ready_notification.push_sent user_id=%s token=%s...",
+                    user_id,
+                    token[:30],
+                )
+            else:
+                log.warning(
+                    "analysis_ready_notification.push_rejected user_id=%s status=%s",
+                    user_id,
+                    resp.status_code,
+                )
+        except Exception as exc:
+            log.warning(
+                "analysis_ready_notification.push_failed user_id=%s error=%s",
+                user_id,
+                exc,
+            )
+    return any_sent
+
+
+__all__ = [
+    "AnalysisNotificationResult",
+    "dispatch_analysis_ready_notification",
+]

--- a/app/services/email_templates/base.py
+++ b/app/services/email_templates/base.py
@@ -483,8 +483,94 @@ def render_due_soon_email(
     return html, text
 
 
+def render_analysis_ready_email(
+    *,
+    first_name: str,
+    summary_preview: str,
+) -> tuple[str, str]:
+    """Render the 'AI analysis ready' notification email.
+
+    Args:
+        first_name: User's first name for personalisation.
+        summary_preview: Short 1-2 sentence AI-generated preview to include.
+
+    Returns:
+        (html, text) tuple ready to pass to EmailMessage.
+    """
+    email_title = f"Sua análise financeira está pronta, {first_name}!"
+    preview = "Novos insights sobre suas finanças estão disponíveis no Auraxis."
+    dashboard_url = f"{_APP_URL}/dashboard"
+
+    body_html = f"""
+      <h1 style="font-family: {_FONT_HEADING}; font-size: 26px; font-weight: 700;
+                 color: {_COLOR_TEXT_PRIMARY}; margin: 0 0 8px; line-height: 1.2;">
+        Sua análise financeira está pronta
+      </h1>
+      <p style="font-family: {_FONT_BODY}; font-size: 13px; font-weight: 600;
+                color: {_COLOR_BRAND}; margin: 0 0 24px; text-transform: uppercase;
+                letter-spacing: 1px;">
+        Auraxis &mdash; Inteligência Financeira
+      </p>
+
+      <div style="border-top: 1px solid {_COLOR_BG_ELEVATED}; margin: 0 0 28px;"></div>
+
+      <p style="font-family: {_FONT_BODY}; font-size: 15px; color: {_COLOR_TEXT_SECONDARY};
+                line-height: 1.65; margin: 0 0 16px;">
+        Olá, <strong style="color: {_COLOR_TEXT_PRIMARY};">{first_name}</strong>!
+        Geramos uma nova análise das suas finanças com inteligência artificial.
+      </p>
+
+      <div style="background: {_COLOR_BG_SURFACE}; border-left: 3px solid {_COLOR_BRAND};
+                  border-radius: 4px; padding: 16px 20px; margin: 0 0 28px;">
+        <p style="font-family: {_FONT_BODY}; font-size: 14px; color: {_COLOR_TEXT_SECONDARY};
+                  line-height: 1.6; margin: 0; font-style: italic;">
+          {summary_preview}
+        </p>
+      </div>
+
+      <!-- CTA -->
+      <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin: 8px 0 32px;">
+        <tr>
+          <td align="left" style="border-radius: 8px; background-color: {_COLOR_BRAND};">
+            <a href="{dashboard_url}"
+               style="display: inline-block; padding: 14px 28px; font-family: {_FONT_BODY};
+                      font-size: 15px; font-weight: 700; color: #0b0909; text-decoration: none;
+                      border-radius: 8px; letter-spacing: 0.3px;">
+              Ver análise completa
+            </a>
+          </td>
+        </tr>
+      </table>
+
+      <p style="font-family: {_FONT_BODY}; font-size: 12px; color: {_COLOR_TEXT_MUTED};
+                line-height: 1.6; margin: 0;">
+        Para gerenciar suas preferências de notificação, acesse as configurações no aplicativo.
+      </p>
+    """
+
+    html = _base_layout(
+        title=email_title,
+        preview_text=preview,
+        body_html=body_html,
+    )
+
+    text = (
+        f"Sua análise financeira está pronta — Auraxis\n"
+        f"=============================================\n\n"
+        f"Olá, {first_name}!\n\n"
+        f"{summary_preview}\n\n"
+        f"Acesse o Auraxis para ver a análise completa:\n"
+        f"{dashboard_url}\n\n"
+        f"Para gerenciar preferências de notificação, acesse as configurações no app.\n\n"
+        f"— Equipe Auraxis\n"
+    )
+
+    return html, text
+
+
 __all__ = [
     "render_account_deletion_email",
+    "render_analysis_ready_email",
     "render_confirmation_email",
     "render_due_soon_email",
     "render_password_reset_email",

--- a/tests/test_analysis_ready_notification.py
+++ b/tests/test_analysis_ready_notification.py
@@ -1,0 +1,236 @@
+"""Tests for analysis_ready_notification_service and the email_reminders
+entitlement gate added to transaction_reminder_service (#1207)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date, timedelta
+from decimal import Decimal
+from unittest.mock import patch
+
+from app.application.services.transaction_reminder_service import (
+    dispatch_due_transaction_reminders,
+)
+from app.config.plan_features import PLAN_FEATURES, PREMIUM_FEATURES
+from app.extensions.database import db
+from app.models.transaction import Transaction, TransactionStatus, TransactionType
+from app.models.user import User
+from app.services.analysis_ready_notification_service import (
+    dispatch_analysis_ready_notification,
+)
+from app.services.email_provider import get_email_outbox
+from app.services.entitlement_service import activate_premium, deactivate_premium
+
+# ---------------------------------------------------------------------------
+# plan_features catalog
+# ---------------------------------------------------------------------------
+
+
+def test_email_reminders_in_premium_plan() -> None:
+    assert "email_reminders" in PLAN_FEATURES["premium"]
+
+
+def test_email_reminders_in_trial_plan() -> None:
+    assert "email_reminders" in PLAN_FEATURES["trial"]
+
+
+def test_email_reminders_not_in_free_plan() -> None:
+    assert "email_reminders" not in PLAN_FEATURES["free"]
+
+
+def test_email_reminders_is_a_premium_feature() -> None:
+    assert "email_reminders" in PREMIUM_FEATURES
+
+
+# ---------------------------------------------------------------------------
+# analysis_ready_notification_service
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_analysis_ready_skips_free_user(app) -> None:
+    with app.app_context():
+        user = User(
+            id=uuid.uuid4(),
+            name="Free User",
+            email=f"free-{uuid.uuid4()}@test.com",
+            password="hash",
+        )
+        db.session.add(user)
+        db.session.commit()
+        deactivate_premium(user.id)
+
+        result = dispatch_analysis_ready_notification(user_id=user.id)
+
+        assert result.email_sent is False
+        assert result.push_sent is False
+        assert result.skipped_reason == "no_entitlement"
+
+
+def test_dispatch_analysis_ready_sends_email_to_premium_user(app) -> None:
+    with app.app_context():
+        user = User(
+            id=uuid.uuid4(),
+            name="Premium User",
+            email=f"premium-{uuid.uuid4()}@test.com",
+            password="hash",
+        )
+        db.session.add(user)
+        db.session.commit()
+        activate_premium(user.id, expires_at=None)
+
+        outbox = get_email_outbox()
+        before = len(outbox)
+
+        result = dispatch_analysis_ready_notification(
+            user_id=user.id,
+            summary_preview="Seus gastos subiram 10% este mês.",
+        )
+
+        assert result.email_sent is True
+        assert result.push_sent is False
+        assert result.skipped_reason is None
+        assert len(outbox) == before + 1
+        sent = outbox[-1]
+        subject = sent["subject"].lower()
+        assert "análise" in subject or "pronta" in subject
+        assert "Premium User".split()[0] in sent["subject"]
+
+
+def test_dispatch_analysis_ready_skips_nonexistent_user(app) -> None:
+    # A non-existent user has no entitlement rows, so the gate fires first.
+    with app.app_context():
+        fake_id = uuid.uuid4()
+        result = dispatch_analysis_ready_notification(user_id=fake_id)
+
+        assert result.email_sent is False
+        assert result.skipped_reason in ("no_entitlement", "user_not_found")
+
+
+def test_dispatch_analysis_ready_sends_expo_push_to_premium_user(app) -> None:
+    with app.app_context():
+        user = User(
+            id=uuid.uuid4(),
+            name="Push User",
+            email=f"push-{uuid.uuid4()}@test.com",
+            password="hash",
+        )
+        db.session.add(user)
+        db.session.commit()
+        activate_premium(user.id, expires_at=None)
+
+        from app.models.push_subscription import PushSubscription, PushTransport
+
+        sub = PushSubscription(
+            user_id=user.id,
+            transport=PushTransport.expo,
+            endpoint=f"ExponentPushToken[test-{uuid.uuid4()}]",
+        )
+        db.session.add(sub)
+        db.session.commit()
+
+        with patch(
+            "app.services.analysis_ready_notification_service.http_client.post"
+        ) as mock_post:
+            mock_post.return_value.ok = True
+            result = dispatch_analysis_ready_notification(
+                user_id=user.id,
+                summary_preview="Gastos acima do esperado.",
+            )
+
+        assert result.push_sent is True
+        mock_post.assert_called_once()
+        call_body = mock_post.call_args.kwargs["json"]
+        assert "ExponentPushToken" in call_body["to"]
+        assert "Análise" in call_body["title"] or "pronta" in call_body["title"]
+
+
+def test_dispatch_analysis_ready_handles_email_failure(app) -> None:
+    with app.app_context():
+        user = User(
+            id=uuid.uuid4(),
+            name="Error User",
+            email=f"err-{uuid.uuid4()}@test.com",
+            password="hash",
+        )
+        db.session.add(user)
+        db.session.commit()
+        activate_premium(user.id, expires_at=None)
+
+        with patch(
+            "app.services.analysis_ready_notification_service.get_default_email_provider"
+        ) as mock_provider:
+            mock_provider.return_value.send.side_effect = RuntimeError("SMTP down")
+            result = dispatch_analysis_ready_notification(user_id=user.id)
+
+        assert result.email_sent is False
+
+
+# ---------------------------------------------------------------------------
+# transaction_reminder_service — entitlement gate
+# ---------------------------------------------------------------------------
+
+
+def test_reminder_skips_free_user_with_email_reminders_gate(app) -> None:
+    """Free users must NOT receive transaction reminders after the gate."""
+    today = date(2030, 8, 1)
+    with app.app_context():
+        user = User(
+            id=uuid.uuid4(),
+            name="Free Reminder",
+            email=f"free-reminder-{uuid.uuid4()}@test.com",
+            password="hash",
+        )
+        db.session.add(user)
+        db.session.flush()
+        deactivate_premium(user.id)
+
+        transaction = Transaction(
+            user_id=user.id,
+            title="Conta de água",
+            amount=Decimal("80.00"),
+            type=TransactionType.EXPENSE,
+            status=TransactionStatus.PENDING,
+            due_date=today + timedelta(days=7),
+        )
+        db.session.add(transaction)
+        db.session.commit()
+
+        outbox = get_email_outbox()
+        before = len(outbox)
+        result = dispatch_due_transaction_reminders(days_before_due=7, today=today)
+
+        assert len(outbox) == before, "Free user should not receive reminder email"
+        assert result.skipped >= 1
+
+
+def test_reminder_sends_to_premium_user(app) -> None:
+    """Premium users MUST receive transaction reminders."""
+    today = date(2030, 9, 1)
+    with app.app_context():
+        user = User(
+            id=uuid.uuid4(),
+            name="Premium Reminder",
+            email=f"prem-reminder-{uuid.uuid4()}@test.com",
+            password="hash",
+        )
+        db.session.add(user)
+        db.session.flush()
+        activate_premium(user.id, expires_at=None)
+
+        transaction = Transaction(
+            user_id=user.id,
+            title="Aluguel",
+            amount=Decimal("1500.00"),
+            type=TransactionType.EXPENSE,
+            status=TransactionStatus.PENDING,
+            due_date=today + timedelta(days=7),
+        )
+        db.session.add(transaction)
+        db.session.commit()
+
+        outbox = get_email_outbox()
+        before = len(outbox)
+        result = dispatch_due_transaction_reminders(days_before_due=7, today=today)
+
+        assert result.sent >= 1
+        assert len(outbox) >= before + 1

--- a/tests/test_reminders_cli.py
+++ b/tests/test_reminders_cli.py
@@ -8,6 +8,7 @@ from app.extensions.database import db
 from app.models.transaction import Transaction, TransactionStatus, TransactionType
 from app.models.user import User
 from app.services.email_provider import get_email_outbox
+from app.services.entitlement_service import activate_premium
 
 
 def test_dispatch_due_soon_sends_reminders(app) -> None:
@@ -21,6 +22,7 @@ def test_dispatch_due_soon_sends_reminders(app) -> None:
         )
         db.session.add(user)
         db.session.flush()
+        activate_premium(user.id, expires_at=None)
 
         tx_7 = Transaction(
             user_id=user.id,
@@ -98,6 +100,7 @@ def test_dispatch_due_soon_email_provider_error_queues_to_dlq_and_exits_zero(
             )
             db.session.add(user)
             db.session.flush()
+            activate_premium(user.id, expires_at=None)
             tx = Transaction(
                 user_id=user.id,
                 title="Conta teste",

--- a/tests/test_transaction_reminder_service.py
+++ b/tests/test_transaction_reminder_service.py
@@ -23,6 +23,7 @@ from app.models.alert import Alert, AlertStatus
 from app.models.transaction import Transaction, TransactionStatus, TransactionType
 from app.models.user import User
 from app.services.email_provider import get_email_outbox
+from app.services.entitlement_service import activate_premium
 
 # ---------------------------------------------------------------------------
 # Integration tests — happy path + idempotency
@@ -40,6 +41,7 @@ def test_transaction_reminder_service_dispatches_due_soon_email(app) -> None:
         )
         db.session.add(user)
         db.session.flush()
+        activate_premium(user.id, expires_at=None)
         transaction = Transaction(
             user_id=user.id,
             title="Conta de energia",
@@ -72,6 +74,7 @@ def test_transaction_reminder_service_is_idempotent_per_day(app) -> None:
         )
         db.session.add(user)
         db.session.flush()
+        activate_premium(user.id, expires_at=None)
         transaction = Transaction(
             user_id=user.id,
             title="Conta de internet",


### PR DESCRIPTION
## Resumo

### Gate premium em transaction reminders
- Adiciona `email_reminders` ao `PLAN_FEATURES` (premium + trial)
- `dispatch_due_transaction_reminders` verifica entitlement antes de enviar email
- Usuarios free sao ignorados silenciosamente (sem erro, sem email)

### Servico de notificacao 'analise pronta'
- `analysis_ready_notification_service.py` — despacha email + Expo push quando IA gera analise
- Template `render_analysis_ready_email` dark-theme com preview e CTA para dashboard
- Expo push: dispara para todos os tokens ExponentPushToken do usuario (tolerante a falhas por token)
- Integracao: `AIWeeklySummaryResource` chama `_notify_analysis_ready` fire-and-forget apos gerar briefing

### Testes
- 11 testes: gate free/premium em reminders, envio de email, Expo push mockado, falha de SMTP, catalog de features

## Test plan
- [ ] Usuario free nao recebe reminder por email
- [ ] Usuario premium recebe reminder
- [ ] `dispatch_analysis_ready_notification` envia email + push apenas para premium
- [ ] `GET /ai/insights/weekly-summary` dispara notificacao apos gerar briefing

Closes #1207