### PR TITLE
[BACKEND] fix(deploy): apply alembic migrations + validate rollback URI

### DIFF
--- a/scripts/aws_deploy_i6.py
+++ b/scripts/aws_deploy_i6.py
@@ -36,6 +36,7 @@ import argparse
 import base64
 import json
 import os
+import re
 import subprocess
 import sys
 import time
@@ -50,6 +51,43 @@ DEFAULT_PROD_INSTANCE_ID = "i-0057e3b52162f78f8"
 DEFAULT_DEV_INSTANCE_ID = "i-0bddcfc8ea56c2ba3"
 
 DEPLOY_STATE_PATH = "/var/lib/auraxis/deploy_state.json"
+
+# Bump this when the on-disk shape of deploy_state.json changes. Older state
+# files (no schema_version key) trigger a warning on read so operators know to
+# repair them. See issue #1253.
+DEPLOY_STATE_SCHEMA_VERSION = 2
+
+# Canonical GHCR image URI pattern. Used in two places:
+#  - Python validator (is_valid_ghcr_image_uri) for unit-testable behavior.
+#  - Bash regex inside the SSM script for in-instance rollback validation.
+# Both must agree; tests pin the shape via GHCR_IMAGE_URI_PATTERN. The pattern
+# is intentionally minimal (matches the AC in issue #1253) so it works under
+# both Python ``re`` and POSIX ERE (``grep -E``) without character-class
+# portability issues.
+GHCR_IMAGE_URI_PATTERN = r"^ghcr\.io/.+:.+$"
+# Stricter pure-Python check used by ``is_valid_ghcr_image_uri``: forbids
+# whitespace inside the path/tag, which the bash regex also rejects (the
+# rollback validator pipes the value through ``printf '%s'`` and ``grep -Eq``,
+# and any embedded newline would already break the bash branch).
+_GHCR_IMAGE_URI_RE = re.compile(r"^ghcr\.io/[^:\s]+:[^\s]+$")
+
+
+def is_valid_ghcr_image_uri(value: Any) -> bool:
+    """Return True iff ``value`` looks like a canonical GHCR image URI.
+
+    Accepts: ``ghcr.io/<owner>/<repo>:<tag>`` (tag = git SHA, semver, etc.).
+    Rejects: bare git SHAs, Docker Hub references, empty/whitespace, non-strings.
+
+    This is the validator used in the rollback path of ``aws_deploy_i6.py`` to
+    catch legacy state files (issue #1253) where ``previous`` was stored as a
+    bare 40-char git SHA — which ``docker pull`` then interprets as Docker Hub
+    and refuses with an opaque "access denied" error.
+    """
+    if not isinstance(value, str):
+        return False
+    if not value.strip():
+        return False
+    return _GHCR_IMAGE_URI_RE.match(value) is not None
 
 
 @dataclass(frozen=True)
