### PR TITLE
fix(ai): support RDS compose in insights job

### DIFF
--- a/scripts/aws_ai_insights_job.py
+++ b/scripts/aws_ai_insights_job.py
@@ -275,12 +275,35 @@ if ! docker info >/dev/null 2>&1; then
   exit 5
 fi
 
-docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d db redis
+COMPOSE_SERVICES="$(
+  docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" config --services
+)"
+
+service_is_defined() {{
+  service="$1"
+  printf '%s\n' "$COMPOSE_SERVICES" | grep -Fxq "$service"
+}}
+
+SERVICE_START_ARGS=()
+for SERVICE in db redis; do
+  if service_is_defined "$SERVICE"; then
+    SERVICE_START_ARGS+=("$SERVICE")
+  else
+    echo "[ai-insights] skipping $SERVICE; not defined in compose"
+  fi
+done
+
+if [ "${{#SERVICE_START_ARGS[@]}}" -gt 0 ]; then
+  docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" \\
+    up -d "${{SERVICE_START_ARGS[@]}}"
+else
+  echo "[ai-insights] no optional infrastructure services to start"
+fi
 
 INSPECT_HEALTH='{{{{if .State.Health}}}}{{{{.State.Health.Status}}}}\
 {{{{else}}}}{{{{.State.Status}}}}{{{{end}}}}'
 
-for SERVICE in db redis; do
+for SERVICE in "${{SERVICE_START_ARGS[@]}}"; do
   CID=""
   for _ in $(seq 1 30); do
     CID="$(docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" ps -q "$SERVICE")"
@@ -293,7 +316,7 @@ for SERVICE in db redis; do
     sleep 2
   done
   if [ -z "$CID" ]; then
-    echo "[ai-insights] $SERVICE container was not created"
+    echo "[ai-insights] $SERVICE container was not created or is not running"
     exit 6
   fi
 done

--- a/tests/test_aws_ai_insights_job.py
+++ b/tests/test_aws_ai_insights_job.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from scripts import aws_ai_insights_job
+
+
+def test_build_script_discovers_optional_compose_services_before_starting() -> None:
+    script = aws_ai_insights_job._build_script(env_name="prod", mode="weekly")
+
+    service_list_cmd = (
+        'docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" config --services'
+    )
+    assert service_list_cmd in script
+    assert "COMPOSE_SERVICES" in script
+    assert "SERVICE_START_ARGS=()" in script
+    assert "for SERVICE in db redis; do" in script
+    assert "service_is_defined" in script
+    assert 'echo "[ai-insights] skipping $SERVICE; not defined in compose"' in script
+    assert 'up -d "${SERVICE_START_ARGS[@]}"' in script
+    assert "up -d db redis" not in script
+
+
+def test_build_script_waits_only_for_services_started_by_the_job() -> None:
+    script = aws_ai_insights_job._build_script(env_name="prod", mode="weekly")
+
+    assert 'for SERVICE in "${SERVICE_START_ARGS[@]}"; do' in script
+    assert "db container was not created" not in script
+    assert "redis container was not created" not in script
+
+
+def test_build_script_still_runs_weekly_command_inside_web_without_deps() -> None:
+    script = aws_ai_insights_job._build_script(env_name="prod", mode="weekly")
+
+    assert "run --rm --no-deps \\" in script
+    assert "web flask ai weekly-insights" in script
+
+
+def test_build_script_passes_month_to_monthly_command() -> None:
+    script = aws_ai_insights_job._build_script(
+        env_name="prod",
+        mode="monthly",
+        month="2026-05",
+    )
+
+    assert "web flask ai monthly-insights --month 2026-05" in script


### PR DESCRIPTION
## Summary
- Fix the SSM AI insights batch job to discover compose services before starting optional infrastructure.
- Start and wait only for defined db/redis services, so RDS-only production compose no longer fails with no such service: db.
- Add regression tests for weekly/monthly command rendering and optional service bootstrap.

## Validation
- PYTHONPATH=. /Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-api/.venv/bin/python -m pytest tests/test_aws_ai_insights_job.py -q
- PYTHON_BIN=/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-api/.venv/bin/python bash scripts/run_ci_quality_local.sh --local
- Commit hooks and pre-push hooks passed with PYTHON_BIN set.

Closes #1249