### PR TITLE
feat(ai): align insight history and batches

### DIFF
--- a/app/cli/ai_insights_cli.py
+++ b/app/cli/ai_insights_cli.py
@@ -23,8 +23,8 @@ from flask import Flask
 from flask.cli import AppGroup
 
 from app.extensions.database import db
+from app.models.ai_insight import AIInsight, InsightType
 from app.models.entitlement import Entitlement
-from app.models.llm_audit_log import LLMAuditLog
 from app.models.user import User
 from app.services.ai_advisory_service import AIAdvisoryService
 from app.services.llm_provider import LLMProviderError
@@ -32,8 +32,6 @@ from app.services.llm_provider import LLMProviderError
 ai_insights_cli = AppGroup("ai", help="Scheduled AI insights batch commands.")
 
 _BRT = timezone(timedelta(hours=-3))
-_WEEKLY_ENDPOINT = "weekly_summary_batch"
-_MONTHLY_ENDPOINT = "spending_insights_batch"
 
 
 def _brt_today() -> date:
@@ -61,20 +59,38 @@ def _all_active_user_ids() -> list[uuid.UUID]:
     return [r.id for r in rows]
 
 
-def _already_run_today(user_id: uuid.UUID, endpoint: str) -> bool:
-    """Return True if a batch insight was already generated today (UTC).
+def _monthly_anchor(month: str | None) -> date:
+    if month is not None:
+        year, mon = int(month[:4]), int(month[5:7])
+        return date(year, mon, 1)
 
-    created_at is stored as a naive UTC datetime, so db.func.date() returns
-    the UTC calendar date. We compare it to the current UTC date explicitly
-    to avoid mismatches when the local system timezone differs from UTC.
-    """
-    today_utc = datetime.now(timezone.utc).date()
+    today = _brt_today()
+    first_of_month = today.replace(day=1)
+    prev_month_last = first_of_month - timedelta(days=1)
+    return prev_month_last.replace(day=1)
+
+
+def _period_label(*, insight_type: InsightType, anchor_date: date) -> str:
+    if insight_type == InsightType.weekly:
+        iso = anchor_date.isocalendar()
+        return f"{iso.year}-W{iso.week:02d}"
+    if insight_type == InsightType.monthly:
+        return anchor_date.strftime("%Y-%m")
+    return anchor_date.isoformat()
+
+
+def _already_has_insight(
+    *,
+    user_id: uuid.UUID,
+    insight_type: InsightType,
+    period_label: str,
+) -> bool:
     exists = (
-        db.session.query(LLMAuditLog.id)
-        .filter(
-            LLMAuditLog.user_id == user_id,
-            LLMAuditLog.endpoint == endpoint,
-            db.func.date(LLMAuditLog.created_at) == today_utc,
+        db.session.query(AIInsight.id)
+        .filter_by(
+            user_id=user_id,
+            insight_type=insight_type,
+            period_label=period_label,
         )
         .first()
     )
@@ -84,10 +100,11 @@ def _already_run_today(user_id: uuid.UUID, endpoint: str) -> bool:
 def _run_batch(
     *,
     user_ids: list[uuid.UUID],
-    endpoint: str,
-    generate_fn_name: str,
+    insight_type: InsightType,
+    anchor_date: date,
     label: str,
     dry_run: bool,
+    dry_run_subject: str,
 ) -> int:
     """Run a batch insight generation job.
 
@@ -100,25 +117,36 @@ def _run_batch(
 
     if dry_run:
         click.echo(
-            f"{label} dry-run: {len(user_ids)} eligible Premium users — no calls made."
+            f"{label} dry-run: {len(user_ids)} {dry_run_subject} — no calls made."
         )
         return 0
 
+    period_label = _period_label(insight_type=insight_type, anchor_date=anchor_date)
     processed = 0
     failures = 0
     skipped = 0
     total_cost = 0.0
 
     for user_id in user_ids:
-        if _already_run_today(user_id, endpoint):
+        if _already_has_insight(
+            user_id=user_id,
+            insight_type=insight_type,
+            period_label=period_label,
+        ):
             skipped += 1
             continue
 
         service = AIAdvisoryService(user_id=user_id)
         try:
-            result = getattr(service, generate_fn_name)()
-            total_cost += float(result.get("cost_usd", 0))
-            processed += 1
+            result = service.generate_financial_insights(
+                period_type=insight_type.value,
+                anchor_date=anchor_date,
+            )
+            if result.get("cached") is True:
+                skipped += 1
+            else:
+                total_cost += float(result.get("cost_usd", 0))
+                processed += 1
         except (LLMProviderError, Exception) as exc:  # noqa: BLE001
             click.echo(
                 f"{label} ERROR user={user_id} error={exc}",
@@ -128,7 +156,7 @@ def _run_batch(
 
     click.echo(
         f"{label}: processed={processed} failures={failures} "
-        f"skipped={skipped} cost_usd={total_cost:.6f}"
+        f"skipped={skipped} cost_usd={total_cost:.6f} period={period_label}"
     )
 
     if failures > 0 and processed == 0 and skipped == 0:
@@ -157,10 +185,11 @@ def weekly_insights(dry_run: bool) -> None:
     user_ids = _premium_user_ids()
     exit_code = _run_batch(
         user_ids=user_ids,
-        endpoint=_WEEKLY_ENDPOINT,
-        generate_fn_name="generate_weekly_summary_narrative",
+        insight_type=InsightType.weekly,
+        anchor_date=_brt_today(),
         label="weekly_insights",
         dry_run=dry_run,
+        dry_run_subject="eligible Premium users",
     )
     sys.exit(exit_code)
 
@@ -189,50 +218,20 @@ def monthly_insights(month: str | None, dry_run: bool) -> None:
     Intended to run on the 1st of each month at 03:00 UTC (00:00 BRT).
     Idempotent: skips users who already have a monthly summary today.
     """
-    if month is None:
-        today = _brt_today()
-        first_of_month = today.replace(day=1)
-        prev_month_last = first_of_month - timedelta(days=1)
-        month = prev_month_last.strftime("%Y-%m")
-
+    anchor_date = _monthly_anchor(month)
+    month_label = anchor_date.strftime("%Y-%m")
     user_ids = _all_active_user_ids()
-
-    if dry_run:
-        click.echo(
-            f"monthly_insights dry-run: {len(user_ids)} eligible users "
-            f"(Free + Premium) for month={month} — no calls made."
-        )
-        sys.exit(0)
-
-    processed = 0
-    failures = 0
-    skipped = 0
-    total_cost = 0.0
-
-    for user_id in user_ids:
-        if _already_run_today(user_id, _MONTHLY_ENDPOINT):
-            skipped += 1
-            continue
-
-        service = AIAdvisoryService(user_id=user_id)
-        try:
-            result = service.generate_spending_insights(month=month)
-            total_cost += float(result.get("cost_usd", 0))
-            processed += 1
-        except (LLMProviderError, Exception) as exc:  # noqa: BLE001
-            click.echo(
-                f"monthly_insights ERROR user={user_id} error={exc}",
-                err=True,
-            )
-            failures += 1
-
-    click.echo(
-        f"monthly_insights: processed={processed} failures={failures} "
-        f"skipped={skipped} cost_usd={total_cost:.6f} month={month}"
+    exit_code = _run_batch(
+        user_ids=user_ids,
+        insight_type=InsightType.monthly,
+        anchor_date=anchor_date,
+        label="monthly_insights",
+        dry_run=dry_run,
+        dry_run_subject=f"eligible users (Free + Premium) for month={month_label}",
     )
-
-    if failures > 0 and processed == 0 and skipped == 0:
-        sys.exit(1)
+    if not dry_run:
+        click.echo(f"monthly_insights month={month_label}")
+    sys.exit(exit_code)
 
 
 def register_ai_insights_commands(app: Flask) -> None:

--- a/app/controllers/ai/resources.py
+++ b/app/controllers/ai/resources.py
@@ -10,6 +10,7 @@ All endpoints require a valid JWT and the "advanced_simulations" entitlement.
 
 from __future__ import annotations
 
+import json
 import logging
 import uuid
 from datetime import date
@@ -210,6 +211,7 @@ class AIInsightGenerateResource(MethodResource):
                         }
                     ],
                     "context_version": "financial_insight_snapshot.v1",
