### PR TITLE
fix(infra): default MIGRATE_ON_START to false in prod

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -23,7 +23,7 @@ services:
       FLASK_DEBUG: "false"
       DOCS_EXPOSURE_POLICY: "${DOCS_EXPOSURE_POLICY:-disabled}"
       AUTO_CREATE_DB: "${AUTO_CREATE_DB:-false}"
-      MIGRATE_ON_START: "${MIGRATE_ON_START:-true}"
+      MIGRATE_ON_START: "${MIGRATE_ON_START:-false}"
       # DATABASE_URL in .env.prod points to RDS:
       # auraxis-prod.cav02gmeg759.us-east-1.rds.amazonaws.com:5432
       RATE_LIMIT_REDIS_URL: "${RATE_LIMIT_REDIS_URL:-redis://redis:6379/0}"


### PR DESCRIPTION
## Problem

After the RDS cutover, the production entrypoint tries to run Alembic migrations on every container start using `DB_HOST`/`DB_USER`/`DB_PASS`. These individual vars are not used by the Flask app (which connects via `DATABASE_URL`) and the Alembic connection fails without SSL, causing the container to crash-loop.

## Fix

Change the default of `MIGRATE_ON_START` from `true` to `false` in `docker-compose.prod.yml`.

In production the schema is already at HEAD. Migrations must be triggered explicitly by passing `MIGRATE_ON_START=true` during a controlled deploy step — not on every container restart.

## Context

- Discovered during `OPENAI_API_KEY` deployment on 2026-05-11
- The server's `.env.prod` already has `MIGRATE_ON_START=false` as a workaround
- This PR makes the git source match the running state and prevents regression on next deploy

Closes #1210