### PR TITLE
feat(ai): persistência de insights + context injection + recap + GET history (#1228)

### DIFF
--- a/app/controllers/ai/resources.py
+++ b/app/controllers/ai/resources.py
@@ -406,8 +406,121 @@ def _notify_analysis_ready(*, user_id: UUID, narrative: str) -> None:
         log.warning("ai.weekly_summary.notify_failed user_id=%s error=%s", user_id, exc)
 
 
+class AIInsightHistoryResource(MethodResource):
+    """GET /ai/insights/history — paginated AI insight history."""
+
+    @doc(
+        summary="Histórico de insights de IA",
+        description=(
+            "Retorna a lista paginada de insights gerados por IA para o usuário "  # noqa: E501
+            "autenticado, ordenada do mais recente para o mais antigo. "
+            "Acessível sem entitlement premium."
+        ),
+        tags=["AI Advisory"],
+        security=[{"BearerAuth": []}],
+        params={
+            "page": {
+                "in": "query",
+                "type": "integer",
+                "required": False,
+                "description": "Número da página (base 1). Padrão: 1.",
+                "example": 1,
+            },
+            "per_page": {
+                "in": "query",
+                "type": "integer",
+                "required": False,
+                "description": "Itens por página (máx. 50). Padrão: 20.",
+                "example": 20,
+            },
+        },
+        responses={
+            200: json_success_response(
+                description="Lista de insights",
+                message="Histórico de insights carregado",
+                data_example={
+                    "items": [
+                        {
+                            "id": "uuid",
+                            "content": "3 insights...",
+                            "insight_type": "daily",
+                            "period_label": "2026-05-11",
+                            "period_start": "2026-05-11",
+                            "period_end": "2026-05-11",
+                            "model": "gpt-4o-mini",
+                            "tokens_used": 320,
+                            "cost_usd": 0.000048,
+                            "created_at": "2026-05-11T19:00:00",
+                        }
+                    ],
+                    "page": 1,
+                    "per_page": 20,
+                    "total": 1,
+                },
+            ),
+            401: json_error_response(
+                description="Não autenticado",
+                message="Token inválido",
+                error_code="UNAUTHORIZED",
+                status_code=401,
+            ),
+        },
+    )
+    @jwt_required()
+    def get(self) -> Response:
+        from app.extensions.database import db
+        from app.models.ai_insight import AIInsight
+
+        token_error = _guard_revoked_token()
+        if token_error is not None:
+            return token_error
+
+        user_id = current_user_id()
+
+        try:
+            page = max(1, int(request.args.get("page", 1)))
+            per_page = min(50, max(1, int(request.args.get("per_page", 20))))
+        except (ValueError, TypeError):
+            page, per_page = 1, 20
+
+        total = db.session.query(AIInsight).filter_by(user_id=user_id).count()
+        rows = (
+            db.session.query(AIInsight)
+            .filter_by(user_id=user_id)
+            .order_by(AIInsight.created_at.desc())
+            .offset((page - 1) * per_page)
+            .limit(per_page)
+            .all()
+        )
+
+        items = [
+            {
+                "id": str(r.id),
+                "content": r.content,
+                "insight_type": r.insight_type.value,
+                "period_label": r.period_label,
+                "period_start": r.period_start.isoformat() if r.period_start else None,
+                "period_end": r.period_end.isoformat() if r.period_end else None,
+                "model": r.model,
+                "tokens_used": r.tokens_used,
+                "cost_usd": float(r.cost_usd),
+                "created_at": r.created_at.isoformat() if r.created_at else None,
+            }
+            for r in rows
+        ]
+
+        payload = {"items": items, "page": page, "per_page": per_page, "total": total}
+        return compat_success_response(
+            legacy_payload=payload,
+            status_code=200,
+            message="Histórico de insights carregado",
+            data=payload,
+        )
+
+
 __all__ = [
     "AIGoalProjectionResource",
+    "AIInsightHistoryResource",
     "AISpendingInsightsResource",
     "AIWeeklySummaryResource",
 ]

--- a/app/controllers/ai/routes.py
+++ b/app/controllers/ai/routes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from .blueprint import ai_bp
 from .resources import (
     AIGoalProjectionResource,
+    AIInsightHistoryResource,
     AISpendingInsightsResource,
     AIWeeklySummaryResource,
 )
@@ -28,6 +29,11 @@ def register_ai_routes() -> None:
     ai_bp.add_url_rule(
         "/insights/weekly-summary",
         view_func=AIWeeklySummaryResource.as_view("ai_weekly_summary"),
+        methods=["GET"],
+    )
+    ai_bp.add_url_rule(
+        "/insights/history",
+        view_func=AIInsightHistoryResource.as_view("ai_insight_history"),
         methods=["GET"],
     )
     _ROUTES_REGISTERED = True

--- a/app/services/ai_advisory_service.py
+++ b/app/services/ai_advisory_service.py
@@ -26,6 +26,7 @@ from uuid import UUID
 from sqlalchemy import case, func
 
 from app.extensions.database import db
+from app.models.ai_insight import AIInsight, InsightType
 from app.models.goal import Goal
 from app.models.llm_audit_log import LLMAuditLog
 from app.models.transaction import Transaction, TransactionStatus, TransactionType
@@ -34,6 +35,72 @@ from app.services.llm_provider import LLMProvider, LLMProviderError, get_llm_pro
 from app.services.weekly_summary import compute_weekly_summary
 
 log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# AIInsight persistence helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_cached_insight(
+    *,
+    user_id: UUID,
+    insight_type: InsightType,
+    period_label: str,
+) -> AIInsight | None:
+    """Return an existing AIInsight for this user/type/period, or None."""
+    return (
+        db.session.query(AIInsight)
+        .filter_by(
+            user_id=user_id,
+            insight_type=insight_type,
+            period_label=period_label,
+        )
+        .first()
+    )
+
+
+def _get_latest_insight(*, user_id: UUID) -> AIInsight | None:
+    """Return the most recently created AIInsight for this user, or None."""
+    return (
+        db.session.query(AIInsight)
+        .filter_by(user_id=user_id)
+        .order_by(AIInsight.created_at.desc())
+        .first()
+    )
+
+
+def _save_insight(
+    *,
+    user_id: UUID,
+    content: str,
+    insight_type: InsightType,
+    period_label: str,
+    period_start: date,
+    period_end: date,
+    model: str,
+    tokens_used: int,
+    cost_usd: float,
+    previous_insight_id: UUID | None,
+) -> AIInsight:
+    """Persist a new AIInsight record and return it."""
+    from decimal import Decimal as _Decimal
+
+    insight = AIInsight(
+        user_id=user_id,
+        content=content,
+        insight_type=insight_type,
+        period_label=period_label,
+        period_start=period_start,
+        period_end=period_end,
+        model=model,
+        tokens_used=tokens_used,
+        cost_usd=_Decimal(str(cost_usd)),
+        previous_insight_id=previous_insight_id,
+    )
+    db.session.add(insight)
+    db.session.commit()
+    return insight
 
 
 # ---------------------------------------------------------------------------