+                    "context_hash": "sha256",
                     "cached": False,
                     "model": "gpt-4o-mini",
                     "tokens_used": 420,
@@ -621,6 +623,52 @@ def _notify_analysis_ready(*, user_id: UUID, narrative: str) -> None:
         log.warning("ai.weekly_summary.notify_failed user_id=%s error=%s", user_id, exc)
 
 
+def _strip_history_json_code_fence(content: str) -> str:
+    text = content.strip()
+    if not text.startswith("```"):
+        return text
+    first_newline = text.find("\n")
+    if first_newline == -1:
+        return text
+    text = text[first_newline + 1 :]
+    if text.rstrip().endswith("```"):
+        text = text.rstrip()[:-3]
+    return text.strip()
+
+
+def _parse_history_content(
+    content: str,
+) -> tuple[str | None, list[dict[str, Any]], str | None, str | None]:
+    try:
+        parsed = json.loads(_strip_history_json_code_fence(content))
+    except json.JSONDecodeError:
+        return None, [], None, None
+
+    if isinstance(parsed, list):
+        return None, [item for item in parsed if isinstance(item, dict)], None, None
+
+    if not isinstance(parsed, dict):
+        return None, [], None, None
+
+    summary = parsed.get("summary") if isinstance(parsed.get("summary"), str) else None
+    raw_items = parsed.get("items")
+    items = (
+        [item for item in raw_items if isinstance(item, dict)]
+        if isinstance(raw_items, list)
+        else []
+    )
+    raw_metadata = parsed.get("metadata")
+    metadata = raw_metadata if isinstance(raw_metadata, dict) else {}
+    context_schema_version = metadata.get("context_schema_version")
+    context_hash = metadata.get("context_hash")
+    return (
+        summary,
+        items,
+        context_schema_version if isinstance(context_schema_version, str) else None,
+        context_hash if isinstance(context_hash, str) else None,
+    )
+
+
 class AIInsightHistoryResource(MethodResource):
     """GET /ai/insights/history — paginated AI insight history."""
 
