### PR TITLE
feat(ai): add financial insight context builder

### DIFF
--- a/app/services/financial_insight_context_builder.py
+++ b/app/services/financial_insight_context_builder.py
@@ -27,7 +27,10 @@ _CURRENCY = "BRL"
 _TIMEZONE = "America/Sao_Paulo"
 _MONEY_QUANT = Decimal("0.01")
 _PERCENT_QUANT = Decimal("0.01")
-_EMAIL_RE = re.compile(r"[\w.+-]+@[\w-]+(?:\.[\w-]+)+")
+_EMAIL_MASK = "[email]"
+_MAX_EMAIL_TOKEN_LENGTH = 320
+_EMAIL_LOCAL_SYMBOLS = "._%+-"
+_EMAIL_DOMAIN_SYMBOLS = "-_"
 _CPF_RE = re.compile(r"\b\d{3}\.\d{3}\.\d{3}-\d{2}\b")
 _LONG_NUMBER_RE = re.compile(r"\b\d{8,}\b")
 
@@ -56,6 +59,94 @@ def _safe_pct(numerator: Decimal, denominator: Decimal) -> str:
     return _percent_str(numerator / denominator * Decimal("100"))
 
 
+def _is_email_candidate_char(char: str) -> bool:
+    return char.isalnum() or char == "@" or char in _EMAIL_LOCAL_SYMBOLS
+
+
+def _is_email_local_char(char: str) -> bool:
+    return char.isalnum() or char in _EMAIL_LOCAL_SYMBOLS
+
+
+def _is_email_domain_char(char: str) -> bool:
+    return char.isalnum() or char in _EMAIL_DOMAIN_SYMBOLS
+
+
+def _strip_email_boundary_dots(token: str) -> tuple[str, str, str]:
+    prefix = ""
+    suffix = ""
+    candidate = token
+
+    while candidate.startswith("."):
+        prefix += "."
+        candidate = candidate[1:]
+    while candidate.endswith("."):
+        suffix = "." + suffix
+        candidate = candidate[:-1]
+
+    return prefix, candidate, suffix
+
+
+def _looks_like_email(candidate: str) -> bool:
+    if candidate.count("@") != 1:
+        return False
+
+    local_part, domain = candidate.split("@", 1)
+    if (
+        not local_part
+        or not domain
+        or len(local_part) > 64
+        or len(domain) > 253
+        or "." not in domain
+        or local_part.startswith(".")
+        or local_part.endswith(".")
+    ):
+        return False
+
+    if not all(_is_email_local_char(char) for char in local_part):
+        return False
+
+    labels = domain.split(".")
+    return all(
+        label
+        and len(label) <= 63
+        and not label.startswith("-")
+        and not label.endswith("-")
+        and all(_is_email_domain_char(char) for char in label)
+        for label in labels
+    )
+
+
+def _redact_email_token(token: str) -> str:
+    prefix, candidate, suffix = _strip_email_boundary_dots(token)
+    if "@" not in candidate:
+        return token
+    if len(candidate) > _MAX_EMAIL_TOKEN_LENGTH or candidate.count("@") > 1:
+        return f"{prefix}{_EMAIL_MASK}{suffix}"
+    if _looks_like_email(candidate):
+        return f"{prefix}{_EMAIL_MASK}{suffix}"
+    return token
+
+
+def _redact_email_tokens(text: str) -> str:
+    redacted: list[str] = []
+    token_chars: list[str] = []
+
+    for char in text:
+        if _is_email_candidate_char(char):
+            token_chars.append(char)
+            continue
+
+        if token_chars:
+            redacted.append(_redact_email_token("".join(token_chars)))
+            token_chars = []
+        redacted.append(char)
+
+    if token_chars:
+        redacted.append(_redact_email_token("".join(token_chars)))
+
+    return "".join(redacted)
+
+
 def _sanitize_text(value: object, *, max_length: int = 120) -> str | None:
     if value is None:
         return None
@@ -64,7 +155,7 @@ def _sanitize_text(value: object, *, max_length: int = 120) -> str | None:
     if not text:
         return None
 
-    text = _EMAIL_RE.sub("[email]", text)
+    text = _redact_email_tokens(text)
     text = _CPF_RE.sub("[cpf]", text)
     text = _LONG_NUMBER_RE.sub("[number]", text)
     text = " ".join(text.split())

