### PR TITLE
feat(ai): jobs semanal e mensal de insights — CLI + SSM + workflows (#1215, #1216)

### DIFF
--- a/.github/workflows/monthly-ai-insights.yml
+++ b/.github/workflows/monthly-ai-insights.yml
@@ -1,0 +1,162 @@
+name: Monthly AI Insights Job
+
+on:
+  schedule:
+    # 1st of each month at 03:00 UTC = 00:00 BRT
+    - cron: "0 3 1 * *"
+  workflow_dispatch:
+    inputs:
+      month:
+        description: "Month to process (YYYY-MM). Leave blank for previous month."
+        type: string
+        default: ""
+      dry_run:
+        description: "Dry-run only (print eligible users, no LLM calls)"
+        type: boolean
+        default: false
+
+concurrency:
+  group: monthly-ai-insights
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+  issues: write
+
+jobs:
+  monthly-insights:
+    name: Generate Monthly AI Insights (Free + Premium users)
+    runs-on: ubuntu-latest
+    environment: prod
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate required variables
+        run: |
+          [ -n "${AWS_REGION:-}" ] || { echo "Missing var AWS_REGION"; exit 1; }
+          [ -n "${AWS_ROLE_ARN_PROD:-}" ] || { echo "Missing var AWS_ROLE_ARN_PROD"; exit 1; }
+          [ -n "${AURAXIS_PROD_INSTANCE_ID:-}" ] || { echo "Missing var AURAXIS_PROD_INSTANCE_ID"; exit 1; }
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+          AWS_ROLE_ARN_PROD: ${{ vars.AWS_ROLE_ARN_PROD }}
+          AURAXIS_PROD_INSTANCE_ID: ${{ vars.AURAXIS_PROD_INSTANCE_ID }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN_PROD }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Run monthly AI insights via SSM
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+          PROD_INSTANCE_ID: ${{ vars.AURAXIS_PROD_INSTANCE_ID }}
+          DIAGNOSTICS_PATH: ${{ runner.temp }}/monthly-ai-insights-diagnostics.json
+          MONTH_INPUT: ${{ inputs.month || '' }}
+        run: |
+          MONTH_FLAG=""
+          if [ -n "${MONTH_INPUT:-}" ]; then
+            MONTH_FLAG="--month ${MONTH_INPUT}"
+          fi
+          python scripts/aws_ai_insights_job.py \
+            --mode monthly \
+            ${MONTH_FLAG} \
+            --profile "" \
+            --region "${AWS_REGION}" \
+            --env prod \
+            --instance-id "${PROD_INSTANCE_ID}" \
+            --diagnostics-json-path "${DIAGNOSTICS_PATH}"
+
+      - name: Upload diagnostics artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: monthly-ai-insights-diagnostics
+          path: ${{ runner.temp }}/monthly-ai-insights-diagnostics.json
+          if-no-files-found: ignore
+
+      - name: Notify failure via GitHub Issue
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const now = new Date().toISOString();
+            const title = '🚨 [monthly-ai-insights] Falha na geração de insights mensais';
+            const issueBody = [
+              '## Monthly AI Insights Job falhou',
+              '',
+              `**Última falha:** ${now}`,
+              `**Run:** ${runUrl}`,
+              '',
+              'O job agendado de geração de insights mensais com IA falhou via SSM.',
+              'Verifique os logs do workflow e o artifact de diagnóstico.',
+              '',
+              '### Ações sugeridas',
+              '- Revisar logs da execução no link acima',
+              '- Verificar o artifact `monthly-ai-insights-diagnostics`',
+              '- Confirmar que `OPENAI_API_KEY` e `LLM_PROVIDER=openai` estão no SSM Parameter Store (`/auraxis/prod/`)',
+              '- Executar `flask ai monthly-insights --dry-run` no container para validar a listagem de usuários',
+              '- Para reprocessamento manual: usar `workflow_dispatch` com o campo `month`',
+              '',
+              '_Issue criada automaticamente pelo GitHub Actions._',
+            ].join('\n');
+            const commentBody = [
+              'Nova falha detectada no monthly AI insights job.',
+              '',
+              `- Data: ${now}`,
+              `- Run: ${runUrl}`,
+            ].join('\n');
+            const query = [
+              `repo:${context.repo.owner}/${context.repo.repo}`,
+              'is:issue',
+              'in:title',
+              `"${title}"`,
+            ].join(' ');
+            const search = await github.rest.search.issuesAndPullRequests({
+              q: query,
+              per_page: 10,
+            });
+            const matchingIssue = search.data.items.find(
+              (item) => item.title === title,
+            );
+            if (matchingIssue) {
+              if (matchingIssue.state === 'closed') {
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: matchingIssue.number,
+                  state: 'open',
+                });
+              }
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: matchingIssue.number,
+                body: commentBody,
+              });
+              return;
+            }
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body: issueBody,
+              labels: ['bug', 'ops'],
+            });