@@ -657,11 +705,16 @@ class AIInsightHistoryResource(MethodResource):
                     "items": [
                         {
                             "id": "uuid",
-                            "content": "3 insights...",
+                            "content": '{"summary":"Resumo","items":[]}',
+                            "summary": "Resumo",
+                            "items": [],
+                            "period_type": "daily",
                             "insight_type": "daily",
                             "period_label": "2026-05-11",
                             "period_start": "2026-05-11",
                             "period_end": "2026-05-11",
+                            "context_schema_version": ("financial_insight_snapshot.v1"),
+                            "context_hash": "sha256",
                             "model": "gpt-4o-mini",
                             "tokens_used": 320,
                             "cost_usd": 0.000048,
@@ -708,21 +761,32 @@ class AIInsightHistoryResource(MethodResource):
             .all()
         )
 
-        items = [
-            {
-                "id": str(r.id),
-                "content": r.content,
-                "insight_type": r.insight_type.value,
-                "period_label": r.period_label,
-                "period_start": r.period_start.isoformat() if r.period_start else None,
-                "period_end": r.period_end.isoformat() if r.period_end else None,
-                "model": r.model,
-                "tokens_used": r.tokens_used,
-                "cost_usd": float(r.cost_usd),
-                "created_at": r.created_at.isoformat() if r.created_at else None,
-            }
-            for r in rows
-        ]
+        items = []
+        for r in rows:
+            summary, insight_items, context_schema_version, context_hash = (
+                _parse_history_content(r.content)
+            )
+            items.append(
+                {
+                    "id": str(r.id),
+                    "content": r.content,
+                    "insight_type": r.insight_type.value,
+                    "period_type": r.insight_type.value,
+                    "period_label": r.period_label,
+                    "period_start": r.period_start.isoformat()
+                    if r.period_start
+                    else None,
+                    "period_end": r.period_end.isoformat() if r.period_end else None,
+                    "summary": summary,
+                    "items": insight_items,
+                    "context_schema_version": context_schema_version,
+                    "context_hash": context_hash,
+                    "model": r.model,
+                    "tokens_used": r.tokens_used,
+                    "cost_usd": float(r.cost_usd),
+                    "created_at": r.created_at.isoformat() if r.created_at else None,
+                }
+            )
 
         payload = {"items": items, "page": page, "per_page": per_page, "total": total}
         return compat_success_response(

--- a/app/services/ai_advisory_service.py
+++ b/app/services/ai_advisory_service.py
@@ -15,6 +15,7 @@ Required env vars (configure in .env — never set here):
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 from calendar import monthrange
@@ -264,9 +265,53 @@ def _coerce_spending_insight_items(content: str) -> list[InsightItem]:
     return items
 
 
+def _coerce_financial_insight_item(candidate: object) -> FinancialInsightItem:
+    if not isinstance(candidate, dict):
+        raise LLMProviderError("Invalid financial insight item.")
+
+    item_type = candidate.get("type")
+    title = candidate.get("title")
+    message = candidate.get("message")
+    evidence = candidate.get("evidence")
+    if (
+        not isinstance(item_type, str)
+        or item_type.strip() not in _SPENDING_INSIGHT_TYPES
+        or not isinstance(title, str)
+        or not title.strip()
+        or not isinstance(message, str)
+        or not message.strip()
+        or not isinstance(evidence, list)
+        or not evidence
+        or not all(isinstance(item, str) and item.strip() for item in evidence)
+    ):
+        raise LLMProviderError("Invalid financial insight item fields.")
+
+    return {
+        "type": item_type.strip(),
+        "title": title.strip(),
+        "message": message.strip(),
+        "evidence": [item.strip() for item in evidence],
+    }
+
+
+def _coerce_financial_insight_metadata(parsed: dict[str, Any]) -> dict[str, str]:
+    metadata: dict[str, str] = {}
+    candidate_metadata = parsed.get("metadata")
+    if not isinstance(candidate_metadata, dict):
+        return metadata
+
+    context_schema_version = candidate_metadata.get("context_schema_version")
+    context_hash = candidate_metadata.get("context_hash")
+    if isinstance(context_schema_version, str) and context_schema_version.strip():
+        metadata["context_schema_version"] = context_schema_version.strip()
+    if isinstance(context_hash, str) and context_hash.strip():
+        metadata["context_hash"] = context_hash.strip()
+    return metadata
+
+
 def _coerce_financial_insight_response(
     content: str,
-) -> tuple[str, list[FinancialInsightItem]]:
+) -> tuple[str, list[FinancialInsightItem], dict[str, str]]:
     raw = _strip_json_code_fence(content)
     try:
         parsed = json.loads(raw)
@@ -284,38 +329,10 @@ def _coerce_financial_insight_response(
     if not isinstance(candidate_items, list) or not candidate_items:
         raise LLMProviderError("Invalid financial insight items.")
 
-    items: list[FinancialInsightItem] = []
-    for candidate in candidate_items:
-        if not isinstance(candidate, dict):
-            raise LLMProviderError("Invalid financial insight item.")
+    items = [_coerce_financial_insight_item(item) for item in candidate_items]
+    metadata = _coerce_financial_insight_metadata(parsed)
 
-        item_type = candidate.get("type")
-        title = candidate.get("title")
-        message = candidate.get("message")
-        evidence = candidate.get("evidence")
-        if (
-            not isinstance(item_type, str)
-            or item_type.strip() not in _SPENDING_INSIGHT_TYPES
-            or not isinstance(title, str)
-            or not title.strip()
-            or not isinstance(message, str)
-            or not message.strip()
-            or not isinstance(evidence, list)
-            or not evidence
-            or not all(isinstance(item, str) and item.strip() for item in evidence)
-        ):
-            raise LLMProviderError("Invalid financial insight item fields.")
-
-        items.append(
-            {
-                "type": item_type.strip(),
-                "title": title.strip(),
-                "message": message.strip(),
-                "evidence": [item.strip() for item in evidence],
-            }
-        )
-
-    return summary.strip(), items
+    return summary.strip(), items, metadata
 
 
 def _serialize_spending_insight_items(items: list[InsightItem]) -> str:
@@ -326,12 +343,27 @@ def _serialize_financial_insight_response(
     *,
     summary: str,
     items: list[FinancialInsightItem],
+    metadata: dict[str, str] | None = None,
 ) -> str:
+    payload: dict[str, Any] = {"summary": summary, "items": items}
+    if metadata:
+        payload["metadata"] = metadata
     return json.dumps(
-        {"summary": summary, "items": items},
+        payload,
         ensure_ascii=False,
         separators=(",", ":"),
     )
+
+
+def _financial_context_hash(snapshot: dict[str, Any]) -> str:
+    serialized = json.dumps(
+        snapshot,
+        ensure_ascii=False,
+        sort_keys=True,
+        default=str,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
 
 
 def _log_llm_call(
@@ -449,9 +481,11 @@ class AIAdvisoryService:
         )
         if cached is not None:
             try:
-                cached_summary, cached_items = _coerce_financial_insight_response(
-                    cached.content
-                )
+                (
+                    cached_summary,
+                    cached_items,
+                    cached_metadata,
+                ) = _coerce_financial_insight_response(cached.content)
             except LLMProviderError:
                 log.warning(
                     "ai_advisory.financial_insights.cached_parse_failed "
@@ -467,7 +501,10 @@ class AIAdvisoryService:
                     "period_end": cached.period_end.isoformat(),
                     "summary": cached_summary,
                     "items": cached_items,
-                    "context_version": context_version,
+                    "context_version": cached_metadata.get(
+                        "context_schema_version", context_version
+                    ),
+                    "context_hash": cached_metadata.get("context_hash"),
                     "tokens_used": cached.tokens_used,
                     "cost_usd": float(cached.cost_usd),
                     "model": cached.model,
@@ -475,8 +512,10 @@ class AIAdvisoryService:
                 }
 
         previous = _get_latest_insight(user_id=self._user_id)
+        prompt_snapshot = minimize_prompt_data(snapshot)
+        context_hash = _financial_context_hash(prompt_snapshot)
         prompt = _build_financial_insight_prompt(
-            minimize_prompt_data(snapshot),
+            prompt_snapshot,
             period_type=normalized_period_type,
             previous_insight=previous.content if previous else None,
         )
@@ -496,10 +535,15 @@ class AIAdvisoryService:
             )
             raise
 
-        summary, items = _coerce_financial_insight_response(llm_resp.content)
+        summary, items, _ = _coerce_financial_insight_response(llm_resp.content)
+        metadata = {
+            "context_schema_version": context_version,
+            "context_hash": context_hash,
+        }
         serialized_content = _serialize_financial_insight_response(
             summary=summary,
             items=items,
+            metadata=metadata,
         )
 
         _log_llm_call(
@@ -531,6 +575,7 @@ class AIAdvisoryService:
             "summary": summary,
             "items": items,
             "context_version": context_version,
+            "context_hash": context_hash,
             "tokens_used": llm_resp.total_tokens,
             "cost_usd": llm_resp.estimated_cost_usd,
             "model": llm_resp.model,

--- a/docs/adr/0005-ai-insight-persistence-model.md
+++ b/docs/adr/0005-ai-insight-persistence-model.md
@@ -48,6 +48,32 @@ Precisávamos decidir: usar `llm_audit_logs` como store primário ou criar uma n
 - Metadados técnicos mínimos: `model`, `tokens_used`, `cost_usd`
 - Self-referential FK: `previous_insight_id` → cadeia de contexto entre dias
 
+Para o contrato period-aware, `content` passa a armazenar JSON canônico no formato:
+
+```json
+{
+  "summary": "Resumo do período.",
+  "items": [
+    {
+      "type": "saude_financeira",
+      "title": "Saldo positivo",
+      "message": "Mensagem acionável.",
+      "evidence": ["current_period.paid.balance"]
+    }
+  ],
+  "metadata": {
+    "context_schema_version": "financial_insight_snapshot.v1",
+    "context_hash": "sha256-do-snapshot-sanitizado"
+  }
+}
+```
+
+Decisão: não criar colunas dedicadas para `context_schema_version` e
+`context_hash` neste ciclo. A alternativa auditável é persistir esses campos no
+JSON de produto e expô-los no DTO de histórico. O hash é calculado sobre o
+snapshot já sanitizado/minimizado que alimenta o prompt, permitindo comparar
+reexecuções sem guardar o snapshot completo em `ai_insights`.
+
 ### llm_audit_logs (inalterado)
 - Continua recebendo TODA chamada LLM (via `_log_llm_call()`)
 - Inclui `prompt` completo, `response_text` completo, latência

--- a/docs/wiki/AI-Insights-Structured-Output.md
+++ b/docs/wiki/AI-Insights-Structured-Output.md
@@ -61,6 +61,30 @@ The spending insight endpoint must return both legacy and structured fields:
 `insights` remains for backward compatibility, but must be a valid JSON string
 without Markdown fences. `items` is the preferred field for new clients.
 
+## Period-Aware History Contract
+
+`POST /ai/insights/generate` persists period-aware insights as canonical JSON
+with `summary`, `items[]` and `metadata`. `GET /ai/insights/history` must expose
+those fields directly so Web/App clients do not parse `content` themselves:
+
+```json
+{
+  "id": "uuid",
+  "content": "{\"summary\":\"Resumo\",\"items\":[],\"metadata\":{...}}",
+  "insight_type": "weekly",
+  "period_type": "weekly",
+  "period_label": "2026-W20",
+  "summary": "Resumo",
+  "items": [],
+  "context_schema_version": "financial_insight_snapshot.v1",
+  "context_hash": "sha256-do-snapshot-sanitizado"
+}
+```
+
+Legacy rows that contain a JSON array remain readable: history returns the
+array as `items` and leaves `summary`, `context_schema_version` and
+`context_hash` as `null`.
+
 ## OpenAI Output Rule
 
 For OpenAI Chat Completions, use Structured Outputs with

--- a/openapi.json
+++ b/openapi.json
@@ -1388,6 +1388,7 @@
                 "example": {
                   "data": {
                     "cached": false,
+                    "context_hash": "sha256",
                     "context_version": "financial_insight_snapshot.v1",
                     "cost_usd": 6.3e-05,
                     "items": [
@@ -1608,15 +1609,20 @@
                   "data": {
                     "items": [
                       {
-                        "content": "3 insights...",
+                        "content": "{\"summary\":\"Resumo\",\"items\":[]}",
+                        "context_hash": "sha256",
+                        "context_schema_version": "financial_insight_snapshot.v1",
                         "cost_usd": 4.8e-05,
                         "created_at": "2026-05-11T19:00:00",
                         "id": "uuid",
                         "insight_type": "daily",
+                        "items": [],
                         "model": "gpt-4o-mini",
                         "period_end": "2026-05-11",
                         "period_label": "2026-05-11",
                         "period_start": "2026-05-11",
+                        "period_type": "daily",
+                        "summary": "Resumo",
                         "tokens_used": 320
                       }
                     ],

--- a/tests/test_ai_advisory_service.py
+++ b/tests/test_ai_advisory_service.py
@@ -297,6 +297,7 @@ class TestAIAdvisoryServiceFinancialInsights:
         with app.app_context():
             from app.extensions.database import db
             from app.models.ai_insight import AIInsight, InsightType
+            from app.models.llm_audit_log import LLMAuditLog
             from app.services.ai_advisory_service import AIAdvisoryService
 
             user_id = uuid.uuid4()
@@ -351,6 +352,15 @@ class TestAIAdvisoryServiceFinancialInsights:
             assert saved.insight_type == InsightType.daily
             assert saved.period_label == "2026-05-17"
             assert "current_period.paid.balance" in saved.content
+            assert "context_hash" in saved.content
+
+            audit = (
+                db.session.query(LLMAuditLog)
+                .filter_by(user_id=user_id, endpoint="financial_insights_daily")
+                .one()
+            )
+            assert audit.model == "gpt-4o-mini"
+            assert audit.total_tokens == 140
 
     def test_financial_insights_return_cached_period_without_provider_call(
         self,

--- a/tests/test_ai_insight_persistence.py
+++ b/tests/test_ai_insight_persistence.py
@@ -357,6 +357,60 @@ class TestAIInsightHistoryEndpoint:
         for field in ("id", "content", "insight_type", "period_label", "created_at"):
             assert field in item, f"Missing field: {field}"
 
+    def test_response_exposes_structured_insight_without_client_parsing(
+        self, app, client
+    ) -> None:
+        token = _register_and_login(client, "hist-structured")
+
+        with app.app_context():
+            from flask_jwt_extended import decode_token
+
+            from app.extensions.database import db
+
+            user_id = uuid.UUID(decode_token(token)["sub"])
+            today = date(2026, 5, 17)
+            content = {
+                "summary": "Resumo financeiro estruturado.",
+                "items": [
+                    {
+                        "type": "saude_financeira",
+                        "title": "Saldo positivo",
+                        "message": "Você fechou o período com saldo positivo.",
+                        "evidence": ["current_period.paid.balance"],
+                    }
+                ],
+                "metadata": {
+                    "context_schema_version": "financial_insight_snapshot.v1",
+                    "context_hash": "abc123",
+                },
+            }
+            db.session.add(
+                AIInsight(
+                    user_id=user_id,
+                    content=json.dumps(content),
+                    insight_type=InsightType.weekly,
+                    period_label="2026-W20",
+                    period_start=today,
+                    period_end=today + timedelta(days=6),
+                    model="gpt-4o-mini",
+                    tokens_used=150,
+                    cost_usd=0.000022,
+                )
+            )
+            db.session.commit()
+
+        resp = client.get("/ai/insights/history", headers=_auth(token))
+        assert resp.status_code == 200
+        data = resp.get_json()
+        items = (data.get("data") or {}).get("items") or []
+        assert len(items) == 1
+        item = items[0]
+        assert item["period_type"] == "weekly"
+        assert item["summary"] == "Resumo financeiro estruturado."
+        assert item["items"] == content["items"]
+        assert item["context_schema_version"] == "financial_insight_snapshot.v1"
+        assert item["context_hash"] == "abc123"
+
     def test_user_only_sees_own_insights(self, app, client) -> None:
         token_a = _register_and_login(client, "hist-isola")
         token_b = _register_and_login(client, "hist-isolb")

--- a/tests/test_ai_weekly_insights_cli.py
+++ b/tests/test_ai_weekly_insights_cli.py
@@ -14,7 +14,7 @@ Coverage areas:
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from unittest.mock import patch
 
 from click.testing import CliRunner
@@ -79,21 +79,22 @@ def _log_weekly_summary_today(app, user_id: uuid.UUID) -> None:
     """Simulate that a weekly summary was already generated today."""
     with app.app_context():
         from app.extensions.database import db
-        from app.models.llm_audit_log import LLMAuditLog
+        from app.models.ai_insight import AIInsight, InsightType
 
-        log = LLMAuditLog(
+        today = date.today()
+        iso = today.isocalendar()
+        insight = AIInsight(
             user_id=user_id,
-            endpoint="weekly_summary_batch",
+            content='{"summary":"cached","items":[]}',
+            insight_type=InsightType.weekly,
+            period_label=f"{iso.year}-W{iso.week:02d}",
+            period_start=today - timedelta(days=today.weekday()),
+            period_end=today - timedelta(days=today.weekday()) + timedelta(days=6),
             model="stub",
-            prompt="test",
-            response_text="ok",
-            prompt_tokens=10,
-            completion_tokens=20,
-            total_tokens=30,
-            estimated_cost_usd=0.0,
-            latency_ms=0,
+            tokens_used=30,
+            cost_usd=0.0,
         )
-        db.session.add(log)
+        db.session.add(insight)
         db.session.commit()
 
 
@@ -122,12 +123,13 @@ class TestWeeklyInsightsCLI:
 
         with patch(
             "app.services.ai_advisory_service.AIAdvisoryService"
-            ".generate_weekly_summary_narrative",
+            ".generate_financial_insights",
             return_value={
-                "narrative": "ok",
+                "summary": "ok",
+                "items": [],
+                "period_type": "weekly",
                 "tokens_used": 150,
                 "cost_usd": 0.00002,
-                "summary": {},
                 "model": "stub",
             },
         ) as mock_gen:
@@ -135,6 +137,7 @@ class TestWeeklyInsightsCLI:
 
         assert result.exit_code == 0
         assert mock_gen.call_count == 1
+        assert mock_gen.call_args.kwargs["period_type"] == "weekly"
         assert "processed=1" in result.output
         assert "failures=0" in result.output
 
@@ -145,12 +148,13 @@ class TestWeeklyInsightsCLI:
 
         with patch(
             "app.services.ai_advisory_service.AIAdvisoryService"
-            ".generate_weekly_summary_narrative",
+            ".generate_financial_insights",
             return_value={
-                "narrative": "ok",
+                "summary": "ok",
+                "items": [],
+                "period_type": "weekly",
                 "tokens_used": 150,
                 "cost_usd": 0.00002,
-                "summary": {},
                 "model": "stub",
             },
         ) as mock_gen:
@@ -174,16 +178,17 @@ class TestWeeklyInsightsCLI:
             if call_count == 1:
                 raise LLMProviderError("LLM down")
             return {
-                "narrative": "ok",
+                "summary": "ok",
+                "items": [],
+                "period_type": "weekly",
                 "tokens_used": 100,
                 "cost_usd": 0.0,
-                "summary": {},
                 "model": "stub",
             }
 
         with patch(
             "app.services.ai_advisory_service.AIAdvisoryService"
-            ".generate_weekly_summary_narrative",
+            ".generate_financial_insights",
             side_effect=_side_effect,
         ):
             result = self._invoke(app)
@@ -199,7 +204,7 @@ class TestWeeklyInsightsCLI:
 
         with patch(
             "app.services.ai_advisory_service.AIAdvisoryService"
-            ".generate_weekly_summary_narrative",
+            ".generate_financial_insights",
             side_effect=LLMProviderError("total failure"),
         ):
             result = self._invoke(app)
@@ -214,9 +219,112 @@ class TestWeeklyInsightsCLI:
 
         with patch(
             "app.services.ai_advisory_service.AIAdvisoryService"
-            ".generate_weekly_summary_narrative",
+            ".generate_financial_insights",
         ) as mock_gen:
             result = self._invoke(app)
+
+        assert result.exit_code == 0
+        assert mock_gen.call_count == 0
+        assert "skipped=1" in result.output
+
+    def test_weekly_dry_run_prints_count_without_calling_service(self, app) -> None:
+        user_id = _create_user(app)
+        _grant_advanced_simulations(app, user_id)
+
+        with patch(
+            "app.services.ai_advisory_service.AIAdvisoryService"
+            ".generate_financial_insights",
+        ) as mock_gen:
+            result = self._invoke(app, "--dry-run")
+
+        assert result.exit_code == 0
+        assert mock_gen.call_count == 0
+        assert "dry-run" in result.output.lower() or "dry_run" in result.output.lower()
+
+    def test_weekly_deleted_users_excluded(self, app) -> None:
+        user_id = _create_user(app)
+        _grant_advanced_simulations(app, user_id)
+
+        with app.app_context():
+            from app.extensions.database import db
+            from app.models.user import User
+
+            User.query.filter_by(id=user_id).update(
+                {"deleted_at": datetime.now(timezone.utc)}
+            )
+            db.session.commit()
+
+        with patch(
+            "app.services.ai_advisory_service.AIAdvisoryService"
+            ".generate_financial_insights",
+        ) as mock_gen:
+            self._invoke(app)
+
+        assert mock_gen.call_count == 0
+
+
+class TestMonthlyInsightsCLI:
+    def _invoke(self, app, *args: str) -> object:
+        from app.cli.ai_insights_cli import ai_insights_cli
+
+        runner = CliRunner()
+        with app.app_context():
+            result = runner.invoke(ai_insights_cli, ["monthly-insights", *args])
+        return result
+
+    def test_explicit_month_uses_period_aware_monthly_generation(self, app) -> None:
+        _create_user(app)
+
+        with patch(
+            "app.services.ai_advisory_service.AIAdvisoryService"
+            ".generate_financial_insights",
+            return_value={
+                "summary": "ok",
+                "items": [],
+                "period_type": "monthly",
+                "tokens_used": 150,
+                "cost_usd": 0.00002,
+                "model": "stub",
+            },
+        ) as mock_gen:
+            result = self._invoke(app, "--month", "2026-05")
+
+        assert result.exit_code == 0
+        assert mock_gen.call_count == 1
+        assert mock_gen.call_args.kwargs == {
+            "period_type": "monthly",
+            "anchor_date": date(2026, 5, 1),
+        }
+        assert "processed=1" in result.output
+        assert "month=2026-05" in result.output
+
+    def test_monthly_idempotency_skips_existing_period(self, app) -> None:
+        user_id = _create_user(app)
+
+        with app.app_context():
+            from app.extensions.database import db
+            from app.models.ai_insight import AIInsight, InsightType
+
+            db.session.add(
+                AIInsight(
+                    user_id=user_id,
+                    content='{"summary":"cached","items":[]}',
+                    insight_type=InsightType.monthly,
+                    period_label="2026-05",
+                    period_start=date(2026, 5, 1),
+                    period_end=date(2026, 5, 31),
+                    model="stub",
+                    tokens_used=30,
+                    cost_usd=0.0,
+                )
+            )
+            db.session.commit()
+
+        with patch(
+            "app.services.ai_advisory_service.AIAdvisoryService"
+            ".generate_financial_insights",
+        ) as mock_gen:
+            result = self._invoke(app, "--month", "2026-05")
 
         assert result.exit_code == 0
         assert mock_gen.call_count == 0
@@ -228,7 +336,7 @@ class TestWeeklyInsightsCLI:
 
         with patch(
             "app.services.ai_advisory_service.AIAdvisoryService"
-            ".generate_weekly_summary_narrative",
+            ".generate_financial_insights",
         ) as mock_gen:
             result = self._invoke(app, "--dry-run")
 
@@ -251,7 +359,7 @@ class TestWeeklyInsightsCLI:
 
         with patch(
             "app.services.ai_advisory_service.AIAdvisoryService"
-            ".generate_weekly_summary_narrative",
+            ".generate_financial_insights",
         ) as mock_gen:
             self._invoke(app)
 


### PR DESCRIPTION
## Summary
- expose structured history fields: period_type, summary, items, context_schema_version and context_hash, without requiring clients to parse content
- persist auditable context metadata inside canonical AIInsight.content and keep LLM audit rows for period-aware generations
- switch weekly/monthly CLI batches to generate_financial_insights with weekly/monthly snapshots and AIInsight period idempotency
- update OpenAPI and technical docs for the history/metadata contract

## Validation
- PYTHON_BIN=/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-api/.venv/bin/python bash scripts/run_ci_quality_local.sh --local
- pre-commit hooks during commit
- pre-push hooks during push

Closes #1271