### PR TITLE
fix(infra): make entrypoint RDS-aware to unblock prod deploys (#1254)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,3 +1,10 @@
+# Production compose is RDS-canonical: no local `db` service is provisioned.
+# The web container resolves the database via DATABASE_URL loaded from
+# .env.prod (points to the RDS endpoint at
+# auraxis-prod.cav02gmeg759.us-east-1.rds.amazonaws.com:5432).
+# Local Postgres for offline dev lives in docker-compose.dev.yml.
+# Re-introducing a `db` service here will reopen issue #1254 (wait-for-db hang
+# on deploy) — keep this file RDS-only.
 services:
   redis:
     image: ${REDIS_IMAGE:-public.ecr.aws/docker/library/redis:7-alpine}

--- a/scripts/entrypoint_prod.sh
+++ b/scripts/entrypoint_prod.sh
@@ -1,18 +1,57 @@
 #!/bin/sh
 set -eu
 
-DB_HOST="${DB_HOST:-db}"
-DB_PORT="${DB_PORT:-5432}"
+# ── Resolve database connection target ────────────────────────────────────────
+# Production uses RDS via DATABASE_URL (canonical). The legacy DB_HOST/DB_PORT
+# pair is kept as a fallback for dev/test compose stacks where a local
+# Postgres service is reachable as `db:5432`.
+#
+# Issue #1254: previously this script defaulted DB_HOST to the literal "db",
+# which made the wait-for-db loop hang on prod (where no `db` container
+# exists) and brought the API down with 502s every time the web container was
+# recreated. Now we derive host/port from DATABASE_URL when present and only
+# fall back to DB_HOST/DB_PORT when explicitly set — no implicit `db` default.
+
 DB_WAIT_TIMEOUT="${DB_WAIT_TIMEOUT:-60}"
 
-echo "Waiting for database at ${DB_HOST}:${DB_PORT}..."
+# Resolve DB_HOST/DB_PORT for the wait-for-db loop. Prefer DATABASE_URL.
+if [ -n "${DATABASE_URL:-}" ]; then
+  RESOLVED_HOST_PORT="$(
+    DATABASE_URL="${DATABASE_URL}" python - <<'PY'
+import os
+from urllib.parse import urlparse
+
+url = os.environ["DATABASE_URL"]
+parsed = urlparse(url)
+host = parsed.hostname or ""
+port = parsed.port or 5432
+print(f"{host}:{port}")
+PY
+  )"
+  RESOLVED_HOST="${RESOLVED_HOST_PORT%:*}"
+  RESOLVED_PORT="${RESOLVED_HOST_PORT##*:}"
+else
+  RESOLVED_HOST="${DB_HOST:-}"
+  RESOLVED_PORT="${DB_PORT:-5432}"
+fi
+
+if [ -z "${RESOLVED_HOST}" ]; then
+  echo "ERROR: cannot determine database host." >&2
+  echo "Set DATABASE_URL (preferred) or DB_HOST in the environment." >&2
+  exit 1
+fi
+
+export DB_WAIT_HOST="${RESOLVED_HOST}"
+export DB_WAIT_PORT="${RESOLVED_PORT}"
+
+echo "Waiting for database at ${DB_WAIT_HOST}:${DB_WAIT_PORT}..."
 python - <<'PY'
 import os
 import socket
 import time
 
-host = os.getenv("DB_HOST", "db")
-port = int(os.getenv("DB_PORT", "5432"))
+host = os.environ["DB_WAIT_HOST"]
+port = int(os.environ["DB_WAIT_PORT"])
 timeout = int(os.getenv("DB_WAIT_TIMEOUT", "60"))
 deadline = time.time() + timeout
 
@@ -34,16 +73,26 @@ if [ "${MIGRATE_ON_START:-true}" = "true" ]; then
     BASELINE_ACTION="$(
       python - <<'PY'
 import os
+from urllib.parse import urlparse
 
 import psycopg2
 
-host = os.getenv("DB_HOST", "db")
-port = int(os.getenv("DB_PORT", "5432"))
-dbname = os.getenv("DB_NAME")
-user = os.getenv("DB_USER")
-password = os.getenv("DB_PASS")
+database_url = os.getenv("DATABASE_URL")
+if database_url:
+    parsed = urlparse(database_url)
+    host = parsed.hostname or ""
+    port = parsed.port or 5432
+    dbname = (parsed.path or "").lstrip("/") or None
+    user = parsed.username
+    password = parsed.password
+else:
+    host = os.getenv("DB_HOST", "")
+    port = int(os.getenv("DB_PORT", "5432"))
+    dbname = os.getenv("DB_NAME")
+    user = os.getenv("DB_USER")
+    password = os.getenv("DB_PASS")
 
-if not all([dbname, user, password]):
+if not all([host, dbname, user, password]):
     print("skip_missing_db_env")
     raise SystemExit(0)
 


### PR DESCRIPTION
## Context

Closes #1254.

The 2026-05-16 prod incident traced to `scripts/entrypoint_prod.sh` defaulting `DB_HOST` to the literal `"db"` — a hostname that only resolves inside the legacy local-Postgres compose topology. After the RDS cutover (commit `a6a1ead`, May 10), `docker-compose.prod.yml` was correctly cleaned up: no `db` service, no `depends_on: db`, no hardcoded `DB_HOST: db` env. But the entrypoint kept polling `db:5432` because:

- `.env.prod` on the EC2 box still carries the legacy `DB_HOST=db` (per `.env.prod.example`), and
- when `DB_HOST` is unset, the entrypoint's fallback was `${DB_HOST:-db}` and `os.getenv("DB_HOST", "db")` — the same trap.

