### PR TITLE
fix(billing): grant founder premium entitlement

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -11,6 +11,9 @@ AWS_REGION=us-east-1
 # Optional override for container log group (default: /auraxis/${AURAXIS_ENV}/containers)
 # AURAXIS_CW_LOG_GROUP=/auraxis/dev/containers
 MAX_REQUEST_BYTES=1048576
+# Optional comma-separated internal user UUIDs that should receive premium
+# entitlement overrides without hardcoding identities in the codebase.
+AURAXIS_PREMIUM_OVERRIDE_USER_IDS=
 CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173
 
 # Database (Docker dev)

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -4,6 +4,9 @@ JWT_SECRET_KEY=replace-with-strong-random-value
 FLASK_DEBUG=false
 SECURITY_ENFORCE_STRONG_SECRETS=true
 MAX_REQUEST_BYTES=1048576
+# Optional comma-separated internal user UUIDs that should receive premium
+# entitlement overrides without hardcoding identities in the codebase.
+AURAXIS_PREMIUM_OVERRIDE_USER_IDS=
 # CORS allowed origins (comma-separated):
 #   https://app.auraxis.com.br  — production web app (AWS CloudFront)
 #   https://pilot.auraxis.com.br — staging/pilot frontend (used for pre-release validation)
@@ -146,5 +149,4 @@ AWS_REGION=us-east-1
 # AURAXIS_CW_LOG_GROUP=/auraxis/prod/containers
 AURAXIS_SSM_PATH=/auraxis/prod
 # AURAXIS_SECRETS_MANAGER_ID=auraxis/prod/app
-
 

