### PR TITLE
fix(security): retry com backoff no download do osv-scanner (502 transiente)

### DIFF
--- a/scripts/run_osv_scanner.sh
+++ b/scripts/run_osv_scanner.sh
@@ -44,6 +44,11 @@ resolve_platform() {
 
 ensure_osv_scanner() {
   local platform cache_dir binary_path asset_url
+  local -i attempt=0
+  local -i max_attempts=5
+  local -i sleep_seconds=5
+  local curl_exit=0
+
   platform="$(resolve_platform)"
   cache_dir="${ROOT_DIR}/.cache/tools/osv-scanner/${OSV_SCANNER_VERSION}"
   binary_path="${cache_dir}/osv-scanner"
@@ -55,8 +60,41 @@ ensure_osv_scanner() {
 
   mkdir -p "${cache_dir}"
   asset_url="https://github.com/google/osv-scanner/releases/download/v${OSV_SCANNER_VERSION}/osv-scanner_${platform}"
-  curl -fsSL "${asset_url}" -o "${binary_path}"
+
+  # Retry with exponential-ish backoff: 5s, 10s, 20s, 40s, 80s.
+  # Handles transient upstream 5xx (CDN/GitHub releases) and DNS hiccups.
+  while (( attempt < max_attempts )); do
+    attempt=$((attempt + 1))
+    curl_exit=0
+    curl --fail --silent --show-error --location \
+         --retry 3 --retry-delay 2 --retry-connrefused \
+         --max-time 60 \
+         "${asset_url}" -o "${binary_path}" \
+         || curl_exit=$?
+    if [[ "${curl_exit}" -eq 0 && -s "${binary_path}" ]]; then
+      break
+    fi
+    rm -f "${binary_path}"
+    if (( attempt >= max_attempts )); then
+      echo "[osv-scanner] failed to download after ${max_attempts} attempts (curl exit=${curl_exit}, url=${asset_url})" >&2
+      return 1
+    fi
+    echo "[osv-scanner] download attempt ${attempt}/${max_attempts} failed (curl exit=${curl_exit}); retrying in ${sleep_seconds}s" >&2
+    sleep "${sleep_seconds}"
+    sleep_seconds=$((sleep_seconds * 2))
+  done
+
+  if [[ ! -s "${binary_path}" ]]; then
+    echo "[osv-scanner] download produced empty file at ${binary_path}" >&2
+    rm -f "${binary_path}"
+    return 1
+  fi
+
   chmod +x "${binary_path}"
+  if [[ ! -x "${binary_path}" ]]; then
+    echo "[osv-scanner] binary not executable after chmod: ${binary_path}" >&2
+    return 1
+  fi
   printf '%s\n' "${binary_path}"
 }
 


### PR DESCRIPTION
## Summary
- `ensure_osv_scanner()` agora retenta o download 5x com backoff (5/10/20/40/80s) antes de desistir, com `curl --fail --retry 3 --retry-connrefused --max-time 60`
- Verifica explicitamente que o arquivo existe, não está vazio, e é executável depois de `chmod +x`
- Falha terminal loga mensagem clara em stderr e retorna 1 — não mais silenciosa
- Cache hit (binário já existe) continua zero-cost

## Why
GitHub releases CDN retornou 502 transitoriamente, derrubando CI mesmo sendo problema upstream. `set -euo pipefail` com command substitution não propagava o erro corretamente, resultando em `chmod: cannot access` + `Process completed with exit code 1` sem indicação clara da causa raiz.

## Test plan
- [ ] CI quality gate passa
- [ ] Cache hit (run subsequente) não retenta — log mostra zero-cost path
- [ ] Validação manual local: rodar `bash scripts/run_osv_scanner.sh` em cold cache → deve baixar com sucesso

Closes #1291