--- a/app/services/financial_insight_context_builder.py
+++ b/app/services/financial_insight_context_builder.py
@@ -1,0 +1,613 @@
+"""Period-aware financial context snapshots for AI insights.
+
+The builder computes deterministic facts from internal transaction data before
+any LLM call. It deliberately emits sanitized dictionaries instead of model
+instances so prompts and audit logs do not receive user PII or raw IDs.
+"""
+
+from __future__ import annotations
+
+import re
+from calendar import monthrange
+from datetime import date, timedelta
+from decimal import Decimal, InvalidOperation
+from typing import Any, cast
+from uuid import UUID
+
+from app.models.budget import Budget
+from app.models.goal import Goal
+from app.models.transaction import (
+    Transaction,
+    TransactionStatus,
+    TransactionType,
+)
+
+_SNAPSHOT_VERSION = "financial_insight_snapshot.v1"
+_CURRENCY = "BRL"
+_TIMEZONE = "America/Sao_Paulo"
+_MONEY_QUANT = Decimal("0.01")
+_PERCENT_QUANT = Decimal("0.01")
+_EMAIL_RE = re.compile(r"[\w.+-]+@[\w-]+(?:\.[\w-]+)+")
+_CPF_RE = re.compile(r"\b\d{3}\.\d{3}\.\d{3}-\d{2}\b")
+_LONG_NUMBER_RE = re.compile(r"\b\d{8,}\b")
+
+
+def _money(value: object) -> Decimal:
+    try:
+        return Decimal(str(value or "0")).quantize(_MONEY_QUANT)
+    except (InvalidOperation, ValueError):
+        return Decimal("0.00")
+
+
+def _money_str(value: object) -> str:
+    return f"{_money(value):.2f}"
+
+
+def _percent_str(value: object) -> str:
+    try:
+        return f"{Decimal(str(value or '0')).quantize(_PERCENT_QUANT):.2f}"
+    except (InvalidOperation, ValueError):
+        return "0.00"
+
+
+def _safe_pct(numerator: Decimal, denominator: Decimal) -> str:
+    if denominator == 0:
+        return "0.00"
+    return _percent_str(numerator / denominator * Decimal("100"))
+
+
+def _sanitize_text(value: object, *, max_length: int = 120) -> str | None:
+    if value is None:
+        return None
+
+    text = str(value).strip()
+    if not text:
+        return None
+
+    text = _EMAIL_RE.sub("[email]", text)
+    text = _CPF_RE.sub("[cpf]", text)
+    text = _LONG_NUMBER_RE.sub("[number]", text)
+    text = " ".join(text.split())
+    if len(text) > max_length:
+        return text[: max_length - 1].rstrip() + "..."
+    return text
+
+
+def _enum_value(value: object) -> str | None:
+    if value is None:
+        return None
+    enum_value = getattr(value, "value", None)
+    return str(enum_value if enum_value is not None else value)
+
+
+def _same_day_previous_month(anchor_date: date) -> date | None:
+    previous_year = anchor_date.year
+    previous_month = anchor_date.month - 1
+    if previous_month == 0:
+        previous_year -= 1
+        previous_month = 12
+
+    days_in_previous_month = monthrange(previous_year, previous_month)[1]
+    if anchor_date.day > days_in_previous_month:
+        return None
+    return date(previous_year, previous_month, anchor_date.day)
+
+
+def _month_bounds(anchor_date: date) -> tuple[date, date]:
+    last_day = monthrange(anchor_date.year, anchor_date.month)[1]
+    return date(anchor_date.year, anchor_date.month, 1), date(
+        anchor_date.year,
+        anchor_date.month,
+        last_day,
+    )
+
+
+def _week_bounds(anchor_date: date) -> tuple[date, date]:
+    start = anchor_date - timedelta(days=anchor_date.weekday())
+    return start, start + timedelta(days=6)
+
+
+def _date_period(start: date, end: date, label: str) -> dict[str, str]:
+    return {
+        "start": start.isoformat(),
+        "end": end.isoformat(),
+        "label": label,
+    }
+
+
+class FinancialInsightContextBuilder:
+    """Build sanitized financial snapshots for daily, weekly and monthly insights."""
+
+    def build_daily(self, *, user_id: UUID, anchor_date: date) -> dict[str, Any]:
+        """Return a daily snapshot with yesterday, prior-month and MTD comparison."""
+        current = self._period_snapshot(
+            user_id=user_id,
+            start=anchor_date,
+            end=anchor_date,
+            label=anchor_date.isoformat(),
+            period_type="daily",
+        )
+        yesterday = anchor_date - timedelta(days=1)
+        same_day_previous_month = _same_day_previous_month(anchor_date)
+        month_start = date(anchor_date.year, anchor_date.month, 1)
+
+        missing_comparisons: list[str] = []
+        if same_day_previous_month is None:
+            missing_comparisons.append("same_day_previous_month")
+
+        comparisons: dict[str, Any] = {
+            "yesterday": self._comparison_snapshot(
+                user_id=user_id,
+                current=current,
+                start=yesterday,
+                end=yesterday,
+                label=yesterday.isoformat(),
+            ),
+            "month_to_date": self._compact_period_snapshot(
+                self._period_snapshot(
+                    user_id=user_id,
+                    start=month_start,
+                    end=anchor_date,
+                    label=f"{anchor_date:%Y-%m}-to-{anchor_date:%d}",
+                    period_type="month_to_date",
+                )
+            ),
+        }
+        if same_day_previous_month is not None:
+            comparisons["same_day_previous_month"] = self._comparison_snapshot(
+                user_id=user_id,
+                current=current,
+                start=same_day_previous_month,
+                end=same_day_previous_month,
+                label=same_day_previous_month.isoformat(),
+            )
+
+        current["comparisons"] = comparisons
+        current["data_quality"]["missing_comparison_periods"] = missing_comparisons
+        return current
+
+    def build_weekly(self, *, user_id: UUID, anchor_date: date) -> dict[str, Any]:
+        """Return a weekly snapshot for the ISO week containing ``anchor_date``."""
+        start, end = _week_bounds(anchor_date)
+        current = self._period_snapshot(
+            user_id=user_id,
+            start=start,
+            end=end,
+            label=f"{anchor_date.isocalendar().year}-W{anchor_date.isocalendar().week:02d}",
+            period_type="weekly",
+            include_daily_series=True,
+        )
+        previous_start = start - timedelta(days=7)
+        previous_end = start - timedelta(days=1)
+        current["comparisons"] = {
+            "previous_period": self._comparison_snapshot(
+                user_id=user_id,
+                current=current,
+                start=previous_start,
+                end=previous_end,
+                label=(
+                    f"{previous_start.isocalendar().year}-"
+                    f"W{previous_start.isocalendar().week:02d}"
+                ),
+            )
+        }
+        return current
+
+    def build_monthly(self, *, user_id: UUID, anchor_date: date) -> dict[str, Any]:
+        """Return a monthly snapshot for the calendar month containing anchor."""
+        start, end = _month_bounds(anchor_date)
+        return self._period_snapshot(
+            user_id=user_id,
+            start=start,
+            end=end,
+            label=f"{anchor_date:%Y-%m}",
+            period_type="monthly",
+            include_daily_series=True,
+            include_budgets=True,
+            include_goals=True,
+        )
+
+    def _comparison_snapshot(
+        self,
+        *,
+        user_id: UUID,
+        current: dict[str, Any],
+        start: date,
+        end: date,
+        label: str,
+    ) -> dict[str, Any]:
+        comparison = self._period_snapshot(
+            user_id=user_id,
+            start=start,
+            end=end,
+            label=label,
+            period_type="comparison",
+        )
+        compact = self._compact_period_snapshot(comparison)
+        compact["delta"] = self._delta(current["current_period"], comparison)
+        return compact
+
+    def _compact_period_snapshot(self, snapshot: dict[str, Any]) -> dict[str, Any]:
+        current_period = snapshot["current_period"]
+        return {
+            "period": snapshot["period"],
+            "paid": current_period["paid"],
+            "commitments": current_period["commitments"],
+            "cancelled_transaction_count": current_period[
+                "cancelled_transaction_count"
+            ],
+            "transaction_count": snapshot["transactions"]["included_count"],
+            "data_quality": snapshot["data_quality"],
+        }
+
+    def _period_snapshot(
+        self,
+        *,
+        user_id: UUID,
+        start: date,
+        end: date,
+        label: str,
+        period_type: str,
+        include_daily_series: bool = False,
+        include_budgets: bool = False,
+        include_goals: bool = False,
+    ) -> dict[str, Any]:
+        transactions = self._fetch_transactions(user_id=user_id, start=start, end=end)
+        non_cancelled = [
+            tx for tx in transactions if tx.status != TransactionStatus.CANCELLED
+        ]
+        paid = [tx for tx in non_cancelled if tx.status == TransactionStatus.PAID]
+
+        current_period = self._current_period_summary(transactions)
+        snapshot: dict[str, Any] = {
+            "schema_version": _SNAPSHOT_VERSION,
+            "period_type": period_type,
+            "currency": _CURRENCY,
+            "timezone": _TIMEZONE,
+            "anchor_date": end.isoformat(),
+            "period": _date_period(start, end, label),
+            "current_period": current_period,
+            "comparisons": {},
+            "daily_series": self._daily_series(paid, start=start, end=end)
+            if include_daily_series
+            else [],
+            "extremes": self._day_extremes(paid, start=start, end=end),
+            "categories": {
+                "top_expense_categories": self._top_expense_categories(paid)
+            },
+            "transactions": self._transactions_payload(non_cancelled),
+            "budgets": self._budgets_payload(user_id=user_id, start=start, end=end)
+            if include_budgets
+            else [],
+            "goals": self._goals_payload(user_id=user_id) if include_goals else [],
+            "data_quality": {
+                "has_transactions": bool(non_cancelled),
+                "missing_comparison_periods": [],
+            },
+        }
+        return snapshot
+
+    def _fetch_transactions(
+        self,
+        *,
+        user_id: UUID,
+        start: date,
+        end: date,
+    ) -> list[Transaction]:
+        rows = (
+            Transaction.query.filter(
+                Transaction.user_id == user_id,
+                Transaction.deleted.is_(False),
+                Transaction.due_date >= start,
+                Transaction.due_date <= end,
+            )
+            .order_by(Transaction.due_date.asc(), Transaction.created_at.asc())
+            .all()
+        )
+        return cast(list[Transaction], rows)
+
+    def _current_period_summary(
+        self,
+        transactions: list[Transaction],
+    ) -> dict[str, Any]:
+        paid = [tx for tx in transactions if tx.status == TransactionStatus.PAID]
+        pending = [tx for tx in transactions if tx.status == TransactionStatus.PENDING]
+        overdue = [tx for tx in transactions if tx.status == TransactionStatus.OVERDUE]
+        cancelled_count = sum(
+            1 for tx in transactions if tx.status == TransactionStatus.CANCELLED
+        )
+
+        paid_income = self._sum(paid, TransactionType.INCOME)
+        paid_expense = self._sum(paid, TransactionType.EXPENSE)
+        pending_expense = self._sum(pending, TransactionType.EXPENSE)
+        overdue_expense = self._sum(overdue, TransactionType.EXPENSE)
+
+        return {
+            "paid": {
+                "income_total": _money_str(paid_income),
+                "expense_total": _money_str(paid_expense),
+                "balance": _money_str(paid_income - paid_expense),
+                "transaction_count": len(paid),
+            },
+            "commitments": {
+                "pending_expense_total": _money_str(pending_expense),
+                "overdue_expense_total": _money_str(overdue_expense),
+                "transaction_count": len(pending) + len(overdue),
+            },
+            "cancelled_transaction_count": cancelled_count,
+        }
+
+    def _delta(
+        self,
+        current_period: dict[str, Any],
+        comparison_snapshot: dict[str, Any],
+    ) -> dict[str, str]:
+        current_paid = current_period["paid"]
+        comparison_paid = comparison_snapshot["current_period"]["paid"]
+        income_delta = _money(current_paid["income_total"]) - _money(
+            comparison_paid["income_total"]
+        )
+        expense_delta = _money(current_paid["expense_total"]) - _money(
+            comparison_paid["expense_total"]
+        )
+        balance_delta = _money(current_paid["balance"]) - _money(
+            comparison_paid["balance"]
+        )
+
+        return {
+            "income_total": _money_str(income_delta),
+            "income_pct": _safe_pct(
+                income_delta, _money(comparison_paid["income_total"])
+            ),
+            "expense_total": _money_str(expense_delta),
+            "expense_pct": _safe_pct(
+                expense_delta,
+                _money(comparison_paid["expense_total"]),
+            ),
+            "balance": _money_str(balance_delta),
+            "balance_pct": _safe_pct(
+                balance_delta,
+                _money(comparison_paid["balance"]),
+            ),
+        }
+
+    def _daily_series(
+        self,
+        transactions: list[Transaction],
+        *,
+        start: date,
+        end: date,
+    ) -> list[dict[str, Any]]:
+        index: dict[date, dict[str, Decimal | int]] = {}
+        cursor = start
+        while cursor <= end:
+            index[cursor] = {
+                "income": Decimal("0.00"),
+                "expense": Decimal("0.00"),
+                "count": 0,
+            }
+            cursor += timedelta(days=1)
+
+        for tx in transactions:
+            day = cast(date, tx.due_date)
+            entry = index.setdefault(
+                day,
+                {"income": Decimal("0.00"), "expense": Decimal("0.00"), "count": 0},
+            )
+            if tx.type == TransactionType.INCOME:
+                entry["income"] = cast(Decimal, entry["income"]) + _money(tx.amount)
+            elif tx.type == TransactionType.EXPENSE:
+                entry["expense"] = cast(Decimal, entry["expense"]) + _money(tx.amount)
+            entry["count"] = cast(int, entry["count"]) + 1
+
+        series: list[dict[str, Any]] = []
+        cursor = start
+        while cursor <= end:
+            entry = index[cursor]
+            income = cast(Decimal, entry["income"])
+            expense = cast(Decimal, entry["expense"])
+            series.append(
+                {
+                    "date": cursor.isoformat(),
+                    "income_total": _money_str(income),
+                    "expense_total": _money_str(expense),
+                    "balance": _money_str(income - expense),
+                    "transaction_count": cast(int, entry["count"]),
+                }
+            )
+            cursor += timedelta(days=1)
+        return series
+
+    def _day_extremes(
+        self,
+        transactions: list[Transaction],
+        *,
+        start: date,
+        end: date,
+    ) -> dict[str, dict[str, str] | None]:
+        series = self._daily_series(transactions, start=start, end=end)
+        expense_days = [
+            (item["date"], _money(item["expense_total"]))
+            for item in series
+            if _money(item["expense_total"]) > 0
+        ]
+        income_days = [
+            (item["date"], _money(item["income_total"]))
+            for item in series
+            if _money(item["income_total"]) > 0
+        ]
+        return {
+            "max_expense_day": self._extreme_day(expense_days, highest=True),
+            "min_expense_day_with_activity": self._extreme_day(
+                expense_days,
+                highest=False,
+            ),
+            "max_income_day": self._extreme_day(income_days, highest=True),
+            "min_income_day_with_activity": self._extreme_day(
+                income_days,
+                highest=False,
+            ),
+        }
+
+    def _extreme_day(
+        self,
+        days: list[tuple[str, Decimal]],
+        *,
+        highest: bool,
+    ) -> dict[str, str] | None:
+        if not days:
+            return None
+        day, amount = (
+            max(days, key=lambda item: item[1])
+            if highest
+            else min(
+                days,
+                key=lambda item: item[1],
+            )
+        )
+        return {"date": day, "amount": _money_str(amount)}
+
+    def _top_expense_categories(
+        self,
+        transactions: list[Transaction],
+    ) -> list[dict[str, str]]:
+        totals: dict[str, Decimal] = {}
+        for tx in transactions:
+            if tx.type != TransactionType.EXPENSE or tx.category is None:
+                continue
+            category = _enum_value(tx.category)
+            if category is None:
+                continue
+            totals[category] = totals.get(category, Decimal("0.00")) + _money(tx.amount)
+
+        return [
+            {"category": category, "total": _money_str(total)}
+            for category, total in sorted(
+                totals.items(),
+                key=lambda item: (-item[1], item[0]),
+            )
+        ]
+
+    def _transactions_payload(
+        self,
+        transactions: list[Transaction],
+        *,
+        sample_limit: int = 20,
+    ) -> dict[str, Any]:
+        sorted_transactions = sorted(
+            transactions,
+            key=lambda tx: (tx.due_date, _money(tx.amount)),
+        )
+        return {
+            "included_count": len(transactions),
+            "sample": [
+                self._serialize_transaction(tx)
+                for tx in sorted_transactions[:sample_limit]
+            ],
+        }
+
+    def _serialize_transaction(self, transaction: Transaction) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "date": transaction.due_date.isoformat(),
+            "type": _enum_value(transaction.type),
+            "status": _enum_value(transaction.status),
+            "amount": _money_str(transaction.amount),
+            "currency": transaction.currency or _CURRENCY,
+            "title": _sanitize_text(transaction.title),
+            "is_recurring": bool(transaction.is_recurring),
+            "is_installment": bool(transaction.is_installment),
+        }
+        description = _sanitize_text(transaction.description)
+        category = _enum_value(transaction.category)
+        if description and description != payload["title"]:
+            payload["description"] = description
+        if category:
+            payload["category"] = category
+        return payload
+
+    def _budgets_payload(
+        self,
+        *,
+        user_id: UUID,
+        start: date,
+        end: date,
+    ) -> list[dict[str, Any]]:
+        rows = (
+            Budget.query.filter(
+                Budget.user_id == user_id,
+                Budget.is_active.is_(True),
+                Budget.period == "monthly",
+            )
+            .order_by(Budget.created_at.asc())
+            .all()
+        )
+        budgets = cast(list[Budget], rows)
+        paid = [
+            tx
+            for tx in self._fetch_transactions(user_id=user_id, start=start, end=end)
+            if tx.status == TransactionStatus.PAID
+            and tx.type == TransactionType.EXPENSE
+        ]
+
+        result: list[dict[str, Any]] = []
+        for budget in budgets:
+            category = str(budget.category) if budget.category else None
+            spent = Decimal("0.00")
+            for tx in paid:
+                if category is None or _enum_value(tx.category) == category:
+                    spent += _money(tx.amount)
+
+            amount = _money(budget.amount)
+            result.append(
+                {
+                    "name": _sanitize_text(budget.name) or "Orçamento",
+                    "category": category,
+                    "period": str(budget.period),
+                    "amount": _money_str(amount),
+                    "spent": _money_str(spent),
+                    "utilization_pct": _safe_pct(spent, amount),
+                    "exceeded": spent > amount,
+                }
+            )
+        return result
+
+    def _goals_payload(self, *, user_id: UUID) -> list[dict[str, Any]]:
+        rows = (
+            Goal.query.filter(
+                Goal.user_id == user_id,
+                Goal.status == "active",
+            )
+            .order_by(Goal.priority.asc(), Goal.created_at.asc())
+            .all()
+        )
+        goals = cast(list[Goal], rows)
+
+        result: list[dict[str, Any]] = []
+        for goal in goals:
+            current = _money(goal.current_amount)
+            target = _money(goal.target_amount)
+            result.append(
+                {
+                    "title": _sanitize_text(goal.title) or "Meta",
+                    "current_amount": _money_str(current),
+                    "target_amount": _money_str(target),
+                    "progress_pct": _safe_pct(current, target),
+                    "target_date": goal.target_date.isoformat()
+                    if goal.target_date
+                    else None,
+                }
+            )
+        return result
+
+    def _sum(
+        self,
+        transactions: list[Transaction],
+        transaction_type: TransactionType,
+    ) -> Decimal:
+        return sum(
+            (_money(tx.amount) for tx in transactions if tx.type == transaction_type),
+            Decimal("0.00"),
+        )
+
+
+__all__ = ["FinancialInsightContextBuilder"]

