### PR TITLE
feat(graphql): AIInsightType + aiInsightHistory query — GraphQL parity

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -29,4 +29,13 @@ regexes = [
   '''TestPass\w*''',
   '''Password@\w*''',
   '''Senha@\w*''',
+  '''StrongPass@\w+''',
+]
+
+[[allowlists]]
+description = "HTTP status codes in comments/docstrings — not secrets"
+stopwords = [
+  "401-equivalent",
+  "HTTP 401",
+  "HTTP 403",
 ]

--- a/app/graphql/docs_catalog.py
+++ b/app/graphql/docs_catalog.py
@@ -7,6 +7,7 @@ GraphQLOperationType = Literal["query", "mutation"]
 GraphQLOperationAccess = Literal["public", "auth_required"]
 GraphQLDomain = Literal[
     "accounts",
+    "ai_advisory",
     "auth",
     "billing",
     "dashboard",
@@ -20,6 +21,7 @@ GraphQLDomain = Literal[
     "wallet",
 ]
 
+QUERY_AI_INSIGHT_MODULE = "app.graphql.queries.ai_insight"
 QUERY_USER_MODULE = "app.graphql.queries.user"
 QUERY_DASHBOARD_MODULE = "app.graphql.queries.dashboard"
 QUERY_TRANSACTION_MODULE = "app.graphql.queries.transaction"
@@ -707,6 +709,18 @@ GRAPHQL_OPERATION_CATALOG: tuple[GraphQLOperationDoc, ...] = (
             "Suporta modos 'selective' e 'replace_month'."
         ),
         source_module=MUTATION_BANK_STATEMENT_MODULE,
+    ),
+    # AI Advisory (#1231)
+    GraphQLOperationDoc(
+        name="aiInsightHistory",
+        operation_type="query",
+        domain="ai_advisory",
+        access="auth_required",
+        summary=(
+            "Retorna o histórico paginado de insights gerados por IA para o usuário "
+            "autenticado, ordenado do mais recente ao mais antigo."
+        ),
+        source_module=QUERY_AI_INSIGHT_MODULE,
     ),
 )
 

--- a/app/graphql/queries/__init__.py
+++ b/app/graphql/queries/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import graphene
 
 from .account import AccountQueryMixin
+from .ai_insight import AIInsightQueryMixin
 from .budget import BudgetQueryMixin
 from .dashboard import DashboardQueryMixin
 from .goal import GoalQueryMixin
@@ -29,6 +30,7 @@ class Query(
     NotificationQueryMixin,
     TagQueryMixin,
     AccountQueryMixin,
+    AIInsightQueryMixin,
     graphene.ObjectType,
 ):
     pass
@@ -48,4 +50,5 @@ __all__ = [
     "NotificationQueryMixin",
     "TagQueryMixin",
     "AccountQueryMixin",
+    "AIInsightQueryMixin",
 ]