--- a/.github/workflows/weekly-ai-insights.yml
+++ b/.github/workflows/weekly-ai-insights.yml
@@ -1,0 +1,151 @@
+name: Weekly AI Insights Job
+
+on:
+  schedule:
+    # Every Saturday at 03:00 UTC = 00:00 BRT
+    - cron: "0 3 * * 6"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry-run only (print eligible users, no LLM calls)"
+        type: boolean
+        default: false
+
+concurrency:
+  group: weekly-ai-insights
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+  issues: write
+
+jobs:
+  weekly-insights:
+    name: Generate Weekly AI Insights (Premium users)
+    runs-on: ubuntu-latest
+    environment: prod
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate required variables
+        run: |
+          [ -n "${AWS_REGION:-}" ] || { echo "Missing var AWS_REGION"; exit 1; }
+          [ -n "${AWS_ROLE_ARN_PROD:-}" ] || { echo "Missing var AWS_ROLE_ARN_PROD"; exit 1; }
+          [ -n "${AURAXIS_PROD_INSTANCE_ID:-}" ] || { echo "Missing var AURAXIS_PROD_INSTANCE_ID"; exit 1; }
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+          AWS_ROLE_ARN_PROD: ${{ vars.AWS_ROLE_ARN_PROD }}
+          AURAXIS_PROD_INSTANCE_ID: ${{ vars.AURAXIS_PROD_INSTANCE_ID }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN_PROD }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Run weekly AI insights via SSM
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+          PROD_INSTANCE_ID: ${{ vars.AURAXIS_PROD_INSTANCE_ID }}
+          DIAGNOSTICS_PATH: ${{ runner.temp }}/weekly-ai-insights-diagnostics.json
+        run: |
+          python scripts/aws_ai_insights_job.py \
+            --mode weekly \
+            --profile "" \
+            --region "${AWS_REGION}" \
+            --env prod \
+            --instance-id "${PROD_INSTANCE_ID}" \
+            --diagnostics-json-path "${DIAGNOSTICS_PATH}"
+
+      - name: Upload diagnostics artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: weekly-ai-insights-diagnostics
+          path: ${{ runner.temp }}/weekly-ai-insights-diagnostics.json
+          if-no-files-found: ignore
+
+      - name: Notify failure via GitHub Issue
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const now = new Date().toISOString();
+            const title = '🚨 [weekly-ai-insights] Falha na geração de insights semanais';
+            const issueBody = [
+              '## Weekly AI Insights Job falhou',
+              '',
+              `**Última falha:** ${now}`,
+              `**Run:** ${runUrl}`,
+              '',
+              'O job agendado de geração de insights semanais com IA falhou via SSM.',
+              'Verifique os logs do workflow e o artifact de diagnóstico.',
+              '',
+              '### Ações sugeridas',
+              '- Revisar logs da execução no link acima',
+              '- Verificar o artifact `weekly-ai-insights-diagnostics`',
+              '- Confirmar que `OPENAI_API_KEY` e `LLM_PROVIDER=openai` estão no SSM Parameter Store (`/auraxis/prod/`)',
+              '- Executar `flask ai weekly-insights --dry-run` no container para validar a listagem de usuários',
+              '',
+              '_Issue criada automaticamente pelo GitHub Actions._',
+            ].join('\n');
+            const commentBody = [
+              'Nova falha detectada no weekly AI insights job.',
+              '',
+              `- Data: ${now}`,
+              `- Run: ${runUrl}`,
+            ].join('\n');
+            const query = [
+              `repo:${context.repo.owner}/${context.repo.repo}`,
+              'is:issue',
+              'in:title',
+              `"${title}"`,
+            ].join(' ');
+            const search = await github.rest.search.issuesAndPullRequests({
+              q: query,
+              per_page: 10,
+            });
+            const matchingIssue = search.data.items.find(
+              (item) => item.title === title,
+            );
+            if (matchingIssue) {
+              if (matchingIssue.state === 'closed') {
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: matchingIssue.number,
+                  state: 'open',
+                });
+              }
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: matchingIssue.number,
+                body: commentBody,
+              });
+              return;
+            }
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body: issueBody,
+              labels: ['bug', 'ops'],
+            });

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -12,6 +12,7 @@ from flask_marshmallow import Marshmallow
 from flask_migrate import Migrate
 from sqlalchemy.pool import NullPool
 
+from app.cli.ai_insights_cli import register_ai_insights_commands
 from app.cli.features import features as features_cli_group
 from app.cli.openapi_export import openapi_export_command
 from app.cli.worker_cli import worker_cli_group
@@ -289,6 +290,7 @@ def create_app(*, enable_http_runtime: bool = True) -> Flask:
     register_integration_metrics_commands(app)
     register_billing_webhooks_commands(app)
     register_reminders_commands(app)
+    register_ai_insights_commands(app)
     register_email_dlq_commands(app)
     app.cli.add_command(features_cli_group, "features")
     app.cli.add_command(openapi_export_command)