--- a/app/services/entitlement_service.py
+++ b/app/services/entitlement_service.py
@@ -66,6 +66,18 @@ def has_entitlement(user_id: str | UUID, feature_key: str) -> bool:
     Redis is unavailable the function falls through to the database query so
     that a cache outage never incorrectly blocks a legitimate user.
     """
+    try:
+        from app.services.subscription_service import (
+            ensure_premium_override_subscription,
+            is_premium_override_user_id,
+        )
+
+        normalized_user_id = UUID(str(user_id))
+        if is_premium_override_user_id(normalized_user_id):
+            ensure_premium_override_subscription(normalized_user_id)
+    except (TypeError, ValueError):
+        pass
+
     cache = get_cache_service()
     cache_key = _entitlement_cache_key(user_id, feature_key)
 
@@ -377,6 +389,13 @@ class EntitlementService:
         self.user_id = user_id
 
     def list_entitlements(self) -> list[Entitlement]:
+        from app.services.subscription_service import (
+            ensure_premium_override_subscription,
+            is_premium_override_user_id,
+        )
+
+        if is_premium_override_user_id(self.user_id):
+            ensure_premium_override_subscription(self.user_id)
         now = utc_now_naive()
         return list(
             Entitlement.query.filter_by(user_id=self.user_id)

--- a/app/services/subscription_service.py
+++ b/app/services/subscription_service.py
@@ -6,8 +6,12 @@ keeping controllers thin and provider-agnostic.
 
 from __future__ import annotations
 
+import os
+from datetime import datetime
 from typing import cast
 from uuid import UUID
+
+from flask import current_app, has_app_context
 
 from app.config.billing_plans import parse_billing_cycle, resolve_checkout_plan_offer
 from app.config.plan_features import PLAN_FEATURES
@@ -16,8 +20,120 @@ from app.models.subscription import BillingCycle, Subscription, SubscriptionStat
 from app.models.user import User
 from app.services.billing_adapter import BillingProvider, BillingSubscriptionSnapshot
 from app.services.entitlement_service import sync_entitlements_from_subscription
+from app.utils.datetime_utils import utc_now_naive
 
 _FREE_PLAN_CODE = "free"
+_PREMIUM_OVERRIDE_USER_IDS_CONFIG_KEY = "AURAXIS_PREMIUM_OVERRIDE_USER_IDS"
+_PREMIUM_PLAN_CODE = "premium"
+
+
+def _premium_override_user_ids_config() -> str:
+    if has_app_context():
+        configured = current_app.config.get(_PREMIUM_OVERRIDE_USER_IDS_CONFIG_KEY)
+        if configured is not None:
+            return str(configured)
+    return os.getenv(_PREMIUM_OVERRIDE_USER_IDS_CONFIG_KEY, "")
+
+
+def _configured_premium_override_user_ids() -> frozenset[UUID]:
+    configured_user_ids: set[UUID] = set()
+    raw_config = _premium_override_user_ids_config()
+    for token in raw_config.replace(";", ",").split(","):
+        candidate = token.strip()
+        if not candidate:
+            continue
+        try:
+            configured_user_ids.add(UUID(candidate))
+        except ValueError:
+            continue
+    return frozenset(configured_user_ids)
+
+
+def is_premium_override_user_id(user_id: UUID) -> bool:
+    return user_id in _configured_premium_override_user_ids()
+
+
+def _premium_override_has_active_entitlements(user_id: UUID) -> bool:
+    from app.models.entitlement import Entitlement
+
+    premium_features = set(PLAN_FEATURES[_PREMIUM_PLAN_CODE])
+    now = utc_now_naive()
+    active_keys = {
+        row.feature_key
+        for row in Entitlement.query.filter(
+            Entitlement.user_id == user_id,
+            Entitlement.feature_key.in_(premium_features),
+            (Entitlement.expires_at.is_(None)) | (Entitlement.expires_at > now),
+        ).all()
+    }
+    return premium_features.issubset(active_keys)
+
+
+def ensure_premium_override_subscription(
+    user_id: UUID,
+    *,
+    subscription: Subscription | None = None,
+) -> Subscription | None:
+    """Promote configured internal accounts to premium for product validation.
+
+    The override is intentionally scoped to configured user IDs and is
+    idempotent: regular users keep their existing subscription state, while the
+    configured account gets a permanent premium subscription and matching feature
+    entitlements even when an older row still says ``free``.
+    """
+    user = cast(User | None, db.session.get(User, user_id))
+    if user is None or not is_premium_override_user_id(user_id):
+        return None
+
+    if subscription is None:
+        subscription = cast(
+            Subscription | None,
+            Subscription.query.filter_by(user_id=user_id).first(),
+        )
+
+    changed = False
+    if subscription is None:
+        subscription = Subscription(user_id=user_id)
+        db.session.add(subscription)
+        changed = True
+
+    subscription.plan_code, did_change = _set_if_changed(
+        subscription.plan_code,
+        _PREMIUM_PLAN_CODE,
+    )
+    changed = changed or did_change
+    subscription.status, did_change = _set_if_changed(
+        subscription.status,
+        SubscriptionStatus.ACTIVE,
+    )
+    changed = changed or did_change
+    subscription.billing_cycle, did_change = _set_if_changed(
+        subscription.billing_cycle,
+        BillingCycle.MONTHLY,
+    )
+    changed = changed or did_change
+    subscription.trial_ends_at, did_change = _set_nullable_datetime_if_changed(
+        subscription.trial_ends_at,
+        None,
+    )
+    changed = changed or did_change
+    subscription.current_period_end, did_change = _set_nullable_datetime_if_changed(
+        subscription.current_period_end,
+        None,
+    )
+    changed = changed or did_change
+    subscription.canceled_at, did_change = _set_nullable_datetime_if_changed(
+        subscription.canceled_at,
+        None,
+    )
+    changed = changed or did_change
+
+    if changed or not _premium_override_has_active_entitlements(user_id):
+        sync_entitlements_from_subscription(subscription)
+        _bump_entitlements_version(user_id)
+        db.session.commit()
+
+    return subscription
 
 
 def _normalize_plan_snapshot(
@@ -56,7 +172,13 @@ def get_or_create_subscription(user_id: UUID) -> Subscription:
         )
         db.session.add(subscription)
         db.session.commit()
-    return subscription
+    return (
+        ensure_premium_override_subscription(
+            user_id,
+            subscription=subscription,
+        )
+        or subscription
+    )
 
 
 def _bump_entitlements_version(user_id: UUID) -> None:
@@ -75,6 +197,15 @@ def _sync_access_if_needed(subscription: Subscription, *, changed: bool) -> None
 
 def _set_if_changed[T](current: T, next_value: T | None) -> tuple[T, bool]:
     if next_value is None or current == next_value:
+        return current, False
+    return next_value, True
+
+
+def _set_nullable_datetime_if_changed(
+    current: datetime | None,
+    next_value: datetime | None,
+) -> tuple[datetime | None, bool]:
+    if current == next_value:
         return current, False
     return next_value, True
 
@@ -155,10 +286,23 @@ def sync_subscription_from_provider(
     provider-side subscription to sync).
     """
     if not subscription.provider_subscription_id:
-        return subscription
+        return (
+            ensure_premium_override_subscription(
+                subscription.user_id,
+                subscription=subscription,
+            )
+            or subscription
+        )
 
     data = provider.get_subscription(subscription.provider_subscription_id)
-    return apply_subscription_snapshot(subscription, data)
+    subscription = apply_subscription_snapshot(subscription, data)
+    return (
+        ensure_premium_override_subscription(
+            subscription.user_id,
+            subscription=subscription,
+        )
+        or subscription
+    )
 
 
 def cancel_subscription(

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -102,6 +102,9 @@ class Config:
     # Keep False until legacy clients have migrated. Header X-Refresh-Cookie-Only
     # lets individual requests opt in without flipping the global switch.
     AURAXIS_REFRESH_COOKIE_ONLY = _read_bool_env("AURAXIS_REFRESH_COOKIE_ONLY", False)
+    AURAXIS_PREMIUM_OVERRIDE_USER_IDS = os.getenv(
+        "AURAXIS_PREMIUM_OVERRIDE_USER_IDS", ""
+    )
 
     DEBUG = _read_bool_env("FLASK_DEBUG", False)
 

--- a/tests/test_premium_override_entitlement.py
+++ b/tests/test_premium_override_entitlement.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from flask_jwt_extended import create_access_token, get_jti
+
+from app.extensions.database import db
+from app.models.entitlement import Entitlement
+from app.models.subscription import BillingCycle, Subscription, SubscriptionStatus
+from app.models.user import User
+
+_PREMIUM_OVERRIDE_CONFIG_KEY = "AURAXIS_PREMIUM_OVERRIDE_USER_IDS"
+_PREMIUM_FEATURE = "advanced_simulations"
+
+
+def _create_authenticated_user(
+    app,
+    *,
+    user_id: uuid.UUID,
+    email: str,
+    plan_code: str = "free",
+    status: SubscriptionStatus = SubscriptionStatus.FREE,
+) -> str:
+    with app.app_context():
+        user = User(
+            id=user_id,
+            name="Premium Override Test",
+            email=email,
+            password="hash",
+        )
+        db.session.add(user)
+        db.session.flush()
+        db.session.add(
+            Subscription(
+                user_id=user.id,
+                plan_code=plan_code,
+                status=status,
+            )
+        )
+        db.session.flush()
+
+        token = create_access_token(identity=str(user.id))
+        user.current_jti = get_jti(token)
+        db.session.commit()
+        return token
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_configured_override_existing_free_subscription_is_returned_as_premium(
+    app,
+    client,
+) -> None:
+    user_id = uuid.uuid4()
+    app.config[_PREMIUM_OVERRIDE_CONFIG_KEY] = str(user_id)
+    token = _create_authenticated_user(
+        app,
+        user_id=user_id,
+        email="premium-override@auraxis.test",
+    )
+    with app.app_context():
+        stale_subscription = Subscription.query.filter_by(user_id=user_id).one()
+        stale_subscription.trial_ends_at = datetime(2026, 5, 1)
+        stale_subscription.current_period_end = datetime(2026, 5, 1)
+        stale_subscription.canceled_at = datetime(2026, 5, 1)
+        db.session.commit()
+
+    response = client.get("/subscriptions/me", headers=_auth(token))
+
+    assert response.status_code == 200, response.get_json()
+    subscription = response.get_json()["data"]["subscription"]
+    assert subscription["plan_code"] == "premium"
+    assert subscription["offer_code"] == "premium_monthly"
+    assert subscription["status"] == "active"
+    assert subscription["billing_cycle"] == "monthly"
+
+    with app.app_context():
+        stored = Subscription.query.filter_by(user_id=user_id).one()
+        assert stored.plan_code == "premium"
+        assert stored.status == SubscriptionStatus.ACTIVE
+        assert stored.billing_cycle == BillingCycle.MONTHLY
+        assert stored.trial_ends_at is None
+        assert stored.current_period_end is None
+        assert stored.canceled_at is None
+        entitlement = Entitlement.query.filter_by(
+            user_id=user_id,
+            feature_key=_PREMIUM_FEATURE,
+        ).one_or_none()
+        assert entitlement is not None
+        assert entitlement.expires_at is None
+
+
+def test_configured_override_entitlement_check_is_active_without_subscription_call(
+    app,
+    client,
+) -> None:
+    user_id = uuid.uuid4()
+    app.config[_PREMIUM_OVERRIDE_CONFIG_KEY] = str(user_id)
+    token = _create_authenticated_user(
+        app,
+        user_id=user_id,
+        email="premium-override-check@auraxis.test",
+    )
+
+    response = client.get(
+        f"/entitlements/check?feature_key={_PREMIUM_FEATURE}",
+        headers=_auth(token),
+    )
+
+    assert response.status_code == 200, response.get_json()
+    assert response.get_json()["active"] is True
+
+
+def test_unconfigured_user_is_not_promoted_by_identity(
+    app,
+    client,
+) -> None:
+    user_id = uuid.uuid4()
+    app.config[_PREMIUM_OVERRIDE_CONFIG_KEY] = ""
+    token = _create_authenticated_user(
+        app,
+        user_id=user_id,
+        email="not-configured@auraxis.test",
+    )
+
+    subscription_response = client.get("/subscriptions/me", headers=_auth(token))
+
+    assert subscription_response.status_code == 200, subscription_response.get_json()
+    subscription = subscription_response.get_json()["data"]["subscription"]
+    assert subscription["plan_code"] == "free"
+    assert subscription["offer_code"] == "free"
+    assert subscription["status"] == "free"
+
+
+def test_regular_free_user_is_not_promoted(
+    app,
+    client,
+) -> None:
+    user_id = uuid.uuid4()
+    app.config[_PREMIUM_OVERRIDE_CONFIG_KEY] = str(uuid.uuid4())
+    token = _create_authenticated_user(
+        app,
+        user_id=user_id,
+        email="regular-free@auraxis.test",
+    )
+
+    subscription_response = client.get("/subscriptions/me", headers=_auth(token))
+    entitlement_response = client.get(
+        f"/entitlements/check?feature_key={_PREMIUM_FEATURE}",
+        headers=_auth(token),
+    )
+
+    assert subscription_response.status_code == 200, subscription_response.get_json()
+    subscription = subscription_response.get_json()["data"]["subscription"]
+    assert subscription["plan_code"] == "free"
+    assert subscription["offer_code"] == "free"
+    assert subscription["status"] == "free"
+    assert entitlement_response.status_code == 200, entitlement_response.get_json()
+    assert entitlement_response.get_json()["active"] is False


### PR DESCRIPTION
## Summary
- replaces the hardcoded founder UUID/email with the configurable `AURAXIS_PREMIUM_OVERRIDE_USER_IDS` allowlist
- promotes only configured user IDs to premium/active and materializes premium entitlements before checks/listing
- adds regression coverage for configured overrides, unconfigured identities, and regular free users
- documents the optional override env with an empty value in env examples

## Validation
- PYTHONPATH=. /Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-api/.venv/bin/python -m pytest tests/test_premium_override_entitlement.py -q
- /Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-api/.venv/bin/python -m ruff check app/services/subscription_service.py app/services/entitlement_service.py tests/test_premium_override_entitlement.py config/__init__.py
- /Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-api/.venv/bin/python -m mypy app/services/subscription_service.py app/services/entitlement_service.py config/__init__.py
- PYTHONPATH=. /Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-api/.venv/bin/python -m pytest tests/test_premium_override_entitlement.py tests/test_billing.py tests/test_entitlement_contract.py tests/test_j12_entitlement_enforcement.py tests/test_j9_billing_subscriptions.py -q
- PYTHON_BIN=/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-api/.venv/bin/python bash scripts/run_ci_quality_local.sh --local

Closes #1250