@@ -281,6 +319,8 @@ def _build_script(
     git_ref_setup = f'GIT_REF="{git_ref}"' if git_ref is not None else 'GIT_REF=""'
     web_image_setup = f'WEB_IMAGE="{web_image}"'
     ghcr_token_setup = f'GHCR_TOKEN="{ghcr_token}"'
+    ghcr_pattern = GHCR_IMAGE_URI_PATTERN
+    schema_version = DEPLOY_STATE_SCHEMA_VERSION
 
     return f"""\
 set -euo pipefail
@@ -355,6 +395,7 @@ CURRENT_BRANCH="$(
 
 STATE_CURRENT=""
 STATE_PREVIOUS=""
+STATE_SCHEMA_VERSION=""
 if [ -f "$STATE_PATH" ]; then
   STATE_CURRENT="$(python3 - <<'PY' "$STATE_PATH"
 import json,sys
@@ -376,6 +417,22 @@ except Exception:
   print('')
 PY
 )"
+  STATE_SCHEMA_VERSION="$(python3 - <<'PY' "$STATE_PATH"
+import json,sys
+p=sys.argv[1]
+try:
+  data=json.load(open(p,'r',encoding='utf-8'))
+  v=data.get('schema_version','')
+  print(v if v == '' else str(v))
+except Exception:
+  print('')
+PY
+)"
+  if [ -z "$STATE_SCHEMA_VERSION" ]; then
+    echo "[i6] WARNING: deploy_state.json missing 'schema_version'; \
+treating as legacy v1 — will be upgraded to v{schema_version} on next \
+successful deploy."
+  fi
 fi
 
 if [ "$MODE" = "status" ]; then
@@ -388,6 +445,20 @@ if [ "$MODE" = "rollback" ]; then
   if [ -z "$STATE_PREVIOUS" ]; then
     echo "[i6] rollback requested but no previous deploy recorded in $STATE_PATH"
     exit 12
+  fi
+  # Defensive: 'previous' must be a fully-qualified GHCR image URI. Legacy
+  # state files (pre-#1253) stored bare 40-char git SHAs here, which docker
+  # pull then interpreted as Docker Hub references and rejected with an
+  # opaque "access denied" error. Fail fast with an actionable message so
+  # on-call can repair $STATE_PATH instead of chasing a docker auth red
+  # herring.
+  if ! printf '%s' "$STATE_PREVIOUS" \\
+       | grep -Eq '{ghcr_pattern}'; then
+    echo "[i6] rollback aborted: previous='$STATE_PREVIOUS' is not a valid \
+GHCR image URI (expected 'ghcr.io/<owner>/<repo>:<tag>')."
+    echo "[i6] inspect $STATE_PATH and repair the 'previous' field (or clear \
+it to fail-fast on the next rollback)."
+    exit 14
   fi
   # Rollback uses the previously deployed image URI from state — not a git ref.
   WEB_IMAGE="$STATE_PREVIOUS"
@@ -971,6 +1042,53 @@ if [ "$WEB_HEALTH" != "healthy" ]; then
   exit 34
 fi
 
+# Apply pending Alembic migrations against the canonical DB (RDS in prod).
+# This runs inside the freshly-started web container, after the container is
+# healthy (gunicorn up, DATABASE_URL connectable) but BEFORE the /healthz
+# smoke check validates the deploy. Rationale: /healthz does not exercise
+# schema-bound endpoints, so it passes even when the DB is N revisions behind
+# the deployed code — meaning a broken schema would ship and only break on
+# the first real request. Failing here aborts the deploy and blocks traffic.
+# See issue #1252.
+#
+# We intentionally do NOT run this in rollback mode: rolling back schema is
+# risky with multi-head merges and out-of-scope for the rollback path
+# (forward-only migrations is the policy).
+if [ "$MODE" = "deploy" ]; then
+  echo "[i6] applying pending alembic migrations (flask db upgrade)..."
+  ALEMBIC_STDERR="$(mktemp)"
+  if ! docker compose --env-file "$ENV_FILE" -f docker-compose.prod.yml \\
+       exec -T web flask db upgrade 2>"$ALEMBIC_STDERR"; then
+    echo "[i6] alembic upgrade failed"
+    echo "[i6] stderr:"
+    cat "$ALEMBIC_STDERR" || true
+    rm -f "$ALEMBIC_STDERR" || true
+    dump_compose_diagnostics
+    exit 36
+  fi
+  rm -f "$ALEMBIC_STDERR" || true
+  echo "[i6] alembic upgrade OK"
+
+  # Drift gate: assert flask db current == flask db heads. Mirrors the
+  # alembic_single_head CI gate but at deploy-time against the live DB. If
+  # this fails the deploy has applied migrations but the resulting tip
+  # diverges from the code's expected head — indicates alembic config drift
+  # or a manual edit to the live DB. Abort before flipping traffic.
+  CUR_REV="$(docker compose --env-file "$ENV_FILE" -f docker-compose.prod.yml \\
+    exec -T web flask db current 2>/dev/null \\
+    | awk '{{print $1}}' | tail -1)"
+  HEAD_REV="$(docker compose --env-file "$ENV_FILE" -f docker-compose.prod.yml \\
+    exec -T web flask db heads 2>/dev/null \\
+    | awk '{{print $1}}' | tail -1)"
+  echo "[i6] alembic current=$CUR_REV heads=$HEAD_REV"
+  if [ -z "$CUR_REV" ] || [ -z "$HEAD_REV" ] || [ "$CUR_REV" != "$HEAD_REV" ]; then
+    echo "[i6] alembic drift detected after upgrade: current='$CUR_REV' \
+heads='$HEAD_REV' — aborting deploy before traffic flips."
+    dump_compose_diagnostics
+    exit 37
+  fi
+fi
+
 echo "[i6] ensuring runtime TLS mode..."
 AUTO_REQUEST_TLS_CERT="true"
 if [ "{env_name}" = "dev" ]; then
@@ -1012,12 +1130,17 @@ PY
   if [ "$WEB_OK" = "true" ] \\
     && curl $CURL_FLAGS "$EDGE_HEALTH_URL" -H "Host: {domain}" >/dev/null; then
     echo "[i6] OK"
-    python3 - <<'PY' "$STATE_PATH" "$STATE_CURRENT" "$WEB_IMAGE"
+    python3 - <<'PY' "$STATE_PATH" "$STATE_CURRENT" "$WEB_IMAGE" "{schema_version}"
 import json,sys
 path=sys.argv[1]
 prev=sys.argv[2] or ""
 cur=sys.argv[3] or ""
-data={{"previous": prev, "current": cur}}
+schema_version=int(sys.argv[4])
+data={{
+  "schema_version": schema_version,
+  "previous": prev,
+  "current": cur,
+}}
 with open(path,"w",encoding="utf-8") as f:
   json.dump(data,f,indent=2,sort_keys=True)
 print("[i6] wrote deploy state:", path, data)

--- a/tests/test_aws_deploy_i6.py
+++ b/tests/test_aws_deploy_i6.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -8,6 +9,215 @@ from typing import Any
 import pytest
 
 from scripts import aws_deploy_i6
+
+# ---------------------------------------------------------------------------
+# GHCR URI validator (#1253)
+# ---------------------------------------------------------------------------
+
+
+def test_is_valid_ghcr_image_uri_accepts_canonical_ghcr_form() -> None:
+    assert (
+        aws_deploy_i6.is_valid_ghcr_image_uri("ghcr.io/italofelipe/auraxis-api:abc123")
+        is True
+    )
+
+
+def test_is_valid_ghcr_image_uri_accepts_full_sha_tag() -> None:
+    sha = "3d8274a495d97980753586a0fb80f71e595a7a9d"
+    assert (
+        aws_deploy_i6.is_valid_ghcr_image_uri(f"ghcr.io/italofelipe/auraxis-api:{sha}")
+        is True
+    )
+
+
+def test_is_valid_ghcr_image_uri_rejects_bare_git_sha() -> None:
+    bare_sha = "347450dd08db94595e192dfb90a0e194ab9fa890"
+    assert aws_deploy_i6.is_valid_ghcr_image_uri(bare_sha) is False
+
+
+def test_is_valid_ghcr_image_uri_rejects_dockerhub_form() -> None:
+    assert aws_deploy_i6.is_valid_ghcr_image_uri("library/auraxis-api:latest") is False
+
+
+def test_is_valid_ghcr_image_uri_rejects_missing_tag() -> None:
+    assert (
+        aws_deploy_i6.is_valid_ghcr_image_uri("ghcr.io/italofelipe/auraxis-api")
+        is False
+    )
+
+
+def test_is_valid_ghcr_image_uri_rejects_empty_string() -> None:
+    assert aws_deploy_i6.is_valid_ghcr_image_uri("") is False
+
+
+def test_is_valid_ghcr_image_uri_rejects_whitespace_only() -> None:
+    assert aws_deploy_i6.is_valid_ghcr_image_uri("   ") is False
+
+
+def test_is_valid_ghcr_image_uri_rejects_none_like_inputs() -> None:
+    assert aws_deploy_i6.is_valid_ghcr_image_uri(None) is False  # type: ignore[arg-type]
+    assert aws_deploy_i6.is_valid_ghcr_image_uri(123) is False  # type: ignore[arg-type]
+
+
+def test_ghcr_image_uri_pattern_matches_bash_regex() -> None:
+    """The Python validator and the bash regex must agree on the same shape.
+
+    The deploy script embeds an extended-regex (ERE) variant of this pattern
+    inside the SSM bash heredoc for in-container validation. If they diverge,
+    operators get inconsistent behavior between dry-run and live-run paths.
+    """
+    pattern = aws_deploy_i6.GHCR_IMAGE_URI_PATTERN
+    assert pattern.startswith("^ghcr\\.io/")
+    # The pattern must require a tag (":<something>").
+    assert ":" in pattern
+    compiled = re.compile(pattern)
+    assert compiled.match("ghcr.io/italofelipe/auraxis-api:v1") is not None
+    assert compiled.match("347450dd08db94595e192dfb90a0e194ab9fa890") is None
+
+
+# ---------------------------------------------------------------------------
+# Rollback bash-template assertions (#1253)
+# ---------------------------------------------------------------------------
+
+
+def test_build_script_rollback_validates_state_previous_against_ghcr_regex() -> None:
+    script = aws_deploy_i6._build_script(
+        env_name="prod",
+        aws_region="us-east-1",
+        git_ref=None,
+        mode="rollback",
+    )
+    # The rollback branch must guard STATE_PREVIOUS with the canonical pattern
+    # before assigning it to WEB_IMAGE.
+    assert 'if [ "$MODE" = "rollback" ]; then' in script
+    assert "ghcr\\.io/" in script
+    # The error message must mention the state file path so operators can
+    # locate and repair it.
+    assert aws_deploy_i6.DEPLOY_STATE_PATH in script
+    assert "not a valid GHCR image URI" in script
+    # Must use a distinct exit code from "no previous deploy recorded" (12).
+    assert "exit 14" in script
+
+
+def test_build_script_rollback_preserves_empty_state_previous_path() -> None:
+    """Empty STATE_PREVIOUS must still hit the original 'no previous deploy
+    recorded' branch (exit 12), not the new invalid-URI branch (exit 14).
+    """
+    script = aws_deploy_i6._build_script(
+        env_name="prod",
+        aws_region="us-east-1",
+        git_ref=None,
+        mode="rollback",
+    )
+    # Empty-string guard appears before the format validation guard.
+    empty_guard_idx = script.find('if [ -z "$STATE_PREVIOUS" ]; then')
+    format_guard_idx = script.find("not a valid GHCR image URI")
+    assert empty_guard_idx != -1, "expected empty-state guard"
+    assert format_guard_idx != -1, "expected format-validation guard"
+    assert empty_guard_idx < format_guard_idx, (
+        "empty-state guard must run before format-validation guard so empty "
+        "STATE_PREVIOUS exits 12, not 14"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Deploy-state schema versioning (#1253)
+# ---------------------------------------------------------------------------
+
+
+def test_deploy_state_schema_version_constant_is_defined() -> None:
+    assert isinstance(aws_deploy_i6.DEPLOY_STATE_SCHEMA_VERSION, int)
+    assert aws_deploy_i6.DEPLOY_STATE_SCHEMA_VERSION >= 2
+
+
+def test_build_script_writes_schema_version_to_deploy_state() -> None:
+    script = aws_deploy_i6._build_script(
+        env_name="prod",
+        aws_region="us-east-1",
+        git_ref="origin/master",
+        mode="deploy",
+    )
+    # The script must persist the schema_version so future state migrations
+    # can detect this format.
+    assert "schema_version" in script
+    assert f"{aws_deploy_i6.DEPLOY_STATE_SCHEMA_VERSION}" in script
+
+
+# ---------------------------------------------------------------------------
+# Migration step on deploy (#1252)
+# ---------------------------------------------------------------------------
+
+
+def test_build_script_deploy_runs_flask_db_upgrade_before_healthz_validation() -> None:
+    script = aws_deploy_i6._build_script(
+        env_name="prod",
+        aws_region="us-east-1",
+        git_ref="origin/master",
+        mode="deploy",
+    )
+
+    # Must invoke 'flask db upgrade' inside the running web container.
+    assert "flask db upgrade" in script
+
+    # Position check: the migration step must appear AFTER 'compose ... up -d'
+    # for the web container, and BEFORE the /healthz curl validation loop.
+    upgrade_idx = script.find("flask db upgrade")
+    healthz_idx = script.find("validating healthz")
+    web_up_idx = script.find("swapping web container")
+
+    assert web_up_idx != -1, "expected web container swap section"
+    assert upgrade_idx != -1, "expected flask db upgrade invocation"
+    assert healthz_idx != -1, "expected /healthz validation section"
+    assert web_up_idx < upgrade_idx < healthz_idx, (
+        "flask db upgrade must run after the web container is up and "
+        "before the /healthz validation loop"
+    )
+
+
+def test_build_script_aborts_when_alembic_upgrade_fails() -> None:
+    script = aws_deploy_i6._build_script(
+        env_name="prod",
+        aws_region="us-east-1",
+        git_ref="origin/master",
+        mode="deploy",
+    )
+    # The script must abort with a distinct exit code if the alembic upgrade
+    # exits non-zero. We use exit 36 (next free slot after the existing
+    # 30-35 deploy-stage exits).
+    assert "exit 36" in script
+    # Must surface the alembic stderr in the log so on-call has a starting
+    # point — the existing dump_compose_diagnostics helper covers this.
+    assert "alembic upgrade failed" in script
+
+
+def test_build_script_asserts_alembic_current_equals_heads_after_upgrade() -> None:
+    """AC: post-deploy assertion that flask db current == flask db heads."""
+    script = aws_deploy_i6._build_script(
+        env_name="prod",
+        aws_region="us-east-1",
+        git_ref="origin/master",
+        mode="deploy",
+    )
+    assert "flask db current" in script
+    assert "flask db heads" in script
+    # Drift exit code, distinct from upgrade failure (36).
+    assert "exit 37" in script
+
+
+def test_build_script_rollback_does_not_run_flask_db_upgrade() -> None:
+    """Rollback must NOT run migrations — schema downgrades are out of scope."""
+    script = aws_deploy_i6._build_script(
+        env_name="prod",
+        aws_region="us-east-1",
+        git_ref=None,
+        mode="rollback",
+    )
+    # Note: the script template is the same for deploy and rollback; the
+    # migration block must be gated by MODE so it only runs on deploy.
+    # We assert the gate is present.
+    assert 'if [ "$MODE" = "deploy" ]; then' in script or (
+        '[ "$MODE" = "deploy" ]' in script
+    )
 
 
 def test_extract_invocation_report_truncates_and_maps_fields() -> None:


### PR DESCRIPTION
## Summary

Bundles two P0 deploy-script fixes uncovered by the 2026-05-16 production incident. Both fixes touch the same file (`scripts/aws_deploy_i6.py`) so they ship together.

Closes #1252
Closes #1253

## #1252 — Apply Alembic migrations before /healthz

The SSM bash heredoc now runs `flask db upgrade` inside the freshly-started web container, **after** Docker reports the container healthy and **before** the `/healthz` smoke check. Rationale: `/healthz` doesn't exercise schema-bound endpoints, so it passes even when the DB is N revisions behind the deployed code (root cause of the 2026-05-16 outage).

- If `flask db upgrade` exits non-zero: surface stderr, dump compose diagnostics, abort with **exit 36** — no traffic flips.
- Post-upgrade drift gate: assert `flask db current == flask db heads` against the live DB; abort with **exit 37** on divergence.
- The migration block is gated by `MODE = "deploy"` so rollback never attempts schema changes.

## #1253 — Validate rollback target as GHCR URI

In the rollback branch, `STATE_PREVIOUS` is now matched against the canonical GHCR URI pattern (`^ghcr\.io/.+:.+$`) **before** being assigned to `WEB_IMAGE`.

- Legacy state files (pre-#1253) storing bare 40-char git SHAs trigger **exit 14** with an actionable message pointing at `$STATE_PATH` and the expected format.
- Distinct from existing **exit 12** (`no previous deploy recorded`) so on-call can tell the two failure modes apart at a glance.
- Validation lives in `is_valid_ghcr_image_uri()` at module level for unit-testability; bash uses the equivalent ERE pattern via `grep -Eq`.
- Bumps `deploy_state.json` to `schema_version=2` on every successful deploy; older files without `schema_version` trigger a one-line warning on read.

## Out of scope (per issue bodies)

- `repair-state` subcommand listed as "optional" in #1253 — skipped to keep the PR focused; the explicit error message tells operators exactly which file to repair manually. Capture in a follow-up if it's needed in practice.
- `docker-compose.prod.yml` and `scripts/entrypoint_prod.sh` — owned by the parallel #1254 PR; zero overlap with this branch.

## Tests added (21 cases, all green)

`tests/test_aws_deploy_i6.py` gained:

- GHCR validator: accepts canonical form, full-SHA tag; rejects bare SHA, Docker Hub form, missing tag, empty, whitespace, non-strings.
- Pattern parity: confirms `GHCR_IMAGE_URI_PATTERN` compiles under Python `re` and stays in sync with the bash regex.
- Rollback bash assertions: empty-state guard precedes format-validation guard so empty `STATE_PREVIOUS` still hits exit 12 (not 14); error message references `DEPLOY_STATE_PATH`; exit 14 is present.
- Schema-version: constant defined as int ≥ 2; rendered bash persists `schema_version` into deploy_state.json.
- Migration step: rendered bash invokes `flask db upgrade` strictly between `swapping web container` and `validating healthz`; aborts with exit 36 on upgrade failure ("alembic upgrade failed" in log); current/heads drift gate present with exit 37; rollback mode does NOT contain the migration block ungated.

## Test plan

- [x] `pytest tests/test_aws_deploy_i6.py` — 21/21 passed locally.
- [x] `ruff check` + `ruff format --check` — clean on changed files and full project.
- [x] `mypy app` — clean (96 pre-existing `Untyped decorator` warnings unrelated to this PR exist on master under a fresh pyenv install; they reproduce on `git checkout origin/master`).
- [x] Bandit — `app/` clean (only B404/B603 on `scripts/` for `subprocess`, both pre-existing on master and skipped by the project bandit gate which only scans `app/`).
- [ ] CI green on PR.
- [ ] Production rehearsal of `aws_deploy_i6.py deploy --env prod` against a no-op revision before next real deploy.

## Coverage scope note

The project `--cov=app --cov-fail-under=85` gate explicitly excludes `scripts/`, so this PR adds extensive bash-template assertions and pure-Python validator tests but does not move the coverage needle for `app/`. Expanding the coverage gate to include `scripts/` is a separate decision out of scope here.

## Operator changes

- Rollback now exits 14 instead of attempting a doomed `docker pull` on a bare SHA. Runbook follow-up: document the `inspect $STATE_PATH` repair step.
- Deploys that need pending migrations no longer require manual SSM intervention — they apply automatically before traffic flips. A migration failure now aborts the deploy with the alembic stderr in the CloudWatch log instead of allowing a broken-schema container to take traffic.