--- a/app/cli/ai_insights_cli.py
+++ b/app/cli/ai_insights_cli.py
@@ -1,0 +1,241 @@
+"""Flask CLI commands for scheduled AI insights batch jobs (#1215, #1216).
+
+Commands:
+  flask ai weekly-insights   — Premium users, runs every Saturday 03:00 UTC
+  flask ai monthly-insights  — All users, runs on the 1st of each month 03:00 UTC
+
+Both commands follow the same pattern:
+  1. Query eligible users
+  2. Check idempotency (skip if already generated today)
+  3. Call AIAdvisoryService
+  4. Log per-user result; continue on individual failures
+  5. Exit non-zero if ALL users failed (total failure)
+"""
+
+from __future__ import annotations
+
+import sys
+import uuid
+from datetime import date, datetime, timedelta, timezone
+
+import click
+from flask import Flask
+from flask.cli import AppGroup
+
+from app.extensions.database import db
+from app.models.entitlement import Entitlement
+from app.models.llm_audit_log import LLMAuditLog
+from app.models.user import User
+from app.services.ai_advisory_service import AIAdvisoryService
+from app.services.llm_provider import LLMProviderError
+
+ai_insights_cli = AppGroup("ai", help="Scheduled AI insights batch commands.")
+
+_BRT = timezone(timedelta(hours=-3))
+_WEEKLY_ENDPOINT = "weekly_summary_batch"
+_MONTHLY_ENDPOINT = "spending_insights_batch"
+
+
+def _brt_today() -> date:
+    return datetime.now(_BRT).date()
+
+
+def _premium_user_ids() -> list[uuid.UUID]:
+    """Return UUIDs of all non-deleted users with advanced_simulations entitlement."""
+    rows = (
+        db.session.query(Entitlement.user_id)
+        .join(User, User.id == Entitlement.user_id)
+        .filter(
+            Entitlement.feature_key == "advanced_simulations",
+            User.deleted_at.is_(None),
+        )
+        .distinct()
+        .all()
+    )
+    return [r.user_id for r in rows]
+
+
+def _all_active_user_ids() -> list[uuid.UUID]:
+    """Return UUIDs of all non-deleted users (Free + Premium)."""
+    rows = db.session.query(User.id).filter(User.deleted_at.is_(None)).all()
+    return [r.id for r in rows]
+
+
+def _already_run_today(user_id: uuid.UUID, endpoint: str) -> bool:
+    """Return True if a batch insight was already generated today (BRT)."""
+    today = _brt_today()
+    exists = (
+        db.session.query(LLMAuditLog.id)
+        .filter(
+            LLMAuditLog.user_id == user_id,
+            LLMAuditLog.endpoint == endpoint,
+            db.func.date(LLMAuditLog.created_at) == today,
+        )
+        .first()
+    )
+    return exists is not None
+
+
+def _run_batch(
+    *,
+    user_ids: list[uuid.UUID],
+    endpoint: str,
+    generate_fn_name: str,
+    label: str,
+    dry_run: bool,
+) -> int:
+    """Run a batch insight generation job.
+
+    Returns:
+        Exit code: 0 if at least one user succeeded (or no users); 1 if all failed.
+    """
+    if not user_ids:
+        click.echo(f"{label}: processed=0 failures=0 skipped=0 cost_usd=0.000000")
+        return 0
+
+    if dry_run:
+        click.echo(
+            f"{label} dry-run: {len(user_ids)} eligible Premium users — no calls made."
+        )
+        return 0
+
+    processed = 0
+    failures = 0
+    skipped = 0
+    total_cost = 0.0
+
+    for user_id in user_ids:
+        if _already_run_today(user_id, endpoint):
+            skipped += 1
+            continue
+
+        service = AIAdvisoryService(user_id=user_id)
+        try:
+            result = getattr(service, generate_fn_name)()
+            total_cost += float(result.get("cost_usd", 0))
+            processed += 1
+        except (LLMProviderError, Exception) as exc:  # noqa: BLE001
+            click.echo(
+                f"{label} ERROR user={user_id} error={exc}",
+                err=True,
+            )
+            failures += 1
+
+    click.echo(
+        f"{label}: processed={processed} failures={failures} "
+        f"skipped={skipped} cost_usd={total_cost:.6f}"
+    )
+
+    if failures > 0 and processed == 0 and skipped == 0:
+        return 1
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# weekly-insights command
+# ---------------------------------------------------------------------------
+
+
+@ai_insights_cli.command("weekly-insights")
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Print eligible user count without making LLM calls.",
+)
+def weekly_insights(dry_run: bool) -> None:
+    """Generate weekly financial briefing for all Premium users.
+
+    Intended to run every Saturday at 03:00 UTC (00:00 BRT).
+    Idempotent: skips users who already have a weekly summary today.
+    """
+    user_ids = _premium_user_ids()
+    exit_code = _run_batch(
+        user_ids=user_ids,
+        endpoint=_WEEKLY_ENDPOINT,
+        generate_fn_name="generate_weekly_summary_narrative",
+        label="weekly_insights",
+        dry_run=dry_run,
+    )
+    sys.exit(exit_code)
+
+
+# ---------------------------------------------------------------------------
+# monthly-insights command
+# ---------------------------------------------------------------------------
+
+
+@ai_insights_cli.command("monthly-insights")
+@click.option(
+    "--month",
+    default=None,
+    metavar="YYYY-MM",
+    help="Month to generate insights for. Defaults to the previous calendar month.",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Print eligible user count without making LLM calls.",
+)
+def monthly_insights(month: str | None, dry_run: bool) -> None:
+    """Generate monthly spending recap for ALL active users (Free + Premium).
+
+    Intended to run on the 1st of each month at 03:00 UTC (00:00 BRT).
+    Idempotent: skips users who already have a monthly summary today.
+    """
+    if month is None:
+        today = _brt_today()
+        first_of_month = today.replace(day=1)
+        prev_month_last = first_of_month - timedelta(days=1)
+        month = prev_month_last.strftime("%Y-%m")
+
+    user_ids = _all_active_user_ids()
+
+    if dry_run:
+        click.echo(
+            f"monthly_insights dry-run: {len(user_ids)} eligible users "
+            f"(Free + Premium) for month={month} — no calls made."
+        )
+        sys.exit(0)
+
+    processed = 0
+    failures = 0
+    skipped = 0
+    total_cost = 0.0
+
+    for user_id in user_ids:
+        if _already_run_today(user_id, _MONTHLY_ENDPOINT):
+            skipped += 1
+            continue
+
+        service = AIAdvisoryService(user_id=user_id)
+        try:
+            result = service.generate_spending_insights(month=month)
+            total_cost += float(result.get("cost_usd", 0))
+            processed += 1
+        except (LLMProviderError, Exception) as exc:  # noqa: BLE001
+            click.echo(
+                f"monthly_insights ERROR user={user_id} error={exc}",
+                err=True,
+            )
+            failures += 1
+
+    click.echo(
+        f"monthly_insights: processed={processed} failures={failures} "
+        f"skipped={skipped} cost_usd={total_cost:.6f} month={month}"
+    )
+
+    if failures > 0 and processed == 0 and skipped == 0:
+        sys.exit(1)
+
+
+def register_ai_insights_commands(app: Flask) -> None:
+    """Register the ``ai`` CLI group on *app*."""
+    app.cli.add_command(ai_insights_cli)
+
+
+__all__ = [
+    "ai_insights_cli",
+    "register_ai_insights_commands",
+]