--- a/app/graphql/queries/ai_insight.py
+++ b/app/graphql/queries/ai_insight.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import graphene
+
+from app.extensions.database import db
+from app.graphql.auth import get_current_user_required
+from app.models.ai_insight import AIInsight
+
+
+class AIInsightType(graphene.ObjectType):
+    id = graphene.ID(required=True)
+    content = graphene.String(required=True)
+    insight_type = graphene.String(required=True)
+    period_label = graphene.String(required=True)
+    period_start = graphene.String(required=True)
+    period_end = graphene.String(required=True)
+    model = graphene.String(required=True)
+    tokens_used = graphene.Int(required=True)
+    cost_usd = graphene.Float(required=True)
+    created_at = graphene.String(required=True)
+
+
+class AIInsightHistoryResultType(graphene.ObjectType):
+    items = graphene.List(graphene.NonNull(AIInsightType), required=True)
+    page = graphene.Int(required=True)
+    per_page = graphene.Int(required=True)
+    total = graphene.Int(required=True)
+
+
+def _to_ai_insight_type(row: AIInsight) -> AIInsightType:
+    return AIInsightType(
+        id=str(row.id),
+        content=row.content,
+        insight_type=row.insight_type.value,
+        period_label=row.period_label,
+        period_start=row.period_start.isoformat() if row.period_start else "",
+        period_end=row.period_end.isoformat() if row.period_end else "",
+        model=row.model,
+        tokens_used=row.tokens_used,
+        cost_usd=float(row.cost_usd),
+        created_at=row.created_at.isoformat() if row.created_at else "",
+    )
+
+
+class AIInsightQueryMixin:
+    ai_insight_history = graphene.Field(
+        AIInsightHistoryResultType,
+        page=graphene.Int(default_value=1),
+        per_page=graphene.Int(default_value=20),
+    )
+
+    def resolve_ai_insight_history(
+        self,
+        _info: graphene.ResolveInfo,
+        page: int,
+        per_page: int,
+    ) -> AIInsightHistoryResultType:
+        user = get_current_user_required()
+        user_id = user.id
+
+        total = db.session.query(AIInsight).filter_by(user_id=user_id).count()
+        rows = (
+            db.session.query(AIInsight)
+            .filter_by(user_id=user_id)
+            .order_by(AIInsight.created_at.desc())
+            .offset((page - 1) * per_page)
+            .limit(per_page)
+            .all()
+        )
+
+        return AIInsightHistoryResultType(
+            items=[_to_ai_insight_type(r) for r in rows],
+            page=page,
+            per_page=per_page,
+            total=total,
+        )

--- a/docs/adr/0005-ai-insight-persistence-model.md
+++ b/docs/adr/0005-ai-insight-persistence-model.md
@@ -1,0 +1,92 @@
+# ADR 0005 — Modelo de Persistência de AI Insights
+
+**Status:** Accepted
+**Data:** 2026-05-12
+**Issues:** #1227, #1228
+
+---
+
+## Contexto
+
+Antes deste ADR, os insights gerados pelo `AIAdvisoryService` eram apenas logados em `llm_audit_logs` (tabela de auditoria de custo/tokens). Isso significava que:
+- Insights não eram recuperáveis por data
+- Não havia histórico para o usuário
+- O AI não tinha acesso ao insight anterior para injetar contexto
+
+Precisávamos decidir: usar `llm_audit_logs` como store primário ou criar uma nova tabela `ai_insights`.
+
+---
+
+## Decisão
+
+**Criar uma tabela separada `ai_insights` como store primário.**
+
+`llm_audit_logs` continua existindo como registro financeiro/de auditoria (custo, tokens, latência por chamada). É write-only da perspectiva da aplicação.
+
+`ai_insights` é o registro de produto — recuperável, exibível ao usuário, encadeável via `previous_insight_id`.
+
+---
+
+## Motivação
+
+### Por que não usar `llm_audit_logs` como store primário?
+
+1. **Separação de responsabilidades:** `llm_audit_logs` é auditoria técnica (custo, latência, prompt raw). `ai_insights` é produto (o que o usuário vê, o que o AI lê como contexto).
+
+2. **Schema diferente:** O audit log armazena o prompt completo (dados potencialmente sensíveis). O insight armazena apenas o `content` (resultado final) — menor superfície de exposição.
+
+3. **Endpoint de histórico:** `GET /ai/insights/history` precisaria de joins e filtros complexos sobre `llm_audit_logs` para distinguir "insight diário manual" de "job semanal batch" de "chamada interna". Com `ai_insights`, o filtro é simples: `WHERE user_id = ? ORDER BY created_at DESC`.
+
+4. **Context injection:** O AI precisa ler o insight anterior (`previous_insight_id`). Em `llm_audit_logs` isso seria buscar o `response_text` mais recente de endpoint `spending_insights` — frágil e lento.
+
+---
+
+## Estrutura decidida
+
+### ai_insights
+- Campos de produto: `content`, `insight_type`, `period_label`, `period_start`, `period_end`
+- Metadados técnicos mínimos: `model`, `tokens_used`, `cost_usd`
+- Self-referential FK: `previous_insight_id` → cadeia de contexto entre dias
+
+### llm_audit_logs (inalterado)
+- Continua recebendo TODA chamada LLM (via `_log_llm_call()`)
+- Inclui `prompt` completo, `response_text` completo, latência
+- Serve para auditoria de custo e debugging
+
+---
+
+## Convenção de enums
+
+`insight_type` usa `native_enum=False` (VARCHAR + CHECK constraint) em vez de `CREATE TYPE` PostgreSQL.
+
+**Motivo:** Em conformidade com a resolução pós-post-mortem PR #1174. `native_enum=True` (default SQLAlchemy) registra DDL listener que emite `CREATE TYPE` antes da migration, causando conflito quando a migration tenta criá-lo novamente → falha silenciosa no CI.
+
+---
+
+## Idempotência por `period_label`
+
+O campo `period_label` é a chave natural de idempotência:
+
+| Tipo | Formato | Exemplo |
+|------|---------|---------|
+| daily | `YYYY-MM-DD` | `2026-05-12` |
+| weekly | `YYYY-WNN` | `2026-W20` |
+| monthly | `YYYY-MM` | `2026-05` |
+| recap | `YYYY-MM-recap` | `2026-05-recap` |
+
+A query `_get_cached_insight(user_id, insight_type, period_label)` garante que uma segunda chamada no mesmo dia retorna o insight existente sem chamar o LLM.
+
+---
+
+## Consequências
+
+**Positivas:**
+- Histórico completo disponível via `GET /ai/insights/history`
+- Context injection simples via `_get_latest_insight(user_id)`
+- Schema limpo e orientado ao produto
+- `llm_audit_logs` permanece como fonte de verdade de custo
+
+**Negativas/Trade-offs:**
+- Dois stores para a mesma chamada LLM (overhead de escrita)
+- `cost_usd` e `tokens_used` ficam denormalizados em dois lugares
+- Eventual inconsistência se `_save_insight` falhar após `_log_llm_call` (mitigado: falha no audit log é silenciosa e não impede o insight de ser retornado)