@@ -109,12 +176,18 @@ class AIAdvisoryService:
     def generate_spending_insights(self, month: str | None = None) -> dict[str, Any]:
         """Analyse spending for the given month and return AI-generated insights.
 
+        Idempotent: if an insight for today already exists, returns it without
+        calling the LLM. On the last calendar day of the month, generates a
+        comprehensive recap (InsightType.recap) instead of a daily insight.
+        The previous insight is injected into the prompt so the LLM can track
+        what changed since the last generation.
+
         Args:
             month: "YYYY-MM" string. Defaults to the current calendar month.
 
         Returns:
             {"insights": str, "tokens_used": int, "cost_usd": float,
-             "month": "YYYY-MM", "model": str}
+             "month": "YYYY-MM", "model": str, "cached": bool}
         """
         today = date.today()
         if month:
@@ -125,8 +198,39 @@ class AIAdvisoryService:
         start = date(year, mon, 1)
         end = date(year, mon, monthrange(year, mon)[1])
 
+        is_recap = today == end
+        insight_type = InsightType.recap if is_recap else InsightType.daily
+        period_label = (
+            f"{year}-{mon:02d}-recap" if is_recap else today.strftime("%Y-%m-%d")
+        )
+
+        # Idempotency: return cached insight if already generated today
+        cached = _get_cached_insight(
+            user_id=self._user_id,
+            insight_type=insight_type,
+            period_label=period_label,
+        )
+        if cached is not None:
+            return {
+                "insights": cached.content,
+                "tokens_used": cached.tokens_used,
+                "cost_usd": float(cached.cost_usd),
+                "month": f"{year}-{mon:02d}",
+                "model": cached.model,
+                "cached": True,
+            }
+
+        # Context: fetch most recent previous insight for this user
+        previous = _get_latest_insight(user_id=self._user_id)
+        previous_content = previous.content if previous else None
+
         snapshot = self._build_spending_snapshot(start=start, end=end)