--- a/tests/test_financial_insight_context_builder.py
+++ b/tests/test_financial_insight_context_builder.py
@@ -6,6 +6,7 @@ import json
 import uuid
 from datetime import date
 from decimal import Decimal
+from inspect import getsource
 from typing import Any
 
 from app.extensions.database import db
@@ -18,6 +19,7 @@ from app.models.transaction import (
     TransactionType,
 )
 from app.models.user import User
+from app.services import financial_insight_context_builder
 from app.services.financial_insight_context_builder import (
     FinancialInsightContextBuilder,
 )
@@ -303,6 +305,19 @@ class TestFinancialInsightContextBuilderDaily:
         assert "external_id" not in serialized
         assert "bank_name" not in serialized
         assert snapshot["transactions"]["sample"][0]["title"] == "Consulta CPF [cpf]"
+
+    def test_email_redaction_does_not_use_backtracking_regex(self) -> None:
+        source = getsource(financial_insight_context_builder)
+
+        assert "_EMAIL_RE" not in source
+        assert r"(?:\.[\w-]+)+" not in source
+
+        assert (
+            financial_insight_context_builder._sanitize_text(
+                "Enviar para <ana@example.com>, cópia pix:financeiro+pix@example.com"
+            )
+            == "Enviar para <[email]>, cópia pix:[email]"
+        )
 
 
 class TestFinancialInsightContextBuilderWeekly:

--- a/tests/test_financial_insight_context_builder.py
+++ b/tests/test_financial_insight_context_builder.py
@@ -1,0 +1,508 @@
+"""Tests for the financial snapshot builder used by AI insights (#1269)."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import date
+from decimal import Decimal
+from typing import Any
+
+from app.extensions.database import db
+from app.models.budget import Budget
+from app.models.goal import Goal
+from app.models.transaction import (
+    Transaction,
+    TransactionCategory,
+    TransactionStatus,
+    TransactionType,
+)
+from app.models.user import User
+from app.services.financial_insight_context_builder import (
+    FinancialInsightContextBuilder,
+)
+
+
+def _make_user() -> uuid.UUID:
+    user = User(
+        name="Ana Cliente",
+        email=f"ana-{uuid.uuid4().hex[:8]}@example.com",
+        password="hashed",
+    )
+    db.session.add(user)
+    db.session.commit()
+    return user.id
+
+
+def _make_transaction(
+    user_id: uuid.UUID,
+    *,
+    title: str,
+    amount: str,
+    tx_type: TransactionType,
+    status: TransactionStatus,
+    due_date: date,
+    category: TransactionCategory | None = None,
+    description: str | None = None,
+    observation: str | None = None,
+    external_id: str | None = None,
+    bank_name: str | None = None,
+) -> Transaction:
+    tx = Transaction(
+        user_id=user_id,
+        title=title,
+        description=description if description is not None else title,
+        observation=observation,
+        external_id=external_id,
+        bank_name=bank_name,
+        amount=Decimal(amount),
+        type=tx_type,
+        status=status,
+        due_date=due_date,
+        category=category,
+    )
+    db.session.add(tx)
+    db.session.commit()
+    db.session.refresh(tx)
+    return tx
+
+
+def _make_budget(
+    user_id: uuid.UUID,
+    *,
+    name: str,
+    amount: str,
+    category: TransactionCategory | None = None,
+) -> Budget:
+    budget = Budget(
+        user_id=user_id,
+        name=name,
+        amount=Decimal(amount),
+        period="monthly",
+        category=category.value if category else None,
+        is_active=True,
+    )
+    db.session.add(budget)
+    db.session.commit()
+    return budget
+
+
+def _make_goal(
+    user_id: uuid.UUID,
+    *,
+    title: str,
+    current_amount: str,
+    target_amount: str,
+    target_date: date | None = None,
+) -> Goal:
+    goal = Goal(
+        user_id=user_id,
+        title=title,
+        current_amount=Decimal(current_amount),
+        target_amount=Decimal(target_amount),
+        target_date=target_date,
+        status="active",
+    )
+    db.session.add(goal)
+    db.session.commit()
+    return goal
+
+
+def _as_json(value: dict[str, Any]) -> str:
+    return json.dumps(value, ensure_ascii=False, default=str)
+
+
+class TestFinancialInsightContextBuilderDaily:
+    def test_daily_snapshot_compares_today_yesterday_previous_month_and_mtd(
+        self, app
+    ) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            anchor = date(2026, 5, 17)
+            _make_transaction(
+                user_id,
+                title="Salário",
+                amount="1000.00",
+                tx_type=TransactionType.INCOME,
+                status=TransactionStatus.PAID,
+                due_date=anchor,
+            )
+            _make_transaction(
+                user_id,
+                title="Mercado",
+                amount="250.00",
+                tx_type=TransactionType.EXPENSE,
+                status=TransactionStatus.PAID,
+                due_date=anchor,
+                category=TransactionCategory.alimentacao,
+            )
+            _make_transaction(
+                user_id,
+                title="Conta pendente",
+                amount="80.00",
+                tx_type=TransactionType.EXPENSE,
+                status=TransactionStatus.PENDING,
+                due_date=anchor,
+            )
+            _make_transaction(
+                user_id,
+                title="Conta vencida",
+                amount="33.25",
+                tx_type=TransactionType.EXPENSE,
+                status=TransactionStatus.OVERDUE,
+                due_date=anchor,
+            )
+            _make_transaction(
+                user_id,
+                title="Despesa cancelada",
+                amount="999.00",
+                tx_type=TransactionType.EXPENSE,
+                status=TransactionStatus.CANCELLED,
+                due_date=anchor,
+            )
+            _make_transaction(
+                user_id,
+                title="Ontem mercado",
+                amount="400.00",
+                tx_type=TransactionType.EXPENSE,
+                status=TransactionStatus.PAID,
+                due_date=date(2026, 5, 16),
+            )
+            _make_transaction(
+                user_id,
+                title="Dia mês passado",
+                amount="100.00",
+                tx_type=TransactionType.EXPENSE,
+                status=TransactionStatus.PAID,
+                due_date=date(2026, 4, 17),
+            )
+            _make_transaction(
+                user_id,
+                title="Receita mês passado",
+                amount="500.00",
+                tx_type=TransactionType.INCOME,
+                status=TransactionStatus.PAID,
+                due_date=date(2026, 4, 17),
+            )
+            _make_transaction(
+                user_id,
+                title="Gasto do mês",
+                amount="50.00",
+                tx_type=TransactionType.EXPENSE,
+                status=TransactionStatus.PAID,
+                due_date=date(2026, 5, 1),
+            )
+            _make_transaction(
+                user_id,
+                title="Receita do mês",
+                amount="234.00",
+                tx_type=TransactionType.INCOME,
+                status=TransactionStatus.PAID,
+                due_date=date(2026, 5, 1),
+            )
+
+            snapshot = FinancialInsightContextBuilder().build_daily(
+                user_id=user_id,
+                anchor_date=anchor,
+            )
+
+        assert snapshot["schema_version"] == "financial_insight_snapshot.v1"
+        assert snapshot["period_type"] == "daily"
+        assert snapshot["period"] == {
+            "start": "2026-05-17",
+            "end": "2026-05-17",
+            "label": "2026-05-17",
+        }
+        assert snapshot["current_period"]["paid"] == {
+            "income_total": "1000.00",
+            "expense_total": "250.00",
+            "balance": "750.00",
+            "transaction_count": 2,
+        }
+        assert snapshot["current_period"]["commitments"]["pending_expense_total"] == (
+            "80.00"
+        )
+        assert snapshot["current_period"]["commitments"]["overdue_expense_total"] == (
+            "33.25"
+        )
+        assert snapshot["current_period"]["commitments"]["transaction_count"] == 2
+        assert snapshot["current_period"]["cancelled_transaction_count"] == 1
+        assert snapshot["comparisons"]["yesterday"]["paid"]["expense_total"] == (
+            "400.00"
+        )
+        assert snapshot["comparisons"]["yesterday"]["delta"]["expense_total"] == (
+            "-150.00"
+        )
+        assert (
+            snapshot["comparisons"]["same_day_previous_month"]["paid"]["income_total"]
+            == "500.00"
+        )
+        assert (
+            snapshot["comparisons"]["same_day_previous_month"]["delta"]["income_total"]
+            == "500.00"
+        )
+        assert (
+            snapshot["comparisons"]["month_to_date"]["paid"]["expense_total"]
+            == "700.00"
+        )
+
+    def test_daily_snapshot_marks_missing_previous_month_same_day(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            anchor = date(2026, 3, 31)
+            _make_transaction(
+                user_id,
+                title="Receita do dia",
+                amount="100.00",
+                tx_type=TransactionType.INCOME,
+                status=TransactionStatus.PAID,
+                due_date=anchor,
+            )
+
+            snapshot = FinancialInsightContextBuilder().build_daily(
+                user_id=user_id,
+                anchor_date=anchor,
+            )
+
+        assert "same_day_previous_month" not in snapshot["comparisons"]
+        assert snapshot["data_quality"]["missing_comparison_periods"] == [
+            "same_day_previous_month"
+        ]
+
+    def test_snapshot_redacts_user_pii_and_sensitive_transaction_fields(
+        self, app
+    ) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            _make_transaction(
+                user_id,
+                title="Consulta CPF 123.456.789-00",
+                description="Enviar recibo para ana@example.com",
+                observation="Observação privada com telefone 11999998888",
+                external_id="bank-secret-123",
+                bank_name="Banco Sensível",
+                amount="70.00",
+                tx_type=TransactionType.EXPENSE,
+                status=TransactionStatus.PAID,
+                due_date=date(2026, 5, 17),
+            )
+
+            snapshot = FinancialInsightContextBuilder().build_daily(
+                user_id=user_id,
+                anchor_date=date(2026, 5, 17),
+            )
+
+        serialized = _as_json(snapshot)
+        assert "Ana Cliente" not in serialized
+        assert "ana@example.com" not in serialized
+        assert "123.456.789-00" not in serialized
+        assert "11999998888" not in serialized
+        assert "bank-secret-123" not in serialized
+        assert "Banco Sensível" not in serialized
+        assert "observation" not in serialized
+        assert "external_id" not in serialized
+        assert "bank_name" not in serialized
+        assert snapshot["transactions"]["sample"][0]["title"] == "Consulta CPF [cpf]"
+
+
+class TestFinancialInsightContextBuilderWeekly:
+    def test_weekly_snapshot_summarizes_day_extremes_and_previous_week(
+        self, app
+    ) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            anchor = date(2026, 5, 13)  # Wednesday, ISO week starts 2026-05-11
+            _make_transaction(
+                user_id,
+                title="Segunda gasto",
+                amount="100.00",
+                tx_type=TransactionType.EXPENSE,
+                status=TransactionStatus.PAID,
+                due_date=date(2026, 5, 11),
+                category=TransactionCategory.transporte,
+            )
+            _make_transaction(
+                user_id,
+                title="Segunda receita",
+                amount="10.00",
+                tx_type=TransactionType.INCOME,
+                status=TransactionStatus.PAID,
+                due_date=date(2026, 5, 11),
+            )
+            _make_transaction(
+                user_id,
+                title="Terça gasto",
+                amount="500.00",
+                tx_type=TransactionType.EXPENSE,
+                status=TransactionStatus.PAID,
+                due_date=date(2026, 5, 12),
+                category=TransactionCategory.alimentacao,
+            )
+            _make_transaction(
+                user_id,
+                title="Quarta receita",
+                amount="1000.00",
+                tx_type=TransactionType.INCOME,
+                status=TransactionStatus.PAID,
+                due_date=date(2026, 5, 13),
+            )
+            _make_transaction(
+                user_id,
+                title="Domingo gasto",
+                amount="50.00",
+                tx_type=TransactionType.EXPENSE,
+                status=TransactionStatus.PAID,
+                due_date=date(2026, 5, 17),
+                category=TransactionCategory.lazer,
+            )
+            _make_transaction(
+                user_id,
+                title="Semana anterior",
+                amount="200.00",
+                tx_type=TransactionType.EXPENSE,
+                status=TransactionStatus.PAID,
+                due_date=date(2026, 5, 5),
+            )
+
+            snapshot = FinancialInsightContextBuilder().build_weekly(
+                user_id=user_id,
+                anchor_date=anchor,
+            )
+
+        assert snapshot["period_type"] == "weekly"
+        assert snapshot["period"]["start"] == "2026-05-11"
+        assert snapshot["period"]["end"] == "2026-05-17"
+        assert len(snapshot["daily_series"]) == 7
+        assert snapshot["current_period"]["paid"]["expense_total"] == "650.00"
+        assert (
+            snapshot["comparisons"]["previous_period"]["paid"]["expense_total"]
+            == "200.00"
+        )
+        assert snapshot["extremes"]["max_expense_day"] == {
+            "date": "2026-05-12",
+            "amount": "500.00",
+        }
+        assert snapshot["extremes"]["min_expense_day_with_activity"] == {
+            "date": "2026-05-17",
+            "amount": "50.00",
+        }
+        assert snapshot["extremes"]["max_income_day"] == {
+            "date": "2026-05-13",
+            "amount": "1000.00",
+        }
+        assert snapshot["extremes"]["min_income_day_with_activity"] == {
+            "date": "2026-05-11",
+            "amount": "10.00",
+        }
+        assert snapshot["categories"]["top_expense_categories"][0] == {
+            "category": "alimentacao",
+            "total": "500.00",
+        }
+
+
+class TestFinancialInsightContextBuilderMonthly:
+    def test_monthly_snapshot_includes_day_extremes_budgets_and_goals(
+        self, app
+    ) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            anchor = date(2026, 5, 17)
+            _make_transaction(
+                user_id,
+                title="Maior gasto",
+                amount="1000.00",
+                tx_type=TransactionType.EXPENSE,
+                status=TransactionStatus.PAID,
+                due_date=date(2026, 5, 2),
+                category=TransactionCategory.alimentacao,
+            )
+            _make_transaction(
+                user_id,
+                title="Menor gasto",
+                amount="100.00",
+                tx_type=TransactionType.EXPENSE,
+                status=TransactionStatus.PAID,
+                due_date=date(2026, 5, 7),
+                category=TransactionCategory.transporte,
+            )
+            _make_transaction(
+                user_id,
+                title="Maior receita",
+                amount="2000.00",
+                tx_type=TransactionType.INCOME,
+                status=TransactionStatus.PAID,
+                due_date=date(2026, 5, 20),
+            )
+            _make_transaction(
+                user_id,
+                title="Menor receita",
+                amount="300.00",
+                tx_type=TransactionType.INCOME,
+                status=TransactionStatus.PAID,
+                due_date=date(2026, 5, 3),
+            )
+            _make_budget(
+                user_id,
+                name="Alimentação",
+                amount="800.00",
+                category=TransactionCategory.alimentacao,
+            )
+            _make_goal(
+                user_id,
+                title="Comprar carro",
+                current_amount="1200.00",
+                target_amount="5000.00",
+                target_date=date(2026, 12, 31),
+            )
+
+            snapshot = FinancialInsightContextBuilder().build_monthly(
+                user_id=user_id,
+                anchor_date=anchor,
+            )
+
+        assert snapshot["period_type"] == "monthly"
+        assert snapshot["period"]["start"] == "2026-05-01"
+        assert snapshot["period"]["end"] == "2026-05-31"
+        assert len(snapshot["daily_series"]) == 31
+        assert snapshot["current_period"]["paid"] == {
+            "income_total": "2300.00",
+            "expense_total": "1100.00",
+            "balance": "1200.00",
+            "transaction_count": 4,
+        }
+        assert snapshot["extremes"]["max_expense_day"] == {
+            "date": "2026-05-02",
+            "amount": "1000.00",
+        }
+        assert snapshot["extremes"]["min_expense_day_with_activity"] == {
+            "date": "2026-05-07",
+            "amount": "100.00",
+        }
+        assert snapshot["extremes"]["max_income_day"] == {
+            "date": "2026-05-20",
+            "amount": "2000.00",
+        }
+        assert snapshot["extremes"]["min_income_day_with_activity"] == {
+            "date": "2026-05-03",
+            "amount": "300.00",
+        }
+        assert snapshot["budgets"] == [
+            {
+                "name": "Alimentação",
+                "category": "alimentacao",
+                "period": "monthly",
+                "amount": "800.00",
+                "spent": "1000.00",
+                "utilization_pct": "125.00",
+                "exceeded": True,
+            }
+        ]
+        assert snapshot["goals"] == [
+            {
+                "title": "Comprar carro",
+                "current_amount": "1200.00",
+                "target_amount": "5000.00",
+                "progress_pct": "24.00",
+                "target_date": "2026-12-31",
+            }
+        ]


### PR DESCRIPTION
## Summary
- Adds `FinancialInsightContextBuilder` for `daily`, `weekly`, and `monthly` AI insight snapshots.
- Builds deterministic SQLAlchemy-backed financial context without HTTP calls to `/transactions`.
- Separates `paid`, `pending`, `overdue`, and cancelled counts, redacts direct PII, and includes period comparisons, daily series, extremes, top categories, budgets, and goals.

## Validation
- `PYTHON_BIN=/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-api/.venv/bin/python bash scripts/run_ci_quality_local.sh --local`
- Result: 2075 passed, 1 skipped, coverage 91.10%.
- Pre-commit and pre-push hooks passed with the same `PYTHON_BIN` so the worktree used the repo venv instead of the fallback pyenv interpreter.

Closes #1269
