### PR TITLE
fix(ai): enforce structured spending insights

### DIFF
--- a/app/controllers/ai/resources.py
+++ b/app/controllers/ai/resources.py
@@ -81,11 +81,22 @@ class AISpendingInsightsResource(MethodResource):
                 description="Insights gerados com sucesso",
                 message="Insights de gastos gerados com sucesso",
                 data_example={
-                    "insights": "1. Gasto elevado em alimentação...",
+                    "insights": (
+                        '[{"type":"saude_financeira","title":"Resumo",'
+                        '"message":"Mensagem acionável."}]'
+                    ),
+                    "items": [
+                        {
+                            "type": "saude_financeira",
+                            "title": "Resumo",
+                            "message": "Mensagem acionável.",
+                        }
+                    ],
                     "tokens_used": 320,
                     "cost_usd": 0.000048,
                     "month": "2026-05",
                     "model": "gpt-4o-mini",
+                    "cached": False,
                 },
             ),
             401: json_error_response(

--- a/app/services/ai_advisory_service.py
+++ b/app/services/ai_advisory_service.py
@@ -39,6 +39,51 @@ from app.services.weekly_summary import compute_weekly_summary
 
 log = logging.getLogger(__name__)
 
+_SPENDING_INSIGHT_TYPES = (
+    "gasto_elevado",
+    "oportunidade_economia",
+    "saude_financeira",
+    "alerta_orcamento",
+    "padrao_gasto",
+    "alerta_meta",
+    "progresso_meta",
+    "orcamento_ultrapassado",
+    "planejamento_meta",
+    "saude_orcamento_mensal",
+    "conquista_meta",
+    "savings_rate_gap",
+)
+
+_SPENDING_INSIGHTS_RESPONSE_SCHEMA: dict[str, Any] = {
+    "name": "spending_insight_items",
+    "strict": True,
+    "schema": {
+        "type": "object",
+        "properties": {
+            "items": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "enum": list(_SPENDING_INSIGHT_TYPES),
+                        },
+                        "title": {"type": "string"},
+                        "message": {"type": "string"},
+                    },
+                    "required": ["type", "title", "message"],
+                    "additionalProperties": False,
+                },
+            }
+        },
+        "required": ["items"],
+        "additionalProperties": False,
+    },
+}
+
+InsightItem = dict[str, str]
+
 
 # ---------------------------------------------------------------------------
 # AIInsight persistence helpers
@@ -52,7 +97,7 @@ def _get_cached_insight(
     period_label: str,
 ) -> AIInsight | None:
     """Return an existing AIInsight for this user/type/period, or None."""