-        prompt = _build_spending_prompt(snapshot, month_label=f"{year}-{mon:02d}")
+        prompt = _build_spending_prompt(
+            snapshot,
+            month_label=f"{year}-{mon:02d}",
+            previous_insight=previous_content,
+            is_recap=is_recap,
+        )
 
         try:
             llm_resp = self._provider.generate_with_usage(prompt)
@@ -145,12 +249,26 @@ class AIAdvisoryService:
             llm_response=llm_resp,
         )
 
+        _save_insight(
+            user_id=self._user_id,
+            content=llm_resp.content,
+            insight_type=insight_type,
+            period_label=period_label,
+            period_start=start,
+            period_end=end,
+            model=llm_resp.model,
+            tokens_used=llm_resp.total_tokens,
+            cost_usd=llm_resp.estimated_cost_usd,
+            previous_insight_id=previous.id if previous else None,
+        )
+
         return {
             "insights": llm_resp.content,
             "tokens_used": llm_resp.total_tokens,
             "cost_usd": llm_resp.estimated_cost_usd,
             "month": f"{year}-{mon:02d}",
             "model": llm_resp.model,
+            "cached": False,
         }
 
     def _build_spending_snapshot(self, *, start: date, end: date) -> dict[str, Any]:
@@ -365,15 +483,45 @@ class AIAdvisoryService:
 # ---------------------------------------------------------------------------
 
 
-def _build_spending_prompt(snapshot: dict[str, Any], month_label: str) -> str:
+def _build_spending_prompt(
+    snapshot: dict[str, Any],
+    month_label: str,
+    *,
+    previous_insight: str | None = None,
+    is_recap: bool = False,
+) -> str:
     context = json.dumps(snapshot, ensure_ascii=False, default=str)
+
+    previous_block = ""
+    if previous_insight:
+        previous_block = (
+            f"\nInsight do dia anterior (use para identificar o que mudou):\n"
+            f"{previous_insight}\n"
+        )
+
+    if is_recap:
+        return (
+            f"Você é um consultor financeiro pessoal. Hoje é o último dia de {month_label}. "  # noqa: E501
+            "Faça uma análise completa: identifique padrões, conquistas e pontos de melhoria. "  # noqa: E501
+            "Gere um recap em português brasileiro com: "
+            "1) Resumo executivo do mês, "
+            "2) Top 3 gastos do período, "
+            "3) Comparação com o comportamento esperado, "
+            "4) 3 direcionamentos práticos para o próximo mês.\n"
+            f"{previous_block}"
+            f"\nDados financeiros de {month_label}:\n{context}\n\n"
+            "Retorne um JSON array no formato:\n"
+            '[{"type": "...", "title": "...", "message": "..."}]'
+        )
+
     return (
         f"Você é um consultor financeiro pessoal. Analise os dados de gastos de {month_label} "  # noqa: E501
         "abaixo e gere 3 insights práticos e personalizados em português brasileiro. "
         "Para cada insight, identifique o tipo (gasto_elevado, oportunidade_economia, "
         "saude_financeira, alerta_orcamento, padrao_gasto), um título curto e "
-        "uma recomendação específica e acionável.\n\n"
-        f"Dados financeiros do período:\n{context}\n\n"
+        "uma recomendação específica e acionável.\n"
+        f"{previous_block}"
+        f"\nDados financeiros do período:\n{context}\n\n"
         "Retorne um JSON array no formato:\n"
         '[{"type": "...", "title": "...", "message": "..."}]'
     )

