### PR TITLE
[BACKEND] feat: GraphQL parity — Fiscal domain (receivables + documents)

### DIFF
--- a/app/graphql/docs_catalog.py
+++ b/app/graphql/docs_catalog.py
@@ -11,6 +11,7 @@ GraphQLDomain = Literal[
     "auth",
     "billing",
     "dashboard",
+    "fiscal",
     "goals",
     "investments",
     "notifications",
@@ -22,6 +23,8 @@ GraphQLDomain = Literal[
 ]
 
 QUERY_AI_INSIGHT_MODULE = "app.graphql.queries.ai_insight"
+QUERY_FISCAL_MODULE = "app.graphql.queries.fiscal"
+MUTATION_FISCAL_MODULE = "app.graphql.mutations.fiscal"
 QUERY_USER_MODULE = "app.graphql.queries.user"
 QUERY_DASHBOARD_MODULE = "app.graphql.queries.dashboard"
 QUERY_TRANSACTION_MODULE = "app.graphql.queries.transaction"
@@ -709,6 +712,84 @@ GRAPHQL_OPERATION_CATALOG: tuple[GraphQLOperationDoc, ...] = (
             "Suporta modos 'selective' e 'replace_month'."
         ),
         source_module=MUTATION_BANK_STATEMENT_MODULE,
+    ),
+    # Fiscal domain (#1247)
+    GraphQLOperationDoc(
+        name="receivables",
+        operation_type="query",
+        domain="fiscal",
+        access="auth_required",
+        summary=(
+            "Lista recebíveis do usuário. Filtro opcional por status: "
+            "pending | received | cancelled. Valores estimativos — exibir disclaimer."
+        ),
+        source_module=QUERY_FISCAL_MODULE,
+    ),
+    GraphQLOperationDoc(
+        name="receivablesSummary",
+        operation_type="query",
+        domain="fiscal",
+        access="auth_required",
+        summary=(
+            "Retorna totais agregados de receitas esperadas, recebidas e pendentes. "
+            "Valores são estimativos — exibir o campo 'disclaimer' ao usuário."
+        ),
+        source_module=QUERY_FISCAL_MODULE,
+    ),
+    GraphQLOperationDoc(
+        name="fiscalDocuments",
+        operation_type="query",
+        domain="fiscal",
+        access="auth_required",
+        summary=(
+            "Lista documentos fiscais do usuário. Filtro opcional por tipo: "
+            "service_invoice | product_invoice | receipt | debit_note | credit_note."
+        ),
+        source_module=QUERY_FISCAL_MODULE,
+    ),
+    GraphQLOperationDoc(
+        name="createReceivable",
+        operation_type="mutation",
+        domain="fiscal",
+        access="auth_required",
+        summary=(
+            "Cria um recebível manual. "
+            "Deprecated: preferir POST /fiscal/receivables (ADR-0002)."
+        ),
+        source_module=MUTATION_FISCAL_MODULE,
+    ),
+    GraphQLOperationDoc(
+        name="markReceivableReceived",
+        operation_type="mutation",
+        domain="fiscal",
+        access="auth_required",
+        summary=(
+            "Marca um recebível como recebido com data e valor. "
+            "Deprecated: preferir PATCH /fiscal/receivables/{id}/receive (ADR-0002)."
+        ),
+        source_module=MUTATION_FISCAL_MODULE,
+    ),
+    GraphQLOperationDoc(
+        name="cancelReceivable",
+        operation_type="mutation",
+        domain="fiscal",
+        access="auth_required",
+        summary=(
+            "Cancela um recebível pendente. "
+            "Deprecated: preferir DELETE /fiscal/receivables/{id} (ADR-0002)."
+        ),
+        source_module=MUTATION_FISCAL_MODULE,
+    ),
+    GraphQLOperationDoc(
+        name="createFiscalDocument",
+        operation_type="mutation",
+        domain="fiscal",
+        access="auth_required",
+        summary=(
+            "Cria um documento fiscal. "
+            "Deprecated: preferir POST /fiscal/fiscal-documents (ADR-0002)."
+        ),
+        source_module=MUTATION_FISCAL_MODULE,
     ),
     # AI Advisory (#1231)
     GraphQLOperationDoc(

--- a/app/graphql/mutations/__init__.py
+++ b/app/graphql/mutations/__init__.py
@@ -28,6 +28,12 @@ from app.graphql.mutations.budget import (
     DeleteBudgetMutation,
     UpdateBudgetMutation,
 )
+from app.graphql.mutations.fiscal import (
+    CancelReceivableMutation,
+    CreateFiscalDocumentMutation,
+    CreateReceivableMutation,
+    MarkReceivableReceivedMutation,
+)
 from app.graphql.mutations.goal import (
     CreateGoalMutation,
     DeleteGoalMutation,
@@ -159,6 +165,19 @@ class Mutation(graphene.ObjectType):
     # Bank Statement Import — canonical GraphQL surface (#1148)
     preview_bank_statement = PreviewBankStatementMutation.Field()
     confirm_bank_import = ConfirmBankImportMutation.Field()
+    # Fiscal domain (#1247) — ADR-0002: REST is canonical for writes
+    create_receivable = CreateReceivableMutation.Field(
+        deprecation_reason="ADR-0002: use POST /fiscal/receivables"
+    )
+    mark_receivable_received = MarkReceivableReceivedMutation.Field(
+        deprecation_reason="ADR-0002: use PATCH /fiscal/receivables/{id}/receive"
+    )
+    cancel_receivable = CancelReceivableMutation.Field(
+        deprecation_reason="ADR-0002: use DELETE /fiscal/receivables/{id}"
+    )
+    create_fiscal_document = CreateFiscalDocumentMutation.Field(
+        deprecation_reason="ADR-0002: use POST /fiscal/fiscal-documents"
+    )
 
 
 __all__ = ["Mutation"]

--- a/app/graphql/mutations/fiscal.py
+++ b/app/graphql/mutations/fiscal.py
@@ -1,0 +1,271 @@
+"""GraphQL mutations for the Fiscal domain (#1247).
+
+Per ADR-0002, REST is the canonical write surface. These mutations are
+deprecated shims — kept for GraphQL-only clients. New integrations should
+use the REST endpoints listed in each deprecation_reason.
+"""
+
+from __future__ import annotations
+
+from datetime import date as _date
+from decimal import Decimal, InvalidOperation
+
+import graphene
+
+from app.graphql.auth import get_current_user_required
+from app.graphql.errors import build_public_graphql_error
+from app.graphql.observability import log_graphql_resolver
+from app.graphql.types import (
+    FiscalDocumentPayload,
+    FiscalDocumentType,
+    ReceivableEntryType,
+    ReceivablePayload,
+)
+from app.services.fiscal_service import (
+    FiscalDocumentNotFoundError,
+    create_fiscal_document,
+)
+from app.services.receivable_service import (
+    ReceivableAlreadySettledError,
+    ReceivableNotFoundError,
+    cancel_receivable,
+    create_receivable,
+    mark_received,
+)
+
+_DISCLAIMER = (
+    "Este valor é estimativo e não substitui cálculo fiscal por profissional habilitado"
+)
+
+
+def _parse_date(value: str) -> _date:
+    for fmt in ("%Y-%m-%d", "%d/%m/%Y"):
+        try:
+            from datetime import datetime
+
+            return datetime.strptime(value, fmt).date()
+        except ValueError:
+            continue
+    raise ValueError(f"Invalid date format: {value!r}. Use YYYY-MM-DD.")
+
+
+def _to_receivable_type(entry: object) -> ReceivableEntryType:
+    return ReceivableEntryType(
+        id=str(entry.id),  # type: ignore[attr-defined]
+        fiscal_document_id=str(entry.fiscal_document_id),  # type: ignore[attr-defined]
+        expected_net_amount=entry.expected_net_amount,  # type: ignore[attr-defined]
+        received_amount=entry.received_amount,  # type: ignore[attr-defined]
+        outstanding_amount=entry.outstanding_amount,  # type: ignore[attr-defined]
+        reconciliation_status=entry.reconciliation_status.value,  # type: ignore[attr-defined]
+        received_at=(
+            entry.received_at.isoformat()  # type: ignore[attr-defined]
+            if entry.received_at  # type: ignore[attr-defined]
+            else None
+        ),
+        created_at=(
+            entry.created_at.isoformat()  # type: ignore[attr-defined]
+            if entry.created_at  # type: ignore[attr-defined]
+            else ""
+        ),
+        disclaimer=_DISCLAIMER,
+    )
+
+
+def _to_fiscal_doc_type(doc: object) -> FiscalDocumentType:
+    return FiscalDocumentType(
+        id=str(doc.id),  # type: ignore[attr-defined]
+        external_id=doc.external_id,  # type: ignore[attr-defined]
+        type=doc.type.value,  # type: ignore[attr-defined]
+        status=doc.status.value,  # type: ignore[attr-defined]
+        issued_at=(
+            doc.issued_at.isoformat() if doc.issued_at else ""  # type: ignore[attr-defined]
+        ),
+        counterparty=doc.counterparty,  # type: ignore[attr-defined]
+        gross_amount=doc.gross_amount,  # type: ignore[attr-defined]
+        currency=doc.currency,  # type: ignore[attr-defined]
+        description=doc.description,  # type: ignore[attr-defined]
+        created_at=(
+            doc.created_at.isoformat() if doc.created_at else ""  # type: ignore[attr-defined]
+        ),
+    )
+
+
+class CreateReceivableMutation(graphene.Mutation):
+    class Arguments:
+        description = graphene.String(required=True)
+        amount = graphene.String(required=True)
+        expected_date = graphene.String(required=True, description="YYYY-MM-DD")
+        category = graphene.String()
+
+    Output = ReceivablePayload
+
+    @log_graphql_resolver("createReceivable")
+    def mutate(
+        self,
+        _info: graphene.ResolveInfo,
+        description: str,
+        amount: str,
+        expected_date: str,
+        category: str | None = None,
+    ) -> ReceivablePayload:
+        user = get_current_user_required()
+        description = description.strip()
+        if not description:
+            raise build_public_graphql_error(
+                "description is required", code="VALIDATION_ERROR"
+            )
+        try:
+            decimal_amount = Decimal(str(amount))
+        except InvalidOperation as exc:
+            raise build_public_graphql_error(
+                "amount must be a valid decimal", code="VALIDATION_ERROR"
+            ) from exc
+        try:
+            parsed_date = _parse_date(expected_date)
+        except ValueError as exc:
+            raise build_public_graphql_error(str(exc), code="VALIDATION_ERROR") from exc
+
+        _doc, entry = create_receivable(
+            user_id=str(user.id),
+            description=description,
+            amount=decimal_amount,
+            expected_date=parsed_date,
+            category=category,
+        )
+        return ReceivablePayload(
+            ok=True,
+            message="Recebível criado com sucesso.",
+            errors=[],
+            data=_to_receivable_type(entry),
+        )
+
+
+class MarkReceivableReceivedMutation(graphene.Mutation):
+    class Arguments:
+        entry_id = graphene.UUID(required=True)
+        received_date = graphene.String(required=True, description="YYYY-MM-DD")
+        received_amount = graphene.String()
+
+    Output = ReceivablePayload
+
+    @log_graphql_resolver("markReceivableReceived")
+    def mutate(
+        self,
+        _info: graphene.ResolveInfo,
+        entry_id: object,
+        received_date: str,
+        received_amount: str | None = None,
+    ) -> ReceivablePayload:
+        user = get_current_user_required()
+        try:
+            parsed_date = _parse_date(received_date)
+        except ValueError as exc:
+            raise build_public_graphql_error(str(exc), code="VALIDATION_ERROR") from exc
+
+        decimal_received: Decimal | None = None
+        if received_amount is not None:
+            try:
+                decimal_received = Decimal(str(received_amount))
+            except InvalidOperation as exc:
+                raise build_public_graphql_error(
+                    "received_amount must be a valid decimal", code="VALIDATION_ERROR"
+                ) from exc
+
+        try:
+            entry = mark_received(
+                str(entry_id), str(user.id), parsed_date, decimal_received
+            )
+        except ReceivableNotFoundError as exc:
+            raise build_public_graphql_error(str(exc), code="NOT_FOUND") from exc
+        except ReceivableAlreadySettledError as exc:
+            raise build_public_graphql_error(str(exc), code="ALREADY_SETTLED") from exc
+
+        return ReceivablePayload(
+            ok=True,
+            message="Recebível marcado como recebido.",
+            errors=[],
+            data=_to_receivable_type(entry),
+        )
+
+
+class CancelReceivableMutation(graphene.Mutation):
+    class Arguments:
+        entry_id = graphene.UUID(required=True)
+
+    Output = ReceivablePayload
+
+    @log_graphql_resolver("cancelReceivable")
+    def mutate(
+        self, _info: graphene.ResolveInfo, entry_id: object
+    ) -> ReceivablePayload:
+        user = get_current_user_required()
+        try:
+            entry = cancel_receivable(str(entry_id), str(user.id))
+        except ReceivableNotFoundError as exc:
+            raise build_public_graphql_error(str(exc), code="NOT_FOUND") from exc
+        except ReceivableAlreadySettledError as exc:
+            raise build_public_graphql_error(str(exc), code="ALREADY_SETTLED") from exc
+
+        return ReceivablePayload(
+            ok=True,
+            message="Recebível cancelado com sucesso.",
+            errors=[],
+            data=_to_receivable_type(entry),
+        )
+
+
+class CreateFiscalDocumentMutation(graphene.Mutation):
+    class Arguments:
+        type = graphene.String(
+            required=True,
+            description=(
+                "service_invoice | product_invoice | receipt | debit_note | credit_note"
+            ),
+        )
+        amount = graphene.String(required=True)
+        issued_at = graphene.String(required=True, description="YYYY-MM-DD")
+        counterpart_name = graphene.String()
+        external_id = graphene.String()
+
+    Output = FiscalDocumentPayload
+
+    @log_graphql_resolver("createFiscalDocument")
+    def mutate(
+        self,
+        _info: graphene.ResolveInfo,
+        type: str,
+        amount: str,
+        issued_at: str,
+        counterpart_name: str | None = None,
+        external_id: str | None = None,
+    ) -> FiscalDocumentPayload:
+        user = get_current_user_required()
+        try:
+            decimal_amount = Decimal(str(amount))
+        except InvalidOperation as exc:
+            raise build_public_graphql_error(
+                "amount must be a valid decimal", code="VALIDATION_ERROR"
+            ) from exc
+        try:
+            parsed_date = _parse_date(issued_at)
+        except ValueError as exc:
+            raise build_public_graphql_error(str(exc), code="VALIDATION_ERROR") from exc
+
+        try:
+            doc = create_fiscal_document(
+                user_id=str(user.id),
+                doc_type=type,
+                amount=decimal_amount,
+                issued_at=parsed_date,
+                counterpart_name=counterpart_name,
+                external_id=external_id,
+            )
+        except (ValueError, FiscalDocumentNotFoundError) as exc:
+            raise build_public_graphql_error(str(exc), code="VALIDATION_ERROR") from exc
+
+        return FiscalDocumentPayload(
+            ok=True,
+            message="Documento fiscal criado com sucesso.",
+            errors=[],
+            data=_to_fiscal_doc_type(doc),
+        )

--- a/app/graphql/queries/__init__.py
+++ b/app/graphql/queries/__init__.py
@@ -6,6 +6,7 @@ from .account import AccountQueryMixin
 from .ai_insight import AIInsightQueryMixin
 from .budget import BudgetQueryMixin
 from .dashboard import DashboardQueryMixin
+from .fiscal import FiscalQueryMixin
 from .goal import GoalQueryMixin
 from .investment import InvestmentQueryMixin
 from .notification import NotificationQueryMixin
@@ -31,6 +32,7 @@ class Query(
     TagQueryMixin,
     AccountQueryMixin,
     AIInsightQueryMixin,
+    FiscalQueryMixin,
     graphene.ObjectType,
 ):
     pass
@@ -51,4 +53,5 @@ __all__ = [
     "TagQueryMixin",
     "AccountQueryMixin",
     "AIInsightQueryMixin",
+    "FiscalQueryMixin",
 ]

--- a/app/graphql/queries/fiscal.py
+++ b/app/graphql/queries/fiscal.py
@@ -1,0 +1,111 @@
+"""GraphQL queries for the Fiscal domain (#1247).
+
+Read-only surface (canonical per ADR-0002).
+Wraps the service layer — no direct ORM access.
+"""
+
+from __future__ import annotations
+
+import graphene
+
+from app.graphql.auth import get_current_user_required
+from app.graphql.observability import log_graphql_resolver
+from app.graphql.types import (
+    FiscalDocumentListType,
+    FiscalDocumentType,
+    ReceivableEntryType,
+    ReceivableListType,
+    ReceivableSummaryType,
+)
+from app.models.fiscal import FiscalDocument, ReceivableEntry
+from app.services.fiscal_service import list_fiscal_documents
+from app.services.receivable_service import get_revenue_summary, list_receivables
+
+_DISCLAIMER = (
+    "Este valor é estimativo e não substitui cálculo fiscal por profissional habilitado"
+)
+
+
+def _to_fiscal_doc_type(doc: FiscalDocument) -> FiscalDocumentType:
+    return FiscalDocumentType(
+        id=str(doc.id),
+        external_id=doc.external_id,
+        type=doc.type.value,
+        status=doc.status.value,
+        issued_at=doc.issued_at.isoformat() if doc.issued_at else "",
+        counterparty=doc.counterparty,
+        gross_amount=doc.gross_amount,
+        currency=doc.currency,
+        description=doc.description,
+        created_at=doc.created_at.isoformat() if doc.created_at else "",
+    )
+
+
+def _to_receivable_type(entry: ReceivableEntry) -> ReceivableEntryType:
+    return ReceivableEntryType(
+        id=str(entry.id),
+        fiscal_document_id=str(entry.fiscal_document_id),
+        expected_net_amount=entry.expected_net_amount,
+        received_amount=entry.received_amount,
+        outstanding_amount=entry.outstanding_amount,
+        reconciliation_status=entry.reconciliation_status.value,
+        received_at=entry.received_at.isoformat() if entry.received_at else None,
+        created_at=entry.created_at.isoformat() if entry.created_at else "",
+        disclaimer=_DISCLAIMER,
+    )
+
+
+class FiscalQueryMixin:
+    receivables = graphene.Field(
+        ReceivableListType,
+        status=graphene.String(description="Filter: pending | received | cancelled"),
+    )
+    receivables_summary = graphene.Field(ReceivableSummaryType)
+    fiscal_documents = graphene.Field(
+        FiscalDocumentListType,
+        type=graphene.String(
+            description=(
+                "Filter by document type: service_invoice | product_invoice | "
+                "receipt | debit_note | credit_note"
+            )
+        ),
+    )
+
+    @log_graphql_resolver("receivables")
+    def resolve_receivables(
+        self,
+        _info: graphene.ResolveInfo,
+        status: str | None = None,
+    ) -> ReceivableListType:
+        user = get_current_user_required()
+        entries = list_receivables(str(user.id), status=status)
+        return ReceivableListType(
+            receivables=[_to_receivable_type(e) for e in entries],
+            total=len(entries),
+        )
+
+    @log_graphql_resolver("receivablesSummary")
+    def resolve_receivables_summary(
+        self, _info: graphene.ResolveInfo
+    ) -> ReceivableSummaryType:
+        user = get_current_user_required()
+        summary = get_revenue_summary(str(user.id))
+        return ReceivableSummaryType(
+            expected_total=summary["expected_total"],
+            received_total=summary["received_total"],
+            pending_total=summary["pending_total"],
+            disclaimer=summary["disclaimer"],
+        )
+
+    @log_graphql_resolver("fiscalDocuments")
+    def resolve_fiscal_documents(
+        self,
+        _info: graphene.ResolveInfo,
+        type: str | None = None,
+    ) -> FiscalDocumentListType:
+        user = get_current_user_required()
+        docs = list_fiscal_documents(str(user.id), doc_type=type)
+        return FiscalDocumentListType(
+            fiscal_documents=[_to_fiscal_doc_type(d) for d in docs],
+            total=len(docs),
+        )

--- a/app/graphql/types.py
+++ b/app/graphql/types.py
@@ -752,3 +752,70 @@ class BankImportConfirmationPayload(MutationPayload):
     skipped_duplicates = graphene.Int()
     replaced_count = graphene.Int()
     transactions = graphene.List(graphene.NonNull(ImportedTransactionType))
+
+
+# ---------------------------------------------------------------------------
+# Fiscal domain (#1247 — GraphQL parity with REST /fiscal/*)
+# ---------------------------------------------------------------------------
+
+
+class FiscalDocumentType(graphene.ObjectType):
+    id = graphene.ID(required=True)
+    external_id = graphene.String(required=True)
+    type = graphene.String(required=True)
+    status = graphene.String(required=True)
+    issued_at = graphene.String(required=True)
+    counterparty = graphene.String(required=True)
+    gross_amount = DecimalScalar(required=True)
+    currency = graphene.String(required=True)
+    description = graphene.String()
+    created_at = graphene.String(required=True)
+
+
+class FiscalDocumentListType(graphene.ObjectType):
+    fiscal_documents = graphene.List(
+        graphene.NonNull(FiscalDocumentType), required=True
+    )
+    total = graphene.Int(required=True)
+
+
+class FiscalDocumentPayload(MutationPayload):
+    data = graphene.Field(FiscalDocumentType)
+
+
+class ReceivableEntryType(graphene.ObjectType):
+    """
+    IMPORTANT: expected_net_amount is advisory-only. Clients MUST display
+    the ``disclaimer`` field alongside any monetary value derived from it.
+    """
+
+    id = graphene.ID(required=True)
+    fiscal_document_id = graphene.ID(required=True)
+    expected_net_amount = DecimalScalar()
+    received_amount = DecimalScalar()
+    outstanding_amount = DecimalScalar()
+    reconciliation_status = graphene.String(required=True)
+    received_at = graphene.String()
+    created_at = graphene.String(required=True)
+    disclaimer = graphene.String(required=True)
+
+
+class ReceivableListType(graphene.ObjectType):
+    receivables = graphene.List(graphene.NonNull(ReceivableEntryType), required=True)
+    total = graphene.Int(required=True)
+
+
+class ReceivablePayload(MutationPayload):
+    data = graphene.Field(ReceivableEntryType)
+
+
+class ReceivableSummaryType(graphene.ObjectType):
+    """
+    IMPORTANT: all monetary values are advisory-only estimates.
+    Always display the ``disclaimer`` field.
+    """
+
+    expected_total = graphene.String(required=True)
+    received_total = graphene.String(required=True)
+    pending_total = graphene.String(required=True)
+    disclaimer = graphene.String(required=True)

--- a/graphql.introspection.json
+++ b/graphql.introspection.json
@@ -135,6 +135,68 @@
             {
               "args": [
                 {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": "Filter: pending | received | cancelled",
+                  "isDeprecated": false,
+                  "name": "status",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "receivables",
+              "type": {
+                "kind": "OBJECT",
+                "name": "ReceivableListType",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "receivablesSummary",
+              "type": {
+                "kind": "OBJECT",
+                "name": "ReceivableSummaryType",
+                "ofType": null
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": "Filter by document type: service_invoice | product_invoice | receipt | debit_note | credit_note",
+                  "isDeprecated": false,
+                  "name": "type",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "fiscalDocuments",
+              "type": {
+                "kind": "OBJECT",
+                "name": "FiscalDocumentListType",
+                "ofType": null
+              }
+            },
+            {
+              "args": [
+                {
                   "defaultValue": "1",
                   "deprecationReason": null,
                   "description": null,
@@ -1495,6 +1557,538 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "receivables",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "ReceivableEntryType",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "total",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "ReceivableListType",
+          "possibleTypes": null,
+          "specifiedByURL": null
+        },
+        {
+          "description": "IMPORTANT: expected_net_amount is advisory-only. Clients MUST display\nthe ``disclaimer`` field alongside any monetary value derived from it.",
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "id",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "fiscalDocumentId",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "expectedNetAmount",
+              "type": {
+                "kind": "SCALAR",
+                "name": "DecimalScalar",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "receivedAmount",
+              "type": {
+                "kind": "SCALAR",
+                "name": "DecimalScalar",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "outstandingAmount",
+              "type": {
+                "kind": "SCALAR",
+                "name": "DecimalScalar",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "reconciliationStatus",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "receivedAt",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "createdAt",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "disclaimer",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "ReceivableEntryType",
+          "possibleTypes": null,
+          "specifiedByURL": null
+        },
+        {
+          "description": "The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `\"4\"`) or integer (such as `4`) input value will be accepted as an ID.",
+          "enumValues": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "SCALAR",
+          "name": "ID",
+          "possibleTypes": null,
+          "specifiedByURL": null
+        },
+        {
+          "description": "Arbitrary-precision decimal serialised as a string.\n\nOutput: always a string in fixed-point notation (no scientific exponent).\nInput: accepts string, int, float, or Decimal — coerced via ``Decimal(str(x))``.\nNull is preserved.",
+          "enumValues": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "SCALAR",
+          "name": "DecimalScalar",
+          "possibleTypes": null,
+          "specifiedByURL": null
+        },
+        {
+          "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
+          "enumValues": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "SCALAR",
+          "name": "String",
+          "possibleTypes": null,
+          "specifiedByURL": null
+        },
+        {
+          "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.",
+          "enumValues": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "SCALAR",
+          "name": "Int",
+          "possibleTypes": null,
+          "specifiedByURL": null
+        },
+        {
+          "description": "IMPORTANT: all monetary values are advisory-only estimates.\nAlways display the ``disclaimer`` field.",
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "expectedTotal",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "receivedTotal",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "pendingTotal",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "disclaimer",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "ReceivableSummaryType",
+          "possibleTypes": null,
+          "specifiedByURL": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "fiscalDocuments",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "FiscalDocumentType",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "total",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "FiscalDocumentListType",
+          "possibleTypes": null,
+          "specifiedByURL": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "id",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "externalId",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "type",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "status",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "issuedAt",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "counterparty",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "grossAmount",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "DecimalScalar",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "currency",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "description",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "createdAt",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "FiscalDocumentType",
+          "possibleTypes": null,
+          "specifiedByURL": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "items",
               "type": {
                 "kind": "NON_NULL",
@@ -1743,39 +2337,6 @@
           "specifiedByURL": null
         },
         {
-          "description": "The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `\"4\"`) or integer (such as `4`) input value will be accepted as an ID.",
-          "enumValues": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "kind": "SCALAR",
-          "name": "ID",
-          "possibleTypes": null,
-          "specifiedByURL": null
-        },
-        {
-          "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
-          "enumValues": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "kind": "SCALAR",
-          "name": "String",
-          "possibleTypes": null,
-          "specifiedByURL": null
-        },
-        {
-          "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.",
-          "enumValues": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "kind": "SCALAR",
-          "name": "Int",
-          "possibleTypes": null,
-          "specifiedByURL": null
-        },
-        {
           "description": "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).",
           "enumValues": null,
           "fields": null,
@@ -1919,17 +2480,6 @@
           "interfaces": [],
           "kind": "OBJECT",
           "name": "AccountType",
-          "possibleTypes": null,
-          "specifiedByURL": null
-        },
-        {
-          "description": "Arbitrary-precision decimal serialised as a string.\n\nOutput: always a string in fixed-point notation (no scientific exponent).\nInput: accepts string, int, float, or Decimal — coerced via ``Decimal(str(x))``.\nNull is preserved.",
-          "enumValues": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "kind": "SCALAR",
-          "name": "DecimalScalar",
           "possibleTypes": null,
           "specifiedByURL": null
         },
@@ -11747,6 +12297,250 @@
                 "name": "BankImportConfirmationPayload",
                 "ofType": null
               }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "amount",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "category",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "description",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": "YYYY-MM-DD",
+                  "isDeprecated": false,
+                  "name": "expectedDate",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": "ADR-0002: use POST /fiscal/receivables",
+              "description": null,
+              "isDeprecated": true,
+              "name": "createReceivable",
+              "type": {
+                "kind": "OBJECT",
+                "name": "ReceivablePayload",
+                "ofType": null
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "entryId",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "UUID",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "receivedAmount",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": "YYYY-MM-DD",
+                  "isDeprecated": false,
+                  "name": "receivedDate",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": "ADR-0002: use PATCH /fiscal/receivables/{id}/receive",
+              "description": null,
+              "isDeprecated": true,
+              "name": "markReceivableReceived",
+              "type": {
+                "kind": "OBJECT",
+                "name": "ReceivablePayload",
+                "ofType": null
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "entryId",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "UUID",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": "ADR-0002: use DELETE /fiscal/receivables/{id}",
+              "description": null,
+              "isDeprecated": true,
+              "name": "cancelReceivable",
+              "type": {
+                "kind": "OBJECT",
+                "name": "ReceivablePayload",
+                "ofType": null
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "amount",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "counterpartName",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "externalId",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": "YYYY-MM-DD",
+                  "isDeprecated": false,
+                  "name": "issuedAt",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": "service_invoice | product_invoice | receipt | debit_note | credit_note",
+                  "isDeprecated": false,
+                  "name": "type",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": "ADR-0002: use POST /fiscal/fiscal-documents",
+              "description": null,
+              "isDeprecated": true,
+              "name": "createFiscalDocument",
+              "type": {
+                "kind": "OBJECT",
+                "name": "FiscalDocumentPayload",
+                "ofType": null
+              }
             }
           ],
           "inputFields": null,
@@ -14541,6 +15335,166 @@
           "interfaces": null,
           "kind": "INPUT_OBJECT",
           "name": "SelectedEntryInput",
+          "possibleTypes": null,
+          "specifiedByURL": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "True when the mutation completed without errors.",
+              "isDeprecated": false,
+              "name": "ok",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Human-readable status message.",
+              "isDeprecated": false,
+              "name": "message",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Field-level validation errors (empty on success).",
+              "isDeprecated": false,
+              "name": "errors",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "ValidationError",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "data",
+              "type": {
+                "kind": "OBJECT",
+                "name": "ReceivableEntryType",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "ReceivablePayload",
+          "possibleTypes": null,
+          "specifiedByURL": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "True when the mutation completed without errors.",
+              "isDeprecated": false,
+              "name": "ok",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Human-readable status message.",
+              "isDeprecated": false,
+              "name": "message",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Field-level validation errors (empty on success).",
+              "isDeprecated": false,
+              "name": "errors",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "ValidationError",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "data",
+              "type": {
+                "kind": "OBJECT",
+                "name": "FiscalDocumentType",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "FiscalDocumentPayload",
           "possibleTypes": null,
           "specifiedByURL": null
         },

--- a/graphql.operations.manifest.json
+++ b/graphql.operations.manifest.json
@@ -616,6 +616,62 @@
   },
   {
     "access": "auth_required",
+    "domain": "fiscal",
+    "name": "receivables",
+    "operation_type": "query",
+    "source_module": "app.graphql.queries.fiscal",
+    "summary": "Lista recebíveis do usuário. Filtro opcional por status: pending | received | cancelled. Valores estimativos — exibir disclaimer."
+  },
+  {
+    "access": "auth_required",
+    "domain": "fiscal",
+    "name": "receivablesSummary",
+    "operation_type": "query",
+    "source_module": "app.graphql.queries.fiscal",
+    "summary": "Retorna totais agregados de receitas esperadas, recebidas e pendentes. Valores são estimativos — exibir o campo 'disclaimer' ao usuário."
+  },
+  {
+    "access": "auth_required",
+    "domain": "fiscal",
+    "name": "fiscalDocuments",
+    "operation_type": "query",
+    "source_module": "app.graphql.queries.fiscal",
+    "summary": "Lista documentos fiscais do usuário. Filtro opcional por tipo: service_invoice | product_invoice | receipt | debit_note | credit_note."
+  },
+  {
+    "access": "auth_required",
+    "domain": "fiscal",
+    "name": "createReceivable",
+    "operation_type": "mutation",
+    "source_module": "app.graphql.mutations.fiscal",
+    "summary": "Cria um recebível manual. Deprecated: preferir POST /fiscal/receivables (ADR-0002)."
+  },
+  {
+    "access": "auth_required",
+    "domain": "fiscal",
+    "name": "markReceivableReceived",
+    "operation_type": "mutation",
+    "source_module": "app.graphql.mutations.fiscal",
+    "summary": "Marca um recebível como recebido com data e valor. Deprecated: preferir PATCH /fiscal/receivables/{id}/receive (ADR-0002)."
+  },
+  {
+    "access": "auth_required",
+    "domain": "fiscal",
+    "name": "cancelReceivable",
+    "operation_type": "mutation",
+    "source_module": "app.graphql.mutations.fiscal",
+    "summary": "Cancela um recebível pendente. Deprecated: preferir DELETE /fiscal/receivables/{id} (ADR-0002)."
+  },
+  {
+    "access": "auth_required",
+    "domain": "fiscal",
+    "name": "createFiscalDocument",
+    "operation_type": "mutation",
+    "source_module": "app.graphql.mutations.fiscal",
+    "summary": "Cria um documento fiscal. Deprecated: preferir POST /fiscal/fiscal-documents (ADR-0002)."
+  },
+  {
+    "access": "auth_required",
     "domain": "ai_advisory",
     "name": "aiInsightHistory",
     "operation_type": "query",

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,4 +1,15 @@
 type Query {
+  receivables(
+    """Filter: pending | received | cancelled"""
+    status: String
+  ): ReceivableListType
+  receivablesSummary: ReceivableSummaryType
+  fiscalDocuments(
+    """
+    Filter by document type: service_invoice | product_invoice | receipt | debit_note | credit_note
+    """
+    type: String
+  ): FiscalDocumentListType
   aiInsightHistory(page: Int = 1, perPage: Int = 20): AIInsightHistoryResultType
   accounts: AccountListType
   account(accountId: UUID!): AccountType
@@ -36,6 +47,65 @@ type Query {
   me: UserType
 }
 
+type ReceivableListType {
+  receivables: [ReceivableEntryType!]!
+  total: Int!
+}
+
+"""
+IMPORTANT: expected_net_amount is advisory-only. Clients MUST display
+the ``disclaimer`` field alongside any monetary value derived from it.
+"""
+type ReceivableEntryType {
+  id: ID!
+  fiscalDocumentId: ID!
+  expectedNetAmount: DecimalScalar
+  receivedAmount: DecimalScalar
+  outstandingAmount: DecimalScalar
+  reconciliationStatus: String!
+  receivedAt: String
+  createdAt: String!
+  disclaimer: String!
+}
+
+"""
+Arbitrary-precision decimal serialised as a string.
+
+Output: always a string in fixed-point notation (no scientific exponent).
+Input: accepts string, int, float, or Decimal — coerced via ``Decimal(str(x))``.
+Null is preserved.
+"""
+scalar DecimalScalar
+
+"""
+IMPORTANT: all monetary values are advisory-only estimates.
+Always display the ``disclaimer`` field.
+"""
+type ReceivableSummaryType {
+  expectedTotal: String!
+  receivedTotal: String!
+  pendingTotal: String!
+  disclaimer: String!
+}
+
+type FiscalDocumentListType {
+  fiscalDocuments: [FiscalDocumentType!]!
+  total: Int!
+}
+
+type FiscalDocumentType {
+  id: ID!
+  externalId: String!
+  type: String!
+  status: String!
+  issuedAt: String!
+  counterparty: String!
+  grossAmount: DecimalScalar!
+  currency: String!
+  description: String
+  createdAt: String!
+}
+
 type AIInsightHistoryResultType {
   items: [AIInsightType!]!
   page: Int!
@@ -68,15 +138,6 @@ type AccountType {
   institution: String
   initialBalance: DecimalScalar
 }
-
-"""
-Arbitrary-precision decimal serialised as a string.
-
-Output: always a string in fixed-point notation (no scientific exponent).
-Input: accepts string, int, float, or Decimal — coerced via ``Decimal(str(x))``.
-Null is preserved.
-"""
-scalar DecimalScalar
 
 """
 Leverages the internal Python implementation of UUID (uuid.UUID) to provide native UUID objects
@@ -737,6 +798,33 @@ type Mutation {
     month: String!
     selectedEntries: [SelectedEntryInput!]!
   ): BankImportConfirmationPayload
+  createReceivable(
+    amount: String!
+    category: String
+    description: String!
+
+    """YYYY-MM-DD"""
+    expectedDate: String!
+  ): ReceivablePayload @deprecated(reason: "ADR-0002: use POST /fiscal/receivables")
+  markReceivableReceived(
+    entryId: UUID!
+    receivedAmount: String
+
+    """YYYY-MM-DD"""
+    receivedDate: String!
+  ): ReceivablePayload @deprecated(reason: "ADR-0002: use PATCH /fiscal/receivables/{id}/receive")
+  cancelReceivable(entryId: UUID!): ReceivablePayload @deprecated(reason: "ADR-0002: use DELETE /fiscal/receivables/{id}")
+  createFiscalDocument(
+    amount: String!
+    counterpartName: String
+    externalId: String
+
+    """YYYY-MM-DD"""
+    issuedAt: String!
+
+    """service_invoice | product_invoice | receipt | debit_note | credit_note"""
+    type: String!
+  ): FiscalDocumentPayload @deprecated(reason: "ADR-0002: use POST /fiscal/fiscal-documents")
 }
 
 type AuthPayloadType {
@@ -1086,4 +1174,28 @@ input SelectedEntryInput {
   amount: String!
   transactionType: String!
   bankName: String!
+}
+
+type ReceivablePayload {
+  """True when the mutation completed without errors."""
+  ok: Boolean!
+
+  """Human-readable status message."""
+  message: String!
+
+  """Field-level validation errors (empty on success)."""
+  errors: [ValidationError!]!
+  data: ReceivableEntryType
+}
+
+type FiscalDocumentPayload {
+  """True when the mutation completed without errors."""
+  ok: Boolean!
+
+  """Human-readable status message."""
+  message: String!
+
+  """Field-level validation errors (empty on success)."""
+  errors: [ValidationError!]!
+  data: FiscalDocumentType
 }

--- a/tests/test_graphql_fiscal_api.py
+++ b/tests/test_graphql_fiscal_api.py
@@ -1,0 +1,434 @@
+"""GraphQL tests for the Fiscal domain (#1247).
+
+Covers: receivables query, receivablesSummary, fiscalDocuments,
+        createReceivable mutation, markReceivableReceived, cancelReceivable,
+        createFiscalDocument, and auth-required enforcement.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from flask.testing import FlaskClient
+
+
+def _register_and_login(client: FlaskClient, prefix: str = "fiscal") -> str:
+    suffix = uuid.uuid4().hex[:8]
+    email = f"{prefix}-{suffix}@test.com"
+    password = "StrongPass@123"
+    r = client.post(
+        "/auth/register",
+        json={"name": f"{prefix}-{suffix}", "email": email, "password": password},
+    )
+    assert r.status_code == 201
+    r2 = client.post("/auth/login", json={"email": email, "password": password})
+    assert r2.status_code == 200
+    return r2.get_json()["token"]
+
+
+def _gql(
+    client: FlaskClient,
+    query: str,
+    variables: dict | None = None,
+    token: str | None = None,
+) -> dict:
+    headers = {}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    res = client.post(
+        "/graphql", json={"query": query, "variables": variables or {}}, headers=headers
+    )
+    assert res.status_code in {200, 401}
+    if res.status_code == 401:
+        return {
+            "errors": [
+                {"message": "Unauthorized", "extensions": {"code": "UNAUTHORIZED"}}
+            ]
+        }
+    return res.get_json()
+
+
+# ---------------------------------------------------------------------------
+# Query strings
+# ---------------------------------------------------------------------------
+
+_RECEIVABLES_QUERY = """
+query Receivables($status: String) {
+  receivables(status: $status) {
+    total
+    receivables {
+      id
+      fiscalDocumentId
+      reconciliationStatus
+      expectedNetAmount
+      disclaimer
+    }
+  }
+}
+"""
+
+_RECEIVABLES_SUMMARY = """
+{
+  receivablesSummary {
+    expectedTotal
+    receivedTotal
+    pendingTotal
+    disclaimer
+  }
+}
+"""
+
+_FISCAL_DOCS_QUERY = """
+query FiscalDocs($type: String) {
+  fiscalDocuments(type: $type) {
+    total
+    fiscalDocuments {
+      id
+      type
+      status
+      counterparty
+      grossAmount
+      currency
+    }
+  }
+}
+"""
+
+_CREATE_RECEIVABLE = """
+mutation CreateReceivable(
+  $description: String!
+  $amount: String!
+  $expectedDate: String!
+  $category: String
+) {
+  createReceivable(
+    description: $description
+    amount: $amount
+    expectedDate: $expectedDate
+    category: $category
+  ) {
+    ok
+    message
+    errors { field message }
+    data {
+      id
+      reconciliationStatus
+      expectedNetAmount
+      disclaimer
+    }
+  }
+}
+"""
+
+_MARK_RECEIVED = """
+mutation MarkReceived(
+  $entryId: UUID!
+  $receivedDate: String!
+  $receivedAmount: String
+) {
+  markReceivableReceived(
+    entryId: $entryId
+    receivedDate: $receivedDate
+    receivedAmount: $receivedAmount
+  ) {
+    ok
+    message
+    data { id reconciliationStatus receivedAmount }
+  }
+}
+"""
+
+_CANCEL_RECEIVABLE = """
+mutation CancelReceivable($entryId: UUID!) {
+  cancelReceivable(entryId: $entryId) {
+    ok
+    message
+    data { id reconciliationStatus }
+  }
+}
+"""
+
+_CREATE_FISCAL_DOC = """
+mutation CreateFiscalDoc(
+  $type: String!
+  $amount: String!
+  $issuedAt: String!
+  $counterpartName: String
+) {
+  createFiscalDocument(
+    type: $type
+    amount: $amount
+    issuedAt: $issuedAt
+    counterpartName: $counterpartName
+  ) {
+    ok
+    message
+    errors { field message }
+    data { id type status counterparty grossAmount }
+  }
+}
+"""
+
+
+# ---------------------------------------------------------------------------
+# Tests — Receivables queries
+# ---------------------------------------------------------------------------
+
+
+class TestReceivablesQuery:
+    def test_empty_list(self, client: FlaskClient) -> None:
+        token = _register_and_login(client, "recvq")
+        body = _gql(client, _RECEIVABLES_QUERY, token=token)
+        assert "errors" not in body
+        data = body["data"]["receivables"]
+        assert data["total"] == 0
+        assert data["receivables"] == []
+
+    def test_requires_auth(self, client: FlaskClient) -> None:
+        body = _gql(client, _RECEIVABLES_QUERY)
+        assert body["errors"][0]["extensions"]["code"] == "UNAUTHORIZED"
+
+    def test_summary_disclaimer_present(self, client: FlaskClient) -> None:
+        token = _register_and_login(client, "recvs")
+        body = _gql(client, _RECEIVABLES_SUMMARY, token=token)
+        assert "errors" not in body
+        summary = body["data"]["receivablesSummary"]
+        assert "estimativo" in summary["disclaimer"]
+        assert summary["expectedTotal"] == "0"
+        assert summary["pendingTotal"] == "0"
+
+    def test_summary_requires_auth(self, client: FlaskClient) -> None:
+        body = _gql(client, _RECEIVABLES_SUMMARY)
+        assert body["errors"][0]["extensions"]["code"] == "UNAUTHORIZED"
+
+
+# ---------------------------------------------------------------------------
+# Tests — Fiscal documents query
+# ---------------------------------------------------------------------------
+
+
+class TestFiscalDocumentsQuery:
+    def test_empty_list(self, client: FlaskClient) -> None:
+        token = _register_and_login(client, "fdocq")
+        body = _gql(client, _FISCAL_DOCS_QUERY, token=token)
+        assert "errors" not in body
+        data = body["data"]["fiscalDocuments"]
+        assert data["total"] == 0
+        assert data["fiscalDocuments"] == []
+
+    def test_requires_auth(self, client: FlaskClient) -> None:
+        body = _gql(client, _FISCAL_DOCS_QUERY)
+        assert body["errors"][0]["extensions"]["code"] == "UNAUTHORIZED"
+
+
+# ---------------------------------------------------------------------------
+# Tests — createReceivable mutation
+# ---------------------------------------------------------------------------
+
+
+class TestCreateReceivableMutation:
+    def test_create_success(self, client: FlaskClient) -> None:
+        token = _register_and_login(client, "recv-create")
+        body = _gql(
+            client,
+            _CREATE_RECEIVABLE,
+            variables={
+                "description": "Consultoria Q1",
+                "amount": "5000.00",
+                "expectedDate": "2026-06-30",
+                "category": "consulting",
+            },
+            token=token,
+        )
+        assert "errors" not in body
+        result = body["data"]["createReceivable"]
+        assert result["ok"] is True
+        assert result["errors"] == []
+        entry = result["data"]
+        assert entry["id"]
+        assert entry["reconciliationStatus"] == "pending"
+        assert entry["expectedNetAmount"] == "5000.00"
+        assert "estimativo" in entry["disclaimer"]
+
+    def test_create_appears_in_list(self, client: FlaskClient) -> None:
+        token = _register_and_login(client, "recv-list")
+        _gql(
+            client,
+            _CREATE_RECEIVABLE,
+            variables={
+                "description": "Projeto Alpha",
+                "amount": "1000.00",
+                "expectedDate": "2026-07-15",
+            },
+            token=token,
+        )
+        body = _gql(client, _RECEIVABLES_QUERY, token=token)
+        assert body["data"]["receivables"]["total"] == 1
+
+    def test_invalid_amount(self, client: FlaskClient) -> None:
+        token = _register_and_login(client, "recv-badamt")
+        body = _gql(
+            client,
+            _CREATE_RECEIVABLE,
+            variables={
+                "description": "Test",
+                "amount": "not-a-number",
+                "expectedDate": "2026-06-01",
+            },
+            token=token,
+        )
+        assert body["errors"]
+
+    def test_invalid_date(self, client: FlaskClient) -> None:
+        token = _register_and_login(client, "recv-baddate")
+        body = _gql(
+            client,
+            _CREATE_RECEIVABLE,
+            variables={
+                "description": "Test",
+                "amount": "100.00",
+                "expectedDate": "not-a-date",
+            },
+            token=token,
+        )
+        assert body["errors"]
+
+    def test_requires_auth(self, client: FlaskClient) -> None:
+        body = _gql(
+            client,
+            _CREATE_RECEIVABLE,
+            variables={
+                "description": "X",
+                "amount": "1.00",
+                "expectedDate": "2026-01-01",
+            },
+        )
+        assert body["errors"][0]["extensions"]["code"] == "UNAUTHORIZED"
+
+
+# ---------------------------------------------------------------------------
+# Tests — markReceivableReceived + cancelReceivable
+# ---------------------------------------------------------------------------
+
+
+class TestReceivableLifecycle:
+    def _create_receivable(self, client: FlaskClient, token: str) -> str:
+        body = _gql(
+            client,
+            _CREATE_RECEIVABLE,
+            variables={
+                "description": "Lifecycle test",
+                "amount": "2500.00",
+                "expectedDate": "2026-08-01",
+            },
+            token=token,
+        )
+        return body["data"]["createReceivable"]["data"]["id"]
+
+    def test_mark_received(self, client: FlaskClient) -> None:
+        token = _register_and_login(client, "recv-mark")
+        entry_id = self._create_receivable(client, token)
+        body = _gql(
+            client,
+            _MARK_RECEIVED,
+            variables={
+                "entryId": entry_id,
+                "receivedDate": "2026-08-05",
+                "receivedAmount": "2500.00",
+            },
+            token=token,
+        )
+        assert "errors" not in body
+        result = body["data"]["markReceivableReceived"]
+        assert result["ok"] is True
+        assert result["data"]["receivedAmount"] == "2500.00"
+
+    def test_cancel_receivable(self, client: FlaskClient) -> None:
+        token = _register_and_login(client, "recv-cancel")
+        entry_id = self._create_receivable(client, token)
+        body = _gql(
+            client,
+            _CANCEL_RECEIVABLE,
+            variables={"entryId": entry_id},
+            token=token,
+        )
+        assert "errors" not in body
+        result = body["data"]["cancelReceivable"]
+        assert result["ok"] is True
+
+    def test_not_found(self, client: FlaskClient) -> None:
+        token = _register_and_login(client, "recv-nf")
+        fake_id = str(uuid.uuid4())
+        body = _gql(
+            client,
+            _MARK_RECEIVED,
+            variables={"entryId": fake_id, "receivedDate": "2026-01-01"},
+            token=token,
+        )
+        assert body["errors"]
+        assert body["errors"][0]["extensions"]["code"] == "NOT_FOUND"
+
+
+# ---------------------------------------------------------------------------
+# Tests — createFiscalDocument mutation
+# ---------------------------------------------------------------------------
+
+
+class TestCreateFiscalDocumentMutation:
+    def test_create_success(self, client: FlaskClient) -> None:
+        token = _register_and_login(client, "fdoc-create")
+        body = _gql(
+            client,
+            _CREATE_FISCAL_DOC,
+            variables={
+                "type": "service_invoice",
+                "amount": "3000.00",
+                "issuedAt": "2026-05-01",
+                "counterpartName": "Acme Corp",
+            },
+            token=token,
+        )
+        assert "errors" not in body
+        result = body["data"]["createFiscalDocument"]
+        assert result["ok"] is True
+        doc = result["data"]
+        assert doc["type"] == "service_invoice"
+        assert doc["counterparty"] == "Acme Corp"
+        assert doc["grossAmount"] == "3000.00"
+
+    def test_invalid_type(self, client: FlaskClient) -> None:
+        token = _register_and_login(client, "fdoc-badtype")
+        body = _gql(
+            client,
+            _CREATE_FISCAL_DOC,
+            variables={
+                "type": "not_a_valid_type",
+                "amount": "100.00",
+                "issuedAt": "2026-01-01",
+            },
+            token=token,
+        )
+        assert body["errors"]
+
+    def test_appears_in_list(self, client: FlaskClient) -> None:
+        token = _register_and_login(client, "fdoc-list")
+        _gql(
+            client,
+            _CREATE_FISCAL_DOC,
+            variables={
+                "type": "receipt",
+                "amount": "500.00",
+                "issuedAt": "2026-04-10",
+            },
+            token=token,
+        )
+        body = _gql(client, _FISCAL_DOCS_QUERY, token=token)
+        assert body["data"]["fiscalDocuments"]["total"] == 1
+
+    def test_requires_auth(self, client: FlaskClient) -> None:
+        body = _gql(
+            client,
+            _CREATE_FISCAL_DOC,
+            variables={"type": "receipt", "amount": "1.00", "issuedAt": "2026-01-01"},
+        )
+        assert body["errors"][0]["extensions"]["code"] == "UNAUTHORIZED"


### PR DESCRIPTION
## Summary

Implementa cobertura GraphQL completa do domínio Fiscal, completando a paridade iniciada em #1148.

**Queries (canonical read surface):**
- `receivables(status)` — lista recebíveis com filtro por status
- `receivablesSummary` — totais agregados (expected/received/pending) + disclaimer obrigatório
- `fiscalDocuments(type)` — lista documentos fiscais com filtro por tipo

**Mutations (deprecated per ADR-0002 — REST é canonical para writes):**
- `createReceivable` → deprecated: use POST /fiscal/receivables
- `markReceivableReceived` → deprecated: use PATCH /fiscal/receivables/{id}/receive
- `cancelReceivable` → deprecated: use DELETE /fiscal/receivables/{id}
- `createFiscalDocument` → deprecated: use POST /fiscal/fiscal-documents

**CSV upload/confirm:** REST-only (file upload via GraphQL fora de escopo).

## Changes

- `app/graphql/types.py` — 7 novos types: FiscalDocumentType, FiscalDocumentListType, FiscalDocumentPayload, ReceivableEntryType, ReceivableListType, ReceivablePayload, ReceivableSummaryType
- `app/graphql/queries/fiscal.py` — FiscalQueryMixin com 3 queries
- `app/graphql/mutations/fiscal.py` — 4 mutations deprecadas
- `app/graphql/queries/__init__.py` + `mutations/__init__.py` — wiring
- `app/graphql/docs_catalog.py` — 7 entradas + domínio "fiscal" adicionado
- `schema.graphql` + `graphql.introspection.json` + `graphql.operations.manifest.json` — artefatos atualizados
- `tests/test_graphql_fiscal_api.py` — 18 testes (queries, mutations, auth enforcement, lifecycle)

## Quality

- ruff ✓ | mypy ✓ | pytest 18/18 ✓ | coverage 88% ✓

## Refs

Closes #1247
Umbrella: #1157