### PR TITLE
feat(ai-insights): MVP-3 dimension + credit_cards section + extended comparisons + GraphQL parity (Sprint 3)

### DIFF
--- a/app/controllers/ai/resources.py
+++ b/app/controllers/ai/resources.py
@@ -205,6 +205,7 @@ class AIInsightGenerateResource(MethodResource):
                     "items": [
                         {
                             "type": "saude_financeira",
+                            "dimension": "general",
                             "title": "Saldo positivo",
                             "message": "Você terminou o período com saldo positivo.",
                             "evidence": ["current_period.paid.balance"],

--- a/app/graphql/docs_catalog.py
+++ b/app/graphql/docs_catalog.py
@@ -836,6 +836,19 @@ GRAPHQL_OPERATION_CATALOG: tuple[GraphQLOperationDoc, ...] = (
         ),
         source_module=QUERY_AI_INSIGHT_MODULE,
     ),
+    # AI Advisory — generate (MVP-3 / #1287 #1288)
+    GraphQLOperationDoc(
+        name="generateAiInsight",
+        operation_type="mutation",
+        domain="ai_advisory",
+        access="auth_required",
+        summary=(
+            "Gera um insight financeiro period-aware (daily/weekly/monthly) com "
+            "itens marcados por dimension (general | transactions | credit_cards |"
+            " goals | budgets). Paridade com POST /ai/insights/generate."
+        ),
+        source_module="app.graphql.mutations.ai_insight",
+    ),
 )
 
 

--- a/app/graphql/mutations/__init__.py
+++ b/app/graphql/mutations/__init__.py
@@ -7,6 +7,7 @@ from app.graphql.mutations.account import (
     DeleteAccountMutation,
     UpdateAccountMutation,
 )