--- a/scripts/aws_ai_insights_job.py
+++ b/scripts/aws_ai_insights_job.py
@@ -1,0 +1,406 @@
+#!/usr/bin/env python3
+"""
+Auraxis — AI Insights batch job runner via SSM (#1215, #1216).
+
+Runs ``flask ai weekly-insights`` or ``flask ai monthly-insights`` inside
+the production Docker Compose network via AWS SSM Send-Command.
+
+Usage:
+    python scripts/aws_ai_insights_job.py \\
+        --mode weekly \\
+        --region us-east-1 \\
+        --env prod \\
+        --instance-id i-0057e3b52162f78f8
+
+    python scripts/aws_ai_insights_job.py \\
+        --mode monthly \\
+        --month 2026-04 \\          # optional, defaults to previous month
+        --env prod
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+DEFAULT_PROFILE = "auraxis-admin"
+DEFAULT_REGION = "us-east-1"
+DEFAULT_PROD_INSTANCE_ID = "i-0057e3b52162f78f8"
+DEFAULT_DEV_INSTANCE_ID = "i-0bddcfc8ea56c2ba3"
+
+
+@dataclass(frozen=True)
+class AwsCtx:
+    profile: str
+    region: str
+
+
+class AwsCliError(RuntimeError):
+    pass
+
+
+class SsmCommandFailed(AwsCliError):
+    def __init__(self, report: dict[str, Any]):
+        self.report = report
+        super().__init__(_format_failure_message(report))
+
+
+def _run_aws(ctx: AwsCtx, args: list[str], *, expect_json: bool = True) -> Any:
+    cmd: list[str] = ["aws"]
+    if ctx.profile:
+        cmd.extend(["--profile", ctx.profile])
+    if ctx.region:
+        cmd.extend(["--region", ctx.region])
+    cmd.extend(args)
+    process = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if process.returncode != 0:
+        raise AwsCliError(
+            (process.stderr or "").strip() or f"AWS CLI failed: {' '.join(cmd)}"
+        )
+    if not expect_json:
+        return process.stdout
+    stdout = (process.stdout or "").strip()
+    if not stdout:
+        return {}
+    return json.loads(stdout)
+
+
+def _ssm_send_shell(ctx: AwsCtx, instance_id: str, script: str, comment: str) -> str:
+    b64 = base64.b64encode(script.encode("utf-8")).decode("ascii")
+    cmd = (
+        "TMP=/tmp/auraxis_ssm_ai_insights_$$.sh; "
+        f"echo '{b64}' | base64 -d > \"$TMP\"; "
+        'bash "$TMP"; RC=$?; rm -f "$TMP"; exit $RC'
+    )
+    payload = json.dumps({"commands": [cmd]})
+    out = _run_aws(
+        ctx,
+        [
+            "ssm",
+            "send-command",
+            "--instance-ids",
+            instance_id,
+            "--document-name",
+            "AWS-RunShellScript",
+            "--comment",
+            comment,
+            "--parameters",
+            payload,
+        ],
+    )
+    return str(out["Command"]["CommandId"])
+
+
+def _truncate_output(value: str, *, limit: int = 12000) -> str:
+    if len(value) <= limit:
+        return value
+    return value[-limit:]
+
+
+def _extract_invocation_report(
+    invocation: dict[str, Any], *, instance_id: str, command_id: str
+) -> dict[str, Any]:
+    stdout = str(invocation.get("StandardOutputContent") or "").strip()
+    stderr = str(invocation.get("StandardErrorContent") or "").strip()
+    return {
+        "instance_id": instance_id,
+        "command_id": command_id,
+        "status": str(invocation.get("Status") or "Unknown"),
+        "status_details": str(invocation.get("StatusDetails") or ""),
+        "response_code": invocation.get("ResponseCode"),
+        "execution_start_date_time": str(
+            invocation.get("ExecutionStartDateTime") or ""
+        ),
+        "execution_end_date_time": str(invocation.get("ExecutionEndDateTime") or ""),
+        "standard_output_url": str(invocation.get("StandardOutputUrl") or ""),
+        "standard_error_url": str(invocation.get("StandardErrorUrl") or ""),
+        "stdout_tail": _truncate_output(stdout),
+        "stderr_tail": _truncate_output(stderr),
+    }
+
+
+def _format_failure_message(report: dict[str, Any]) -> str:
+    return (
+        f"AI insights job ({report.get('mode', '?')}) failed. "
+        f"instance_id={report['instance_id']} "
+        f"command_id={report['command_id']} "
+        f"status={report['status']} "
+        f"status_details={report['status_details'] or '<none>'} "
+        f"response_code={report['response_code']}\n"
+        f"STDOUT:\n{report['stdout_tail']}\n"
+        f"STDERR:\n{report['stderr_tail']}"
+    )
+
+
+def _write_diagnostics_json(path: str, payload: dict[str, Any]) -> None:
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def _append_github_summary(report: dict[str, Any]) -> None:
+    summary_path = os.getenv("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+
+    status = str(report.get("status") or "Unknown")
+    mode = str(report.get("mode") or "?")
+    icon = "✅" if status == "Success" else "❌"
+    lines = [
+        f"### {icon} AI Insights Job ({mode}) via SSM",
+        "",
+        f"- Environment: `{report.get('environment', '')}`",
+        f"- Instance ID: `{report.get('instance_id', '')}`",
+        f"- Command ID: `{report.get('command_id', '')}`",
+        f"- Status: `{status}`",
+        f"- Status details: `{report.get('status_details') or '<none>'}`",
+        f"- Response code: `{report.get('response_code')}`",
+    ]
+
+    stdout_tail = str(report.get("stdout_tail") or "")
+    stderr_tail = str(report.get("stderr_tail") or "")
+    if stdout_tail:
+        lines.extend(["", "#### STDOUT tail", "", "```text", stdout_tail, "```"])
+    if stderr_tail:
+        lines.extend(["", "#### STDERR tail", "", "```text", stderr_tail, "```"])
+
+    with open(summary_path, "a", encoding="utf-8") as summary_file:
+        summary_file.write("\n".join(lines) + "\n")
+
+
+def _record_diagnostics(
+    *, diagnostics_json_path: str | None, report: dict[str, Any]
+) -> None:
+    if diagnostics_json_path:
+        _write_diagnostics_json(diagnostics_json_path, report)
+    _append_github_summary(report)
+
+
+def _wait(ctx: AwsCtx, *, command_id: str, instance_id: str) -> dict[str, Any]:
+    deadline = time.time() + 1800  # 30-minute timeout (batch may run longer)
+    while time.time() < deadline:
+        out = _run_aws(
+            ctx,
+            [
+                "ssm",
+                "get-command-invocation",
+                "--command-id",
+                command_id,
+                "--instance-id",
+                instance_id,
+                "--plugin-name",
+                "aws:RunShellScript",
+            ],
+        )
+        status = str(out.get("Status") or "Unknown")
+        if status in {"Pending", "InProgress", "Delayed"}:
+            time.sleep(10)
+            continue
+        if status != "Success":
+            raise SsmCommandFailed(
+                _extract_invocation_report(
+                    out, instance_id=instance_id, command_id=command_id
+                )
+            )
+        return dict(out)
+    raise AwsCliError(
+        "Timeout waiting for AI insights SSM command. "
+        f"instance_id={instance_id} command_id={command_id}"
+    )
+
+
+def _build_script(*, env_name: str, mode: str, month: str | None = None) -> str:
+    env_file = ".env.prod" if env_name == "prod" else ".env.dev"
+    compose_file = (
+        "docker-compose.prod.yml" if env_name == "prod" else "docker-compose.dev.yml"
+    )
+
+    flask_cmd = f"flask ai {mode}-insights"
+    if mode == "monthly" and month:
+        flask_cmd += f" --month {month}"
+
+    return f"""\
+set -euo pipefail
+
+REPO=""
+CANONICAL_REPO=/opt/auraxis
+LEGACY_REPO=/opt/flask_expenses
+
+if [ -d "$CANONICAL_REPO/.git" ] || [ -f "$CANONICAL_REPO/.git" ]; then
+  REPO="$CANONICAL_REPO"
+elif [ -d "$LEGACY_REPO/.git" ] || [ -f "$LEGACY_REPO/.git" ]; then
+  REPO="$LEGACY_REPO"
+fi
+
+if [ -z "$REPO" ]; then
+  echo "[ai-insights] repo not found in /opt"
+  exit 2
+fi
+
+cd "$REPO"
+echo "[ai-insights] repo=$REPO env={env_name} mode={mode}"
+
+ENV_FILE="{env_file}"
+COMPOSE_FILE="{compose_file}"
+
+require_file() {{
+  path="$1"
+  if [ ! -f "$path" ]; then
+    echo "[ai-insights] missing required file: $path"
+    exit 3
+  fi
+}}
+
+require_cmd() {{
+  cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "[ai-insights] missing command: $cmd"
+    exit 4
+  fi
+}}
+
+require_file "$ENV_FILE"
+require_file "$COMPOSE_FILE"
+require_cmd docker
+
+if ! docker info >/dev/null 2>&1; then
+  echo "[ai-insights] docker daemon unavailable"
+  exit 5
+fi
+
+docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d db redis
+
+INSPECT_HEALTH='{{{{if .State.Health}}}}{{{{.State.Health.Status}}}}\
+{{{{else}}}}{{{{.State.Status}}}}{{{{end}}}}'
+
+for SERVICE in db redis; do
+  CID=""
+  for _ in $(seq 1 30); do
+    CID="$(docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" ps -q "$SERVICE")"
+    HEALTH="$(
+      docker inspect -f "$INSPECT_HEALTH" "$CID" 2>/dev/null || true
+    )"
+    if [ -n "$CID" ] && [ "$HEALTH" = "healthy" -o "$HEALTH" = "running" ]; then
+      break
+    fi
+    sleep 2
+  done
+  if [ -z "$CID" ]; then
+    echo "[ai-insights] $SERVICE container was not created"
+    exit 6
+  fi
+done
+
+docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" run --rm --no-deps \\
+  -e FLASK_APP=run.py \\
+  web {flask_cmd}
+"""
+
+
+def run_once(
+    *,
+    ctx: AwsCtx,
+    mode: str,
+    env_name: str,
+    instance_id: str,
+    month: str | None = None,
+    diagnostics_json_path: str | None = None,
+) -> dict[str, Any]:
+    command_id = _ssm_send_shell(
+        ctx,
+        instance_id,
+        _build_script(env_name=env_name, mode=mode, month=month),
+        f"auraxis: ai-insights {mode} ({env_name})",
+    )
+    try:
+        invocation = _wait(ctx, command_id=command_id, instance_id=instance_id)
+        report = {
+            "mode": mode,
+            "environment": env_name,
+            **_extract_invocation_report(
+                invocation, instance_id=instance_id, command_id=command_id
+            ),
+        }
+    except SsmCommandFailed as exc:
+        report = {"mode": mode, "environment": env_name, **exc.report}
+        _record_diagnostics(
+            diagnostics_json_path=diagnostics_json_path,
+            report=report,
+        )
+        raise
+
+    _record_diagnostics(
+        diagnostics_json_path=diagnostics_json_path,
+        report=report,
+    )
+    return report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run Auraxis AI Insights batch job via SSM."
+    )
+    parser.add_argument(
+        "--mode",
+        choices=["weekly", "monthly"],
+        required=True,
+        help="Which batch job to run: 'weekly' or 'monthly'.",
+    )
+    parser.add_argument(
+        "--month",
+        default="",
+        metavar="YYYY-MM",
+        help="Month for monthly mode. Defaults to previous calendar month.",
+    )
+    parser.add_argument(
+        "--profile",
+        default=os.getenv("AWS_PROFILE", DEFAULT_PROFILE),
+        help="AWS profile. Empty string uses env/OIDC credentials.",
+    )
+    parser.add_argument(
+        "--region",
+        default=os.getenv("AWS_REGION", DEFAULT_REGION),
+        help="AWS region.",
+    )
+    parser.add_argument(
+        "--env",
+        choices=["dev", "prod"],
+        default="prod",
+        help="Target environment.",
+    )
+    parser.add_argument(
+        "--instance-id",
+        default="",
+        help="Target EC2 instance id. Defaults to env-specific built-in.",
+    )
+    parser.add_argument(
+        "--diagnostics-json-path",
+        default="",
+        help="Optional path for diagnostics JSON artifact.",
+    )
+    args = parser.parse_args()
+
+    instance_id = args.instance_id or (
+        DEFAULT_PROD_INSTANCE_ID if args.env == "prod" else DEFAULT_DEV_INSTANCE_ID
+    )
+    ctx = AwsCtx(profile=args.profile, region=args.region)
+    run_once(
+        ctx=ctx,
+        mode=args.mode,
+        env_name=args.env,
+        instance_id=instance_id,
+        month=args.month or None,
+        diagnostics_json_path=args.diagnostics_json_path or None,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ai_weekly_insights_cli.py
+++ b/tests/test_ai_weekly_insights_cli.py
@@ -1,0 +1,258 @@
+"""Tests for 'flask ai weekly-insights' CLI command (#1215).
+
+Coverage areas:
+- No Premium users: command exits 0, no service calls
+- 1 Premium user: service called once, result logged
+- N Premium users: each called exactly once
+- LLM failure for 1 user: logged as failure, continues to next user
+- LLM failure for all users: exits with code 1
+- Idempotency: user already has weekly summary today → skipped
+- --dry-run flag: prints count without calling service
+- Deleted/anonymised users are excluded
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from app.services.llm_provider import LLMProviderError, LLMResponse
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_BRT = timezone(timedelta(hours=-3))
+
+
+def _make_stub_response() -> LLMResponse:
+    return LLMResponse(
+        content="Briefing semanal stub",
+        prompt_tokens=50,
+        completion_tokens=100,
+        total_tokens=150,
+        model="stub",
+        latency_ms=10,
+    )
+
+
+def _grant_advanced_simulations(app, user_id: uuid.UUID) -> None:
+    with app.app_context():
+        from app.extensions.database import db
+        from app.models.entitlement import Entitlement, EntitlementSource
+
+        ent = Entitlement(
+            user_id=user_id,
+            feature_key="advanced_simulations",
+            source=EntitlementSource.MANUAL,
+            expires_at=None,
+        )
+        db.session.add(ent)
+        db.session.commit()
+
+
+def _create_user(app) -> uuid.UUID:
+    """Create and return a user_id via the registration endpoint."""
+    with app.app_context():
+        from app.extensions.database import db
+        from app.models.account import Account
+        from app.models.user import User
+
+        uid = uuid.uuid4()
+        u = User(
+            id=uid,
+            name="Weekly Test User",
+            email=f"weekly-{uid.hex[:8]}@test.com",
+            password="x",
+        )
+        db.session.add(u)
+        acct = Account(user_id=uid, name="Main", account_type="checking")
+        db.session.add(acct)
+        db.session.commit()
+        return uid
+
+
+def _log_weekly_summary_today(app, user_id: uuid.UUID) -> None:
+    """Simulate that a weekly summary was already generated today."""
+    with app.app_context():
+        from app.extensions.database import db
+        from app.models.llm_audit_log import LLMAuditLog
+
+        log = LLMAuditLog(
+            user_id=user_id,
+            endpoint="weekly_summary_batch",
+            model="stub",
+            prompt="test",
+            response_text="ok",
+            prompt_tokens=10,
+            completion_tokens=20,
+            total_tokens=30,
+            estimated_cost_usd=0.0,
+            latency_ms=0,
+        )
+        db.session.add(log)
+        db.session.commit()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestWeeklyInsightsCLI:
+    def _invoke(self, app, *args: str) -> object:
+        from app.cli.ai_insights_cli import ai_insights_cli
+
+        runner = CliRunner()
+        with app.app_context():
+            result = runner.invoke(ai_insights_cli, ["weekly-insights", *args])
+        return result
+
+    def test_no_premium_users_exits_zero(self, app) -> None:
+        result = self._invoke(app)
+        assert result.exit_code == 0
+        assert "0" in result.output  # processed=0 or similar
+
+    def test_single_premium_user_called_once(self, app) -> None:
+        user_id = _create_user(app)
+        _grant_advanced_simulations(app, user_id)
+
+        with patch(
+            "app.services.ai_advisory_service.AIAdvisoryService"
+            ".generate_weekly_summary_narrative",
+            return_value={
+                "narrative": "ok",
+                "tokens_used": 150,
+                "cost_usd": 0.00002,
+                "summary": {},
+                "model": "stub",
+            },
+        ) as mock_gen:
+            result = self._invoke(app)
+
+        assert result.exit_code == 0
+        assert mock_gen.call_count == 1
+        assert "processed=1" in result.output
+        assert "failures=0" in result.output
+
+    def test_multiple_premium_users_each_called_once(self, app) -> None:
+        user_ids = [_create_user(app) for _ in range(3)]
+        for uid in user_ids:
+            _grant_advanced_simulations(app, uid)
+
+        with patch(
+            "app.services.ai_advisory_service.AIAdvisoryService"
+            ".generate_weekly_summary_narrative",
+            return_value={
+                "narrative": "ok",
+                "tokens_used": 150,
+                "cost_usd": 0.00002,
+                "summary": {},
+                "model": "stub",
+            },
+        ) as mock_gen:
+            result = self._invoke(app)
+
+        assert result.exit_code == 0
+        assert mock_gen.call_count == 3
+        assert "processed=3" in result.output
+
+    def test_llm_failure_for_one_user_continues_and_counts_failure(self, app) -> None:
+        user_a = _create_user(app)
+        user_b = _create_user(app)
+        _grant_advanced_simulations(app, user_a)
+        _grant_advanced_simulations(app, user_b)
+
+        call_count = 0
+
+        def _side_effect(*a, **kw):  # noqa: ANN202
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise LLMProviderError("LLM down")
+            return {
+                "narrative": "ok",
+                "tokens_used": 100,
+                "cost_usd": 0.0,
+                "summary": {},
+                "model": "stub",
+            }
+
+        with patch(
+            "app.services.ai_advisory_service.AIAdvisoryService"
+            ".generate_weekly_summary_narrative",
+            side_effect=_side_effect,
+        ):
+            result = self._invoke(app)
+
+        # Partial success: one failed, one ok — exit 0 still acceptable,
+        # but failures must be reported.
+        assert "failures=1" in result.output
+        assert "processed=1" in result.output
+
+    def test_all_users_fail_exits_nonzero(self, app) -> None:
+        user_id = _create_user(app)
+        _grant_advanced_simulations(app, user_id)
+
+        with patch(
+            "app.services.ai_advisory_service.AIAdvisoryService"
+            ".generate_weekly_summary_narrative",
+            side_effect=LLMProviderError("total failure"),
+        ):
+            result = self._invoke(app)
+
+        assert result.exit_code != 0
+        assert "failures=1" in result.output
+
+    def test_idempotency_already_run_today_skips_user(self, app) -> None:
+        user_id = _create_user(app)
+        _grant_advanced_simulations(app, user_id)
+        _log_weekly_summary_today(app, user_id)
+
+        with patch(
+            "app.services.ai_advisory_service.AIAdvisoryService"
+            ".generate_weekly_summary_narrative",
+        ) as mock_gen:
+            result = self._invoke(app)
+
+        assert result.exit_code == 0
+        assert mock_gen.call_count == 0
+        assert "skipped=1" in result.output
+
+    def test_dry_run_prints_count_without_calling_service(self, app) -> None:
+        user_id = _create_user(app)
+        _grant_advanced_simulations(app, user_id)
+
+        with patch(
+            "app.services.ai_advisory_service.AIAdvisoryService"
+            ".generate_weekly_summary_narrative",
+        ) as mock_gen:
+            result = self._invoke(app, "--dry-run")
+
+        assert result.exit_code == 0
+        assert mock_gen.call_count == 0
+        assert "dry-run" in result.output.lower() or "dry_run" in result.output.lower()
+
+    def test_deleted_users_excluded(self, app) -> None:
+        user_id = _create_user(app)
+        _grant_advanced_simulations(app, user_id)
+
+        with app.app_context():
+            from app.extensions.database import db
+            from app.models.user import User
+
+            User.query.filter_by(id=user_id).update(
+                {"deleted_at": datetime.now(timezone.utc)}
+            )
+            db.session.commit()
+
+        with patch(
+            "app.services.ai_advisory_service.AIAdvisoryService"
+            ".generate_weekly_summary_narrative",
+        ) as mock_gen:
+            self._invoke(app)
+
+        assert mock_gen.call_count == 0


### PR DESCRIPTION
## Summary

Entrega conjunta de #1215 e #1216 — jobs batch de insights AI.

**CLI (`flask ai`):**
- `flask ai weekly-insights [--dry-run]` — Premium, sábado 00:00 BRT
- `flask ai monthly-insights [--month YYYY-MM] [--dry-run]` — Free + Premium, dia 1

**Idempotência:** verifica `llm_audit_logs` (endpoint `weekly_summary_batch` / `spending_insights_batch`) antes de gerar — segunda execução no mesmo dia não regenera.

**Falhas isoladas:** erro em 1 usuário loga e continua; todos falhando → exit 1.

**SSM:** `scripts/aws_ai_insights_job.py` — padrão `aws_recurrence_job.py`:
- SSM Send-Command → EC2 Docker Compose run → `flask ai {mode}-insights`
- 30-min timeout; diagnostics JSON artifact; GITHUB_STEP_SUMMARY

**Workflows:**
- `weekly-ai-insights.yml`: cron `0 3 * * 6` (sábado 03:00 UTC)
- `monthly-ai-insights.yml`: cron `0 3 1 * *` (dia 1), `workflow_dispatch` com `--month`
- Ambos: auto-criam/reabrem issue de incidente em caso de falha

**Regra de entitlement:**
- Weekly: só usuários Premium (`advanced_simulations`)
- Monthly: todos os usuários ativos (Free + Premium) — bypass de entitlement por ser batch server-side

## Test plan

- [x] No users: exit 0, processed=0
- [x] 1 Premium user: service called once, processed=1 failures=0
- [x] 3 Premium users: each called once
- [x] 1 LLM failure: logged, continues; processed=1 failures=1
- [x] All fail: exit code != 0
- [x] Idempotency: already run today → skipped=1, 0 service calls
- [x] --dry-run: 0 service calls, dry-run in output
- [x] Deleted users excluded

Closes #1215
Closes #1216