Every deploy that recreated the `web` container hit the 60s wait-for-db timeout and exited 1, taking prod offline with 502s. Manual recovery required spinning up a decoy `postgres:16` container just to satisfy the loop.

## What changed

### `scripts/entrypoint_prod.sh` — RDS-aware wait-for-db

- Prefer `DATABASE_URL` when set; parse host/port via `urllib.parse` and use that for the socket-based wait loop.
- Fall back to `DB_HOST`/`DB_PORT` **only when explicitly set** in the environment (dev compose path).
- **Remove the unsafe `:-db` default** — fail fast with a clear error message if neither is set. No more silent hang.
- Same parsing applied to the alembic baseline pre-flight (`psycopg2.connect` now sources `host`/`dbname`/`user`/`password` from `DATABASE_URL` when present; `DB_NAME`/`DB_USER`/`DB_PASS` remain as fallback).

### `docker-compose.prod.yml` — header comment lock

Adds a defensive header comment documenting that this file is RDS-canonical and pointing future contributors at `docker-compose.dev.yml` for local Postgres. No structural change — the file was already free of the `db` service after PR #1068 / commit `a6a1ead`.

### Files NOT touched

- `scripts/aws_deploy_i6.py` — parallel agent owns it for #1252/#1253. Zero overlap confirmed.
- `.env.prod`, `.env.dev`, `.env` — gitignored secrets, untouched.
- `.env.prod.example` — pre-tool-use hook blocks edits to `.env.*` examples; left alone (the actual prod `.env.prod` on EC2 already has `DATABASE_URL` set per the issue body, which is the only file load-bearing for the fix).

## Design choice

**Option C (resilient entrypoint that parses DATABASE_URL).** Option A (compose profiles for `db`) was already implemented in PR #1068 / commit `a6a1ead` — the prod compose has been db-free since May 10. The remaining bug was entirely in the entrypoint, so the minimal surgical fix is to make the entrypoint RDS-aware. Option C also covers the case where any operator's `.env.prod` legacy `DB_HOST=db` would otherwise re-introduce the hang — the new logic explicitly prefers `DATABASE_URL` when present, so the legacy var is shadowed safely.

## Tested

- `docker compose -f docker-compose.prod.yml config -q` → valid
- `docker compose -f docker-compose.dev.yml  config -q` → valid (dev unchanged, still has its own local `db`)
- `docker compose -f docker-compose.yml      config -q` → valid (base unchanged)
- `shellcheck scripts/entrypoint_prod.sh` → clean
- `sh -n scripts/entrypoint_prod.sh` → ok
- `python3 scripts/repo_hygiene_check.py` → clean
- Behavioral matrix of the new URL parser:
  - `DATABASE_URL` with RDS endpoint + explicit port → host + port extracted ✓
  - `DATABASE_URL` without port → defaults to 5432 ✓
  - Legacy `DB_HOST`/`DB_PORT` only (no `DATABASE_URL`) → still resolves (dev path) ✓
  - Neither set → fails fast with clear error message ✓

## Not tested (in this PR / environment)

- Full `bash scripts/run_ci_quality_local.sh --local` — heavy Python venv bootstrap not run locally; CI will exercise it on the PR. The change is shell + a YAML comment, so ruff/mypy/pytest paths are untouched.
- End-to-end deploy to EC2 — needs maintainer to trigger the workflow_dispatch after merge to validate that a fresh container recreation no longer hangs. **Recommend** running the deploy in low-traffic window and verifying `docker compose -f docker-compose.prod.yml logs -f web` shows `Waiting for database at auraxis-prod.cav02gmeg759.us-east-1.rds.amazonaws.com:5432...` followed by `Database reachable.`

## Acceptance criteria (from #1254)

- [x] `docker compose --env-file .env.prod -f docker-compose.prod.yml up -d` brings up `web + redis + reverse-proxy` only — compose was already db-free since #1068; this PR adds a header comment lock to prevent regression.
- [x] Web container's entrypoint exits the wait loop because RDS responds, not because a decoy is up — entrypoint now parses RDS host from `DATABASE_URL`.
- [x] Deploy workflow can recreate `auraxis-web-1` from a fresh GHCR pull with no manual intervention — once this PR lands and the maintainer optionally removes the `DB_HOST=db` line from `.env.prod` (now redundant but harmless, since `DATABASE_URL` wins).
- [x] Dev workflow (`docker compose up` locally) still spins up a local postgres — `docker-compose.dev.yml` unchanged; entrypoint fallback path still honors `DB_HOST`/`DB_PORT` when `DATABASE_URL` is not set.
- [ ] `pgdata_prod` volume review — out of scope for this PR (operational task on the EC2 host); flagged in the issue body for the maintainer.

## Open questions / risk surface

1. The 4-week-old orphan `auraxis-web-run-*` containers from the audit trail — left alone in this PR (they're cleanup tasks, not entrypoint bugs). Maintainer can `docker container prune` after this deploy stabilizes.
2. The maintainer should confirm `.env.prod` on EC2 has `DATABASE_URL` set (per the issue body it does, but the legacy `DB_HOST=db` may still be there — now harmless because `DATABASE_URL` takes precedence in the new entrypoint).
3. No new tests added — there is no existing harness for `entrypoint_prod.sh` (only `Dockerfile.prod` references it). Adding a pytest-driven shell test is a separate concern; leaving for a follow-up if the maintainer wants formal coverage.