+from app.graphql.mutations.ai_insight import GenerateAiInsightMutation
 from app.graphql.mutations.auth import (
     ConfirmEmailMutation,
     ForgotPasswordMutation,
@@ -178,6 +179,8 @@ class Mutation(graphene.ObjectType):
     create_fiscal_document = CreateFiscalDocumentMutation.Field(
         deprecation_reason="ADR-0002: use POST /fiscal/fiscal-documents"
     )
+    # AI Advisory — canonical GraphQL parity for POST /ai/insights/generate
+    generate_ai_insight = GenerateAiInsightMutation.Field()
 
 
 __all__ = ["Mutation"]

--- a/app/graphql/mutations/ai_insight.py
+++ b/app/graphql/mutations/ai_insight.py
@@ -1,0 +1,134 @@
+"""GraphQL mutation to generate period-aware AI financial insights (MVP-3).
+
+Mirrors `POST /ai/insights/generate`. Each item in the response carries a
+`dimension` field (general | transactions | credit_cards | goals | budgets)
+so consumers can filter contextually on the UI.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Any
+
+import graphene
+
+from app.graphql.auth import get_current_user_required
+from app.graphql.errors import build_public_graphql_error
+from app.graphql.observability import log_graphql_resolver
+from app.services.ai_advisory_service import AIAdvisoryService
+from app.services.financial_insight_context_builder import INSIGHT_DIMENSIONS
+from app.services.llm_provider import LLMProviderError
+
+_VALID_PERIOD_TYPES = ("daily", "weekly", "monthly")
+
+
+class AIInsightItemType(graphene.ObjectType):
+    """A single LLM-produced insight item, tagged by dimension."""
+
+    type = graphene.String(required=True)
+    dimension = graphene.String(required=True)
+    title = graphene.String(required=True)
+    message = graphene.String(required=True)
+    evidence = graphene.List(graphene.String)
+
+
+class GenerateAiInsightPayload(graphene.ObjectType):
+    ok = graphene.Boolean(required=True)
+    period_type = graphene.String()
+    period_label = graphene.String()
+    period_start = graphene.String()
+    period_end = graphene.String()
+    summary = graphene.String()
+    items = graphene.List(AIInsightItemType)
+    context_version = graphene.String()
+    cached = graphene.Boolean()
+    model = graphene.String()
+    tokens_used = graphene.Int()
+    cost_usd = graphene.Float()
+
+
+def _to_item_type(item: dict[str, Any]) -> AIInsightItemType:
+    return AIInsightItemType(
+        type=item.get("type", ""),
+        dimension=item.get("dimension", "general"),
+        title=item.get("title", ""),
+        message=item.get("message", ""),
+        evidence=list(item.get("evidence", []) or []),
+    )
+
+
+class GenerateAiInsightMutation(graphene.Mutation):
+    """GraphQL parity for POST /ai/insights/generate.
+
+    Reuses AIAdvisoryService — quota (2x/day Premium), entitlement gate and
+    LGPD consent are enforced inside the service. GraphQL surface exposes the
+    same payload shape so the frontend hub can render either path identically.
+    """
+
+    class Arguments:
+        period_type = graphene.String(required=True)
+        anchor_date = graphene.String()
+
+    Output = GenerateAiInsightPayload
+
+    @log_graphql_resolver("generateAiInsight")
+    def mutate(
+        self,
+        _info: graphene.ResolveInfo,
+        period_type: str,
+        anchor_date: str | None = None,
+    ) -> GenerateAiInsightPayload:
+        user = get_current_user_required()
+
+        normalized = (period_type or "").strip().lower()
+        if normalized not in _VALID_PERIOD_TYPES:
+            raise build_public_graphql_error(
+                "period_type must be one of: " + ", ".join(_VALID_PERIOD_TYPES),
+                code="VALIDATION_ERROR",
+            )
+
+        parsed_anchor: date | None = None
+        if anchor_date:
+            try:
+                parsed_anchor = datetime.strptime(anchor_date, "%Y-%m-%d").date()
+            except ValueError as exc:
+                raise build_public_graphql_error(
+                    "anchor_date must be ISO YYYY-MM-DD",
+                    code="VALIDATION_ERROR",
+                ) from exc
+
+        service = AIAdvisoryService(user_id=user.id)
+        try:
+            result = service.generate_financial_insights(
+                period_type=normalized,
+                anchor_date=parsed_anchor,
+            )
+        except LLMProviderError as exc:
+            raise build_public_graphql_error(
+                "Erro ao gerar insight financeiro",
+                code="LLM_PROVIDER_ERROR",
+            ) from exc
+
+        items = [_to_item_type(item) for item in result.get("items", [])]
+        # All returned items have a dimension; reject malformed (defensive).
+        for item in items:
+            if item.dimension not in INSIGHT_DIMENSIONS:
+                raise build_public_graphql_error(
+                    "Insight item with invalid dimension",
+                    code="LLM_PROVIDER_ERROR",
+                )
+
+        return GenerateAiInsightPayload(
+            ok=True,
+            period_type=result.get("period_type"),
+            period_label=result.get("period_label"),
+            period_start=result.get("period_start"),
+            period_end=result.get("period_end"),
+            summary=result.get("summary"),
+            items=items,
+            context_version=result.get("context_version"),
+            cached=bool(result.get("cached", False)),
+            model=result.get("model"),
+            tokens_used=int(result.get("tokens_used") or 0),
+            cost_usd=float(result.get("cost_usd") or 0),
+        )

--- a/app/services/ai_advisory_service.py
+++ b/app/services/ai_advisory_service.py
@@ -42,6 +42,7 @@ from app.services.ai_lgpd import (
     redact_response_for_audit,
 )
 from app.services.financial_insight_context_builder import (
+    INSIGHT_DIMENSIONS,
     FinancialInsightContextBuilder,
 )
 from app.services.goal_projection_service import GoalProjectionService
@@ -109,6 +110,10 @@ _FINANCIAL_INSIGHT_RESPONSE_SCHEMA: dict[str, Any] = {
                             "type": "string",
                             "enum": list(_SPENDING_INSIGHT_TYPES),
                         },
+                        "dimension": {
+                            "type": "string",
+                            "enum": list(INSIGHT_DIMENSIONS),
+                        },
                         "title": {"type": "string"},
                         "message": {"type": "string"},
                         "evidence": {
@@ -116,7 +121,13 @@ _FINANCIAL_INSIGHT_RESPONSE_SCHEMA: dict[str, Any] = {
                             "items": {"type": "string"},
                         },
                     },
-                    "required": ["type", "title", "message", "evidence"],
+                    "required": [
+                        "type",
+                        "dimension",
+                        "title",
+                        "message",
+                        "evidence",
+                    ],
                     "additionalProperties": False,
                 },
             },
@@ -286,8 +297,20 @@ def _coerce_financial_insight_item(candidate: object) -> FinancialInsightItem:
     ):
         raise LLMProviderError("Invalid financial insight item fields.")
 
+    # Dimension is required for new MVP-3 items; legacy AIInsight rows (pre
+    # 2026-05-18) may not have it — those get coerced to 'general'. Invalid
+    # explicit values are rejected so the schema stays a closed enum.
+    dimension_raw = candidate.get("dimension")
+    if dimension_raw is None:
+        dimension = "general"
+    elif isinstance(dimension_raw, str) and dimension_raw.strip() in INSIGHT_DIMENSIONS:
+        dimension = dimension_raw.strip()
+    else:
+        raise LLMProviderError("Invalid financial insight item dimension.")
+
     return {
         "type": item_type.strip(),
+        "dimension": dimension,
         "title": title.strip(),
         "message": message.strip(),
         "evidence": [item.strip() for item in evidence],

--- a/app/services/financial_insight_context_builder.py
+++ b/app/services/financial_insight_context_builder.py
@@ -15,12 +15,28 @@ from typing import Any, cast
 from uuid import UUID
 
 from app.models.budget import Budget
+from app.models.credit_card import CreditCard
 from app.models.goal import Goal
 from app.models.transaction import (
     Transaction,
     TransactionStatus,
     TransactionType,
 )
+from app.services.credit_card_bill_service import compute_utilization
+
+INSIGHT_DIMENSIONS: tuple[str, ...] = (
+    "general",
+    "transactions",
+    "credit_cards",
+    "goals",
+    "budgets",
+)
+"""Closed enum of dimension labels assigned to each AI insight item.
+
+Decided on 2026-05-17 (MVP-3 wiki): each insight item must declare which
+surface it belongs to so contextual pages can filter, while the global
+`/insights` hub renders all dimensions grouped.
+"""
 
 _SNAPSHOT_VERSION = "financial_insight_snapshot.v1"
 _CURRENCY = "BRL"
@@ -171,6 +187,14 @@ def _enum_value(value: object) -> str | None:
     return str(enum_value if enum_value is not None else value)
 
 
+def _same_day_previous_year(anchor_date: date) -> date | None:
+    """Return the same calendar day a year before, or None when invalid (Feb 29)."""
+    try:
+        return anchor_date.replace(year=anchor_date.year - 1)
+    except ValueError:
+        return None
+
+
 def _same_day_previous_month(anchor_date: date) -> date | None:
     previous_year = anchor_date.year
     previous_month = anchor_date.month - 1
@@ -210,22 +234,22 @@ class FinancialInsightContextBuilder:
     """Build sanitized financial snapshots for daily, weekly and monthly insights."""
 
     def build_daily(self, *, user_id: UUID, anchor_date: date) -> dict[str, Any]:
-        """Return a daily snapshot with yesterday, prior-month and MTD comparison."""
+        """Return a daily snapshot with extended temporal comparisons."""
         current = self._period_snapshot(
             user_id=user_id,
             start=anchor_date,
             end=anchor_date,
             label=anchor_date.isoformat(),
             period_type="daily",
+            include_credit_cards=True,
         )
         yesterday = anchor_date - timedelta(days=1)
+        previous_week = anchor_date - timedelta(days=7)
         same_day_previous_month = _same_day_previous_month(anchor_date)
+        same_day_previous_year = _same_day_previous_year(anchor_date)
         month_start = date(anchor_date.year, anchor_date.month, 1)
 
         missing_comparisons: list[str] = []
-        if same_day_previous_month is None:
-            missing_comparisons.append("same_day_previous_month")
-
         comparisons: dict[str, Any] = {
             "yesterday": self._comparison_snapshot(
                 user_id=user_id,
@@ -233,6 +257,13 @@ class FinancialInsightContextBuilder:
                 start=yesterday,
                 end=yesterday,
                 label=yesterday.isoformat(),
+            ),
+            "previous_week": self._comparison_snapshot(
+                user_id=user_id,
+                current=current,
+                start=previous_week,
+                end=previous_week,
+                label=previous_week.isoformat(),
             ),
             "month_to_date": self._compact_period_snapshot(
                 self._period_snapshot(
@@ -252,6 +283,19 @@ class FinancialInsightContextBuilder:
                 end=same_day_previous_month,
                 label=same_day_previous_month.isoformat(),
             )
+        else:
+            missing_comparisons.append("same_day_previous_month")
+
+        if same_day_previous_year is not None:
+            comparisons["same_day_previous_year"] = self._comparison_snapshot(
+                user_id=user_id,
+                current=current,
+                start=same_day_previous_year,
+                end=same_day_previous_year,
+                label=same_day_previous_year.isoformat(),
+            )
+        else:
+            missing_comparisons.append("same_day_previous_year")
 
         current["comparisons"] = comparisons
         current["data_quality"]["missing_comparison_periods"] = missing_comparisons
@@ -267,6 +311,7 @@ class FinancialInsightContextBuilder:
             label=f"{anchor_date.isocalendar().year}-W{anchor_date.isocalendar().week:02d}",
             period_type="weekly",
             include_daily_series=True,
+            include_credit_cards=True,
         )
         previous_start = start - timedelta(days=7)
         previous_end = start - timedelta(days=1)
@@ -296,6 +341,7 @@ class FinancialInsightContextBuilder:
             include_daily_series=True,
             include_budgets=True,
             include_goals=True,
+            include_credit_cards=True,
         )
 
     def _comparison_snapshot(
@@ -342,6 +388,7 @@ class FinancialInsightContextBuilder:
         include_daily_series: bool = False,
         include_budgets: bool = False,
         include_goals: bool = False,
+        include_credit_cards: bool = False,
     ) -> dict[str, Any]:
         transactions = self._fetch_transactions(user_id=user_id, start=start, end=end)
         non_cancelled = [
@@ -371,12 +418,59 @@ class FinancialInsightContextBuilder:
             if include_budgets
             else [],
             "goals": self._goals_payload(user_id=user_id) if include_goals else [],
+            "credit_cards": self._credit_cards_payload(user_id=user_id, anchor=end)
+            if include_credit_cards
+            else [],
             "data_quality": {
                 "has_transactions": bool(non_cancelled),
                 "missing_comparison_periods": [],
             },
         }
         return snapshot
+
+    def _credit_cards_payload(
+        self,
+        *,
+        user_id: UUID,
+        anchor: date,
+    ) -> list[dict[str, Any]]:
+        """Sanitized list of cards with current-cycle utilization snapshot.
+
+        Returns one entry per card belonging to the user. Cards without
+        closing_day/due_day are skipped (utilization undefined). PII is
+        never emitted — raw user_id / last_four_digits / external IDs stay
+        out of the snapshot.
+        """
+        cards = (
+            CreditCard.query.filter_by(user_id=user_id).order_by(CreditCard.name).all()
+        )
+        payload: list[dict[str, Any]] = []
+        for card in cards:
+            if card.closing_day is None or card.due_day is None:
+                continue
+            util = compute_utilization(card, today=anchor)
+            payload.append(
+                {
+                    "name": _sanitize_text(card.name, max_length=60) or "Cartão",
+                    "brand": _sanitize_text(card.brand, max_length=20) or None,
+                    "bank": _sanitize_text(card.bank, max_length=60) or None,
+                    "limit_amount": _money_str(util.limit_amount or 0)
+                    if util.limit_amount is not None
+                    else None,
+                    "committed_amount": _money_str(util.committed_amount),
+                    "available_amount": _money_str(util.available_amount or 0)
+                    if util.available_amount is not None
+                    else None,
+                    "utilization_pct": util.utilization_pct,
+                    "cycle": {
+                        "start_date": util.cycle.start_date.isoformat(),
+                        "end_date": util.cycle.end_date.isoformat(),
+                        "due_date": util.cycle.due_date.isoformat(),
+                        "status": util.cycle.status,
+                    },
+                }
+            )
+        return payload
 
     def _fetch_transactions(
         self,

--- a/graphql.introspection.json
+++ b/graphql.introspection.json
@@ -13191,6 +13191,47 @@
                 "name": "FiscalDocumentPayload",
                 "ofType": null
               }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "anchorDate",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "periodType",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "GraphQL parity for POST /ai/insights/generate.\n\nReuses AIAdvisoryService — quota (2x/day Premium), entitlement gate and\nLGPD consent are enforced inside the service. GraphQL surface exposes the\nsame payload shape so the frontend hub can render either path identically.",
+              "isDeprecated": false,
+              "name": "generateAiInsight",
+              "type": {
+                "kind": "OBJECT",
+                "name": "GenerateAiInsightPayload",
+                "ofType": null
+              }
             }
           ],
           "inputFields": null,
@@ -16145,6 +16186,262 @@
           "interfaces": [],
           "kind": "OBJECT",
           "name": "FiscalDocumentPayload",
+          "possibleTypes": null,
+          "specifiedByURL": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "ok",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "periodType",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "periodLabel",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "periodStart",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "periodEnd",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "summary",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "items",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "AIInsightItemType",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "contextVersion",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cached",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "model",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "tokensUsed",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "costUsd",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "GenerateAiInsightPayload",
+          "possibleTypes": null,
+          "specifiedByURL": null
+        },
+        {
+          "description": "A single LLM-produced insight item, tagged by dimension.",
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "type",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "dimension",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "title",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "message",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "evidence",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "AIInsightItemType",
           "possibleTypes": null,
           "specifiedByURL": null
         },

--- a/graphql.operations.manifest.json
+++ b/graphql.operations.manifest.json
@@ -701,5 +701,13 @@
     "operation_type": "query",
     "source_module": "app.graphql.queries.ai_insight",
     "summary": "Retorna o histórico paginado de insights gerados por IA para o usuário autenticado, ordenado do mais recente ao mais antigo."
+  },
+  {
+    "access": "auth_required",
+    "domain": "ai_advisory",
+    "name": "generateAiInsight",
+    "operation_type": "mutation",
+    "source_module": "app.graphql.mutations.ai_insight",
+    "summary": "Gera um insight financeiro period-aware (daily/weekly/monthly) com itens marcados por dimension (general | transactions | credit_cards | goals | budgets). Paridade com POST /ai/insights/generate."
   }
 ]

--- a/schema.graphql
+++ b/schema.graphql
@@ -881,6 +881,15 @@ type Mutation {
     """service_invoice | product_invoice | receipt | debit_note | credit_note"""
     type: String!
   ): FiscalDocumentPayload @deprecated(reason: "ADR-0002: use POST /fiscal/fiscal-documents")
+
+  """
+  GraphQL parity for POST /ai/insights/generate.
+  
+  Reuses AIAdvisoryService — quota (2x/day Premium), entitlement gate and
+  LGPD consent are enforced inside the service. GraphQL surface exposes the
+  same payload shape so the frontend hub can render either path identically.
+  """
+  generateAiInsight(anchorDate: String, periodType: String!): GenerateAiInsightPayload
 }
 
 type AuthPayloadType {
@@ -1254,4 +1263,28 @@ type FiscalDocumentPayload {
   """Field-level validation errors (empty on success)."""
   errors: [ValidationError!]!
   data: FiscalDocumentType
+}
+
+type GenerateAiInsightPayload {
+  ok: Boolean!
+  periodType: String
+  periodLabel: String
+  periodStart: String
+  periodEnd: String
+  summary: String
+  items: [AIInsightItemType]
+  contextVersion: String
+  cached: Boolean
+  model: String
+  tokensUsed: Int
+  costUsd: Float
+}
+
+"""A single LLM-produced insight item, tagged by dimension."""
+type AIInsightItemType {
+  type: String!
+  dimension: String!
+  title: String!
+  message: String!
+  evidence: [String]
 }

--- a/tests/test_ai_advisory_service.py
+++ b/tests/test_ai_advisory_service.py
@@ -331,6 +331,7 @@ class TestAIAdvisoryServiceFinancialInsights:
             assert result["items"] == [
                 {
                     "type": "saude_financeira",
+                    "dimension": "general",
                     "title": "Saldo positivo",
                     "message": "Você fechou o dia com saldo positivo.",
                     "evidence": ["current_period.paid.balance"],

--- a/tests/test_financial_insight_mvp3_extensions.py
+++ b/tests/test_financial_insight_mvp3_extensions.py
@@ -1,0 +1,222 @@
+"""Tests for MVP-3 extensions in the FinancialInsightContextBuilder + AI service.
+
+Covers the new pieces required by the MVP-3 wiki:
+- `credit_cards` section in snapshot (reuses bill cycle + utilization service)
+- Extended comparisons in daily snapshot (`previous_week`, `same_day_previous_year`)
+- `dimension` field on each LLM item, validated against the closed enum
+- Legacy AIInsight rows without `dimension` coerced to `general`
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+import pytest
+
+from app.extensions.database import db
+from app.models.credit_card import CreditCard
+from app.models.transaction import Transaction, TransactionStatus, TransactionType
+from app.services.ai_advisory_service import (
+    _FINANCIAL_INSIGHT_RESPONSE_SCHEMA,
+    _coerce_financial_insight_item,
+)
+from app.services.financial_insight_context_builder import (
+    INSIGHT_DIMENSIONS,
+    FinancialInsightContextBuilder,
+)
+from app.services.llm_provider import LLMProviderError
+
+
+def _create_user(client) -> str:
+    suffix = uuid4().hex[:8]
+    email = f"mvp3-{suffix}@email.com"
+    password = "StrongPass@123"
+    register = client.post(
+        "/auth/register",
+        json={"name": f"user-{suffix}", "email": email, "password": password},
+    )
+    assert register.status_code == 201
+    login = client.post("/auth/login", json={"email": email, "password": password})
+    assert login.status_code == 200
+    token = login.get_json()["token"]
+    from flask_jwt_extended import decode_token
+
+    return str(decode_token(token)["sub"])
+
+
+def _create_card(app, *, user_id: str, limit_amount: float = 5000.0) -> str:
+    with app.app_context():
+        card = CreditCard(
+            user_id=UUID(user_id),
+            name="Nubank",
+            brand="mastercard",
+            limit_amount=Decimal(str(limit_amount)),
+            closing_day=10,
+            due_day=15,
+        )
+        db.session.add(card)
+        db.session.commit()
+        return str(card.id)
+
+
+def _add_card_charge(
+    app,
+    *,
+    user_id: str,
+    card_id: str,
+    amount: str,
+    due_date: date,
+    status: TransactionStatus = TransactionStatus.PENDING,
+) -> None:
+    with app.app_context():
+        tx = Transaction(
+            user_id=UUID(user_id),
+            credit_card_id=UUID(card_id),
+            title="charge",
+            amount=Decimal(amount),
+            due_date=due_date,
+            status=status,
+            type=TransactionType.EXPENSE,
+        )
+        db.session.add(tx)
+        db.session.commit()
+
+
+class TestCreditCardsSnapshotSection:
+    def test_daily_snapshot_includes_credit_cards_section(self, app, client):
+        user_id = _create_user(client)
+        card_id = _create_card(app, user_id=user_id, limit_amount=2000.0)
+        _add_card_charge(
+            app,
+            user_id=user_id,
+            card_id=card_id,
+            amount="500.00",
+            due_date=date.today(),
+        )
+
+        with app.app_context():
+            snapshot = FinancialInsightContextBuilder().build_daily(
+                user_id=UUID(user_id),
+                anchor_date=date.today(),
+            )
+
+        assert "credit_cards" in snapshot
+        assert isinstance(snapshot["credit_cards"], list)
+        assert len(snapshot["credit_cards"]) == 1
+        entry = snapshot["credit_cards"][0]
+        # Sensitive PII like raw user_id or full card token must NOT appear.
+        assert "user_id" not in entry
+        assert "limit_amount" in entry
+        assert "utilization_pct" in entry
+        assert "cycle" in entry
+        assert entry["cycle"]["start_date"]
+        assert entry["cycle"]["end_date"]
+
+    def test_user_without_cards_returns_empty_list(self, app, client):
+        user_id = _create_user(client)
+        with app.app_context():
+            snapshot = FinancialInsightContextBuilder().build_daily(
+                user_id=UUID(user_id),
+                anchor_date=date.today(),
+            )
+        assert snapshot["credit_cards"] == []
+
+    def test_monthly_snapshot_also_includes_credit_cards(self, app, client):
+        user_id = _create_user(client)
+        _create_card(app, user_id=user_id)
+        with app.app_context():
+            snapshot = FinancialInsightContextBuilder().build_monthly(
+                user_id=UUID(user_id),
+                anchor_date=date(2026, 5, 17),
+            )
+        assert isinstance(snapshot.get("credit_cards"), list)
+        assert len(snapshot["credit_cards"]) == 1
+
+
+class TestExtendedComparisons:
+    def test_daily_snapshot_emits_same_day_previous_year_when_omitting(
+        self, app, client
+    ):
+        """When there's no data 1 year ago, the comparison is omitted but flagged."""
+        user_id = _create_user(client)
+        with app.app_context():
+            snapshot = FinancialInsightContextBuilder().build_daily(
+                user_id=UUID(user_id),
+                anchor_date=date.today(),
+            )
+        comparisons = snapshot["comparisons"]
+        missing = snapshot["data_quality"]["missing_comparison_periods"]
+        # If there is no prior-year data, key MAY be absent; assert flag instead.
+        if "same_day_previous_year" not in comparisons:
+            assert "same_day_previous_year" in missing
+
+    def test_daily_snapshot_emits_previous_week_comparison(self, app, client):
+        user_id = _create_user(client)
+        with app.app_context():
+            snapshot = FinancialInsightContextBuilder().build_daily(
+                user_id=UUID(user_id),
+                anchor_date=date.today(),
+            )
+        comparisons = snapshot["comparisons"]
+        assert "previous_week" in comparisons or (
+            "previous_week" in snapshot["data_quality"]["missing_comparison_periods"]
+        )
+
+
+class TestInsightDimensions:
+    def test_dimension_enum_has_five_canonical_values(self):
+        assert set(INSIGHT_DIMENSIONS) == {
+            "general",
+            "transactions",
+            "credit_cards",
+            "goals",
+            "budgets",
+        }
+
+    def test_llm_response_schema_requires_dimension_on_items(self):
+        item_schema = _FINANCIAL_INSIGHT_RESPONSE_SCHEMA["schema"]["properties"][
+            "items"
+        ]["items"]
+        assert "dimension" in item_schema["properties"]
+        assert "dimension" in item_schema["required"]
+        assert set(item_schema["properties"]["dimension"]["enum"]) == set(
+            INSIGHT_DIMENSIONS
+        )
+
+    def test_coerce_accepts_valid_dimension(self):
+        coerced = _coerce_financial_insight_item(
+            {
+                "type": "padrao_gasto",
+                "title": "Cartão Nubank no limite",
+                "message": "Você usou 80% do limite este ciclo.",
+                "evidence": ["snap.credit_cards[0].utilization_pct"],
+                "dimension": "credit_cards",
+            }
+        )
+        assert coerced["dimension"] == "credit_cards"
+
+    def test_coerce_rejects_invalid_dimension(self):
+        with pytest.raises(LLMProviderError):
+            _coerce_financial_insight_item(
+                {
+                    "type": "padrao_gasto",
+                    "title": "x",
+                    "message": "y",
+                    "evidence": ["z"],
+                    "dimension": "investments",  # not in enum
+                }
+            )
+
+    def test_coerce_legacy_item_defaults_to_general(self):
+        """Items persisted before MVP-3 have no dimension — default to 'general'."""
+        coerced = _coerce_financial_insight_item(
+            {
+                "type": "padrao_gasto",
+                "title": "Despesas estáveis",
+                "message": "Padrão semelhante ao mês anterior.",
+                "evidence": ["snap.current_period.paid.expense_total"],
+            }
+        )
+        assert coerced["dimension"] == "general"

--- a/tests/test_graphql_generate_ai_insight.py
+++ b/tests/test_graphql_generate_ai_insight.py
@@ -1,0 +1,136 @@
+"""GraphQL parity tests for generateAiInsight mutation (MVP-3)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+from uuid import UUID, uuid4
+
+
+def _register_and_login(client, *, prefix: str) -> str:
+    suffix = uuid4().hex[:8]
+    email = f"{prefix}-{suffix}@email.com"
+    password = "StrongPass@123"
+    register = client.post(
+        "/auth/register",
+        json={"name": f"user-{suffix}", "email": email, "password": password},
+    )
+    assert register.status_code == 201
+    login = client.post("/auth/login", json={"email": email, "password": password})
+    assert login.status_code == 200
+    return login.get_json()["token"]
+
+
+def _gql(client, query, token=None, variables=None):
+    headers = {"Content-Type": "application/json", "X-API-Contract": "v2"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return client.post(
+        "/graphql",
+        json={"query": query, "variables": variables or {}},
+        headers=headers,
+    )
+
+
+_GENERATE_MUTATION = """
+mutation Gen($periodType: String!, $anchorDate: String) {
+  generateAiInsight(periodType: $periodType, anchorDate: $anchorDate) {
+    ok
+    periodType
+    summary
+    items { type dimension title message evidence }
+    cached
+    model
+  }
+}
+"""
+
+
+class TestGenerateAiInsightMutation:
+    def test_rejects_invalid_period_type(self, client):
+        token = _register_and_login(client, prefix="gql-gen-invalid")
+        response = _gql(
+            client,
+            _GENERATE_MUTATION,
+            token,
+            variables={"periodType": "yearly", "anchorDate": None},
+        )
+        body = response.get_json()
+        assert body.get("errors")
+        assert any("period_type" in e.get("message", "") for e in body["errors"])
+
+    def test_rejects_invalid_anchor_date(self, client):
+        token = _register_and_login(client, prefix="gql-gen-bad-date")
+        response = _gql(
+            client,
+            _GENERATE_MUTATION,
+            token,
+            variables={"periodType": "daily", "anchorDate": "17/05/2026"},
+        )
+        body = response.get_json()
+        assert body.get("errors")
+        assert any("anchor_date" in e.get("message", "") for e in body["errors"])
+
+    def test_requires_auth(self, client):
+        response = _gql(client, _GENERATE_MUTATION, variables={"periodType": "daily"})
+        body = response.get_json()
+        assert response.status_code == 401 or body.get("errors")
+
+    def test_returns_items_with_dimension_when_provider_returns_payload(
+        self, app, client
+    ):
+        token = _register_and_login(client, prefix="gql-gen-ok")
+        # Grant entitlement so the service does not block on Premium gate.
+        from flask_jwt_extended import decode_token
+
+        from app.services.entitlement_service import grant_entitlement
+
+        with app.app_context():
+            user_id = UUID(decode_token(token)["sub"])
+            grant_entitlement(
+                user_id=user_id,
+                feature_key="advanced_simulations",
+                source="trial",
+            )
+            from app.extensions.database import db
+
+            db.session.commit()
+
+        fake_result = {
+            "period_type": "daily",
+            "period_label": "2026-05-18",
+            "period_start": "2026-05-18",
+            "period_end": "2026-05-18",
+            "summary": "Resumo do dia.",
+            "items": [
+                {
+                    "type": "saude_financeira",
+                    "dimension": "credit_cards",
+                    "title": "Cartão Nubank no limite",
+                    "message": "Você usou 80% do limite.",
+                    "evidence": ["credit_cards[0].utilization_pct"],
+                }
+            ],
+            "context_version": "financial_insight_snapshot.v1",
+            "context_hash": "abc",
+            "cached": False,
+            "model": "gpt-4o-mini",
+            "tokens_used": 50,
+            "cost_usd": 0.0001,
+        }
+        with patch("app.graphql.mutations.ai_insight.AIAdvisoryService") as MockSvc:
+            instance = MockSvc.return_value
+            instance.generate_financial_insights.return_value = fake_result
+            response = _gql(
+                client,
+                _GENERATE_MUTATION,
+                token,
+                variables={"periodType": "daily", "anchorDate": "2026-05-18"},
+            )
+        body = response.get_json()
+        assert "errors" not in body or not body["errors"], body
+        data = body["data"]["generateAiInsight"]
+        assert data["ok"] is True
+        assert data["summary"] == "Resumo do dia."
+        assert len(data["items"]) == 1
+        assert data["items"][0]["dimension"] == "credit_cards"
+        assert data["items"][0]["evidence"] == ["credit_cards[0].utilization_pct"]


### PR DESCRIPTION
## Summary

Entrega do **Sprint 3 do MVP-3 — extensões do motor de AI Insights** conforme decisões do PO (chat 2026-05-17) e wiki canônica (`auraxis-platform/docs/wiki/MVP-3-Hub-Cartoes-Insights-Globais.md`).

**Closes** #1287 #1288 (supersede de #1269 #1270).

Reusa `compute_bill_cycle` e `compute_utilization` do Sprint 1 (PR #1294, já em master).

## Mudanças

### 1. `INSIGHT_DIMENSIONS` (enum fechado de 5 valores)
Novo módulo `app/services/financial_insight_context_builder.py`: `general | transactions | credit_cards | goals | budgets`.

Cada item gerado pelo LLM carrega `dimension` permitindo:
- Frontend filtra contextualmente (transações mostra só `transactions`/`general` etc)
- `/insights` hub mostra todos agrupados por dimensão
- Mesma record entre superfícies (não duplica)

### 2. LLM response schema com `dimension` requerida
`_FINANCIAL_INSIGHT_RESPONSE_SCHEMA` agora exige `dimension` por item (enum-validated). `_coerce_financial_insight_item`:
- Aceita `dimension` válida → retorna o valor
- Aceita item sem `dimension` (legacy AIInsight rows) → fallback `general`
- Rejeita `dimension` inválida → `LLMProviderError`

### 3. `credit_cards` section no snapshot
`FinancialInsightContextBuilder._credit_cards_payload(user_id, anchor)` reusa `compute_utilization` do Sprint 1. Cada entry sanitizada (PII redacted via `_sanitize_text`) inclui: name, brand, bank, limit_amount, committed_amount, available_amount, utilization_pct, cycle.

Incluída em `build_daily/weekly/monthly` via flag `include_credit_cards=True`.

### 4. Comparações temporais estendidas no `build_daily`
- `yesterday` (já tinha)
- **`previous_week`** ← NEW (7 dias atrás)
- `same_day_previous_month` (já tinha)
- **`same_day_previous_year`** ← NEW (com graceful omit em Feb 29)
- `month_to_date` (já tinha)

`data_quality.missing_comparison_periods` reporta os ausentes (instead of silently dropping).

### 5. GraphQL parity — `generateAiInsight` mutation
`app/graphql/mutations/ai_insight.py`:
- `AIInsightItemType` com `dimension` field
- `GenerateAiInsightPayload` espelha REST `POST /ai/insights/generate`
- Validação ISO date + period_type enum
- Reusa `AIAdvisoryService.generate_financial_insights` (quota + entitlement + LGPD consent enforced no service)
- Registrada em `Mutation` class + `docs_catalog`

### 6. Doc example atualizado
`AIInsightGenerateResource` doc example agora exibe `dimension: "general"` nos items.

## Stats

```
12 files changed, 970 insertions(+), 5 deletions(-)
```

## Test plan

- [x] `pytest tests/test_financial_insight_mvp3_extensions.py` → 10 passed (RED→GREEN TDD)
- [x] `pytest tests/test_graphql_generate_ai_insight.py` → 4 passed
- [x] `pytest tests/test_ai_advisory_service.py tests/test_ai_insight_persistence.py tests/test_ai_insight_weekly_recap.py tests/test_ai_insight_graphql.py tests/test_ai_insight_goals_budget_context.py tests/test_graphql_auth_everywhere.py tests/test_graphql_docs_export.py` → **153 passed** (full regression)
- [x] schema.graphql + graphql.introspection.json + graphql.operations.manifest.json regenerados via `scripts/export_graphql_docs.py --source runtime`
- [x] Pre-commit gates (ruff, mypy, bandit, secrets, alembic, sonar) green em todos os commits
- [ ] CI full quality gate (rodando)

## Próximos passos pós-merge

- **Sprint 4 (Codex)**: cards web `#865 ai-4` (Insights Hub UI) + app `#420 ai-5` consomem o contrato com `dimension` para filtrar contextualmente
- **Sprint 5 (Claude)**: `#1289 obs-1` — observability (Prometheus metrics, snapshot truncation, AIInsight.metadata_json)