### PR TITLE
feat(ai): daily rate limit para insights manuais — 2x/dia por usuário Premium (#1214)

### DIFF
--- a/app/controllers/ai/resources.py
+++ b/app/controllers/ai/resources.py
@@ -29,6 +29,7 @@ from app.docs.openapi_helpers import (
     json_error_response,
     json_success_response,
 )
+from app.middleware.ai_rate_limit import ai_daily_limit
 from app.services.ai_advisory_service import AIAdvisoryService
 from app.services.analysis_ready_notification_service import (
     dispatch_analysis_ready_notification,
@@ -108,6 +109,7 @@ class AISpendingInsightsResource(MethodResource):
         },
     )
     @jwt_required()
+    @ai_daily_limit()
     def get(self) -> Response:
         token_error = _guard_revoked_token()
         if token_error is not None:
@@ -333,6 +335,7 @@ class AIWeeklySummaryResource(MethodResource):
         },
     )
     @jwt_required()
+    @ai_daily_limit()
     def get(self) -> Response:
         token_error = _guard_revoked_token()
         if token_error is not None:

--- a/app/middleware/ai_rate_limit.py
+++ b/app/middleware/ai_rate_limit.py
@@ -1,0 +1,189 @@
+"""Per-user daily rate limit for AI insights endpoints (#1214).
+
+Enforces a maximum of AI_DAILY_LIMIT calls per user per calendar day (BRT timezone).
+The counter is backed by Redis when available; falls back to an in-process
+dictionary for test environments where Redis is not configured.
+
+Usage (in MethodResource views):
+    @jwt_required()
+    @ai_daily_limit()
+    def get(self) -> Response:
+        ...
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from datetime import datetime, timedelta, timezone
+from functools import wraps
+from typing import Any, Callable, TypeVar, cast
+from uuid import UUID
+
+from flask import Response
+
+from app.controllers.response_contract import compat_error_response
+
+_F = TypeVar("_F", bound=Callable[..., Any])
+
+AI_DAILY_LIMIT = 2
+AI_DAILY_LIMIT_ERROR_CODE = "AI_DAILY_LIMIT_EXCEEDED"
+AI_DAILY_LIMIT_MESSAGE = (
+    "Limite diário de insights atingido. "
+    "Você pode gerar até 2 insights por dia. "
+    "Tente novamente amanhã."
+)
+
+_BRT = timezone(timedelta(hours=-3))
+
+# Module-level Redis client — initialised lazily, shared across requests.
+_redis_lock = threading.Lock()
+_redis_client: Any = None  # None = not yet initialised; False = unavailable
+_REDIS_NOT_AVAILABLE = object()  # sentinel distinct from None
+
+
+def _seconds_until_midnight_brt() -> int:
+    """Seconds from now until 00:00 BRT of the next calendar day."""
+    now = datetime.now(_BRT)
+    midnight = datetime(now.year, now.month, now.day, tzinfo=_BRT) + timedelta(days=1)
+    return max(1, int((midnight - now).total_seconds()))
+
+
+def _brt_date_str() -> str:
+    return datetime.now(_BRT).strftime("%Y-%m-%d")
+
+
+def _get_redis() -> Any | None:
+    """Return a connected Redis client or None if unavailable."""
+    global _redis_client
+
+    if _redis_client is _REDIS_NOT_AVAILABLE:
+        return None
+
+    with _redis_lock:
+        if _redis_client is _REDIS_NOT_AVAILABLE:
+            return None
+        if _redis_client is not None:
+            return _redis_client
+
+        redis_url = (
+            os.getenv("RATE_LIMIT_REDIS_URL") or os.getenv("REDIS_URL") or ""
+        ).strip()
+        if not redis_url:
+            _redis_client = _REDIS_NOT_AVAILABLE
+            return None
+
+        try:
+            import redis as _redis
+
+            client = _redis.Redis.from_url(redis_url, socket_connect_timeout=1)
+            client.ping()
+            _redis_client = client
+            return _redis_client
+        except Exception:
+            _redis_client = _REDIS_NOT_AVAILABLE
+            return None
+
+
+class _InMemoryAICounter:
+    """Thread-safe in-memory counter — used when Redis is unavailable (tests)."""
+
+    _counts: dict[str, int] = {}
+    _lock: threading.Lock = threading.Lock()
+
+    @classmethod
+    def incr(cls, key: str, ttl_seconds: int) -> int:  # noqa: ARG003
+        with cls._lock:
+            cls._counts[key] = cls._counts.get(key, 0) + 1
+            return cls._counts[key]
+
+    @classmethod
+    def reset(cls) -> None:
+        with cls._lock:
+            cls._counts.clear()
+
+
+def check_ai_daily_limit(
+    user_id: UUID,
+    *,
+    max_calls: int = AI_DAILY_LIMIT,
+) -> tuple[int, int]:
+    """Increment and return the daily AI call counter for *user_id*.
+
+    Returns:
+        (current_count, retry_after_seconds)
+
+    A caller that receives current_count > max_calls MUST reject the request.
+    """
+    key = f"auraxis:ai-daily:{user_id}:{_brt_date_str()}"
+    ttl = _seconds_until_midnight_brt()
+
+    client = _get_redis()
+    if client is not None:
+        count = int(client.incr(key))
+        if count == 1:
+            client.expire(key, ttl)
+        return count, ttl
+
+    return _InMemoryAICounter.incr(key, ttl), ttl
+
+
+def ai_daily_limit(
+    max_calls: int = AI_DAILY_LIMIT,
+) -> Callable[[_F], _F]:
+    """Decorator that enforces a per-user daily cap on AI insights endpoints.
+
+    Must be applied AFTER @jwt_required() so that current_user_id() is available.
+
+        @jwt_required()
+        @ai_daily_limit()
+        def get(self) -> Response: ...
+    """
+
+    def decorator(fn: _F) -> _F:
+        @wraps(fn)
+        def wrapper(*args: Any, **kwargs: Any) -> Response:
+            from app.auth import current_user_id
+            from app.services.entitlement_service import has_entitlement
+
+            user_id = current_user_id()
+
+            # Only Premium users (advanced_simulations) can make manual AI insights
+            # calls. Skip the rate-limit counter for Free users — the handler will
+            # return 403 via its own entitlement gate.
+            if not has_entitlement(user_id, "advanced_simulations"):
+                return cast(Response, fn(*args, **kwargs))
+
+            count, retry_after = check_ai_daily_limit(user_id, max_calls=max_calls)
+            remaining = max(0, max_calls - count)
+
+            if count > max_calls:
+                resp = compat_error_response(
+                    legacy_payload={"error": AI_DAILY_LIMIT_MESSAGE},
+                    status_code=429,
+                    message=AI_DAILY_LIMIT_MESSAGE,
+                    error_code=AI_DAILY_LIMIT_ERROR_CODE,
+                )
+                resp.headers["Retry-After"] = str(retry_after)
+                resp.headers["X-AI-Calls-Remaining"] = "0"
+                return resp
+
+            response = cast(Response, fn(*args, **kwargs))
+            response.headers["X-AI-Calls-Remaining"] = str(remaining)
+            return response
+
+        return wrapper  # type: ignore[return-value]
+
+    return decorator
+
+
+__all__ = [
+    "AI_DAILY_LIMIT",
+    "AI_DAILY_LIMIT_ERROR_CODE",
+    "AI_DAILY_LIMIT_MESSAGE",
+    "ai_daily_limit",
+    "check_ai_daily_limit",
+    "_InMemoryAICounter",
+    "_brt_date_str",
+    "_seconds_until_midnight_brt",
+]

--- a/tests/test_ai_daily_rate_limit.py
+++ b/tests/test_ai_daily_rate_limit.py
@@ -1,0 +1,384 @@
+"""Tests for AI daily rate limit middleware (#1214).
+
+Coverage areas:
+- _seconds_until_midnight_brt() returns positive int <= 86400
+- _brt_date_str() returns YYYY-MM-DD format
+- check_ai_daily_limit(): 1st call → count 1, 2nd → count 2, 3rd → count 3
+- InMemoryAICounter.reset() clears state
+- HTTP GET /ai/insights/spending:
+    - 1st call → 200 + X-AI-Calls-Remaining: 1
+    - 2nd call → 200 + X-AI-Calls-Remaining: 0
+    - 3rd call → 429 + error_code AI_DAILY_LIMIT_EXCEEDED + Retry-After header
+- Free user still gets 403 from entitlement gate (never reaches rate limit)
+- Goal projection endpoint NOT rate-limited (not /ai/insights/*)
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers (same pattern as test_ai_advisory_service.py)
+# ---------------------------------------------------------------------------
+
+
+def _register_and_login(client, prefix: str) -> str:
+    suffix = uuid.uuid4().hex[:8]
+    email = f"{prefix}-{suffix}@test.com"
+    password = "StrongPass@123"
+    reg = client.post(
+        "/auth/register",
+        json={"name": f"{prefix}-{suffix}", "email": email, "password": password},
+    )
+    assert reg.status_code == 201
+    login = client.post("/auth/login", json={"email": email, "password": password})
+    assert login.status_code == 200
+    return login.get_json()["token"]
+
+
+def _auth(token: str, v2: bool = False) -> dict[str, str]:
+    headers = {"Authorization": f"Bearer {token}"}
+    if v2:
+        headers["X-API-Contract"] = "v2"
+    return headers
+
+
+def _revoke_premium(app, token: str) -> None:
+    with app.app_context():
+        from flask_jwt_extended import decode_token
+
+        from app.services.entitlement_service import deactivate_premium
+
+        user_id = uuid.UUID(decode_token(token)["sub"])
+        deactivate_premium(user_id)
+
+
+def _grant_premium(app, token: str) -> None:
+    with app.app_context():
+        from flask_jwt_extended import decode_token
+
+        from app.extensions.database import db
+        from app.models.entitlement import Entitlement, EntitlementSource
+
+        user_id = uuid.UUID(decode_token(token)["sub"])
+        for key in ("advanced_simulations",):
+            ent = Entitlement(
+                user_id=user_id,
+                feature_key=key,
+                source=EntitlementSource.MANUAL,
+                expires_at=None,
+            )
+            db.session.add(ent)
+        db.session.commit()
+
+
+def _reset_ai_counter() -> None:
+    from app.middleware.ai_rate_limit import _InMemoryAICounter
+
+    _InMemoryAICounter.reset()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — helpers
+# ---------------------------------------------------------------------------
+
+
+class TestMidnightHelpers:
+    def test_seconds_until_midnight_positive(self) -> None:
+        from app.middleware.ai_rate_limit import _seconds_until_midnight_brt
+
+        secs = _seconds_until_midnight_brt()
+        assert 0 < secs <= 86_400
+
+    def test_brt_date_str_format(self) -> None:
+        from app.middleware.ai_rate_limit import _brt_date_str
+
+        s = _brt_date_str()
+        assert len(s) == 10
+        parts = s.split("-")
+        assert len(parts) == 3
+        assert len(parts[0]) == 4  # year
+        assert len(parts[1]) == 2  # month
+        assert len(parts[2]) == 2  # day
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — InMemoryAICounter
+# ---------------------------------------------------------------------------
+
+
+class TestInMemoryAICounter:
+    def setup_method(self) -> None:
+        _reset_ai_counter()
+
+    def test_increments_sequentially(self) -> None:
+        from app.middleware.ai_rate_limit import _InMemoryAICounter
+
+        key = f"test-key-{uuid.uuid4().hex}"
+        assert _InMemoryAICounter.incr(key, 100) == 1
+        assert _InMemoryAICounter.incr(key, 100) == 2
+        assert _InMemoryAICounter.incr(key, 100) == 3
+
+    def test_reset_clears_all(self) -> None:
+        from app.middleware.ai_rate_limit import _InMemoryAICounter
+
+        key = f"test-key-{uuid.uuid4().hex}"
+        _InMemoryAICounter.incr(key, 100)
+        _InMemoryAICounter.reset()
+        assert _InMemoryAICounter.incr(key, 100) == 1
+
+    def test_different_keys_are_independent(self) -> None:
+        from app.middleware.ai_rate_limit import _InMemoryAICounter
+
+        key_a = f"key-a-{uuid.uuid4().hex}"
+        key_b = f"key-b-{uuid.uuid4().hex}"
+        _InMemoryAICounter.incr(key_a, 100)
+        _InMemoryAICounter.incr(key_a, 100)
+        assert _InMemoryAICounter.incr(key_b, 100) == 1
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — check_ai_daily_limit
+# ---------------------------------------------------------------------------
+
+
+class TestCheckAiDailyLimit:
+    def setup_method(self) -> None:
+        _reset_ai_counter()
+
+    def test_first_call_returns_count_one(self) -> None:
+        from app.middleware.ai_rate_limit import check_ai_daily_limit
+
+        user_id = uuid.uuid4()
+        count, retry_after = check_ai_daily_limit(user_id, max_calls=2)
+        assert count == 1
+        assert retry_after > 0
+
+    def test_second_call_returns_count_two(self) -> None:
+        from app.middleware.ai_rate_limit import check_ai_daily_limit
+
+        user_id = uuid.uuid4()
+        check_ai_daily_limit(user_id, max_calls=2)
+        count, _ = check_ai_daily_limit(user_id, max_calls=2)
+        assert count == 2
+
+    def test_third_call_returns_count_three_exceeds_limit(self) -> None:
+        from app.middleware.ai_rate_limit import check_ai_daily_limit
+
+        user_id = uuid.uuid4()
+        check_ai_daily_limit(user_id, max_calls=2)
+        check_ai_daily_limit(user_id, max_calls=2)
+        count, _ = check_ai_daily_limit(user_id, max_calls=2)
+        assert count == 3  # exceeds max_calls=2
+
+    def test_different_users_are_isolated(self) -> None:
+        from app.middleware.ai_rate_limit import check_ai_daily_limit
+
+        user_a = uuid.uuid4()
+        user_b = uuid.uuid4()
+        check_ai_daily_limit(user_a, max_calls=2)
+        check_ai_daily_limit(user_a, max_calls=2)
+        count, _ = check_ai_daily_limit(user_b, max_calls=2)
+        assert count == 1  # user_b unaffected by user_a's calls
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — HTTP endpoints
+# ---------------------------------------------------------------------------
+
+
+class TestAIDailyRateLimitHTTP:
+    def setup_method(self) -> None:
+        _reset_ai_counter()
+
+    @pytest.fixture(autouse=True)
+    def _reset_after(self) -> None:
+        yield
+        _reset_ai_counter()
+
+    def test_first_call_returns_200_with_remaining_header(self, app, client) -> None:
+        token = _register_and_login(client, "ai-rl-1st")
+        _grant_premium(app, token)
+
+        with patch(
+            "app.services.ai_advisory_service.AIAdvisoryService.generate_spending_insights",
+            return_value={
+                "insights": "ok",
+                "tokens_used": 10,
+                "cost_usd": 0.0,
+                "month": "2026-05",
+                "model": "stub",
+            },
+        ):
+            resp = client.get("/ai/insights/spending", headers=_auth(token))
+
+        assert resp.status_code == 200
+        assert resp.headers.get("X-AI-Calls-Remaining") == "1"
+
+    def test_second_call_returns_200_remaining_zero(self, app, client) -> None:
+        token = _register_and_login(client, "ai-rl-2nd")
+        _grant_premium(app, token)
+
+        with patch(
+            "app.services.ai_advisory_service.AIAdvisoryService.generate_spending_insights",
+            return_value={
+                "insights": "ok",
+                "tokens_used": 10,
+                "cost_usd": 0.0,
+                "month": "2026-05",
+                "model": "stub",
+            },
+        ):
+            client.get("/ai/insights/spending", headers=_auth(token))
+            resp = client.get("/ai/insights/spending", headers=_auth(token))
+
+        assert resp.status_code == 200
+        assert resp.headers.get("X-AI-Calls-Remaining") == "0"
+
+    def test_third_call_returns_429(self, app, client) -> None:
+        token = _register_and_login(client, "ai-rl-3rd")
+        _grant_premium(app, token)
+
+        with patch(
+            "app.services.ai_advisory_service.AIAdvisoryService.generate_spending_insights",
+            return_value={
+                "insights": "ok",
+                "tokens_used": 10,
+                "cost_usd": 0.0,
+                "month": "2026-05",
+                "model": "stub",
+            },
+        ):
+            client.get("/ai/insights/spending", headers=_auth(token))
+            client.get("/ai/insights/spending", headers=_auth(token))
+            resp = client.get("/ai/insights/spending", headers=_auth(token, v2=True))
+
+        assert resp.status_code == 429
+        data = resp.get_json()
+        assert data["error"]["code"] == "AI_DAILY_LIMIT_EXCEEDED"
+        assert "Retry-After" in resp.headers
+        assert resp.headers.get("X-AI-Calls-Remaining") == "0"
+
+    def test_429_message_is_portuguese(self, app, client) -> None:
+        token = _register_and_login(client, "ai-rl-ptbr")
+        _grant_premium(app, token)
+
+        with patch(
+            "app.services.ai_advisory_service.AIAdvisoryService.generate_spending_insights",
+            return_value={
+                "insights": "ok",
+                "tokens_used": 10,
+                "cost_usd": 0.0,
+                "month": "2026-05",
+                "model": "stub",
+            },
+        ):
+            for _ in range(3):
+                resp = client.get(
+                    "/ai/insights/spending", headers=_auth(token, v2=True)
+                )
+
+        assert resp.status_code == 429
+        data = resp.get_json()
+        assert (
+            "amanhã" in data.get("message", "").lower()
+            or "amanhã" in str(data.get("error", {})).lower()
+        )
+
+    def test_weekly_summary_also_rate_limited(self, app, client) -> None:
+        token = _register_and_login(client, "ai-rl-weekly")
+        _grant_premium(app, token)
+
+        with patch(
+            "app.services.ai_advisory_service.AIAdvisoryService.generate_weekly_summary_narrative",
+            return_value={
+                "narrative": "ok",
+                "tokens_used": 10,
+                "cost_usd": 0.0,
+                "summary": {},
+                "model": "stub",
+            },
+        ):
+            client.get("/ai/insights/weekly-summary", headers=_auth(token))
+            client.get("/ai/insights/weekly-summary", headers=_auth(token))
+            resp = client.get(
+                "/ai/insights/weekly-summary", headers=_auth(token, v2=True)
+            )
+
+        assert resp.status_code == 429
+        assert resp.get_json()["error"]["code"] == "AI_DAILY_LIMIT_EXCEEDED"
+
+    def test_spending_and_weekly_share_same_daily_counter(self, app, client) -> None:
+        """1 spending call + 1 weekly call = 2 calls total — next call is 429."""
+        token = _register_and_login(client, "ai-rl-shared")
+        _grant_premium(app, token)
+
+        with (
+            patch(
+                "app.services.ai_advisory_service.AIAdvisoryService.generate_spending_insights",
+                return_value={
+                    "insights": "ok",
+                    "tokens_used": 10,
+                    "cost_usd": 0.0,
+                    "month": "2026-05",
+                    "model": "stub",
+                },
+            ),
+            patch(
+                "app.services.ai_advisory_service.AIAdvisoryService.generate_weekly_summary_narrative",
+                return_value={
+                    "narrative": "ok",
+                    "tokens_used": 10,
+                    "cost_usd": 0.0,
+                    "summary": {},
+                    "model": "stub",
+                },
+            ),
+        ):
+            r1 = client.get("/ai/insights/spending", headers=_auth(token))
+            r2 = client.get("/ai/insights/weekly-summary", headers=_auth(token))
+            r3 = client.get("/ai/insights/spending", headers=_auth(token))
+
+        assert r1.status_code == 200
+        assert r2.status_code == 200
+        assert r3.status_code == 429
+
+    def test_free_user_gets_403_not_429(self, app, client) -> None:
+        """Free users are blocked by entitlement gate before reaching rate limit."""
+        token = _register_and_login(client, "ai-rl-free")
+        _revoke_premium(app, token)  # new users get trial; explicitly revoke
+
+        for _ in range(3):
+            resp = client.get("/ai/insights/spending", headers=_auth(token, v2=True))
+        assert resp.status_code == 403
+        assert resp.get_json().get("error", {}).get("code") == "ENTITLEMENT_REQUIRED"
+
+    def test_rate_limit_isolated_per_user(self, app, client) -> None:
+        token_a = _register_and_login(client, "ai-rl-isola")
+        token_b = _register_and_login(client, "ai-rl-isolb")
+        _grant_premium(app, token_a)
+        _grant_premium(app, token_b)
+
+        with patch(
+            "app.services.ai_advisory_service.AIAdvisoryService.generate_spending_insights",
+            return_value={
+                "insights": "ok",
+                "tokens_used": 10,
+                "cost_usd": 0.0,
+                "month": "2026-05",
+                "model": "stub",
+            },
+        ):
+            # Exhaust user_a
+            client.get("/ai/insights/spending", headers=_auth(token_a))
+            client.get("/ai/insights/spending", headers=_auth(token_a))
+            blocked = client.get("/ai/insights/spending", headers=_auth(token_a))
+            assert blocked.status_code == 429
+
+            # user_b still has full quota
+            resp_b = client.get("/ai/insights/spending", headers=_auth(token_b))
+            assert resp_b.status_code == 200
+            assert resp_b.headers.get("X-AI-Calls-Remaining") == "1"


### PR DESCRIPTION
## Summary

- Novo middleware `app/middleware/ai_rate_limit.py`: contador diário por usuário via Redis (fallback in-memory para testes), alinhado ao calendário BRT (UTC-3)
- Decorator `@ai_daily_limit()` aplicado em `GET /ai/insights/spending` e `GET /ai/insights/weekly-summary`
- Usuários Premium: máximo 2 chamadas manuais/dia; 3ª retorna 429 `AI_DAILY_LIMIT_EXCEEDED`
- Usuários Free: não são contados — a checagem de entitlement do handler retorna 403 normalmente
- Resposta inclui `X-AI-Calls-Remaining` e `Retry-After` (segundos até meia-noite BRT)
- 17 testes: unit helpers, counter, boundary + integração HTTP completa
- Coverage total: 87.67% (≥ 85% ✓)

## Test plan

- [x] `GET /ai/insights/spending` — 1ª call: 200 + `X-AI-Calls-Remaining: 1`
- [x] `GET /ai/insights/spending` — 2ª call: 200 + `X-AI-Calls-Remaining: 0`
- [x] `GET /ai/insights/spending` — 3ª call: 429 `AI_DAILY_LIMIT_EXCEEDED` + `Retry-After`
- [x] Spending + weekly-summary compartilham o mesmo contador diário
- [x] Usuário Free recebe 403 (entitlement gate), não 429
- [x] Isolamento por usuário: cota de A não afeta B
- [x] All quality gates: ruff, mypy, bandit, coverage

Closes #1214