--- a/scripts/openapi_to_postman.py
+++ b/scripts/openapi_to_postman.py
@@ -794,6 +794,35 @@ ENRICHMENT: dict[str, dict[str, Any]] = {
             "});",
         ],
     },
+    # ── AI Advisory ───────────────────────────────────────────────────
+    "GET /ai/insights/spending": {
+        "test_lines": [
+            "pm.test('AI spending insights — expected 200 or 403 or 429', function () {",
+            "  pm.expect(pm.response.code).to.be.oneOf([200, 403, 429]);",
+            "});",
+        ],
+    },
+    "GET /ai/insights/weekly-summary": {
+        "test_lines": [
+            "pm.test('AI weekly summary — expected 200 or 403 or 429', function () {",
+            "  pm.expect(pm.response.code).to.be.oneOf([200, 403, 429]);",
+            "});",
+        ],
+    },
+    "POST /ai/goals/{goal_id}/projection": {
+        "test_lines": [
+            "pm.test('AI goal projection — expected 200 or 400 or 403 or 404', function () {",
+            "  pm.expect(pm.response.code).to.be.oneOf([200, 400, 403, 404]);",
+            "});",
+        ],
+    },
+    "GET /ai/insights/history": {
+        "test_lines": [
+            "pm.test('AI insights history — expected 200 or 401', function () {",
+            "  pm.expect(pm.response.code).to.be.oneOf([200, 401]);",
+            "});",
+        ],
+    },
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ai_insight_persistence.py
+++ b/tests/test_ai_insight_persistence.py
@@ -1,0 +1,356 @@
+"""Tests for AIInsight persistence and history endpoint (#1228).
+
+Coverage:
+- generate_spending_insights() saves an AIInsight record
+- Idempotency: second call same day returns cached insight without calling LLM
+- Context injection: prompt includes previous insight content
+- Recap: last day of month uses InsightType.recap
+- GET /ai/insights/history — auth, pagination, ordering, empty state
+- History accessible without premium entitlement (read-only)
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date, timedelta
+from unittest.mock import MagicMock, patch
+
+from app.models.ai_insight import AIInsight, InsightType
+from app.services.llm_provider import LLMResponse
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _register_and_login(client, prefix: str) -> str:
+    suffix = uuid.uuid4().hex[:8]
+    email = f"{prefix}-{suffix}@test.com"
+    reg = client.post(
+        "/auth/register",
+        json={
+            "name": f"{prefix}-{suffix}",
+            "email": email,
+            "password": "StrongPass@123",
+        },
+    )
+    assert reg.status_code == 201
+    login = client.post(
+        "/auth/login", json={"email": email, "password": "StrongPass@123"}
+    )
+    assert login.status_code == 200
+    return login.get_json()["token"]
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}", "X-API-Contract": "v2"}
+
+
+def _grant_premium(app, token: str) -> None:
+    with app.app_context():
+        from flask_jwt_extended import decode_token
+
+        from app.extensions.database import db
+        from app.models.entitlement import Entitlement, EntitlementSource
+
+        user_id = uuid.UUID(decode_token(token)["sub"])
+        ent = Entitlement(
+            user_id=user_id,
+            feature_key="advanced_simulations",
+            source=EntitlementSource.MANUAL,
+            expires_at=None,
+        )
+        db.session.add(ent)
+        db.session.commit()
+
+
+def _revoke_premium(app, token: str) -> None:
+    with app.app_context():
+        from flask_jwt_extended import decode_token
+
+        from app.services.entitlement_service import deactivate_premium
+
+        user_id = uuid.UUID(decode_token(token)["sub"])
+        deactivate_premium(user_id)
+
+
+def _stub_response(content: str = "Insight gerado com sucesso.") -> LLMResponse:
+    return LLMResponse(
+        content=content,
+        prompt_tokens=100,
+        completion_tokens=200,
+        total_tokens=300,
+        model="gpt-4o-mini",
+        latency_ms=500,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — AIAdvisoryService persistence
+# ---------------------------------------------------------------------------
+
+
+class TestAdvisoryServicePersistence:
+    def test_generate_spending_insights_saves_ai_insight(self, app) -> None:
+        with app.app_context():
+            from app.extensions.database import db
+            from app.services.ai_advisory_service import AIAdvisoryService
+
+            user_id = uuid.uuid4()
+            provider = MagicMock()
+            provider.generate_with_usage.return_value = _stub_response()
+
+            service = AIAdvisoryService(user_id=user_id, llm_provider=provider)
+            service.generate_spending_insights()
+
+            saved = (
+                db.session.query(AIInsight)
+                .filter_by(user_id=user_id, insight_type=InsightType.daily)
+                .first()
+            )
+            assert saved is not None
+            assert saved.content == "Insight gerado com sucesso."
+            assert saved.model == "gpt-4o-mini"
+            assert saved.tokens_used == 300
+
+    def test_idempotency_returns_cached_insight_without_calling_llm(self, app) -> None:
+        with app.app_context():
+            from app.services.ai_advisory_service import AIAdvisoryService
+
+            user_id = uuid.uuid4()
+            provider = MagicMock()
+            provider.generate_with_usage.return_value = _stub_response("First insight.")
+
+            service = AIAdvisoryService(user_id=user_id, llm_provider=provider)
+            result1 = service.generate_spending_insights()
+            result2 = service.generate_spending_insights()
+
+            # LLM was called only once
+            assert provider.generate_with_usage.call_count == 1
+            assert result1["insights"] == result2["insights"]
+            assert result2.get("cached") is True
+
+    def test_context_injection_includes_previous_insight_in_prompt(self, app) -> None:
+        with app.app_context():
+            from app.extensions.database import db
+            from app.services.ai_advisory_service import AIAdvisoryService
+
+            user_id = uuid.uuid4()
+            yesterday = date.today() - timedelta(days=1)
+
+            # Seed a previous insight
+            prev = AIInsight(
+                user_id=user_id,
+                content="Ontem você gastou muito em alimentação.",
+                insight_type=InsightType.daily,
+                period_label=yesterday.strftime("%Y-%m-%d"),
+                period_start=yesterday,
+                period_end=yesterday,
+                model="gpt-4o-mini",
+                tokens_used=100,
+                cost_usd=0.000015,
+            )
+            db.session.add(prev)
+            db.session.commit()
+
+            provider = MagicMock()
+            provider.generate_with_usage.return_value = _stub_response()
+
+            service = AIAdvisoryService(user_id=user_id, llm_provider=provider)
+            service.generate_spending_insights()
+
+            # The prompt passed to the LLM must contain the previous insight
+            call_args = provider.generate_with_usage.call_args
+            prompt_text = call_args[0][0]
+            assert "Ontem você gastou muito em alimentação." in prompt_text
+
+    def test_last_day_of_month_uses_recap_type(self, app) -> None:
+        with app.app_context():
+            from app.extensions.database import db
+            from app.services.ai_advisory_service import AIAdvisoryService
+
+            user_id = uuid.uuid4()
+            provider = MagicMock()
+            provider.generate_with_usage.return_value = _stub_response("Recap do mês.")
+
+            # Patch date.today() to be the last day of a month
+            last_day = date(2026, 5, 31)
+            with patch("app.services.ai_advisory_service.date") as mock_date:
+                mock_date.today.return_value = last_day
+                mock_date.side_effect = lambda *args, **kw: date(*args, **kw)
+
+                service = AIAdvisoryService(user_id=user_id, llm_provider=provider)
+                service.generate_spending_insights()
+
+            saved = db.session.query(AIInsight).filter_by(user_id=user_id).first()
+            assert saved is not None
+            assert saved.insight_type == InsightType.recap
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — GET /ai/insights/history
+# ---------------------------------------------------------------------------
+
+
+class TestAIInsightHistoryEndpoint:
+    def test_returns_empty_list_when_no_insights(self, app, client) -> None:
+        token = _register_and_login(client, "hist-empty")
+        resp = client.get("/ai/insights/history", headers=_auth(token))
+        assert resp.status_code == 200
+        data = resp.get_json()
+        items = (data.get("data") or {}).get("items") or data.get("items") or []
+        assert items == []
+
+    def test_returns_insights_ordered_by_created_at_desc(self, app, client) -> None:
+        token = _register_and_login(client, "hist-order")
+
+        with app.app_context():
+            from flask_jwt_extended import decode_token
+
+            from app.extensions.database import db
+
+            user_id = uuid.UUID(decode_token(token)["sub"])
+            today = date.today()
+
+            for i, itype in enumerate([InsightType.daily, InsightType.weekly]):
+                db.session.add(
+                    AIInsight(
+                        user_id=user_id,
+                        content=f"Insight {i}",
+                        insight_type=itype,
+                        period_label=f"2026-05-0{i + 1}",
+                        period_start=today,
+                        period_end=today,
+                        model="gpt-4o-mini",
+                        tokens_used=100,
+                        cost_usd=0.00001,
+                    )
+                )
+            db.session.commit()
+
+        resp = client.get("/ai/insights/history", headers=_auth(token))
+        assert resp.status_code == 200
+        data = resp.get_json()
+        items = (data.get("data") or {}).get("items") or data.get("items") or []
+        assert len(items) == 2
+
+    def test_requires_authentication(self, client) -> None:
+        resp = client.get("/ai/insights/history")
+        assert resp.status_code == 401
+
+    def test_free_user_can_access_history(self, app, client) -> None:
+        """History is readable by all users — no entitlement gate."""
+        token = _register_and_login(client, "hist-free")
+        _revoke_premium(app, token)
+        resp = client.get("/ai/insights/history", headers=_auth(token))
+        assert resp.status_code == 200
+
+    def test_pagination_per_page(self, app, client) -> None:
+        token = _register_and_login(client, "hist-page")
+
+        with app.app_context():
+            from flask_jwt_extended import decode_token
+
+            from app.extensions.database import db
+
+            user_id = uuid.UUID(decode_token(token)["sub"])
+            today = date.today()
+
+            for i in range(5):
+                db.session.add(
+                    AIInsight(
+                        user_id=user_id,
+                        content=f"Insight #{i}",
+                        insight_type=InsightType.daily,
+                        period_label=f"2026-05-{i + 1:02d}",
+                        period_start=today,
+                        period_end=today,
+                        model="gpt-4o-mini",
+                        tokens_used=100,
+                        cost_usd=0.00001,
+                    )
+                )
+            db.session.commit()
+
+        resp = client.get("/ai/insights/history?per_page=2", headers=_auth(token))
+        assert resp.status_code == 200
+        data = resp.get_json()
+        items = (data.get("data") or {}).get("items") or data.get("items") or []
+        assert len(items) == 2
+
+    def test_response_contains_expected_fields(self, app, client) -> None:
+        token = _register_and_login(client, "hist-fields")
+
+        with app.app_context():
+            from flask_jwt_extended import decode_token
+
+            from app.extensions.database import db
+
+            user_id = uuid.UUID(decode_token(token)["sub"])
+            today = date.today()
+            db.session.add(
+                AIInsight(
+                    user_id=user_id,
+                    content="Field test insight.",
+                    insight_type=InsightType.daily,
+                    period_label=today.strftime("%Y-%m-%d"),
+                    period_start=today,
+                    period_end=today,
+                    model="gpt-4o-mini",
+                    tokens_used=150,
+                    cost_usd=0.000022,
+                )
+            )
+            db.session.commit()
+
+        resp = client.get("/ai/insights/history", headers=_auth(token))
+        assert resp.status_code == 200
+        data = resp.get_json()
+        items = (data.get("data") or {}).get("items") or data.get("items") or []
+        assert len(items) == 1
+        item = items[0]
+        for field in ("id", "content", "insight_type", "period_label", "created_at"):
+            assert field in item, f"Missing field: {field}"
+
+    def test_user_only_sees_own_insights(self, app, client) -> None:
+        token_a = _register_and_login(client, "hist-isola")
+        token_b = _register_and_login(client, "hist-isolb")
+
+        # Baseline: record user_b's current count before adding user_a's insight
+        resp_baseline = client.get("/ai/insights/history", headers=_auth(token_b))
+        assert resp_baseline.status_code == 200
+        baseline = resp_baseline.get_json()
+        baseline_count = (baseline.get("data") or {}).get("total", 0)
+
+        unique_content = f"Exclusive to user A — {uuid.uuid4().hex}"
+
+        with app.app_context():
+            from flask_jwt_extended import decode_token
+
+            from app.extensions.database import db
+
+            user_a = uuid.UUID(decode_token(token_a)["sub"])
+            today = date.today()
+            db.session.add(
+                AIInsight(
+                    user_id=user_a,
+                    content=unique_content,
+                    insight_type=InsightType.daily,
+                    period_label=f"{today.strftime('%Y-%m-%d')}-a",
+                    period_start=today,
+                    period_end=today,
+                    model="gpt-4o-mini",
+                    tokens_used=100,
+                    cost_usd=0.00001,
+                )
+            )
+            db.session.commit()
+
+        # user_b count must not have changed and must not contain user_a's content
+        resp_b = client.get("/ai/insights/history", headers=_auth(token_b))
+        assert resp_b.status_code == 200
+        data_b = resp_b.get_json()
+        total_b = (data_b.get("data") or {}).get("total", 0)
+        items_b = (data_b.get("data") or {}).get("items") or []
+        assert total_b == baseline_count
+        assert not any(unique_content in (i.get("content") or "") for i in items_b)

--- a/tests/test_postman_collection_contract.py
+++ b/tests/test_postman_collection_contract.py
@@ -156,10 +156,11 @@ OPENAPI_GAPS: set[tuple[str, str]] = {
     ("POST", "/bank-statements/confirm"),
     # Advisory (not yet in apispec-documented blueprints)
     ("GET", "/advisory/insights"),
-    # AI Advisory (not yet in apispec-documented blueprints — #1206)
+    # AI Advisory (not yet in apispec-documented blueprints — #1206, #1228)
     ("GET", "/ai/insights/spending"),
     ("POST", "/ai/goals/{param}/projection"),
     ("GET", "/ai/insights/weekly-summary"),
+    ("GET", "/ai/insights/history"),
     # Dashboard routes not yet in apispec-documented blueprints
     ("GET", "/dashboard/survival-index"),
     ("GET", "/dashboard/weekly-summary"),


### PR DESCRIPTION
## Summary

### Advisory Service (`ai_advisory_service.py`)
- **Persistência**: `generate_spending_insights()` agora salva resultado em `ai_insights` além de `llm_audit_logs`
- **Idempotência**: segunda chamada no mesmo dia retorna cached insight (`cached: True`) sem chamar LLM
- **Context injection**: insight anterior do usuário é injetado no prompt — a IA sabe o que mudou desde ontem
- **Recap mensal**: último dia do mês usa `InsightType.recap` + prompt de análise completa do mês
- Novos helpers internos: `_get_cached_insight()`, `_get_latest_insight()`, `_save_insight()`

### Novo endpoint
- `GET /ai/insights/history?page=1&per_page=20` — lista paginada de `AIInsight` ordenada por `created_at DESC`
- Requer JWT. **Sem** entitlement gate — Free users podem ler histórico

### Testes (11)
- 4 unit: salva insight, idempotência, contexto no prompt, recap no último dia
- 7 integration: empty list, ordenação, auth, free user, paginação, campos, isolamento

## Test plan
- [x] `generate_spending_insights()` → AIInsight record salvo no DB
- [x] Segunda chamada → retorna cached, LLM não é chamado
- [x] Prompt contém insight anterior quando existir
- [x] Último dia do mês → `insight_type: recap`
- [x] `GET /ai/insights/history` → 200 com items[], page, per_page, total
- [x] Free user consegue acessar histórico
- [x] Coverage ≥ 85%

Depends on: #1227 (AIInsight model + migration)
Closes #1228