--- a/graphql.introspection.json
+++ b/graphql.introspection.json
@@ -133,6 +133,43 @@
           "enumValues": null,
           "fields": [
             {
+              "args": [
+                {
+                  "defaultValue": "1",
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "page",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": "20",
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "perPage",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "aiInsightHistory",
+              "type": {
+                "kind": "OBJECT",
+                "name": "AIInsightHistoryResultType",
+                "ofType": null
+              }
+            },
+            {
               "args": [],
               "deprecationReason": null,
               "description": null,
@@ -1458,6 +1495,306 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "items",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "AIInsightType",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "page",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "perPage",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "total",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "AIInsightHistoryResultType",
+          "possibleTypes": null,
+          "specifiedByURL": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "id",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "content",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "insightType",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "periodLabel",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "periodStart",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "periodEnd",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "model",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "tokensUsed",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "costUsd",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "createdAt",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "AIInsightType",
+          "possibleTypes": null,
+          "specifiedByURL": null
+        },
+        {
+          "description": "The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `\"4\"`) or integer (such as `4`) input value will be accepted as an ID.",
+          "enumValues": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "SCALAR",
+          "name": "ID",
+          "possibleTypes": null,
+          "specifiedByURL": null
+        },
+        {
+          "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
+          "enumValues": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "SCALAR",
+          "name": "String",
+          "possibleTypes": null,
+          "specifiedByURL": null
+        },
+        {
+          "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.",
+          "enumValues": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "SCALAR",
+          "name": "Int",
+          "possibleTypes": null,
+          "specifiedByURL": null
+        },
+        {
+          "description": "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).",
+          "enumValues": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "SCALAR",
+          "name": "Float",
+          "possibleTypes": null,
+          "specifiedByURL": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "accounts",
               "type": {
                 "kind": "NON_NULL",
@@ -1586,28 +1923,6 @@
           "specifiedByURL": null
         },
         {
-          "description": "The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `\"4\"`) or integer (such as `4`) input value will be accepted as an ID.",
-          "enumValues": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "kind": "SCALAR",
-          "name": "ID",
-          "possibleTypes": null,
-          "specifiedByURL": null
-        },
-        {
-          "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
-          "enumValues": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "kind": "SCALAR",
-          "name": "String",
-          "possibleTypes": null,
-          "specifiedByURL": null
-        },
-        {
           "description": "Arbitrary-precision decimal serialised as a string.\n\nOutput: always a string in fixed-point notation (no scientific exponent).\nInput: accepts string, int, float, or Decimal — coerced via ``Decimal(str(x))``.\nNull is preserved.",
           "enumValues": null,
           "fields": null,
@@ -1615,17 +1930,6 @@
           "interfaces": null,
           "kind": "SCALAR",
           "name": "DecimalScalar",
-          "possibleTypes": null,
-          "specifiedByURL": null
-        },
-        {
-          "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.",
-          "enumValues": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "kind": "SCALAR",
-          "name": "Int",
           "possibleTypes": null,
           "specifiedByURL": null
         },
@@ -2504,17 +2808,6 @@
           "interfaces": [],
           "kind": "OBJECT",
           "name": "BudgetType",
-          "possibleTypes": null,
-          "specifiedByURL": null
-        },
-        {
-          "description": "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).",
-          "enumValues": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "kind": "SCALAR",
-          "name": "Float",
           "possibleTypes": null,
           "specifiedByURL": null
         },

--- a/graphql.operations.manifest.json
+++ b/graphql.operations.manifest.json
@@ -613,5 +613,13 @@
     "operation_type": "mutation",
     "source_module": "app.graphql.mutations.bank_statement",
     "summary": "Persiste as entradas selecionadas do extrato bancário como transações. Suporta modos 'selective' e 'replace_month'."
+  },
+  {
+    "access": "auth_required",
+    "domain": "ai_advisory",
+    "name": "aiInsightHistory",
+    "operation_type": "query",
+    "source_module": "app.graphql.queries.ai_insight",
+    "summary": "Retorna o histórico paginado de insights gerados por IA para o usuário autenticado, ordenado do mais recente ao mais antigo."
   }
 ]

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,4 +1,5 @@
 type Query {
+  aiInsightHistory(page: Int = 1, perPage: Int = 20): AIInsightHistoryResultType
   accounts: AccountListType
   account(accountId: UUID!): AccountType
   tags: TagListType
@@ -33,6 +34,26 @@ type Query {
   dashboardOverview(month: String!): TransactionDashboardPayloadType
   weeklySummary(period: String, startDate: String, endDate: String): WeeklySummaryPayloadType
   me: UserType
+}
+
+type AIInsightHistoryResultType {
+  items: [AIInsightType!]!
+  page: Int!
+  perPage: Int!
+  total: Int!
+}
+
+type AIInsightType {
+  id: ID!
+  content: String!
+  insightType: String!
+  periodLabel: String!
+  periodStart: String!
+  periodEnd: String!
+  model: String!
+  tokensUsed: Int!
+  costUsd: Float!
+  createdAt: String!
 }
 
 type AccountListType {

--- a/tests/test_ai_insight_graphql.py
+++ b/tests/test_ai_insight_graphql.py
@@ -1,0 +1,281 @@
+"""Integration tests for GraphQL aiInsightHistory query (#1231).
+
+Coverage:
+- Happy path: authenticated user retrieves their insights
+- Unauthenticated request is rejected with HTTP 401
+- User isolation: each user only sees their own insights
+- Pagination: page and perPage parameters work correctly
+- Empty state: returns empty items list with total=0
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime, timezone
+from typing import Any
+
+from app.extensions.database import db
+from app.models.ai_insight import AIInsight, InsightType
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_GQL_AI_INSIGHT_HISTORY = """
+query AiInsightHistory($page: Int, $perPage: Int) {
+  aiInsightHistory(page: $page, perPage: $perPage) {
+    items {
+      id
+      content
+      insightType
+      periodLabel
+      periodStart
+      periodEnd
+      model
+      tokensUsed
+      costUsd
+      createdAt
+    }
+    page
+    perPage
+    total
+  }
+}
+"""
+
+
+def _graphql(
+    client,
+    query: str,
+    variables: dict[str, Any] | None = None,
+    token: str | None = None,
+) -> Any:
+    headers: dict[str, str] = {}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return client.post(
+        "/graphql",
+        json={"query": query, "variables": variables or {}},
+        headers=headers,
+    )
+
+
+def _register_and_login(client, prefix: str = "gql-ai") -> str:
+    suffix = uuid.uuid4().hex[:8]
+    email = f"{prefix}-{suffix}@test.com"
+    reg = client.post(
+        "/auth/register",
+        json={
+            "name": f"{prefix}-{suffix}",
+            "email": email,
+            "password": "StrongPass@123",
+        },
+    )
+    assert reg.status_code == 201
+    login = client.post(
+        "/auth/login", json={"email": email, "password": "StrongPass@123"}
+    )
+    assert login.status_code == 200
+    return login.get_json()["token"]
+
+
+def _get_user_id(app, token: str) -> uuid.UUID:
+    with app.app_context():
+        from flask_jwt_extended import decode_token
+
+        return uuid.UUID(decode_token(token)["sub"])
+
+
+def _create_insight(
+    app,
+    user_id: uuid.UUID,
+    *,
+    content: str = "Test insight",
+    insight_type: InsightType = InsightType.daily,
+    period_label: str = "2026-05-12",
+    period_start: date | None = None,
+    period_end: date | None = None,
+    model: str = "gpt-4o-mini",
+    tokens_used: int = 100,
+    cost_usd: float = 0.000015,
+) -> AIInsight:
+    with app.app_context():
+        today = date(2026, 5, 12)
+        insight = AIInsight(
+            user_id=user_id,
+            content=content,
+            insight_type=insight_type,
+            period_label=period_label,
+            period_start=period_start or today,
+            period_end=period_end or today,
+            model=model,
+            tokens_used=tokens_used,
+            cost_usd=cost_usd,
+            created_at=datetime(2026, 5, 12, 10, 0, 0, tzinfo=timezone.utc).replace(
+                tzinfo=None
+            ),
+        )
+        db.session.add(insight)
+        db.session.commit()
+        return insight
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestAiInsightHistoryQuery:
+    def test_happy_path_returns_insight(self, client, app):
+        token = _register_and_login(client)
+        user_id = _get_user_id(app, token)
+        _create_insight(app, user_id, content="Daily spending insight")
+
+        resp = _graphql(client, _GQL_AI_INSIGHT_HISTORY, token=token)
+
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert "errors" not in body
+        result = body["data"]["aiInsightHistory"]
+        assert result["total"] == 1
+        assert result["page"] == 1
+        assert result["perPage"] == 20
+        assert len(result["items"]) == 1
+        item = result["items"][0]
+        assert item["content"] == "Daily spending insight"
+        assert item["insightType"] == "daily"
+        assert item["periodLabel"] == "2026-05-12"
+        assert item["periodStart"] == "2026-05-12"
+        assert item["model"] == "gpt-4o-mini"
+        assert item["tokensUsed"] == 100
+        assert isinstance(item["costUsd"], float)
+        assert item["id"] is not None
+        assert item["createdAt"] is not None
+
+    def test_auth_required_without_token(self, client):
+        resp = _graphql(client, _GQL_AI_INSIGHT_HISTORY)
+
+        # The GraphQL auth middleware intercepts unauthenticated requests before
+        # the resolver runs and returns HTTP 401 directly.
+        assert resp.status_code == 401
+
+    def test_user_isolation(self, client, app):
+        token_a = _register_and_login(client, "user-a")
+        token_b = _register_and_login(client, "user-b")
+        user_id_a = _get_user_id(app, token_a)
+        user_id_b = _get_user_id(app, token_b)
+
+        _create_insight(app, user_id_a, content="User A insight")
+        _create_insight(app, user_id_b, content="User B insight")
+
+        resp_a = _graphql(client, _GQL_AI_INSIGHT_HISTORY, token=token_a)
+        body_a = resp_a.get_json()
+        assert "errors" not in body_a
+        result_a = body_a["data"]["aiInsightHistory"]
+        assert result_a["total"] == 1
+        contents_a = [i["content"] for i in result_a["items"]]
+        assert "User A insight" in contents_a
+        assert "User B insight" not in contents_a
+
+        resp_b = _graphql(client, _GQL_AI_INSIGHT_HISTORY, token=token_b)
+        body_b = resp_b.get_json()
+        result_b = body_b["data"]["aiInsightHistory"]
+        assert result_b["total"] == 1
+        contents_b = [i["content"] for i in result_b["items"]]
+        assert "User B insight" in contents_b
+        assert "User A insight" not in contents_b
+
+    def test_pagination(self, client, app):
+        token = _register_and_login(client)
+        user_id = _get_user_id(app, token)
+
+        for i in range(5):
+            _create_insight(
+                app,
+                user_id,
+                content=f"Insight {i}",
+                period_label=f"2026-05-{12 - i:02d}",
+                period_start=date(2026, 5, 12 - i),
+                period_end=date(2026, 5, 12 - i),
+            )
+
+        resp = _graphql(
+            client,
+            _GQL_AI_INSIGHT_HISTORY,
+            variables={"page": 1, "perPage": 2},
+            token=token,
+        )
+        body = resp.get_json()
+        assert "errors" not in body
+        result = body["data"]["aiInsightHistory"]
+        assert result["total"] == 5
+        assert result["page"] == 1
+        assert result["perPage"] == 2
+        assert len(result["items"]) == 2
+
+        resp2 = _graphql(
+            client,
+            _GQL_AI_INSIGHT_HISTORY,
+            variables={"page": 3, "perPage": 2},
+            token=token,
+        )
+        body2 = resp2.get_json()
+        result2 = body2["data"]["aiInsightHistory"]
+        assert result2["total"] == 5
+        assert result2["page"] == 3
+        assert len(result2["items"]) == 1
+
+    def test_empty_history(self, client):
+        token = _register_and_login(client)
+
+        resp = _graphql(client, _GQL_AI_INSIGHT_HISTORY, token=token)
+
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert "errors" not in body
+        result = body["data"]["aiInsightHistory"]
+        assert result["total"] == 0
+        assert result["items"] == []
+        assert result["page"] == 1
+
+    def test_default_pagination_values(self, client, app):
+        token = _register_and_login(client)
+        user_id = _get_user_id(app, token)
+        _create_insight(app, user_id)
+
+        resp = _graphql(client, _GQL_AI_INSIGHT_HISTORY, token=token)
+
+        body = resp.get_json()
+        result = body["data"]["aiInsightHistory"]
+        assert result["page"] == 1
+        assert result["perPage"] == 20
+
+    def test_multiple_insight_types(self, client, app):
+        token = _register_and_login(client)
+        user_id = _get_user_id(app, token)
+
+        _create_insight(
+            app,
+            user_id,
+            insight_type=InsightType.daily,
+            period_label="2026-05-12",
+        )
+        _create_insight(
+            app,
+            user_id,
+            insight_type=InsightType.weekly,
+            period_label="2026-W20",
+        )
+        _create_insight(
+            app,
+            user_id,
+            insight_type=InsightType.monthly,
+            period_label="2026-05",
+        )
+
+        resp = _graphql(client, _GQL_AI_INSIGHT_HISTORY, token=token)
+        body = resp.get_json()
+        result = body["data"]["aiInsightHistory"]
+        assert result["total"] == 3
+        types_returned = {i["insightType"] for i in result["items"]}
+        assert types_returned == {"daily", "weekly", "monthly"}


### PR DESCRIPTION
## Summary

- Adds `AIInsightType` and `AIInsightHistoryResultType` Graphene types mirroring the REST `GET /ai/insights/history` contract
- Adds `AIInsightQueryMixin` with `aiInsightHistory(page, perPage)` resolver — queries `ai_insights` table filtered by authenticated user, paginated, ordered desc
- Registers mixin in `queries/__init__.py` → schema includes the new query
- Updates `docs_catalog.py` with `ai_advisory` domain + catalog entry; regenerates `schema.graphql`, `graphql.introspection.json`, `graphql.operations.manifest.json`
- 7 integration tests: happy path, auth required (HTTP 401), user isolation, pagination, empty state, default pagination values, multiple insight types

## Test plan

- [x] `pytest tests/test_ai_insight_graphql.py` — 7/7 pass
- [x] `bash scripts/run_ci_quality_local.sh --local` — all gates pass (ruff, mypy, bandit, pytest, coverage ≥ 85%, docs bundle parity)

## Refs

Closes #1231