-    return (
+    insight: AIInsight | None = (
         db.session.query(AIInsight)
         .filter_by(
             user_id=user_id,
@@ -61,16 +106,18 @@ def _get_cached_insight(
         )
         .first()
     )
+    return insight
 
 
 def _get_latest_insight(*, user_id: UUID) -> AIInsight | None:
     """Return the most recently created AIInsight for this user, or None."""
-    return (
+    insight: AIInsight | None = (
         db.session.query(AIInsight)
         .filter_by(user_id=user_id)
         .order_by(AIInsight.created_at.desc())
         .first()
     )
+    return insight
 
 
 def _save_insight(
@@ -116,6 +163,65 @@ def _safe_float(value: object) -> float:
         return float(value or 0)  # type: ignore[arg-type]
     except (TypeError, ValueError):
         return 0.0
+
+
+def _strip_json_code_fence(content: str) -> str:
+    text = content.strip()
+    if not text.startswith("```"):
+        return text
+
+    first_newline = text.find("\n")
+    if first_newline == -1:
+        return text
+
+    text = text[first_newline + 1 :]
+    if text.rstrip().endswith("```"):
+        text = text.rstrip()[:-3]
+    return text.strip()
+
+
+def _coerce_spending_insight_items(content: str) -> list[InsightItem]:
+    raw = _strip_json_code_fence(content)
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise LLMProviderError("Invalid spending insight JSON.") from exc
+
+    candidate_items = parsed.get("items") if isinstance(parsed, dict) else parsed
+    if not isinstance(candidate_items, list) or not candidate_items:
+        raise LLMProviderError("Invalid spending insight items.")
+
+    items: list[InsightItem] = []
+    for candidate in candidate_items:
+        if not isinstance(candidate, dict):
+            raise LLMProviderError("Invalid spending insight item.")
+
+        item_type = candidate.get("type")
+        title = candidate.get("title")
+        message = candidate.get("message")
+        if (
+            not isinstance(item_type, str)
+            or not item_type.strip()
+            or not isinstance(title, str)
+            or not title.strip()
+            or not isinstance(message, str)
+            or not message.strip()
+        ):
+            raise LLMProviderError("Invalid spending insight item fields.")
+
+        items.append(
+            {
+                "type": item_type.strip(),
+                "title": title.strip(),
+                "message": message.strip(),
+            }
+        )
+
+    return items
+
+
+def _serialize_spending_insight_items(items: list[InsightItem]) -> str:
+    return json.dumps(items, ensure_ascii=False, separators=(",", ":"))
 
 
 def _log_llm_call(
@@ -189,8 +295,8 @@ class AIAdvisoryService:
             month: "YYYY-MM" string. Defaults to the current calendar month.
 
         Returns:
-            {"insights": str, "tokens_used": int, "cost_usd": float,
-             "month": "YYYY-MM", "model": str, "cached": bool}
+            {"insights": str, "items": list[dict], "tokens_used": int,
+             "cost_usd": float, "month": "YYYY-MM", "model": str, "cached": bool}
         """
         today = date.today()
         if month:
@@ -214,8 +320,19 @@ class AIAdvisoryService:
             period_label=period_label,
         )
         if cached is not None:
+            cached_items: list[InsightItem] = []
+            try:
+                cached_items = _coerce_spending_insight_items(cached.content)
+            except LLMProviderError:
+                log.warning(
+                    "ai_advisory.spending_insights.cached_parse_failed "
+                    "user=%s insight=%s",
+                    self._user_id,
+                    cached.id,
+                )
             return {
                 "insights": cached.content,
+                "items": cached_items,
                 "tokens_used": cached.tokens_used,
                 "cost_usd": float(cached.cost_usd),
                 "month": f"{year}-{mon:02d}",
@@ -277,7 +394,10 @@ class AIAdvisoryService:
         )
 
         try:
-            llm_resp = self._provider.generate_with_usage(prompt)
+            llm_resp = self._provider.generate_with_usage(
+                prompt,
+                response_schema=_SPENDING_INSIGHTS_RESPONSE_SCHEMA,
+            )
         except LLMProviderError as exc:
             log.warning(
                 "ai_advisory.spending_insights.llm_error user=%s error=%s",
@@ -285,6 +405,9 @@ class AIAdvisoryService:
                 exc,
             )
             raise
+
+        insight_items = _coerce_spending_insight_items(llm_resp.content)
+        serialized_insights = _serialize_spending_insight_items(insight_items)
 
         _log_llm_call(
             user_id=self._user_id,
@@ -295,7 +418,7 @@ class AIAdvisoryService:
 
         _save_insight(
             user_id=self._user_id,
-            content=llm_resp.content,
+            content=serialized_insights,
             insight_type=insight_type,
             period_label=period_label,
             period_start=start,
@@ -307,7 +430,8 @@ class AIAdvisoryService:
         )
 
         return {
-            "insights": llm_resp.content,
+            "insights": serialized_insights,
+            "items": insight_items,
             "tokens_used": llm_resp.total_tokens,
             "cost_usd": llm_resp.estimated_cost_usd,
             "month": f"{year}-{mon:02d}",
@@ -375,6 +499,25 @@ class AIAdvisoryService:
             .all()
         )
 
+        pending_expense_rows = (
+            db.session.query(
+                Transaction.description.label("description"),
+                func.sum(Transaction.amount).label("total"),
+            )
+            .filter(
+                Transaction.user_id == self._user_id,
+                Transaction.deleted.is_(False),
+                Transaction.type == TransactionType.EXPENSE,
+                Transaction.status == TransactionStatus.PENDING,
+                Transaction.due_date >= start,
+                Transaction.due_date <= end,
+            )
+            .group_by(Transaction.description)
+            .order_by(func.sum(Transaction.amount).desc())
+            .limit(5)
+            .all()
+        )
+
         top_expenses = [
             {
                 "description": r.description or "Sem descrição",
@@ -382,9 +525,20 @@ class AIAdvisoryService:
             }
             for r in category_rows
         ]
+        pending_expenses = [
+            {
+                "description": r.description or "Sem descrição",
+                "total": _safe_float(r.total),
+            }
+            for r in pending_expense_rows
+        ]
 
         total_expense = _safe_float(row.total_expense)
         total_income = _safe_float(row.total_income)
+        pending_expense_total = round(
+            sum(float(item["total"]) for item in pending_expenses),
+            2,
+        )
         balance = round(total_income - total_expense, 2)
         savings_rate = (
             round((total_income - total_expense) / total_income * 100, 1)
@@ -397,10 +551,12 @@ class AIAdvisoryService:
             "period_end": end.isoformat(),
             "total_expense": round(total_expense, 2),
             "total_income": round(total_income, 2),
+            "pending_expense_total": pending_expense_total,
             "balance": balance,
             "savings_rate_pct": savings_rate,
             "transaction_count": int(row.tx_count or 0),
             "top_expenses": top_expenses,
+            "pending_expenses": pending_expenses,
         }
 
     # ------------------------------------------------------------------
@@ -1011,9 +1167,14 @@ def _build_spending_prompt(
         )
 
     goals_block = ""
-    if goals:
+    if goals is not None and len(goals) > 0:
         goals_json = json.dumps(goals, ensure_ascii=False, default=str)
         goals_block = f"\nMetas financeiras ativas do usuário:\n{goals_json}\n"
+    elif goals is not None:
+        goals_block = (
+            "\nMetas financeiras ativas do usuário: Nenhuma meta financeira ativa "
+            "cadastrada. Não invente metas e não trate orçamento como meta.\n"
+        )
 
     budget_block = ""
     if budget:
@@ -1083,13 +1244,17 @@ def _build_spending_prompt(
 
     return (
         f"Você é um consultor financeiro pessoal. Analise os dados de gastos de {month_label} "  # noqa: E501
-        "abaixo e gere 3 insights práticos e personalizados em português brasileiro. "
+        "abaixo e gere 3 insights detalhados, práticos e personalizados em "
+        "português brasileiro. "
         f"Para cada insight, identifique o tipo ({cross_domain_types}), "
-        "um título curto e uma recomendação específica e acionável.\n"
+        "um título curto e uma mensagem com: evidência numérica dos dados, "
+        "interpretação financeira e uma próxima ação específica.\n"
         f"{previous_block}"
         f"\nDados financeiros do período:\n{context}\n"
         f"{goals_block}"
         f"{budget_block}\n"
+        "Despesas com status pending são compromissos futuros; não trate como gasto "
+        "já realizado.\n"
         "Ao identificar cruzamentos entre gastos e metas (ex: crescimento de gastos "
         "comprometendo prazo de uma meta), priorize insights dos tipos alerta_meta, "
         "progresso_meta ou planejamento_meta.\n\n"

--- a/app/services/llm_provider.py
+++ b/app/services/llm_provider.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import os
 import time
 from dataclasses import dataclass
-from typing import Protocol, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 
 class LLMProviderError(Exception):
@@ -58,7 +58,12 @@ class LLMProvider(Protocol):
         """Generate a response for *prompt*. Raises LLMProviderError on failure."""
         ...
 
-    def generate_with_usage(self, prompt: str) -> LLMResponse:
+    def generate_with_usage(
+        self,
+        prompt: str,
+        *,
+        response_schema: dict[str, Any] | None = None,
+    ) -> LLMResponse:
         """Generate a response and return structured usage data."""
         ...
 
@@ -77,9 +82,20 @@ class StubLLMProvider:
     def generate(self, prompt: str) -> str:  # noqa: ARG002
         return self._STUB_CONTENT
 
-    def generate_with_usage(self, prompt: str) -> LLMResponse:  # noqa: ARG002
+    def generate_with_usage(  # noqa: ARG002
+        self,
+        prompt: str,
+        *,
+        response_schema: dict[str, Any] | None = None,
+    ) -> LLMResponse:
+        content = self._STUB_CONTENT
+        if response_schema is not None:
+            content = (
+                '{"items":[{"type":"saude_financeira","title":"Resumo financeiro",'
+                '"message":"Seus dados financeiros foram analisados com sucesso."}]}'
+            )
         return LLMResponse(
-            content=self._STUB_CONTENT,
+            content=content,
             prompt_tokens=150,
             completion_tokens=80,
             total_tokens=230,
@@ -100,12 +116,29 @@ class OpenAILLMProvider:
     def generate(self, prompt: str) -> str:
         return self.generate_with_usage(prompt).content
 
-    def generate_with_usage(self, prompt: str) -> LLMResponse:
+    def generate_with_usage(
+        self,
+        prompt: str,
+        *,
+        response_schema: dict[str, Any] | None = None,
+    ) -> LLMResponse:
         if not self._api_key:
             raise LLMProviderError("OPENAI_API_KEY is not configured.")
         import requests  # lazy import to keep startup fast
 
         start = time.monotonic()
+        payload: dict[str, Any] = {
+            "model": self._model,
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": 512,
+            "temperature": 0.4,
+        }
+        if response_schema is not None:
+            payload["response_format"] = {
+                "type": "json_schema",
+                "json_schema": response_schema,
+            }
+
         try:
             resp = requests.post(
                 self._BASE_URL,
@@ -113,12 +146,7 @@ class OpenAILLMProvider:
                     "Authorization": f"Bearer {self._api_key}",
                     "Content-Type": "application/json",
                 },
-                json={
-                    "model": self._model,
-                    "messages": [{"role": "user", "content": prompt}],
-                    "max_tokens": 512,
-                    "temperature": 0.4,
-                },
+                json=payload,
                 timeout=20,
             )
             resp.raise_for_status()
@@ -150,7 +178,13 @@ class ClaudeLLMProvider:
     def generate(self, prompt: str) -> str:
         return self.generate_with_usage(prompt).content
 
-    def generate_with_usage(self, prompt: str) -> LLMResponse:
+    def generate_with_usage(
+        self,
+        prompt: str,
+        *,
+        response_schema: dict[str, Any] | None = None,
+    ) -> LLMResponse:
+        _ = response_schema
         if not self._api_key:
             raise LLMProviderError("ANTHROPIC_API_KEY is not configured.")
         import requests

--- a/docs/superpowers/plans/2026-05-17-ai-insights-structured-output.md
+++ b/docs/superpowers/plans/2026-05-17-ai-insights-structured-output.md
@@ -1,0 +1,217 @@
+# AI Insights Structured Output Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make AI spending insights persist and return valid structured data that the Web UI can render.
+
+**Architecture:** The API validates LLM output before persistence and returns both `items` and legacy `insights`. The Web app prefers `items` and tolerates legacy fenced JSON. Production repair normalizes only the known malformed `AIInsight` row.
+
+**Tech Stack:** Flask, SQLAlchemy, OpenAI Chat Completions, pytest, Nuxt 4, Vue 3, TypeScript, Vitest.
+
+---
+
+### Task 1: Production Row Normalization
+
+**Files:**
+- No repository file changes.
+- Production DB row: `ai_insights.id=5508449c-1955-4382-99a7-209092a70d44`
+
+- [x] **Step 1: Read the current content**
+
+Run via AWS SSM on `i-0057e3b52162f78f8`:
+
+```bash
+cd /opt/auraxis
+docker compose --env-file .env.prod -f docker-compose.prod.yml exec -T web python - <<'PY'
+from uuid import UUID
+from app import create_app
+from app.extensions.database import db
+from app.models.ai_insight import AIInsight
+
+app = create_app(enable_http_runtime=False)
+with app.app_context():
+    row = db.session.get(AIInsight, UUID("5508449c-1955-4382-99a7-209092a70d44"))
+    print(repr(row.content if row else None))
+PY
+```
+
+- [x] **Step 2: Normalize only that row**
+
+```bash
+cd /opt/auraxis
+docker compose --env-file .env.prod -f docker-compose.prod.yml exec -T web python - <<'PY'
+import json
+from uuid import UUID
+from app import create_app
+from app.extensions.database import db
+from app.models.ai_insight import AIInsight
+
+def strip_fence(value: str) -> str:
+    text = value.strip()
+    if text.startswith("```"):
+        first_newline = text.find("\n")
+        if first_newline != -1:
+            text = text[first_newline + 1 :]
+        if text.rstrip().endswith("```"):
+            text = text.rstrip()[:-3]
+    return text.strip()
+
+app = create_app(enable_http_runtime=False)
+with app.app_context():
+    row = db.session.get(AIInsight, UUID("5508449c-1955-4382-99a7-209092a70d44"))
+    parsed = json.loads(strip_fence(row.content))
+    row.content = json.dumps(parsed, ensure_ascii=False, separators=(",", ":"))
+    db.session.commit()
+    print(row.content)
+PY
+```
+
+- [x] **Step 3: Verify the UI can now parse the cached insight**
+
+Call `GET /ai/insights/spending` with the user token and confirm `data.insights`
+starts with `[` and not with a Markdown fence.
+
+Production confirmation via SSM: `updated_id=5508449c-1955-4382-99a7-209092a70d44`,
+`after_prefix='[{"type":"pr'`, `items=3`, `valid_json=true`.
+
+### Task 2: Backend Parsing and Structured Output Tests
+
+**Files:**
+- Modify: `tests/test_ai_advisory_service.py`
+- Modify: `tests/test_ai_insight_persistence.py`
+- Modify: `tests/test_ai_insight_goals_budget_context.py`
+
+- [x] **Step 1: Add failing tests**
+
+Add tests asserting that fenced JSON is normalized, `items` is returned,
+malformed JSON raises `LLMProviderError`, and pending expenses appear in the
+prompt as pending context instead of paid expenses.
+
+- [x] **Step 2: Run focused tests and confirm failure**
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tests/test_ai_advisory_service.py \
+  tests/test_ai_insight_persistence.py \
+  tests/test_ai_insight_goals_budget_context.py \
+  -q
+```
+
+Expected: new tests fail because the backend currently persists raw LLM text
+and has no `items` payload.
+
+Observed RED: `OpenAILLMProvider.generate_with_usage()` rejected
+`response_schema`; after provider support, service tests failed on missing
+`items`.
+
+### Task 3: Backend Implementation
+
+**Files:**
+- Modify: `app/services/llm_provider.py`
+- Modify: `app/services/ai_advisory_service.py`
+- Modify: `app/controllers/ai/resources.py`
+- Modify: `docs/wiki/AI-Insights-Structured-Output.md`
+
+- [x] **Step 1: Add optional response schema support**
+
+Extend the provider protocol to accept `response_schema: dict[str, object] | None`
+on `generate_with_usage()`. OpenAI includes `response_format` only when the
+schema is provided.
+
+- [x] **Step 2: Add insight item parsing helpers**
+
+Create helpers in `ai_advisory_service.py` to strip fences, parse JSON, validate
+`type/title/message`, and serialize canonical JSON.
+
+- [x] **Step 3: Use structured output for spending insights**
+
+Pass the spending insight JSON schema to the provider, validate returned items,
+save canonical JSON, and return `items` plus `insights`.
+
+- [x] **Step 4: Enrich prompt context**
+
+Separate paid income, paid expense, pending expense, budgets, and goals. Ensure
+the prompt says no active goals exist when that is true.
+
+- [x] **Step 5: Run backend focused tests**
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tests/test_ai_advisory_service.py \
+  tests/test_ai_insight_persistence.py \
+  tests/test_ai_insight_goals_budget_context.py \
+  tests/test_ai_daily_rate_limit.py \
+  -q
+```
+
+Observed GREEN: `102 passed`.
+
+### Task 4: Frontend Contract and Parser
+
+**Files:**
+- Modify: `app/features/ai-insights/contracts/ai-insight.ts`
+- Modify: `app/features/ai-insights/model/ai-insight.ts`
+- Modify: `app/features/ai-insights/model/ai-insight.spec.ts`
+- Modify: `app/features/ai-insights/composables/useAIInsights.spec.ts`
+
+- [x] **Step 1: Add failing Vitest coverage**
+
+Add tests for fenced JSON, preferred `items`, legacy JSON, malformed fallback,
+and new insight type presentation metadata.
+
+- [x] **Step 2: Implement parser and contract changes**
+
+Add `items?: InsightItem[]` to DTOs, prefer `items` in generated mapping, strip
+code fences before parsing strings, and add labels for new types.
+
+- [x] **Step 3: Run frontend focused tests**
+
+```bash
+pnpm vitest run app/features/ai-insights/model/ai-insight.spec.ts app/features/ai-insights/composables/useAIInsights.spec.ts
+```
+
+Observed GREEN with coverage disabled for focused run:
+`pnpm vitest run --coverage.enabled=false ...` -> 2 files, 11 tests passed.
+
+### Task 5: Final Verification and PRs
+
+**Files:**
+- API PR closes `italofelipe/auraxis-api#1267`
+- Web PR closes `italofelipe/auraxis-web#855`
+
+- [x] **Step 1: API verification**
+
+```bash
+bash scripts/run_ci_quality_local.sh --local
+```
+
+Observed:
+
+- Focused API regression suite passed:
+  `tests/test_llm_provider.py`, `tests/test_ai_advisory_service.py`,
+  `tests/test_ai_insight_persistence.py`,
+  `tests/test_ai_insight_goals_budget_context.py`,
+  `tests/test_ai_daily_rate_limit.py`.
+- Focused `ruff check`, focused `mypy`, and `git diff --check` passed.
+- Full local gate passed feature flag hygiene, repo hygiene, GraphQL auth config,
+  Alembic single-head, entitlement matrix, security exception governance,
+  Bandit, `ruff format`, and `ruff check`.
+- Full local gate stopped at repository-wide `mypy` baseline with 94 errors in
+  34 files outside this change set. No remaining `mypy` errors were reported in
+  `app/services/ai_advisory_service.py` or `app/services/llm_provider.py`.
+
+- [x] **Step 2: Web verification**
+
+```bash
+pnpm quality-check
+```
+
+Observed GREEN: `pnpm quality-check` passed, including lint, typecheck,
+coverage (`3266 passed`), policy, contracts, codegen, and production build.
+
+- [ ] **Step 3: Publish draft PRs**
+
+Create one draft PR per repo. Include issue links, production evidence, local
+verification, and any known CI caveats.

--- a/docs/superpowers/specs/2026-05-17-ai-insights-structured-output-design.md
+++ b/docs/superpowers/specs/2026-05-17-ai-insights-structured-output-design.md
@@ -1,0 +1,89 @@
+# AI Insights Structured Output Design
+
+## Goal
+
+Make AI spending insights reliably renderable and more useful by enforcing a
+structured backend contract, normalizing legacy Markdown JSON, and separating
+financial context sent to the LLM.
+
+## Scope
+
+This work covers:
+
+- `auraxis-api` issue #1267: provider contract, response validation, richer
+  prompt context, API payload, documentation, and production row normalization.
+- `auraxis-web` issue #855: frontend parser tolerance and preferred `items`
+  rendering.
+
+It intentionally does not redesign the whole Insights IA page. The UI keeps the
+current card rendering and becomes compatible with the improved payload.
+
+## Architecture
+
+The backend remains the source of truth for the LLM contract. It will ask OpenAI
+for a schema-constrained object, normalize the result into a list of
+`InsightItem` dictionaries, persist JSON-only content, and return both `items`
+and the legacy `insights` string. The Web app will prefer `items`, but it will
+still parse `insights` or history `content` for old API responses.
+
+## Backend Design
+
+`app/services/llm_provider.py` gets optional structured output support for
+OpenAI Chat Completions. The provider accepts an optional JSON schema argument
+for `generate_with_usage()`. When present, OpenAI receives
+`response_format: {"type": "json_schema", "json_schema": {...}}`.
+
+`app/services/ai_advisory_service.py` owns the spending insight schema and
+validation. It parses the provider response, strips code fences only for legacy
+or non-structured providers, validates that each item has `type`, `title`, and
+`message`, then serializes the list as JSON before saving.
+
+The spending snapshot is expanded to separate paid income, paid expense, and
+pending expense. Budgets and goals are included as separate blocks, with an
+explicit "no active goals" state.
+
+## Frontend Design
+
+`app/features/ai-insights/contracts/ai-insight.ts` accepts optional `items` in
+generation payloads. `mapGeneratedInsight()` prefers `items`; if absent, it
+falls back to parsing `insights`. `parseInsightItems()` strips common Markdown
+code fences before parsing, so old history rows still render.
+
+Presentation metadata is extended for the insight types already produced by the
+backend prompt: `alerta_meta`, `progresso_meta`, `planejamento_meta`,
+`orcamento_ultrapassado`, `saude_orcamento_mensal`, `conquista_meta`, and
+`savings_rate_gap`.
+
+## Error Handling
+
+If the provider returns malformed output, the backend raises `LLMProviderError`
+and returns the existing 500 envelope. No `AIInsight` row is saved. With #1265
+deployed, that failed attempt does not consume the daily AI insight quota.
+
+Cached rows return the parsed `items` field when possible. If a cached row is
+unrecoverable, the backend should still return the legacy content, but the Web
+fallback remains deterministic.
+
+## Tests
+
+Backend tests cover:
+
+- Markdown fenced JSON is normalized to plain JSON.
+- Structured provider output returns `items` and persists JSON-only content.
+- Malformed provider output raises and does not save an insight.
+- Prompt context separates paid and pending transactions.
+- No goals are represented explicitly instead of inferred from budgets.
+
+Frontend tests cover:
+
+- fenced JSON parses successfully;
+- `items` is preferred over legacy strings;
+- legacy JSON still works;
+- malformed content still returns fallback;
+- new insight types have meaningful presentation metadata.
+
+## Production Operation
+
+Normalize the known malformed row in production after the issue/card setup and
+before broad code rollout, because it is a one-row repair and does not change
+business logic. Keep `llm_audit_logs` untouched.

--- a/docs/wiki/AI-Insights-Structured-Output.md
+++ b/docs/wiki/AI-Insights-Structured-Output.md
@@ -1,0 +1,104 @@
+# AI Insights Structured Output
+
+## Incident Summary
+
+On 2026-05-17, `GET /ai/insights/spending` returned HTTP 200 for a Premium
+user, but the Web UI rendered the fallback message:
+
+> Insight indisponível. Não conseguimos interpretar este insight agora.
+
+The API response had `cached=true`, so that specific request did not call
+OpenAI. The real OpenAI call had already happened and had persisted a daily
+`AIInsight` row.
+
+Production evidence for user `ee8d33ca-0ac0-41cc-95bd-c4be49cbcbd5`:
+
+- `ai_insights.id`: `5508449c-1955-4382-99a7-209092a70d44`
+- `period_label`: `2026-05-17`
+- `model`: `gpt-4o-mini-2024-07-18`
+- `tokens_used`: `567`
+- `llm_audit_logs.latency_ms`: `3060`
+- persisted content: Markdown fenced JSON, starting with ```` ```json ````.
+
+## Root Causes
+
+1. The backend asked for JSON only through prompt text. It did not use OpenAI
+   Structured Outputs or `response_format`.
+2. The backend persisted raw LLM text in `ai_insights.content`.
+3. The Web parser expected pure JSON and called `JSON.parse()` directly.
+4. The prompt asked for three cards, not a detailed report.
+5. The spending snapshot only included `paid` transactions. Pending expenses
+   were invisible to the model.
+6. Budgets and goals were not clearly separated in the prompt, allowing the
+   model to treat an overall budget named "Comprar carro novo" as a goal.
+
+## Contract
+
+The spending insight endpoint must return both legacy and structured fields:
+
+```json
+{
+  "success": true,
+  "message": "Insights de gastos gerados com sucesso",
+  "data": {
+    "insights": "[{\"type\":\"...\",\"title\":\"...\",\"message\":\"...\"}]",
+    "items": [
+      {
+        "type": "saude_financeira",
+        "title": "Resumo financeiro",
+        "message": "Mensagem acionável em português brasileiro."
+      }
+    ],
+    "month": "2026-05",
+    "model": "gpt-4o-mini-2024-07-18",
+    "tokens_used": 567,
+    "cost_usd": 0.00000276,
+    "cached": false
+  }
+}
+```
+
+`insights` remains for backward compatibility, but must be a valid JSON string
+without Markdown fences. `items` is the preferred field for new clients.
+
+## OpenAI Output Rule
+
+For OpenAI Chat Completions, use Structured Outputs with
+`response_format.type=json_schema` and `strict=true` when supported by the
+configured model. If a provider response cannot be parsed into the expected
+schema, the service must raise `LLMProviderError` before saving an `AIInsight`.
+
+The current default model, `gpt-4o-mini`, supports Structured Outputs through
+the deployed snapshot `gpt-4o-mini-2024-07-18`.
+
+## Financial Context Rule
+
+The prompt context must separate:
+
+- realized income: paid income transactions;
+- realized expenses: paid expense transactions;
+- pending expenses: pending expense transactions, described as future
+  commitments;
+- active budgets: all active monthly budgets;
+- active goals: only rows from the goals table.
+
+If there are no active goals, the context must state that explicitly. The model
+must not infer a financial goal from a budget name.
+
+## Legacy Normalization
+
+Existing rows may contain Markdown fenced JSON. They are recoverable if the
+content becomes valid JSON after removing a leading code fence such as
+```` ```json ```` and a trailing ```` ``` ````.
+
+Operational normalization for one known row:
+
+1. Read the row by `ai_insights.id`.
+2. Strip Markdown fences.
+3. Parse JSON.
+4. Serialize compact JSON with `ensure_ascii=false`.
+5. Update only that row.
+6. Re-read and confirm JSON parsing succeeds.
+
+Do not rewrite `llm_audit_logs.response_text`; audit logs must preserve the raw
+provider response.

--- a/tests/test_ai_advisory_service.py
+++ b/tests/test_ai_advisory_service.py
@@ -191,6 +191,68 @@ class TestAIAdvisoryServiceSpendingInsights:
             result = service.generate_spending_insights(month="2026-01")
             assert result["month"] == "2026-01"
 
+    def test_generate_spending_insights_normalizes_fenced_json_and_returns_items(
+        self, app
+    ) -> None:
+        with app.app_context():
+            user_id = uuid.uuid4()
+            provider = MagicMock()
+            provider.generate_with_usage.return_value = LLMResponse(
+                content=(
+                    '```json\n[{"type":"saude_financeira","title":"Ok",'
+                    '"message":"Tudo certo."}]\n```'
+                ),
+                prompt_tokens=10,
+                completion_tokens=20,
+                total_tokens=30,
+                model="gpt-4o-mini",
+                latency_ms=100,
+            )
+
+            from app.services.ai_advisory_service import AIAdvisoryService
+
+            service = AIAdvisoryService(user_id=user_id, llm_provider=provider)
+            result = service.generate_spending_insights(month="2026-05")
+
+            assert result["items"] == [
+                {
+                    "type": "saude_financeira",
+                    "title": "Ok",
+                    "message": "Tudo certo.",
+                }
+            ]
+            assert result["insights"] == (
+                '[{"type":"saude_financeira","title":"Ok","message":"Tudo certo."}]'
+            )
+            assert "response_schema" in provider.generate_with_usage.call_args.kwargs
+
+    def test_generate_spending_insights_rejects_malformed_provider_output(
+        self, app
+    ) -> None:
+        with app.app_context():
+            from app.extensions.database import db
+            from app.models.ai_insight import AIInsight
+            from app.services.ai_advisory_service import AIAdvisoryService
+
+            user_id = uuid.uuid4()
+            provider = MagicMock()
+            provider.generate_with_usage.return_value = LLMResponse(
+                content="not-json",
+                prompt_tokens=10,
+                completion_tokens=20,
+                total_tokens=30,
+                model="gpt-4o-mini",
+                latency_ms=100,
+            )
+
+            service = AIAdvisoryService(user_id=user_id, llm_provider=provider)
+
+            with pytest.raises(LLMProviderError, match="Invalid spending insight"):
+                service.generate_spending_insights(month="2026-05")
+
+            saved = db.session.query(AIInsight).filter_by(user_id=user_id).first()
+            assert saved is None
+
     def test_llm_provider_error_propagates(self, app) -> None:
         with app.app_context():
             user_id = uuid.uuid4()

--- a/tests/test_ai_insight_goals_budget_context.py
+++ b/tests/test_ai_insight_goals_budget_context.py
@@ -26,6 +26,7 @@ from app.extensions.database import db
 from app.models.budget import Budget
 from app.models.goal import Goal
 from app.models.goal_contribution import GoalContribution
+from app.models.transaction import Transaction, TransactionStatus, TransactionType
 from app.services.ai_advisory_service import (
     _build_goals_snapshot,
     _build_overall_budget_snapshot,
@@ -124,6 +125,30 @@ def _make_contribution(
             created_at=datetime.utcnow() - timedelta(days=days_ago),
         )
         db.session.add(contrib)
+        db.session.commit()
+
+
+def _make_transaction(
+    app,
+    user_id: uuid.UUID,
+    *,
+    title: str,
+    amount: float,
+    transaction_type: TransactionType,
+    status: TransactionStatus,
+    due_date: date,
+) -> None:
+    with app.app_context():
+        tx = Transaction(
+            user_id=user_id,
+            title=title,
+            description=title,
+            amount=Decimal(str(amount)),
+            type=transaction_type,
+            status=status,
+            due_date=due_date,
+        )
+        db.session.add(tx)
         db.session.commit()
 
 
@@ -305,11 +330,12 @@ class TestBuildSpendingPrompt:
         assert "Viagem Itália" in prompt
         assert "Metas financeiras ativas" in prompt
 
-    def test_omits_goals_section_when_empty(self):
+    def test_states_no_active_goals_when_empty(self):
         prompt = _build_spending_prompt(
             self._snapshot(), "2026-05", goals=[], budget=None
         )
-        assert "Metas financeiras ativas" not in prompt
+        assert "Nenhuma meta financeira ativa cadastrada" in prompt
+        assert "não trate orçamento como meta" in prompt
 
     def test_includes_budget_section_when_provided(self):
         budget = {
@@ -347,6 +373,52 @@ class TestBuildSpendingPrompt:
 
 
 class TestGenerateSpendingInsightsEnrichment:
+    def test_spending_snapshot_separates_paid_and_pending_expenses(self, app, client):
+        _, user_id = _register_and_login(client)
+        month_start = date(2026, 5, 1)
+        _make_transaction(
+            app,
+            user_id,
+            title="Salário",
+            amount=4000.0,
+            transaction_type=TransactionType.INCOME,
+            status=TransactionStatus.PAID,
+            due_date=month_start,
+        )
+        _make_transaction(
+            app,
+            user_id,
+            title="Mercado pago",
+            amount=700.0,
+            transaction_type=TransactionType.EXPENSE,
+            status=TransactionStatus.PAID,
+            due_date=month_start,
+        )
+        _make_transaction(
+            app,
+            user_id,
+            title="Cartão em aberto",
+            amount=2580.0,
+            transaction_type=TransactionType.EXPENSE,
+            status=TransactionStatus.PENDING,
+            due_date=date(2026, 5, 11),
+        )
+
+        with app.app_context():
+            from app.services.ai_advisory_service import AIAdvisoryService
+
+            service = AIAdvisoryService(user_id=user_id, llm_provider=MagicMock())
+            snapshot = service._build_spending_snapshot(
+                start=month_start, end=date(2026, 5, 31)
+            )
+
+        assert snapshot["total_income"] == pytest.approx(4000.0)
+        assert snapshot["total_expense"] == pytest.approx(700.0)
+        assert snapshot["pending_expense_total"] == pytest.approx(2580.0)
+        assert snapshot["pending_expenses"] == [
+            {"description": "Cartão em aberto", "total": 2580.0}
+        ]
+
     def test_prompt_contains_goal_data(self, app, client):
         _, user_id = _register_and_login(client)
         _make_goal(
@@ -373,7 +445,7 @@ class TestGenerateSpendingInsightsEnrichment:
             from app.services.ai_advisory_service import AIAdvisoryService
 
             mock_provider = MagicMock()
-            mock_provider.generate_with_usage.side_effect = lambda p: (
+            mock_provider.generate_with_usage.side_effect = lambda p, **_: (
                 captured_prompts.append(p) or stub_response
             )
 

--- a/tests/test_ai_insight_persistence.py
+++ b/tests/test_ai_insight_persistence.py
@@ -11,6 +11,7 @@ Coverage:
 
 from __future__ import annotations
 
+import json
 import uuid
 from datetime import date, timedelta
 from unittest.mock import MagicMock, patch
@@ -74,7 +75,12 @@ def _revoke_premium(app, token: str) -> None:
         deactivate_premium(user_id)
 
 
-def _stub_response(content: str = "Insight gerado com sucesso.") -> LLMResponse:
+def _stub_response(
+    content: str = (
+        '[{"type":"saude_financeira","title":"Insight",'
+        '"message":"Insight gerado com sucesso."}]'
+    ),
+) -> LLMResponse:
     return LLMResponse(
         content=content,
         prompt_tokens=100,
@@ -109,9 +115,42 @@ class TestAdvisoryServicePersistence:
                 .first()
             )
             assert saved is not None
-            assert saved.content == "Insight gerado com sucesso."
+            assert json.loads(saved.content) == [
+                {
+                    "type": "saude_financeira",
+                    "title": "Insight",
+                    "message": "Insight gerado com sucesso.",
+                }
+            ]
             assert saved.model == "gpt-4o-mini"
             assert saved.tokens_used == 300
+
+    def test_generate_spending_insights_saves_canonical_json_content(self, app) -> None:
+        with app.app_context():
+            from app.extensions.database import db
+            from app.services.ai_advisory_service import AIAdvisoryService
+
+            user_id = uuid.uuid4()
+            provider = MagicMock()
+            provider.generate_with_usage.return_value = _stub_response(
+                '```json\n[{"type":"alerta_meta","title":"Meta",'
+                '"message":"Revise seu plano."}]\n```'
+            )
+
+            service = AIAdvisoryService(user_id=user_id, llm_provider=provider)
+            result = service.generate_spending_insights(month="2026-05")
+
+            saved = (
+                db.session.query(AIInsight)
+                .filter_by(user_id=user_id, insight_type=InsightType.daily)
+                .first()
+            )
+
+            assert saved is not None
+            assert saved.content == result["insights"]
+            assert saved.content.startswith("[")
+            assert "```" not in saved.content
+            assert json.loads(saved.content) == result["items"]
 
     def test_idempotency_returns_cached_insight_without_calling_llm(self, app) -> None:
         with app.app_context():
@@ -119,7 +158,10 @@ class TestAdvisoryServicePersistence:
 
             user_id = uuid.uuid4()
             provider = MagicMock()
-            provider.generate_with_usage.return_value = _stub_response("First insight.")
+            provider.generate_with_usage.return_value = _stub_response(
+                '[{"type":"saude_financeira","title":"Primeiro",'
+                '"message":"First insight."}]'
+            )
 
             service = AIAdvisoryService(user_id=user_id, llm_provider=provider)
             result1 = service.generate_spending_insights()
@@ -171,7 +213,10 @@ class TestAdvisoryServicePersistence:
 
             user_id = uuid.uuid4()
             provider = MagicMock()
-            provider.generate_with_usage.return_value = _stub_response("Recap do mês.")
+            provider.generate_with_usage.return_value = _stub_response(
+                '[{"type":"saude_financeira","title":"Recap",'
+                '"message":"Recap do mês."}]'
+            )
 
             # Patch date.today() to be the last day of a month
             last_day = date(2026, 5, 31)

--- a/tests/test_llm_provider.py
+++ b/tests/test_llm_provider.py
@@ -53,6 +53,37 @@ class TestOpenAILLMProvider:
 
         assert result == "AI insight here"
 
+    def test_generate_with_usage_passes_structured_response_format(self):
+        provider = OpenAILLMProvider()
+        provider._api_key = "test-key"
+        schema = {
+            "name": "spending_insight_items",
+            "strict": True,
+            "schema": {
+                "type": "object",
+                "properties": {"items": {"type": "array", "items": {"type": "object"}}},
+                "required": ["items"],
+                "additionalProperties": False,
+            },
+        }
+
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "choices": [{"message": {"content": '{"items":[]}'}}],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            "model": "gpt-4o-mini-2024-07-18",
+        }
+        mock_resp.raise_for_status.return_value = None
+
+        with patch("requests.post", return_value=mock_resp) as post:
+            provider.generate_with_usage("analyze my finances", response_schema=schema)
+
+        payload = post.call_args.kwargs["json"]
+        assert payload["response_format"] == {
+            "type": "json_schema",
+            "json_schema": schema,
+        }
+
     def test_generate_raises_on_request_failure(self):
         provider = OpenAILLMProvider()
         provider._api_key = "test-key"


### PR DESCRIPTION
## Summary

- Adds optional structured-output support to the LLM provider contract and sends OpenAI Chat Completions `response_format: { type: "json_schema" }` for spending insights.
- Validates/coerces spending insight items before persistence, strips legacy Markdown JSON fences, stores canonical JSON, and returns a typed `items` payload alongside the legacy `insights` string.
- Enriches the spending prompt context with pending expenses and explicit no-goals wording so budgets are not treated as goals.
- Documents the production incident, the API/Web contract, and the one-row normalization runbook.

## Context

The production request that rendered `Insight indisponível` was cached; the original OpenAI call had already persisted Markdown-fenced JSON. The backend now prevents that shape from being saved again and exposes `items` for clients. The known production row `5508449c-1955-4382-99a7-209092a70d44` was normalized in place before this PR; `llm_audit_logs` were intentionally left untouched.

Pairs with `italofelipe/auraxis-web#856`.

## Validation

- `python -m pytest tests/test_llm_provider.py tests/test_ai_advisory_service.py tests/test_ai_insight_persistence.py tests/test_ai_insight_goals_budget_context.py tests/test_ai_daily_rate_limit.py -q`
- `python -m ruff check app/services/llm_provider.py app/services/ai_advisory_service.py app/controllers/ai/resources.py tests/test_llm_provider.py tests/test_ai_advisory_service.py tests/test_ai_insight_persistence.py tests/test_ai_insight_goals_budget_context.py`
- `python -m mypy app/services/llm_provider.py app/services/ai_advisory_service.py`
- `git diff --check`
- `bash scripts/run_ci_quality_local.sh --local` passed hygiene, Bandit, ruff format/check, and related gates, then stopped at repository-wide mypy baseline: 94 errors in 34 files outside this change set.
- Commit and push ran the same hooks with only `mypy` skipped via `SKIP=mypy`; all remaining hooks passed.

## Notes

- The OpenAPI snapshot was checked earlier in this work; the AI blueprint is not currently part of the documented OpenAPI snapshot, and regenerating introduced unrelated drift, so this PR does not change `openapi.json`.
- Failed LLM output still raises the existing error envelope and, with #1265 already merged, does not consume the daily insight quota.

Closes #1267
