### PR TITLE
feat(ai): add period-aware financial insight generation

### DIFF
--- a/api-tests/postman/README.md
+++ b/api-tests/postman/README.md
@@ -7,16 +7,19 @@ Ela cobre as superficies REST criticas por dominio e um smoke representativo de 
 - `api-tests/postman/auraxis.postman_collection.json`
 
 ## Estrutura oficial
-- `00 - Auth and User Bootstrap`
-- `01 - Transactions`
-- `02 - Goals`
-- `03 - Wallet`
-- `04 - Simulations`
-- `05 - Alerts`
-- `06 - Subscriptions and Entitlements`
-- `07 - Shared Entries`
-- `08 - Fiscal`
-- `09 - GraphQL`
+- `00 - Health`
+- `01 - Auth`
+- `02 - User`
+- `03 - Transactions`
+- `04 - Budgets`
+- `05 - Goals`
+- `06 - Wallet`
+- `07 - Simulations`
+- `08 - Entitlements`
+- `09 - Notifications`
+- `10 - LGPD`
+- `11 - AI Advisory`
+- `99 - Cleanup`
 
 ## Ambientes versionados
 - `environments/local.postman_environment.json`

--- a/api-tests/postman/auraxis.postman_collection.json
+++ b/api-tests/postman/auraxis.postman_collection.json
@@ -1,7 +1,7 @@
 {
   "info": {
     "name": "Auraxis API",
-    "description": "Auto-generated from openapi.json (71 paths). Do not edit manually — regenerate with: npm run postman:build",
+    "description": "Auto-generated from openapi.json (76 paths). Do not edit manually — regenerate with: npm run postman:build",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "item": [
@@ -4440,6 +4440,230 @@
                 "exec": [
                   "pm.test('Registrar consentimento — expected 201', function () {",
                   "  pm.response.to.have.status(201);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "11 - AI Advisory",
+      "item": [
+        {
+          "name": "GET — Briefing semanal com IA (Premium)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/ai/insights/weekly-summary",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "ai",
+                "insights",
+                "weekly-summary"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('AI weekly summary — expected 200 or 403 or 429', function () {",
+                  "  pm.expect(pm.response.code).to.be.oneOf([200, 403, 429]);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "GET — Histórico de insights de IA",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/ai/insights/history",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "ai",
+                "insights",
+                "history"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('AI insights history — expected 200 or 401', function () {",
+                  "  pm.expect(pm.response.code).to.be.oneOf([200, 401]);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "GET — Insights de gastos com IA (Premium)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/ai/insights/spending",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "ai",
+                "insights",
+                "spending"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('AI spending insights — expected 200 or 403 or 429', function () {",
+                  "  pm.expect(pm.response.code).to.be.oneOf([200, 403, 429]);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "POST — Gerar insight financeiro period-aware com IA (Premium)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/ai/insights/generate",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "ai",
+                "insights",
+                "generate"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"period_type\": \"daily\",\n  \"anchor_date\": \"{{runToday}}\"\n}"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('AI period insight — expected 200 or 403 or 429', function () {",
+                  "  pm.expect(pm.response.code).to.be.oneOf([200, 403, 429]);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "POST — Narrativa de projeção de meta com IA (Premium)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/ai/goals/:goal_id/projection",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "ai",
+                "goals",
+                ":goal_id",
+                "projection"
+              ],
+              "variable": [
+                {
+                  "key": "goal_id",
+                  "value": "{{goalId}}"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('AI goal projection — expected 200 or 400 or 403 or 404', function () {",
+                  "  pm.expect(pm.response.code).to.be.oneOf([200, 400, 403, 404]);",
                   "});"
                 ],
                 "type": "text/javascript"

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -176,6 +176,7 @@ def _register_documented_endpoints(app: Flask, docs: FlaskApiSpec) -> None:
         "budget",
         "notifications",
         "consents",
+        "ai",
     }
     for endpoint, view_func in sorted(app.view_functions.items()):
         if "." not in endpoint:

--- a/app/controllers/ai/resources.py
+++ b/app/controllers/ai/resources.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import logging
 import uuid
+from datetime import date
 from decimal import Decimal, InvalidOperation
 from typing import Any
 from uuid import UUID
@@ -27,9 +28,11 @@ from app.controllers.response_contract import (
 from app.controllers.transaction.utils import _guard_revoked_token
 from app.docs.openapi_helpers import (
     json_error_response,
+    json_request_body,
     json_success_response,
 )
 from app.middleware.ai_rate_limit import ai_daily_limit
+from app.schemas.ai_insight_schema import AIInsightGenerateRequestSchema
 from app.services.ai_advisory_service import AIAdvisoryService
 from app.services.ai_lgpd import AIConsentRequiredError
 from app.services.analysis_ready_notification_service import (
@@ -43,6 +46,7 @@ from app.utils.typed_decorators import typed_jwt_required as jwt_required
 log = logging.getLogger(__name__)
 
 _ENTITLEMENT_KEY = "advanced_simulations"
+_AI_INSIGHT_PERIOD_TYPES = {"daily", "weekly", "monthly"}
 
 
 def _check_entitlement(user_id: UUID) -> Response | None:
@@ -70,10 +74,10 @@ def _ai_consent_required_response(exc: AIConsentRequiredError) -> Response:
 def _parse_goal_projection_body(
     goal_id_raw: str,
     body: dict[str, Any],
-) -> tuple[Response, None, None] | tuple[None, UUID, Decimal, str]:
+) -> tuple[Response, None, None, None] | tuple[None, UUID, Decimal, str]:
     """Validate the goal projection request payload.
 
-    Returns either ``(error_response, None, None)`` when something is invalid
+    Returns either ``(error_response, None, None, None)`` when something is invalid
     or ``(None, parsed_goal_id, monthly_contribution, user_context)`` on
     success. Extracted from :meth:`AIGoalProjectionResource.post` so the
     controller method stays under the cognitive-complexity threshold.
@@ -90,6 +94,7 @@ def _parse_goal_projection_body(
             ),
             None,
             None,
+            None,
         )
 
     user_context = str(body.get("user_context", ""))
@@ -102,6 +107,7 @@ def _parse_goal_projection_body(
                 message="monthly_contribution é obrigatório",
                 error_code="VALIDATION_ERROR",
             ),
+            None,
             None,
             None,
         )
@@ -122,9 +128,162 @@ def _parse_goal_projection_body(
             ),
             None,
             None,
+            None,
         )
 
     return None, parsed_goal_id, monthly_contribution, user_context
+
+
+def _parse_ai_insight_generate_body(
+    body: dict[str, Any],
+) -> tuple[Response, None, None] | tuple[None, str, date | None]:
+    period_type = str(body.get("period_type", "")).strip().lower()
+    if period_type not in _AI_INSIGHT_PERIOD_TYPES:
+        return (
+            compat_error_response(
+                legacy_payload={
+                    "error": "period_type deve ser daily, weekly ou monthly"
+                },
+                status_code=400,
+                message="period_type deve ser daily, weekly ou monthly",
+                error_code="VALIDATION_ERROR",
+            ),
+            None,
+            None,
+        )
+
+    raw_anchor_date = body.get("anchor_date")
+    if raw_anchor_date in (None, ""):
+        return None, period_type, None
+
+    try:
+        anchor_date = date.fromisoformat(str(raw_anchor_date))
+    except ValueError:
+        return (
+            compat_error_response(
+                legacy_payload={
+                    "error": "anchor_date deve estar no formato YYYY-MM-DD"
+                },
+                status_code=400,
+                message="anchor_date deve estar no formato YYYY-MM-DD",
+                error_code="VALIDATION_ERROR",
+            ),
+            None,
+            None,
+        )
+
+    return None, period_type, anchor_date
+
+
+class AIInsightGenerateResource(MethodResource):
+    """POST /ai/insights/generate — period-aware AI financial insights."""
+
+    @doc(
+        summary="Gerar insight financeiro period-aware com IA (Premium)",
+        description=(
+            "Gera insights financeiros com contexto daily, weekly ou monthly, "
+            "incluindo evidências estruturadas extraídas do snapshot financeiro."
+        ),
+        tags=["AI Advisory"],
+        security=[{"BearerAuth": []}],
+        requestBody=json_request_body(
+            schema=AIInsightGenerateRequestSchema,
+            description="Período que deve ser consolidado antes da chamada à IA.",
+            example={"period_type": "daily", "anchor_date": "2026-05-17"},
+        ),
+        responses={
+            200: json_success_response(
+                description="Insight gerado com sucesso",
+                message="Insight financeiro gerado com sucesso",
+                data_example={
+                    "period_type": "daily",
+                    "period_label": "2026-05-17",
+                    "period_start": "2026-05-17",
+                    "period_end": "2026-05-17",
+                    "summary": "Resumo do período.",
+                    "items": [
+                        {
+                            "type": "saude_financeira",
+                            "title": "Saldo positivo",
+                            "message": "Você terminou o período com saldo positivo.",
+                            "evidence": ["current_period.paid.balance"],
+                        }
+                    ],
+                    "context_version": "financial_insight_snapshot.v1",
+                    "cached": False,
+                    "model": "gpt-4o-mini",
+                    "tokens_used": 420,
+                    "cost_usd": 0.000063,
+                },
+            ),
+            400: json_error_response(
+                description="Parâmetros inválidos",
+                message="period_type deve ser daily, weekly ou monthly",
+                error_code="VALIDATION_ERROR",
+                status_code=400,
+            ),
+            403: json_error_response(
+                description="Entitlement insuficiente",
+                message="Recurso exclusivo para assinantes Premium.",
+                error_code="ENTITLEMENT_REQUIRED",
+                status_code=403,
+            ),
+            500: json_error_response(
+                description="Erro interno ou falha do provider LLM",
+                message="Erro ao gerar insight financeiro",
+                error_code="INTERNAL_ERROR",
+                status_code=500,
+            ),
+        },
+    )
+    @jwt_required()
+    @ai_daily_limit()
+    def post(self) -> Response:
+        token_error = _guard_revoked_token()
+        if token_error is not None:
+            return token_error
+
+        user_id = current_user_id()
+
+        entitlement_error = _check_entitlement(user_id)
+        if entitlement_error is not None:
+            return entitlement_error
+
+        body = request.get_json(silent=True) or {}
+        parse_error, period_type, anchor_date = _parse_ai_insight_generate_body(body)
+        if parse_error is not None:
+            return parse_error
+        assert period_type is not None
+
+        service = AIAdvisoryService(user_id=user_id)
+        try:
+            result = service.generate_financial_insights(
+                period_type=period_type,
+                anchor_date=anchor_date,
+            )
+        except AIConsentRequiredError as exc:
+            return _ai_consent_required_response(exc)
+        except LLMProviderError as exc:
+            return compat_error_response(
+                legacy_payload={"error": str(exc)},
+                status_code=500,
+                message="Erro ao gerar insight financeiro",
+                error_code="INTERNAL_ERROR",
+            )
+        except Exception:
+            return compat_error_response(
+                legacy_payload={"error": "Erro interno ao gerar insight financeiro"},
+                status_code=500,
+                message="Erro interno ao gerar insight financeiro",
+                error_code="INTERNAL_ERROR",
+            )
+
+        return compat_success_response(
+            legacy_payload=result,
+            status_code=200,
+            message="Insight financeiro gerado com sucesso",
+            data=result,
+        )
 
 
 class AISpendingInsightsResource(MethodResource):
@@ -576,6 +735,7 @@ class AIInsightHistoryResource(MethodResource):
 
 __all__ = [
     "AIGoalProjectionResource",
+    "AIInsightGenerateResource",
     "AIInsightHistoryResource",
     "AISpendingInsightsResource",
     "AIWeeklySummaryResource",

--- a/app/controllers/ai/routes.py
+++ b/app/controllers/ai/routes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from .blueprint import ai_bp
 from .resources import (
     AIGoalProjectionResource,
+    AIInsightGenerateResource,
     AIInsightHistoryResource,
     AISpendingInsightsResource,
     AIWeeklySummaryResource,
@@ -16,6 +17,11 @@ def register_ai_routes() -> None:
     if _ROUTES_REGISTERED:
         return
 
+    ai_bp.add_url_rule(
+        "/insights/generate",
+        view_func=AIInsightGenerateResource.as_view("ai_insight_generate"),
+        methods=["POST"],
+    )
     ai_bp.add_url_rule(
         "/insights/spending",
         view_func=AISpendingInsightsResource.as_view("ai_spending_insights"),

--- a/app/docs/api_documentation.py
+++ b/app/docs/api_documentation.py
@@ -61,6 +61,10 @@ TAGS = [
             "Gestão de consentimentos versionados, export e remoção de dados"
         ),
     },
+    {
+        "name": "AI Advisory",
+        "description": "Insights financeiros e narrativas geradas por IA",
+    },
 ]
 
 EXAMPLES = {

--- a/app/schemas/ai_insight_schema.py
+++ b/app/schemas/ai_insight_schema.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from marshmallow import Schema, fields, validate
+
+
+class AIInsightGenerateRequestSchema(Schema):
+    period_type = fields.String(
+        required=True,
+        validate=validate.OneOf(["daily", "weekly", "monthly"]),
+        metadata={
+            "description": "Granularidade do insight financeiro.",
+            "example": "daily",
+        },
+    )
+    anchor_date = fields.Date(
+        required=False,
+        allow_none=True,
+        metadata={
+            "description": "Data âncora do período no formato YYYY-MM-DD.",
+            "example": "2026-05-17",
+        },
+    )
+
+
+__all__ = ["AIInsightGenerateRequestSchema"]

--- a/app/services/ai_advisory_service.py
+++ b/app/services/ai_advisory_service.py
@@ -40,6 +40,9 @@ from app.services.ai_lgpd import (
     redact_prompt_for_audit,
     redact_response_for_audit,
 )
+from app.services.financial_insight_context_builder import (
+    FinancialInsightContextBuilder,
+)
 from app.services.goal_projection_service import GoalProjectionService
 from app.services.llm_provider import LLMProvider, LLMProviderError, get_llm_provider
 from app.services.weekly_summary import compute_weekly_summary
@@ -89,7 +92,41 @@ _SPENDING_INSIGHTS_RESPONSE_SCHEMA: dict[str, Any] = {
     },
 }
 
+_FINANCIAL_INSIGHT_RESPONSE_SCHEMA: dict[str, Any] = {
+    "name": "financial_insight_response",
+    "strict": True,
+    "schema": {
+        "type": "object",
+        "properties": {
+            "summary": {"type": "string"},
+            "items": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "enum": list(_SPENDING_INSIGHT_TYPES),
+                        },
+                        "title": {"type": "string"},
+                        "message": {"type": "string"},
+                        "evidence": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
+                    },
+                    "required": ["type", "title", "message", "evidence"],
+                    "additionalProperties": False,
+                },
+            },
+        },
+        "required": ["summary", "items"],
+        "additionalProperties": False,
+    },
+}
+
 InsightItem = dict[str, str]
+FinancialInsightItem = dict[str, Any]
 
 
 # ---------------------------------------------------------------------------
@@ -227,8 +264,74 @@ def _coerce_spending_insight_items(content: str) -> list[InsightItem]:
     return items
 
 
+def _coerce_financial_insight_response(
+    content: str,
+) -> tuple[str, list[FinancialInsightItem]]:
+    raw = _strip_json_code_fence(content)
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise LLMProviderError("Invalid financial insight JSON.") from exc
+
+    if not isinstance(parsed, dict):
+        raise LLMProviderError("Invalid financial insight response.")
+
+    summary = parsed.get("summary")
+    if not isinstance(summary, str) or not summary.strip():
+        raise LLMProviderError("Invalid financial insight summary.")
+
+    candidate_items = parsed.get("items")
+    if not isinstance(candidate_items, list) or not candidate_items:
+        raise LLMProviderError("Invalid financial insight items.")
+
+    items: list[FinancialInsightItem] = []
+    for candidate in candidate_items:
+        if not isinstance(candidate, dict):
+            raise LLMProviderError("Invalid financial insight item.")
+
+        item_type = candidate.get("type")
+        title = candidate.get("title")
+        message = candidate.get("message")
+        evidence = candidate.get("evidence")
+        if (
+            not isinstance(item_type, str)
+            or item_type.strip() not in _SPENDING_INSIGHT_TYPES
+            or not isinstance(title, str)
+            or not title.strip()
+            or not isinstance(message, str)
+            or not message.strip()
+            or not isinstance(evidence, list)
+            or not evidence
+            or not all(isinstance(item, str) and item.strip() for item in evidence)
+        ):
+            raise LLMProviderError("Invalid financial insight item fields.")
+
+        items.append(
+            {
+                "type": item_type.strip(),
+                "title": title.strip(),
+                "message": message.strip(),
+                "evidence": [item.strip() for item in evidence],
+            }
+        )
+
+    return summary.strip(), items
+
+
 def _serialize_spending_insight_items(items: list[InsightItem]) -> str:
     return json.dumps(items, ensure_ascii=False, separators=(",", ":"))
+
+
+def _serialize_financial_insight_response(
+    *,
+    summary: str,
+    items: list[FinancialInsightItem],
+) -> str:
+    return json.dumps(
+        {"summary": summary, "items": items},
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
 
 
 def _log_llm_call(
@@ -301,6 +404,138 @@ class AIAdvisoryService:
     # ------------------------------------------------------------------
     # 1. Spending insights
     # ------------------------------------------------------------------
+
+    def generate_financial_insights(
+        self,
+        *,
+        period_type: str,
+        anchor_date: date | None = None,
+    ) -> dict[str, Any]:
+        """Generate period-aware financial insights with structured evidence."""
+        normalized_period_type = period_type.strip().lower()
+        insight_type = InsightType(normalized_period_type)
+        anchor = anchor_date or date.today()
+        consent_version = ensure_ai_consent_granted(self._user_id)
+
+        snapshot_builder = FinancialInsightContextBuilder()
+        if insight_type == InsightType.daily:
+            snapshot = snapshot_builder.build_daily(
+                user_id=self._user_id,
+                anchor_date=anchor,
+            )
+        elif insight_type == InsightType.weekly:
+            snapshot = snapshot_builder.build_weekly(
+                user_id=self._user_id,
+                anchor_date=anchor,
+            )
+        elif insight_type == InsightType.monthly:
+            snapshot = snapshot_builder.build_monthly(
+                user_id=self._user_id,
+                anchor_date=anchor,
+            )
+        else:
+            raise ValueError("period_type must be daily, weekly or monthly")
+
+        period = snapshot["period"]
+        period_label = str(period["label"])
+        period_start = date.fromisoformat(str(period["start"]))
+        period_end = date.fromisoformat(str(period["end"]))
+        context_version = str(snapshot["schema_version"])
+
+        cached = _get_cached_insight(
+            user_id=self._user_id,
+            insight_type=insight_type,
+            period_label=period_label,
+        )
+        if cached is not None:
+            try:
+                cached_summary, cached_items = _coerce_financial_insight_response(
+                    cached.content
+                )
+            except LLMProviderError:
+                log.warning(
+                    "ai_advisory.financial_insights.cached_parse_failed "
+                    "user=%s insight=%s",
+                    self._user_id,
+                    cached.id,
+                )
+            else:
+                return {
+                    "period_type": normalized_period_type,
+                    "period_label": cached.period_label,
+                    "period_start": cached.period_start.isoformat(),
+                    "period_end": cached.period_end.isoformat(),
+                    "summary": cached_summary,
+                    "items": cached_items,
+                    "context_version": context_version,
+                    "tokens_used": cached.tokens_used,
+                    "cost_usd": float(cached.cost_usd),
+                    "model": cached.model,
+                    "cached": True,
+                }
+
+        previous = _get_latest_insight(user_id=self._user_id)
+        prompt = _build_financial_insight_prompt(
+            minimize_prompt_data(snapshot),
+            period_type=normalized_period_type,
+            previous_insight=previous.content if previous else None,
+        )
+
+        try:
+            llm_resp = self._provider.generate_with_usage(
+                prompt,
+                response_schema=_FINANCIAL_INSIGHT_RESPONSE_SCHEMA,
+            )
+        except LLMProviderError as exc:
+            log.warning(
+                "ai_advisory.financial_insights.llm_error "
+                "user=%s period_type=%s error=%s",
+                self._user_id,
+                normalized_period_type,
+                exc,
+            )
+            raise
+
+        summary, items = _coerce_financial_insight_response(llm_resp.content)
+        serialized_content = _serialize_financial_insight_response(
+            summary=summary,
+            items=items,
+        )
+
+        _log_llm_call(
+            user_id=self._user_id,
+            endpoint=f"financial_insights_{normalized_period_type}",
+            prompt=prompt,
+            llm_response=llm_resp,
+            consent_version=consent_version,
+        )
+
+        _save_insight(
+            user_id=self._user_id,
+            content=serialized_content,
+            insight_type=insight_type,
+            period_label=period_label,
+            period_start=period_start,
+            period_end=period_end,
+            model=llm_resp.model,
+            tokens_used=llm_resp.total_tokens,
+            cost_usd=llm_resp.estimated_cost_usd,
+            previous_insight_id=previous.id if previous else None,
+        )
+
+        return {
+            "period_type": normalized_period_type,
+            "period_label": period_label,
+            "period_start": period_start.isoformat(),
+            "period_end": period_end.isoformat(),
+            "summary": summary,
+            "items": items,
+            "context_version": context_version,
+            "tokens_used": llm_resp.total_tokens,
+            "cost_usd": llm_resp.estimated_cost_usd,
+            "model": llm_resp.model,
+            "cached": False,
+        }
 
     def generate_spending_insights(self, month: str | None = None) -> dict[str, Any]:
         """Analyse spending for the given month and return AI-generated insights.
@@ -1183,6 +1418,59 @@ def _build_monthly_budget_by_category(
 # ---------------------------------------------------------------------------
 # Prompt builders
 # ---------------------------------------------------------------------------
+
+
+def _build_financial_insight_prompt(
+    snapshot: dict[str, Any],
+    *,
+    period_type: str,
+    previous_insight: str | None = None,
+) -> str:
+    context = json.dumps(snapshot, ensure_ascii=False, default=str)
+    previous_block = ""
+    if previous_insight:
+        previous_block = (
+            "\nInsight anterior persistido para continuidade narrativa:\n"
+            f"{previous_insight}\n"
+        )
+
+    period_instruction = {
+        "daily": (
+            "Para insight diário: compare hoje com ontem, com o mesmo dia do mês "
+            "passado quando disponível, recapitule rapidamente o mês até agora e "
+            "resuma como o usuário está hoje."
+        ),
+        "weekly": (
+            "Para insight semanal: resuma a semana, cite maiores e menores gastos, "
+            "maiores e menores recebimentos, e identifique dias da semana com mais "
+            "e menos consumo/recebimento quando os dados permitirem."
+        ),
+        "monthly": (
+            "Para insight mensal: mostre o dia de maior gasto, maior recebimento, "
+            "menor gasto com atividade, menor recebimento com atividade e faça um "
+            "panorama geral do mês."
+        ),
+    }[period_type]
+
+    insight_types = ", ".join(_SPENDING_INSIGHT_TYPES)
+    return (
+        "Você é um analista financeiro pessoal. Analise exclusivamente o snapshot "
+        "financeiro estruturado abaixo e gere insights em português brasileiro, "
+        "objetivos, personalizados e acionáveis.\n"
+        f"{period_instruction}\n"
+        "Use somente os dados do snapshot fornecido. Não invente transações, metas, "
+        "orçamentos, rendas, despesas, nomes, datas ou valores ausentes. Quando uma "
+        "comparação não existir, mencione a ausência apenas se ela for relevante.\n"
+        "Cada item deve conter evidências que apontem para chaves conhecidas do "
+        "snapshot, como current_period.paid.balance, comparisons.yesterday.delta, "
+        "daily_series, extremes, categories, transactions.sample, budgets ou goals.\n"
+        f"{previous_block}"
+        f"\nSnapshot financeiro ({snapshot.get('schema_version')}):\n{context}\n\n"
+        f"Tipos permitidos: {insight_types}.\n"
+        "Retorne somente JSON no formato:\n"
+        '{"summary":"...","items":[{"type":"saude_financeira",'
+        '"title":"...","message":"...","evidence":["current_period.paid.balance"]}]}'
+    )
 
 
 def _build_spending_prompt(

--- a/app/services/llm_provider.py
+++ b/app/services/llm_provider.py
@@ -89,7 +89,17 @@ class StubLLMProvider:
         response_schema: dict[str, Any] | None = None,
     ) -> LLMResponse:
         content = self._STUB_CONTENT
-        if response_schema is not None:
+        if (
+            response_schema
+            and response_schema.get("name") == "financial_insight_response"
+        ):
+            content = (
+                '{"summary":"Resumo financeiro gerado com sucesso.",'
+                '"items":[{"type":"saude_financeira","title":"Resumo financeiro",'
+                '"message":"Seus dados financeiros foram analisados com sucesso.",'
+                '"evidence":["current_period.paid.balance"]}]}'
+            )
+        elif response_schema is not None:
             content = (
                 '{"items":[{"type":"saude_financeira","title":"Resumo financeiro",'
                 '"message":"Seus dados financeiros foram analisados com sucesso."}]}'

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,6 @@
   "components": {
     "schemas": {
       "InstallmentVsCashCalculation": {
-        "additionalProperties": false,
         "properties": {
           "cash_price": {
             "minimum": 0.01,
@@ -76,7 +75,6 @@
         "type": "object"
       },
       "InstallmentVsCashGoalBridge": {
-        "additionalProperties": false,
         "properties": {
           "category": {
             "default": "planned_purchase",
@@ -127,7 +125,6 @@
         "type": "object"
       },
       "InstallmentVsCashPlannedExpenseBridge": {
-        "additionalProperties": false,
         "properties": {
           "account_id": {
             "default": null,
@@ -214,7 +211,6 @@
         "type": "object"
       },
       "InstallmentVsCashSave": {
-        "additionalProperties": false,
         "properties": {
           "cash_price": {
             "minimum": 0.01,
@@ -288,7 +284,6 @@
         "type": "object"
       },
       "TransactionCreate": {
-        "additionalProperties": false,
         "properties": {
           "account_id": {
             "description": "ID da conta bancária associada",
@@ -469,7 +464,6 @@
         "type": "object"
       },
       "TransactionCreate_7d3b606eab": {
-        "additionalProperties": false,
         "properties": {
           "account_id": {
             "description": "ID da conta bancária associada",
@@ -643,8 +637,32 @@
         },
         "type": "object"
       },
+      "app_schemas_ai_insight_schema_AIInsightGenerateRequestSchema": {
+        "properties": {
+          "anchor_date": {
+            "description": "Data âncora do período no formato YYYY-MM-DD.",
+            "example": "2026-05-17",
+            "format": "date",
+            "nullable": true,
+            "type": "string"
+          },
+          "period_type": {
+            "description": "Granularidade do insight financeiro.",
+            "enum": [
+              "daily",
+              "weekly",
+              "monthly"
+            ],
+            "example": "daily",
+            "type": "string"
+          }
+        },
+        "required": [
+          "period_type"
+        ],
+        "type": "object"
+      },
       "app_schemas_auth_schema_AuthSchema": {
-        "additionalProperties": false,
         "properties": {
           "captcha_token": {
             "default": null,
@@ -672,7 +690,6 @@
         "type": "object"
       },
       "app_schemas_auth_schema_ConfirmEmailSchema": {
-        "additionalProperties": false,
         "properties": {
           "token": {
             "description": "Token de confirmacao recebido por email",
@@ -688,7 +705,6 @@
         "type": "object"
       },
       "app_schemas_auth_schema_ForgotPasswordSchema": {
-        "additionalProperties": false,
         "properties": {
           "email": {
             "description": "Email da conta que deseja recuperar acesso",
@@ -703,7 +719,6 @@
         "type": "object"
       },
       "app_schemas_auth_schema_ResetPasswordSchema": {
-        "additionalProperties": false,
         "properties": {
           "new_password": {
             "description": "Nova senha (mínimo 10 caracteres, com maiúscula, número e símbolo)",
@@ -727,7 +742,6 @@
         "type": "object"
       },
       "app_schemas_consent_schemas_ConsentRecordSchema": {
-        "additionalProperties": false,
         "properties": {
           "action": {
             "enum": [
@@ -770,7 +784,6 @@
         "type": "object"
       },
       "app_schemas_push_subscription_schema_SubscribeSchema": {
-        "additionalProperties": false,
         "properties": {
           "device_label": {
             "default": null,
@@ -805,7 +818,6 @@
         "type": "object"
       },
       "app_schemas_push_subscription_schema_UnsubscribeSchema": {
-        "additionalProperties": false,
         "properties": {
           "endpoint": {
             "type": "string"
@@ -817,7 +829,6 @@
         "type": "object"
       },
       "app_schemas_user_schemas_DeleteAccountSchema": {
-        "additionalProperties": false,
         "properties": {
           "password": {
             "description": "Senha atual do usuário para confirmar a exclusão da conta",
@@ -832,7 +843,6 @@
         "type": "object"
       },
       "app_schemas_user_schemas_QuestionnaireAnswerSchema": {
-        "additionalProperties": false,
         "properties": {
           "answers": {
             "description": "Lista de 5 respostas — pontos da opção escolhida em cada pergunta (1–3).",
@@ -852,7 +862,6 @@
         "type": "object"
       },
       "app_schemas_user_schemas_SalaryIncreaseSimulationRequestSchema": {
-        "additionalProperties": false,
         "properties": {
           "base_date": {
             "description": "Data base do salário atual",
@@ -888,7 +897,6 @@
         "type": "object"
       },
       "app_schemas_user_schemas_UserProfileSchema": {
-        "additionalProperties": false,
         "properties": {
           "birth_date": {
             "description": "Data de nascimento",
@@ -1001,7 +1009,6 @@
         "type": "object"
       },
       "app_schemas_user_schemas_UserRegistrationSchema": {
-        "additionalProperties": false,
         "properties": {
           "captcha_token": {
             "default": null,
@@ -1075,6 +1082,1029 @@
   },
   "openapi": "3.0.2",
   "paths": {
+    "/ai/goals/{goal_id}/projection": {
+      "post": {
+        "description": "Gera uma narrativa motivacional e prática para uma meta financeira específica, combinando projeção matemática com contexto do usuário. Requer entitlement 'advanced_simulations' (plano Premium).",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "goal_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "cost_usd": 6.7e-05,
+                    "model": "gpt-4o-mini",
+                    "narrative": "Com base no seu plano de aportes...",
+                    "projection": {
+                      "months_to_completion": 24
+                    },
+                    "tokens_used": 450
+                  },
+                  "message": "Narrativa de projeção gerada com sucesso"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Narrativa gerada com sucesso",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "VALIDATION_ERROR",
+                  "message": "monthly_contribution deve ser um número positivo",
+                  "status_code": 400
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Parâmetros inválidos",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token inválido",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Não autenticado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "ENTITLEMENT_REQUIRED",
+                  "message": "Recurso exclusivo para assinantes Premium.",
+                  "status_code": 403
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Entitlement insuficiente",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "NOT_FOUND",
+                  "message": "Meta não encontrada",
+                  "status_code": 404
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Meta não encontrada",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Erro ao gerar narrativa de projeção",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Falha do provider LLM",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Narrativa de projeção de meta com IA (Premium)",
+        "tags": [
+          "AI Advisory"
+        ]
+      }
+    },
+    "/ai/insights/generate": {
+      "post": {
+        "description": "Gera insights financeiros com contexto daily, weekly ou monthly, incluindo evidências estruturadas extraídas do snapshot financeiro.",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "description": "Período que deve ser consolidado antes da chamada à IA.",
+              "example": {
+                "anchor_date": "2026-05-17",
+                "period_type": "daily"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/app_schemas_ai_insight_schema_AIInsightGenerateRequestSchema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "cached": false,
+                    "context_version": "financial_insight_snapshot.v1",
+                    "cost_usd": 6.3e-05,
+                    "items": [
+                      {
+                        "evidence": [
+                          "current_period.paid.balance"
+                        ],
+                        "message": "Você terminou o período com saldo positivo.",
+                        "title": "Saldo positivo",
+                        "type": "saude_financeira"
+                      }
+                    ],
+                    "model": "gpt-4o-mini",
+                    "period_end": "2026-05-17",
+                    "period_label": "2026-05-17",
+                    "period_start": "2026-05-17",
+                    "period_type": "daily",
+                    "summary": "Resumo do período.",
+                    "tokens_used": 420
+                  },
+                  "message": "Insight financeiro gerado com sucesso"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Insight gerado com sucesso",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "VALIDATION_ERROR",
+                  "message": "period_type deve ser daily, weekly ou monthly",
+                  "status_code": 400
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Parâmetros inválidos",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "ENTITLEMENT_REQUIRED",
+                  "message": "Recurso exclusivo para assinantes Premium.",
+                  "status_code": 403
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Entitlement insuficiente",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Erro ao gerar insight financeiro",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno ou falha do provider LLM",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Gerar insight financeiro period-aware com IA (Premium)",
+        "tags": [
+          "AI Advisory"
+        ]
+      }
+    },
+    "/ai/insights/history": {
+      "get": {
+        "description": "Retorna a lista paginada de insights gerados por IA para o usuário autenticado, ordenada do mais recente para o mais antigo. Acessível sem entitlement premium.",
+        "parameters": [
+          {
+            "description": "Número da página (base 1). Padrão: 1.",
+            "example": 1,
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "description": "Itens por página (máx. 50). Padrão: 20.",
+            "example": 20,
+            "in": "query",
+            "name": "per_page",
+            "required": false,
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "items": [
+                      {
+                        "content": "3 insights...",
+                        "cost_usd": 4.8e-05,
+                        "created_at": "2026-05-11T19:00:00",
+                        "id": "uuid",
+                        "insight_type": "daily",
+                        "model": "gpt-4o-mini",
+                        "period_end": "2026-05-11",
+                        "period_label": "2026-05-11",
+                        "period_start": "2026-05-11",
+                        "tokens_used": 320
+                      }
+                    ],
+                    "page": 1,
+                    "per_page": 20,
+                    "total": 1
+                  },
+                  "message": "Histórico de insights carregado"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Lista de insights",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token inválido",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Não autenticado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Histórico de insights de IA",
+        "tags": [
+          "AI Advisory"
+        ]
+      }
+    },
+    "/ai/insights/spending": {
+      "get": {
+        "description": "Analisa os gastos do mês informado e retorna insights gerados por LLM em PT-BR. Requer entitlement 'advanced_simulations' (plano Premium).",
+        "parameters": [
+          {
+            "description": "Mês no formato YYYY-MM. Padrão: mês atual.",
+            "example": "2026-05",
+            "in": "query",
+            "name": "month",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "cached": false,
+                    "cost_usd": 4.8e-05,
+                    "insights": "[{\"type\":\"saude_financeira\",\"title\":\"Resumo\",\"message\":\"Mensagem acionável.\"}]",
+                    "items": [
+                      {
+                        "message": "Mensagem acionável.",
+                        "title": "Resumo",
+                        "type": "saude_financeira"
+                      }
+                    ],
+                    "model": "gpt-4o-mini",
+                    "month": "2026-05",
+                    "tokens_used": 320
+                  },
+                  "message": "Insights de gastos gerados com sucesso"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Insights gerados com sucesso",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token inválido",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Não autenticado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "ENTITLEMENT_REQUIRED",
+                  "message": "Recurso exclusivo para assinantes Premium.",
+                  "status_code": 403
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Entitlement insuficiente",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Erro ao gerar insights de gastos",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno ou falha do provider LLM",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Insights de gastos com IA (Premium)",
+        "tags": [
+          "AI Advisory"
+        ]
+      }
+    },
+    "/ai/insights/weekly-summary": {
+      "get": {
+        "description": "Gera um briefing narrativo do resumo financeiro da semana atual. Requer entitlement 'advanced_simulations' (plano Premium).",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "cost_usd": 4.2e-05,
+                    "model": "gpt-4o-mini",
+                    "narrative": "Esta semana você gastou R$ 1.200...",
+                    "summary": {
+                      "current_week": {},
+                      "previous_week": {}
+                    },
+                    "tokens_used": 280
+                  },
+                  "message": "Briefing semanal gerado com sucesso"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Briefing gerado com sucesso",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token inválido",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Não autenticado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "ENTITLEMENT_REQUIRED",
+                  "message": "Recurso exclusivo para assinantes Premium.",
+                  "status_code": 403
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Entitlement insuficiente",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Erro ao gerar briefing semanal",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Falha do provider LLM",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Briefing semanal com IA (Premium)",
+        "tags": [
+          "AI Advisory"
+        ]
+      }
+    },
     "/auth/email/confirm": {
       "post": {
         "description": "Confirma a conta do usuario a partir do token enviado por email.",
@@ -11985,6 +13015,10 @@
     {
       "description": "Gestão de consentimentos versionados, export e remoção de dados",
       "name": "LGPD"
+    },
+    {
+      "description": "Insights financeiros e narrativas geradas por IA",
+      "name": "AI Advisory"
     }
   ]
 }

--- a/scripts/openapi_to_postman.py
+++ b/scripts/openapi_to_postman.py
@@ -48,6 +48,7 @@ TAG_FOLDER_MAP: dict[str, str] = {
     "Entitlements": "08 - Entitlements",
     "Notificações": "09 - Notifications",
     "LGPD": "10 - LGPD",
+    "AI Advisory": "11 - AI Advisory",
 }
 DEFAULT_FOLDER = "99 - Other"
 
@@ -172,6 +173,7 @@ FOLDER_ORDER = [
     "08 - Entitlements",
     "09 - Notifications",
     "10 - LGPD",
+    "11 - AI Advisory",
     "99 - Cleanup",
     "99 - Other",
 ]
@@ -886,6 +888,17 @@ ENRICHMENT: dict[str, dict[str, Any]] = {
     "GET /ai/insights/weekly-summary": {
         "test_lines": [
             "pm.test('AI weekly summary — expected 200 or 403 or 429', function () {",
+            "  pm.expect(pm.response.code).to.be.oneOf([200, 403, 429]);",
+            "});",
+        ],
+    },
+    "POST /ai/insights/generate": {
+        "body_override": json.dumps(
+            {"period_type": "daily", "anchor_date": "{{runToday}}"},
+            indent=2,
+        ),
+        "test_lines": [
+            "pm.test('AI period insight — expected 200 or 403 or 429', function () {",
             "  pm.expect(pm.response.code).to.be.oneOf([200, 403, 429]);",
             "});",
         ],

--- a/tests/test_ai_advisory_service.py
+++ b/tests/test_ai_advisory_service.py
@@ -18,6 +18,7 @@ Coverage areas:
 from __future__ import annotations
 
 import uuid
+from datetime import date
 from decimal import Decimal
 from unittest.mock import MagicMock, patch
 
@@ -79,6 +80,28 @@ def _get_current_user_id(app, token: str) -> uuid.UUID:
 
         decoded = decode_token(token)
         return uuid.UUID(decoded["sub"])
+
+
+def _financial_llm_response(
+    *,
+    summary: str = "Resumo financeiro.",
+    item_type: str = "saude_financeira",
+    evidence: str = "current_period.paid.balance",
+) -> LLMResponse:
+    return LLMResponse(
+        content=(
+            f'{{"summary":"{summary}",'
+            f'"items":[{{"type":"{item_type}",'
+            '"title":"Diagnóstico financeiro",'
+            '"message":"Os dados do período foram analisados.",'
+            f'"evidence":["{evidence}"]}}]}}'
+        ),
+        prompt_tokens=100,
+        completion_tokens=40,
+        total_tokens=140,
+        model="gpt-4o-mini",
+        latency_ms=120,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -265,6 +288,166 @@ class TestAIAdvisoryServiceSpendingInsights:
             with pytest.raises(LLMProviderError):
                 service.generate_spending_insights()
 
+
+class TestAIAdvisoryServiceFinancialInsights:
+    def test_generate_daily_financial_insights_returns_evidence_payload(
+        self,
+        app,
+    ) -> None:
+        with app.app_context():
+            from app.extensions.database import db
+            from app.models.ai_insight import AIInsight, InsightType
+            from app.services.ai_advisory_service import AIAdvisoryService
+
+            user_id = uuid.uuid4()
+            provider = MagicMock()
+            provider.generate_with_usage.return_value = LLMResponse(
+                content=(
+                    '{"summary":"Resumo do dia.",'
+                    '"items":[{"type":"saude_financeira",'
+                    '"title":"Saldo positivo",'
+                    '"message":"Você fechou o dia com saldo positivo.",'
+                    '"evidence":["current_period.paid.balance"]}]}'
+                ),
+                prompt_tokens=100,
+                completion_tokens=40,
+                total_tokens=140,
+                model="gpt-4o-mini",
+                latency_ms=120,
+            )
+
+            service = AIAdvisoryService(user_id=user_id, llm_provider=provider)
+            result = service.generate_financial_insights(
+                period_type="daily",
+                anchor_date=date(2026, 5, 17),
+            )
+
+            assert result["period_type"] == "daily"
+            assert result["period_label"] == "2026-05-17"
+            assert result["period_start"] == "2026-05-17"
+            assert result["period_end"] == "2026-05-17"
+            assert result["summary"] == "Resumo do dia."
+            assert result["items"] == [
+                {
+                    "type": "saude_financeira",
+                    "title": "Saldo positivo",
+                    "message": "Você fechou o dia com saldo positivo.",
+                    "evidence": ["current_period.paid.balance"],
+                }
+            ]
+            assert result["context_version"] == "financial_insight_snapshot.v1"
+            assert result["cached"] is False
+            assert result["tokens_used"] == 140
+
+            call = provider.generate_with_usage.call_args
+            prompt = call.args[0]
+            assert "financial_insight_snapshot.v1" in prompt
+            assert "Não invente transações" in prompt
+            assert (
+                call.kwargs["response_schema"]["name"] == "financial_insight_response"
+            )
+
+            saved = db.session.query(AIInsight).filter_by(user_id=user_id).one()
+            assert saved.insight_type == InsightType.daily
+            assert saved.period_label == "2026-05-17"
+            assert "current_period.paid.balance" in saved.content
+
+    def test_financial_insights_return_cached_period_without_provider_call(
+        self,
+        app,
+    ) -> None:
+        with app.app_context():
+            from app.services.ai_advisory_service import AIAdvisoryService
+
+            user_id = uuid.uuid4()
+            provider = MagicMock()
+            provider.generate_with_usage.return_value = _financial_llm_response(
+                summary="Resumo cache."
+            )
+
+            service = AIAdvisoryService(user_id=user_id, llm_provider=provider)
+            first = service.generate_financial_insights(
+                period_type="daily",
+                anchor_date=date(2026, 5, 17),
+            )
+            second = service.generate_financial_insights(
+                period_type="daily",
+                anchor_date=date(2026, 5, 17),
+            )
+
+            assert first["cached"] is False
+            assert second["cached"] is True
+            assert second["summary"] == "Resumo cache."
+            provider.generate_with_usage.assert_called_once()
+
+    def test_financial_insights_reject_invalid_payload_without_saving(
+        self,
+        app,
+    ) -> None:
+        with app.app_context():
+            from app.extensions.database import db
+            from app.models.ai_insight import AIInsight
+            from app.services.ai_advisory_service import AIAdvisoryService
+
+            user_id = uuid.uuid4()
+            provider = MagicMock()
+            provider.generate_with_usage.return_value = LLMResponse(
+                content='{"summary":"Resumo","items":[{"type":"saude_financeira"}]}',
+                prompt_tokens=100,
+                completion_tokens=40,
+                total_tokens=140,
+                model="gpt-4o-mini",
+                latency_ms=120,
+            )
+
+            service = AIAdvisoryService(user_id=user_id, llm_provider=provider)
+            with pytest.raises(LLMProviderError, match="Invalid financial insight"):
+                service.generate_financial_insights(
+                    period_type="daily",
+                    anchor_date=date(2026, 5, 17),
+                )
+
+            saved = db.session.query(AIInsight).filter_by(user_id=user_id).first()
+            assert saved is None
+
+    @pytest.mark.parametrize(
+        ("period_type", "period_label", "period_start", "period_end"),
+        [
+            ("weekly", "2026-W20", "2026-05-11", "2026-05-17"),
+            ("monthly", "2026-05", "2026-05-01", "2026-05-31"),
+        ],
+    )
+    def test_generate_financial_insights_supports_weekly_and_monthly_periods(
+        self,
+        app,
+        period_type: str,
+        period_label: str,
+        period_start: str,
+        period_end: str,
+    ) -> None:
+        with app.app_context():
+            from app.models.ai_insight import AIInsight, InsightType
+            from app.services.ai_advisory_service import AIAdvisoryService
+
+            user_id = uuid.uuid4()
+            provider = MagicMock()
+            provider.generate_with_usage.return_value = _financial_llm_response()
+
+            service = AIAdvisoryService(user_id=user_id, llm_provider=provider)
+            result = service.generate_financial_insights(
+                period_type=period_type,
+                anchor_date=date(2026, 5, 17),
+            )
+
+            assert result["period_type"] == period_type
+            assert result["period_label"] == period_label
+            assert result["period_start"] == period_start
+            assert result["period_end"] == period_end
+
+            saved = AIInsight.query.filter_by(user_id=user_id).one()
+            assert saved.insight_type == InsightType(period_type)
+            assert saved.period_label == period_label
+
     def test_audit_log_created_on_success(self, app) -> None:
         with app.app_context():
             user_id = uuid.uuid4()
@@ -440,6 +623,88 @@ class TestAISpendingInsightsEndpoint:
         ):
             resp = client.get("/ai/insights/spending", headers=_auth(token))
             assert resp.status_code == 500
+
+
+class TestAIInsightGenerateEndpoint:
+    def test_post_invalid_period_type_returns_400(self, app, client) -> None:
+        token = _register_and_login(client, prefix="ai-generate-invalid")
+        user_id = _get_current_user_id(app, token)
+        _grant_entitlement(app, user_id, "advanced_simulations")
+
+        with patch(
+            "app.services.ai_advisory_service.AIAdvisoryService.generate_financial_insights"
+        ) as mocked_generate:
+            resp = client.post(
+                "/ai/insights/generate",
+                json={"period_type": "yearly"},
+                headers=_auth(token),
+            )
+
+        assert resp.status_code == 400
+        mocked_generate.assert_not_called()
+
+    def test_post_invalid_anchor_date_returns_400(self, app, client) -> None:
+        token = _register_and_login(client, prefix="ai-generate-bad-date")
+        user_id = _get_current_user_id(app, token)
+        _grant_entitlement(app, user_id, "advanced_simulations")
+
+        with patch(
+            "app.services.ai_advisory_service.AIAdvisoryService.generate_financial_insights"
+        ) as mocked_generate:
+            resp = client.post(
+                "/ai/insights/generate",
+                json={"period_type": "daily", "anchor_date": "17/05/2026"},
+                headers=_auth(token),
+            )
+
+        assert resp.status_code == 400
+        mocked_generate.assert_not_called()
+
+    def test_post_daily_generation_returns_period_payload(self, app, client) -> None:
+        token = _register_and_login(client, prefix="ai-generate-daily")
+        user_id = _get_current_user_id(app, token)
+        _grant_entitlement(app, user_id, "advanced_simulations")
+
+        generated = {
+            "period_type": "daily",
+            "period_label": "2026-05-17",
+            "period_start": "2026-05-17",
+            "period_end": "2026-05-17",
+            "summary": "Resumo do dia.",
+            "items": [
+                {
+                    "type": "saude_financeira",
+                    "title": "Dia equilibrado",
+                    "message": "Receitas e despesas foram analisadas.",
+                    "evidence": ["current_period.paid.balance"],
+                }
+            ],
+            "context_version": "financial_insight_snapshot.v1",
+            "cached": False,
+            "model": "stub",
+            "tokens_used": 123,
+            "cost_usd": 0.00001,
+        }
+
+        with patch(
+            "app.services.ai_advisory_service.AIAdvisoryService.generate_financial_insights",
+            return_value=generated,
+        ) as mocked_generate:
+            resp = client.post(
+                "/ai/insights/generate",
+                json={"period_type": "daily", "anchor_date": "2026-05-17"},
+                headers=_auth(token),
+            )
+
+        assert resp.status_code == 200
+        body = resp.get_json()
+        data = body.get("data") or body
+        assert data == generated
+        mocked_generate.assert_called_once()
+        assert mocked_generate.call_args.kwargs == {
+            "period_type": "daily",
+            "anchor_date": date(2026, 5, 17),
+        }
 
 
 class TestAIGoalProjectionEndpoint:

--- a/tests/test_ai_daily_rate_limit.py
+++ b/tests/test_ai_daily_rate_limit.py
@@ -312,6 +312,37 @@ class TestAIDailyRateLimitHTTP:
         assert resp.status_code == 200
         assert resp.headers.get("X-AI-Calls-Remaining") == "2"
 
+    def test_cached_period_generate_does_not_consume_daily_limit(
+        self, app, client
+    ) -> None:
+        token = _register_and_login(client, "ai-rl-generate-cached")
+        _grant_premium(app, token)
+
+        with patch(
+            "app.services.ai_advisory_service.AIAdvisoryService.generate_financial_insights",
+            return_value={
+                "period_type": "daily",
+                "period_label": "2026-05-17",
+                "period_start": "2026-05-17",
+                "period_end": "2026-05-17",
+                "summary": "cached",
+                "items": [],
+                "context_version": "financial_insight_snapshot.v1",
+                "cached": True,
+                "model": "stub",
+                "tokens_used": 10,
+                "cost_usd": 0.0,
+            },
+        ):
+            resp = client.post(
+                "/ai/insights/generate",
+                json={"period_type": "daily", "anchor_date": "2026-05-17"},
+                headers=_auth(token),
+            )
+
+        assert resp.status_code == 200
+        assert resp.headers.get("X-AI-Calls-Remaining") == "2"
+
     def test_429_message_is_portuguese(self, app, client) -> None:
         token = _register_and_login(client, "ai-rl-ptbr")
         _grant_premium(app, token)

--- a/tests/test_postman_collection_contract.py
+++ b/tests/test_postman_collection_contract.py
@@ -156,11 +156,6 @@ OPENAPI_GAPS: set[tuple[str, str]] = {
     ("POST", "/bank-statements/confirm"),
     # Advisory (not yet in apispec-documented blueprints)
     ("GET", "/advisory/insights"),
-    # AI Advisory (not yet in apispec-documented blueprints — #1206, #1228)
-    ("GET", "/ai/insights/spending"),
-    ("POST", "/ai/goals/{param}/projection"),
-    ("GET", "/ai/insights/weekly-summary"),
-    ("GET", "/ai/insights/history"),
     # Dashboard routes not yet in apispec-documented blueprints
     ("GET", "/dashboard/survival-index"),
     ("GET", "/dashboard/weekly-summary"),
@@ -187,6 +182,7 @@ def test_postman_collection_uses_domain_folders() -> None:
         "08 - Entitlements",
         "09 - Notifications",
         "10 - LGPD",
+        "11 - AI Advisory",
         "99 - Cleanup",
     ]
     assert folder_names == expected


### PR DESCRIPTION
## Summary
- add POST /ai/insights/generate for daily, weekly and monthly AI insights backed by FinancialInsightContextBuilder snapshots
- validate structured LLM JSON with summary/items/evidence before saving, preserving cache/idempotency by user/type/period
- document the AI blueprint in OpenAPI/Postman and add request schema/examples for the new endpoint

## Validation
- PYTHON_BIN=/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-api/.venv/bin/python bash scripts/run_ci_quality_local.sh --local
- pre-commit hooks during commit
- pre-push hooks during push

Closes #1270