### PR TITLE
fix(ai): count insight quota only after successful generation

### DIFF
--- a/app/middleware/ai_rate_limit.py
+++ b/app/middleware/ai_rate_limit.py
@@ -4,6 +4,10 @@ Enforces a maximum of AI_DAILY_LIMIT calls per user per calendar day (BRT timezo
 The counter is backed by Redis when available; falls back to an in-process
 dictionary for test environments where Redis is not configured.
 
+Only successful, non-cached insight generations consume the daily allowance.
+Provider/configuration errors and cached responses do not count because no new
+LLM result was produced for the user.
+
 Usage (in MethodResource views):
     @jwt_required()
     @ai_daily_limit()
@@ -98,24 +102,36 @@ class _InMemoryAICounter:
             return cls._counts[key]
 
     @classmethod
+    def get(cls, key: str) -> int:
+        with cls._lock:
+            return cls._counts.get(key, 0)
+
+    @classmethod
     def reset(cls) -> None:
         with cls._lock:
             cls._counts.clear()
 
 
-def check_ai_daily_limit(
-    user_id: UUID,
-    *,
-    max_calls: int = AI_DAILY_LIMIT,
-) -> tuple[int, int]:
-    """Increment and return the daily AI call counter for *user_id*.
+def _counter_key(user_id: UUID) -> str:
+    return f"auraxis:ai-daily:{user_id}:{_brt_date_str()}"
 
-    Returns:
-        (current_count, retry_after_seconds)
 
-    A caller that receives current_count > max_calls MUST reject the request.
-    """
-    key = f"auraxis:ai-daily:{user_id}:{_brt_date_str()}"
+def get_ai_daily_usage(user_id: UUID) -> tuple[int, int]:
+    """Return current daily successful insight count without incrementing it."""
+    key = _counter_key(user_id)
+    ttl = _seconds_until_midnight_brt()
+
+    client = _get_redis()
+    if client is not None:
+        raw_count = client.get(key)
+        return int(raw_count or 0), ttl
+
+    return _InMemoryAICounter.get(key), ttl
+
+
+def record_ai_daily_success(user_id: UUID) -> tuple[int, int]:
+    """Increment the daily counter after a successful, non-cached AI insight."""
+    key = _counter_key(user_id)
     ttl = _seconds_until_midnight_brt()
 
     client = _get_redis()
@@ -126,6 +142,37 @@ def check_ai_daily_limit(
         return count, ttl
 
     return _InMemoryAICounter.incr(key, ttl), ttl
+
+
+def check_ai_daily_limit(
+    user_id: UUID,
+    *,
+    max_calls: int = AI_DAILY_LIMIT,
+) -> tuple[int, int]:
+    """Increment and return the legacy daily AI call counter for *user_id*.
+
+    Returns:
+        (current_count, retry_after_seconds)
+
+    A caller that receives current_count > max_calls MUST reject the request.
+    """
+    _ = max_calls
+    return record_ai_daily_success(user_id)
+
+
+def _is_countable_ai_success(response: Response) -> bool:
+    """Return True when this response represents a new AI generation."""
+    if not 200 <= response.status_code < 300:
+        return False
+
+    payload = response.get_json(silent=True)
+    if isinstance(payload, dict):
+        data = payload.get("data")
+        result_payload = data if isinstance(data, dict) else payload
+        if result_payload.get("cached") is True:
+            return False
+
+    return True
 
 
 def ai_daily_limit(
@@ -154,10 +201,9 @@ def ai_daily_limit(
             if not has_entitlement(user_id, "advanced_simulations"):
                 return cast(Response, fn(*args, **kwargs))
 
-            count, retry_after = check_ai_daily_limit(user_id, max_calls=max_calls)
-            remaining = max(0, max_calls - count)
+            count, retry_after = get_ai_daily_usage(user_id)
 
-            if count > max_calls:
+            if count >= max_calls:
                 resp = compat_error_response(
                     legacy_payload={"error": AI_DAILY_LIMIT_MESSAGE},
                     status_code=429,
@@ -169,6 +215,10 @@ def ai_daily_limit(
                 return resp
 
             response = cast(Response, fn(*args, **kwargs))
+            if _is_countable_ai_success(response):
+                count, retry_after = record_ai_daily_success(user_id)
+
+            remaining = max(0, max_calls - count)
             response.headers["X-AI-Calls-Remaining"] = str(remaining)
             return response
 
@@ -183,6 +233,8 @@ __all__ = [
     "AI_DAILY_LIMIT_MESSAGE",
     "ai_daily_limit",
     "check_ai_daily_limit",
+    "get_ai_daily_usage",
+    "record_ai_daily_success",
     "_InMemoryAICounter",
     "_brt_date_str",
     "_seconds_until_midnight_brt",

--- a/docs/wiki/AI-Insights-Rate-Limit.md
+++ b/docs/wiki/AI-Insights-Rate-Limit.md
@@ -1,0 +1,38 @@
+# AI Insights Rate Limit
+
+Manual AI insights are limited to 2 successful generations per user per BRT
+calendar day.
+
+## What Counts
+
+A request consumes one daily slot only when all of the following are true:
+
+- the user is Premium and passes the entitlement gate;
+- the endpoint returns a 2xx response;
+- the response represents a new LLM generation;
+- the response is not served from the persisted insight cache.
+
+## What Does Not Count
+
+The daily counter is not consumed by:
+
+- unauthenticated requests;
+- users without the `advanced_simulations` entitlement;
+- validation errors;
+- OpenAI/Anthropic provider errors, including quota and invalid-key failures;
+- internal errors before a usable insight is returned;
+- cached spending insights returned with `cached=true`.
+
+This avoids penalizing users for infrastructure, provider, or configuration
+failures where Auraxis did not produce a new AI insight.
+
+## Response Headers
+
+Successful and failed pass-through responses include `X-AI-Calls-Remaining`
+when they reach the AI daily-limit middleware. Requests blocked by the quota
+return:
+
+- HTTP `429`;
+- error code `AI_DAILY_LIMIT_EXCEEDED`;
+- `Retry-After` with seconds until the next BRT day;
+- `X-AI-Calls-Remaining: 0`.

--- a/tests/test_ai_daily_rate_limit.py
+++ b/tests/test_ai_daily_rate_limit.py
@@ -9,6 +9,7 @@ Coverage areas:
     - 1st call → 200 + X-AI-Calls-Remaining: 1
     - 2nd call → 200 + X-AI-Calls-Remaining: 0
     - 3rd call → 429 + error_code AI_DAILY_LIMIT_EXCEEDED + Retry-After header
+    - provider failures and cached responses do not consume the daily allowance
 - Free user still gets 403 from entitlement gate (never reaches rate limit)
 - Goal projection endpoint NOT rate-limited (not /ai/insights/*)
 """
@@ -19,6 +20,8 @@ import uuid
 from unittest.mock import patch
 
 import pytest
+
+from app.services.llm_provider import LLMProviderError
 
 # ---------------------------------------------------------------------------
 # Helpers (same pattern as test_ai_advisory_service.py)
@@ -261,6 +264,53 @@ class TestAIDailyRateLimitHTTP:
         assert data["error"]["code"] == "AI_DAILY_LIMIT_EXCEEDED"
         assert "Retry-After" in resp.headers
         assert resp.headers.get("X-AI-Calls-Remaining") == "0"
+
+    def test_provider_failure_does_not_consume_daily_limit(self, app, client) -> None:
+        token = _register_and_login(client, "ai-rl-provider-fail")
+        _grant_premium(app, token)
+
+        with patch(
+            "app.services.ai_advisory_service.AIAdvisoryService.generate_spending_insights",
+            side_effect=[
+                LLMProviderError("provider down"),
+                {
+                    "insights": "ok",
+                    "tokens_used": 10,
+                    "cost_usd": 0.0,
+                    "month": "2026-05",
+                    "model": "stub",
+                    "cached": False,
+                },
+            ],
+        ):
+            failed = client.get("/ai/insights/spending", headers=_auth(token, v2=True))
+            recovered = client.get("/ai/insights/spending", headers=_auth(token))
+
+        assert failed.status_code == 500
+        assert recovered.status_code == 200
+        assert recovered.headers.get("X-AI-Calls-Remaining") == "1"
+
+    def test_cached_spending_insight_does_not_consume_daily_limit(
+        self, app, client
+    ) -> None:
+        token = _register_and_login(client, "ai-rl-cached")
+        _grant_premium(app, token)
+
+        with patch(
+            "app.services.ai_advisory_service.AIAdvisoryService.generate_spending_insights",
+            return_value={
+                "insights": "cached insight",
+                "tokens_used": 10,
+                "cost_usd": 0.0,
+                "month": "2026-05",
+                "model": "stub",
+                "cached": True,
+            },
+        ):
+            resp = client.get("/ai/insights/spending", headers=_auth(token))
+
+        assert resp.status_code == 200
+        assert resp.headers.get("X-AI-Calls-Remaining") == "2"
 
     def test_429_message_is_portuguese(self, app, client) -> None:
         token = _register_and_login(client, "ai-rl-ptbr")


### PR DESCRIPTION
## Summary
- Split AI insight quota checking from quota consumption.
- Consume the daily slot only after a successful 2xx non-cached insight response.
- Keep provider/configuration failures and cached responses from reducing the user daily allowance.
- Document the AI insights rate-limit behavior in docs/wiki/AI-Insights-Rate-Limit.md.

## Root Cause
The AI daily-limit middleware incremented the counter before the endpoint called the LLM provider. When OpenAI returned quota/auth/config errors, Auraxis returned 500 but still consumed one of the user daily insight slots. Cached insight responses were also counted even though no new LLM generation happened.

## Validation
- `/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-api/.venv/bin/python -m pytest tests/test_ai_daily_rate_limit.py tests/test_ai_advisory_service.py -q` -> 54 passed.
- `/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-api/.venv/bin/python -m ruff check app/middleware/ai_rate_limit.py tests/test_ai_daily_rate_limit.py` -> passed.
- `/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-api/.venv/bin/python -m mypy app/middleware/ai_rate_limit.py` -> passed.
- `git diff --check` -> passed.
- `bash scripts/run_ci_quality_local.sh --local` -> blocked by the existing repo-wide mypy baseline: 96 errors in 35 unrelated files. The changed middleware passes isolated mypy.

Closes #1264