### PR TITLE
feat(ai-insights): observability + snapshot guardrails + metadata persistence (Sprint 5 MVP-3 obs-1)

### DIFF
--- a/app/extensions/prometheus_metrics.py
+++ b/app/extensions/prometheus_metrics.py
@@ -44,8 +44,39 @@ _AUDIT_EVENTS_PURGED_TOTAL: Any = None
 _CACHE_HITS_TOTAL: Any = None
 _CACHE_MISSES_TOTAL: Any = None
 _CACHE_INVALIDATIONS_TOTAL: Any = None
+_AI_INSIGHT_GENERATED_TOTAL: Any = None
+_AI_INSIGHT_TOKENS: Any = None
+_AI_INSIGHT_SNAPSHOT_BYTES: Any = None
 
 _DURATION_BUCKETS = (0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5)
+_AI_TOKENS_BUCKETS = (100, 250, 500, 1000, 2500, 5000, 10000, 25000)
+_AI_SNAPSHOT_BYTES_BUCKETS = (1024, 2048, 4096, 8192, 12288, 16384, 32768)
+
+
+def _init_ai_insight_metrics() -> None:
+    """Lazily initialise the MVP-3 AI insight observability instruments."""
+    global _AI_INSIGHT_GENERATED_TOTAL, _AI_INSIGHT_TOKENS, _AI_INSIGHT_SNAPSHOT_BYTES
+
+    if _AI_INSIGHT_GENERATED_TOTAL is None:
+        _AI_INSIGHT_GENERATED_TOTAL = Counter(
+            "auraxis_ai_insight_generated_total",
+            "AI insights generated, by period_type and dimension",
+            ["period_type", "dimension"],
+        )
+    if _AI_INSIGHT_TOKENS is None:
+        _AI_INSIGHT_TOKENS = Histogram(
+            "auraxis_ai_insight_tokens",
+            "Tokens consumed per AI insight generation",
+            ["period_type"],
+            buckets=_AI_TOKENS_BUCKETS,
+        )
+    if _AI_INSIGHT_SNAPSHOT_BYTES is None:
+        _AI_INSIGHT_SNAPSHOT_BYTES = Histogram(
+            "auraxis_ai_insight_snapshot_bytes",
+            "Snapshot size in bytes sent to the LLM (post truncation)",
+            ["period_type", "truncated"],
+            buckets=_AI_SNAPSHOT_BYTES_BUCKETS,
+        )
 
 
 def _ensure_metrics_initialized() -> None:
@@ -111,6 +142,8 @@ def _ensure_metrics_initialized() -> None:
             ["namespace"],
         )
 
+    _init_ai_insight_metrics()
+
 
 def record_http_request(
     *,
@@ -172,6 +205,35 @@ def record_auth_login(*, status: str) -> None:
         _AUTH_LOGINS_TOTAL.labels(status=status).inc()
 
 
+def record_ai_insight_generated(
+    *,
+    period_type: str,
+    dimensions: list[str],
+    tokens_used: int,
+    snapshot_bytes: int,
+    truncated: bool,
+) -> None:
+    """Record an AI insight generation across counter + histograms (MVP-3).
+
+    Emits one ``auraxis_ai_insight_generated_total`` increment per distinct
+    dimension found in the LLM response (so a single generation contributes
+    to multiple dimensions when the LLM produces multi-surface items).
+    Tokens and snapshot byte size are observed once per call.
+    """
+    _ensure_metrics_initialized()
+    pt = period_type or "unknown"
+    if _AI_INSIGHT_GENERATED_TOTAL is not None:
+        for dim in dimensions or ["general"]:
+            _AI_INSIGHT_GENERATED_TOTAL.labels(period_type=pt, dimension=dim).inc()
+    if _AI_INSIGHT_TOKENS is not None and tokens_used >= 0:
+        _AI_INSIGHT_TOKENS.labels(period_type=pt).observe(tokens_used)
+    if _AI_INSIGHT_SNAPSHOT_BYTES is not None and snapshot_bytes >= 0:
+        _AI_INSIGHT_SNAPSHOT_BYTES.labels(
+            period_type=pt,
+            truncated="true" if truncated else "false",
+        ).observe(snapshot_bytes)
+
+
 def generate_latest_metrics() -> tuple[bytes, str]:
     """Return ``(body_bytes, content_type)`` for the Prometheus scrape endpoint.
 
@@ -221,6 +283,7 @@ def register_prometheus_middleware(app: "Flask") -> None:
 
 __all__ = [
     "generate_latest_metrics",
+    "record_ai_insight_generated",
     "record_audit_purge",
     "record_auth_login",
     "record_cache_hit",

--- a/app/models/ai_insight.py
+++ b/app/models/ai_insight.py
@@ -73,6 +73,32 @@ class AIInsight(db.Model):
         nullable=True,
     )
     created_at = db.Column(db.DateTime, default=utc_now_naive, nullable=False)
+    # Snapshot/audit metadata for observability — populated since MVP-3
+    # (Sprint 5 obs-1). Legacy rows have NULL. Stored as JSON in Text for
+    # SQLite parity with PG; access via `metadata_dict` property.
+    metadata_json = db.Column(db.Text, nullable=True)
+
+    @property
+    def metadata_dict(self) -> dict[str, object]:
+        """Decode `metadata_json` to a dict, or {} when missing/invalid."""
+        import json as _json
+
+        if not self.metadata_json:
+            return {}
+        try:
+            decoded = _json.loads(self.metadata_json)
+        except (ValueError, TypeError):
+            return {}
+        return decoded if isinstance(decoded, dict) else {}
+
+    @metadata_dict.setter
+    def metadata_dict(self, value: dict[str, object] | None) -> None:
+        import json as _json
+
+        if value is None:
+            self.metadata_json = None
+        else:
+            self.metadata_json = _json.dumps(value, ensure_ascii=False, sort_keys=True)
 
     __table_args__ = (
         db.Index("ix_ai_insights_user_id", "user_id"),

--- a/app/services/ai_advisory_service.py
+++ b/app/services/ai_advisory_service.py
@@ -28,6 +28,7 @@ from dateutil.relativedelta import relativedelta
 from sqlalchemy import case, func
 
 from app.extensions.database import db
+from app.extensions.prometheus_metrics import record_ai_insight_generated
 from app.models.ai_insight import AIInsight, InsightType
 from app.models.budget import Budget
 from app.models.goal import Goal
@@ -44,6 +45,7 @@ from app.services.ai_lgpd import (
 from app.services.financial_insight_context_builder import (
     INSIGHT_DIMENSIONS,
     FinancialInsightContextBuilder,
+    truncate_snapshot,
 )
 from app.services.goal_projection_service import GoalProjectionService
 from app.services.llm_provider import LLMProvider, LLMProviderError, get_llm_provider
@@ -188,6 +190,7 @@ def _save_insight(
     tokens_used: int,
     cost_usd: float,
     previous_insight_id: UUID | None,
+    metadata: dict[str, Any] | None = None,
 ) -> AIInsight:
     """Persist a new AIInsight record and return it."""
     from decimal import Decimal as _Decimal
@@ -204,6 +207,8 @@ def _save_insight(
         cost_usd=_Decimal(str(cost_usd)),
         previous_insight_id=previous_insight_id,
     )
+    if metadata:
+        insight.metadata_dict = metadata
     db.session.add(insight)
     db.session.commit()
     return insight
@@ -536,6 +541,9 @@ class AIAdvisoryService:
 
         previous = _get_latest_insight(user_id=self._user_id)
         prompt_snapshot = minimize_prompt_data(snapshot)
+        # Apply 12 KiB cap before hashing/prompting so context_hash matches
+        # whatever we actually send to the LLM.
+        prompt_snapshot, truncation_info = truncate_snapshot(prompt_snapshot)
         context_hash = _financial_context_hash(prompt_snapshot)
         prompt = _build_financial_insight_prompt(
             prompt_snapshot,
@@ -577,6 +585,24 @@ class AIAdvisoryService:
             consent_version=consent_version,
         )
 
+        dimensions_present = sorted(
+            {str(it.get("dimension", "general")) for it in items}
+        )
+        comparisons_available = sorted((snapshot.get("comparisons") or {}).keys())
+        persist_metadata: dict[str, Any] = {
+            "snapshot_version": context_version,
+            "context_hash": context_hash,
+            "comparisons_available": comparisons_available,
+            "dimensions_present": dimensions_present,
+            "snapshot_bytes_original": truncation_info["snapshot_bytes_original"],
+            "snapshot_bytes_final": truncation_info["snapshot_bytes_final"],
+            "truncated": bool(truncation_info["truncated"]),
+        }
+        if truncation_info["dropped_sections"]:
+            persist_metadata["dropped_sections"] = list(
+                truncation_info["dropped_sections"]
+            )
+
         _save_insight(
             user_id=self._user_id,
             content=serialized_content,
@@ -588,7 +614,23 @@ class AIAdvisoryService:
             tokens_used=llm_resp.total_tokens,
             cost_usd=llm_resp.estimated_cost_usd,
             previous_insight_id=previous.id if previous else None,
+            metadata=persist_metadata,
         )
+
+        try:
+            record_ai_insight_generated(
+                period_type=normalized_period_type,
+                dimensions=dimensions_present,
+                tokens_used=int(llm_resp.total_tokens or 0),
+                snapshot_bytes=int(truncation_info["snapshot_bytes_final"]),
+                truncated=bool(truncation_info["truncated"]),
+            )
+        except Exception:  # pragma: no cover — metrics are fire-and-forget
+            log.warning(
+                "ai_advisory.metrics.record_failed user=%s period=%s",
+                self._user_id,
+                normalized_period_type,
+            )
 
         return {
             "period_type": normalized_period_type,

--- a/app/services/financial_insight_context_builder.py
+++ b/app/services/financial_insight_context_builder.py
@@ -7,6 +7,9 @@ instances so prompts and audit logs do not receive user PII or raw IDs.
 
 from __future__ import annotations
 
+import json
+import logging
+import os
 import re
 from calendar import monthrange
 from datetime import date, timedelta
@@ -41,6 +44,17 @@ surface it belongs to so contextual pages can filter, while the global
 _SNAPSHOT_VERSION = "financial_insight_snapshot.v1"
 _CURRENCY = "BRL"
 _TIMEZONE = "America/Sao_Paulo"
+
+# Hard cap on serialized snapshot size sent to the LLM (Sprint 5 obs-1).
+# When exceeded, `truncate_snapshot()` reduces large lists deterministically
+# while preserving the structural backbone (schema_version, current_period,
+# comparisons). Override via AI_SNAPSHOT_MAX_BYTES env for cost experiments.
+DEFAULT_MAX_SNAPSHOT_BYTES = 12 * 1024
+MAX_SNAPSHOT_BYTES = int(
+    os.getenv("AI_SNAPSHOT_MAX_BYTES", str(DEFAULT_MAX_SNAPSHOT_BYTES))
+)
+
+_log = logging.getLogger(__name__)
 _MONEY_QUANT = Decimal("0.01")
 _PERCENT_QUANT = Decimal("0.01")
 _EMAIL_MASK = "[email]"
@@ -795,4 +809,124 @@ class FinancialInsightContextBuilder:
         )
 
 
-__all__ = ["FinancialInsightContextBuilder"]
+def _measure_snapshot_bytes(snapshot: dict[str, Any]) -> int:
+    """Return UTF-8 byte size of the JSON-serialized snapshot."""
+    return len(json.dumps(snapshot, ensure_ascii=False, sort_keys=True).encode("utf-8"))
+
+
+def _trim_transactions(snapshot: dict[str, Any]) -> bool:
+    txs = snapshot.get("transactions")
+    if not isinstance(txs, dict):
+        return False
+    items = txs.get("items")
+    if not (isinstance(items, list) and len(items) > 15):
+        return False
+    expenses = [i for i in items if i.get("type") == "expense"]
+    incomes = [i for i in items if i.get("type") == "income"]
+    kept = (
+        sorted(expenses, key=lambda i: float(i.get("amount", 0) or 0), reverse=True)[
+            :10
+        ]
+        + sorted(incomes, key=lambda i: float(i.get("amount", 0) or 0), reverse=True)[
+            :5
+        ]
+    )
+    snapshot["transactions"] = {**txs, "items": kept}
+    return True
+
+
+def _trim_daily_series(snapshot: dict[str, Any]) -> bool:
+    series = snapshot.get("daily_series")
+    if isinstance(series, list) and len(series) > 7:
+        snapshot["daily_series"] = series[-7:]
+        return True
+    return False
+
+
+def _trim_idle_credit_cards(snapshot: dict[str, Any]) -> bool:
+    cards = snapshot.get("credit_cards")
+    if not (isinstance(cards, list) and cards):
+        return False
+    active = [
+        c
+        for c in cards
+        if isinstance(c, dict) and c.get("utilization_pct") not in (None, 0, 0.0)
+    ]
+    if len(active) < len(cards):
+        snapshot["credit_cards"] = active
+        return True
+    return False
+
+
+def _trim_top_categories(snapshot: dict[str, Any]) -> bool:
+    categories = snapshot.get("categories")
+    if not isinstance(categories, dict):
+        return False
+    top = categories.get("top_expense_categories")
+    if isinstance(top, list) and len(top) > 5:
+        snapshot["categories"] = {**categories, "top_expense_categories": top[:5]}
+        return True
+    return False
+
+
+def truncate_snapshot(
+    snapshot: dict[str, Any],
+    *,
+    max_bytes: int = MAX_SNAPSHOT_BYTES,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Return ``(possibly_truncated, info)`` keeping the snapshot under max_bytes.
+
+    Truncation order (least → most destructive):
+
+    1. transactions: keep top 10 by expense amount, then top 5 income.
+    2. daily_series: keep most recent 7 entries.
+    3. credit_cards: drop entries with zero/None utilization_pct.
+    4. categories.top_expense_categories: keep top 5.
+
+    Always preserved: ``schema_version``, ``period_type``, ``period``,
+    ``current_period``, ``comparisons``, ``data_quality``. Caller receives
+    a dict describing what changed for observability.
+    """
+    original_bytes = _measure_snapshot_bytes(snapshot)
+    info: dict[str, Any] = {
+        "snapshot_bytes_original": original_bytes,
+        "snapshot_bytes_final": original_bytes,
+        "truncated": False,
+        "dropped_sections": [],
+        "max_bytes": max_bytes,
+    }
+    if original_bytes <= max_bytes:
+        return snapshot, info
+
+    truncated = dict(snapshot)
+    dropped: list[str] = info["dropped_sections"]
+    steps = (
+        ("transactions.items", _trim_transactions),
+        ("daily_series", _trim_daily_series),
+        ("credit_cards.idle", _trim_idle_credit_cards),
+        ("categories.top_expense_categories", _trim_top_categories),
+    )
+    for label, step in steps:
+        if step(truncated):
+            dropped.append(label)
+        if _measure_snapshot_bytes(truncated) <= max_bytes:
+            break
+
+    final_bytes = _measure_snapshot_bytes(truncated)
+    info["snapshot_bytes_final"] = final_bytes
+    info["truncated"] = True
+    _log.warning(
+        "ai_advisory.snapshot.truncated original=%d final=%d dropped=%s",
+        original_bytes,
+        final_bytes,
+        dropped,
+    )
+    return truncated, info
+
+
+__all__ = [
+    "FinancialInsightContextBuilder",
+    "INSIGHT_DIMENSIONS",
+    "MAX_SNAPSHOT_BYTES",
+    "truncate_snapshot",
+]

--- a/docs/adr/0006-ai-insight-dimensions-and-observability.md
+++ b/docs/adr/0006-ai-insight-dimensions-and-observability.md
@@ -1,0 +1,144 @@
+# ADR-0006: AI Insight Dimensions + Snapshot Observability
+
+Status: accepted
+Date: 2026-05-18
+Refs: #1287 #1288 #1289 (Sprints 3 + 5 of MVP-3); supersedes parts of #1271
+
+## Context
+
+MVP-3 (Hub de Cartões + Insights Globais) requires every AI insight item to
+declare which surface it belongs to so the frontend can filter contextually
+(transactions page, credit cards page, goals page, budgets page) while the
+`/insights` hub shows everything grouped. We also need observability on token
+spend, snapshot size and dimension distribution to keep LLM cost predictable.
+
+## Decision
+
+### 1. Dimension is a closed enum with a `general` fallback
+
+```python
+INSIGHT_DIMENSIONS = ("general", "transactions", "credit_cards", "goals", "budgets")
+```
+
+- LLM response schema requires `dimension` per item, validated against this
+  enum (strict mode).
+- `_coerce_financial_insight_item` accepts items missing `dimension` and
+  defaults to `general`. This handles AIInsight rows persisted before MVP-3
+  (Sprint 3 cutover) so the history endpoint never breaks.
+- Invalid explicit dimensions raise `LLMProviderError` — silent acceptance
+  would let the model leak the enum surface area over time.
+
+### 2. Quota is global per user, not per dimension
+
+- 2 generations per day per user (Premium). Decision recorded in the wiki
+  (2026-05-17) and re-affirmed in chat.
+- A single generation may contain items across multiple dimensions; that's
+  one quota unit.
+- Rationale: per-dimension quotas multiply LLM cost by 5× without giving
+  users meaningfully better targeting. Users self-prioritise via the surface
+  they trigger generation from.
+
+### 3. Snapshot has a 12 KiB byte cap with deterministic truncation
+
+`MAX_SNAPSHOT_BYTES = 12 * 1024` (overridable via `AI_SNAPSHOT_MAX_BYTES`).
+
+When the JSON-serialized snapshot exceeds the cap, `truncate_snapshot()`
+reduces large lists in this order:
+
+1. `transactions.items` → top 10 expense + top 5 income (by amount).
+2. `daily_series` → last 7 days.
+3. `credit_cards` → drop cards with zero/None utilization.
+4. `categories.top_expense_categories` → keep top 5.
+
+Always preserved: `schema_version`, `period_type`, `period`, `current_period`,
+`comparisons`, `data_quality`.
+
+A structured warning is logged on truncation (`ai_advisory.snapshot.truncated`).
+
+### 4. Persistence: `AIInsight.metadata_json` (nullable Text)
+
+Single nullable JSON-in-Text column on `ai_insights`. Stores per-generation
+observability metadata:
+
+```json
+{
+  "snapshot_version": "financial_insight_snapshot.v1",
+  "context_hash": "sha256:abc...",
+  "comparisons_available": ["yesterday", "previous_week", "same_day_previous_month"],
+  "dimensions_present": ["general", "credit_cards"],
+  "snapshot_bytes_original": 14823,
+  "snapshot_bytes_final": 11942,
+  "truncated": true,
+  "dropped_sections": ["transactions.items", "daily_series"]
+}
+```
+
+Legacy rows (pre-cc2 migration) keep `metadata_json = NULL`. Callers read via
+`AIInsight.metadata_dict` property (transparent JSON encode/decode).
+
+**Why Text JSON, not dedicated columns**: keeps the migration trivial (one
+nullable Text column), maintains SQLite parity for tests, and avoids
+hot-loop schema churn as the metadata vocabulary evolves. Cost: no SQL
+filtering on inner fields. We don't need that — observability is consumed
+via Prometheus, not SQL.
+
+### 5. Prometheus counters and histograms
+
+Added in `app/extensions/prometheus_metrics.py`:
+
+| Metric | Type | Labels | Purpose |
+|---|---|---|---|
+| `auraxis_ai_insight_generated_total` | Counter | `period_type`, `dimension` | Generation volume by surface |
+| `auraxis_ai_insight_tokens` | Histogram | `period_type` | Token spend distribution |
+| `auraxis_ai_insight_snapshot_bytes` | Histogram | `period_type`, `truncated` | Snapshot size before/after truncate gate |
+
+Recorded once per non-cached generation via `record_ai_insight_generated()`.
+Fire-and-forget — failures here never abort the user-facing flow.
+
+## Consequences
+
+### Positive
+
+- Frontend can render contextual dashboards (Sprint 4 by Codex) by filtering
+  on `dimension` without consulting the full snapshot.
+- LLM cost stays bounded: snapshot capped + token histogram surfaces outliers.
+- Single migration (cc2) keeps deployment simple.
+- Adding new comparison periods or sections later doesn't require migrations
+  — the JSON metadata grows without schema churn.
+
+### Negative / accepted trade-offs
+
+- `metadata_json` is opaque to SQL — Grafana dashboards rely on Prometheus,
+  not on querying the column.
+- Closed dimension enum requires a code change + migration of LLM prompt
+  whenever a new surface is added (acceptable: roadmap is bounded).
+- Per-dimension counters can multiply storage rows in long-running Prometheus
+  retention. Bucket cardinality is bounded at 5 dimensions × 3 period_types
+  = 15 series. Negligible.
+
+## Alternatives considered
+
+- **Open-ended `tags: list[str]`** on items instead of closed enum. Rejected:
+  the frontend needs a fixed set of buckets to render UI; open tags push
+  routing complexity to the client.
+- **Per-dimension quota** (2x/day × 5 dimensions = 10 calls/day). Rejected:
+  5× cost without obvious user value. Revisit if users complain about
+  forced prioritisation.
+- **Dedicated columns for `snapshot_bytes_original`, etc.** Rejected: each
+  new metric becomes a migration. JSON-in-Text gives evolution room.
+- **Truncate by simply chopping the JSON string**. Rejected: produces invalid
+  JSON and confuses the LLM. Structured reduction preserves semantics.
+
+## Related ADRs
+
+- ADR-0002 GraphQL ownership (REST canonical for writes — applies to the
+  REST-first POST /ai/insights/generate)
+- ADR-0005 AI insight persistence model
+
+## Verification
+
+- Unit tests for `truncate_snapshot()` cover input below cap, transaction
+  trim path, daily_series trim path (`tests/test_ai_insight_observability.py`).
+- Integration test confirms `metadata_json` populated + counter recorded on
+  every generation.
+- Prometheus scrape returns the new metrics (smoke check via `/metrics`).

--- a/migrations/versions/cc2_ai_insight_metadata.py
+++ b/migrations/versions/cc2_ai_insight_metadata.py
@@ -1,0 +1,40 @@
+"""ai_insight_metadata_json
+
+Adds a nullable Text JSON column on `ai_insights` to persist observability
+metadata produced by the MVP-3 financial insight pipeline:
+
+- snapshot_version (e.g. "financial_insight_snapshot.v1")
+- comparisons_available (list of comparison-period keys present)
+- dimensions_present (list of dimensions used by LLM items)
+- snapshot_bytes_original / snapshot_bytes_final
+- truncated (bool)
+
+Legacy rows keep NULL — caller must handle absence.
+
+Revision ID: cc2_ai_insight_metadata
+Revises: cc1_credit_card_extension
+Create Date: 2026-05-18 12:00:00.000000
+
+Refs: #1289 (auraxis-api), Sprint 5 of MVP-3 wiki.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "cc2_ai_insight_metadata"
+down_revision = "cc1_credit_card_extension"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "ai_insights",
+        sa.Column("metadata_json", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("ai_insights", "metadata_json")

--- a/tests/test_ai_insight_observability.py
+++ b/tests/test_ai_insight_observability.py
@@ -1,0 +1,177 @@
+"""Sprint 5 (obs-1) tests for the AI insight observability stack.
+
+Covers:
+- truncate_snapshot() behaviour below/above the byte cap
+- AIInsight.metadata_json persistence by generate_financial_insights
+- Prometheus metrics emitted on each generation
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from unittest.mock import MagicMock, patch
+from uuid import UUID, uuid4
+
+from app.extensions.database import db
+from app.models.ai_insight import AIInsight
+from app.services.financial_insight_context_builder import (
+    MAX_SNAPSHOT_BYTES,
+    truncate_snapshot,
+)
+from app.services.llm_provider import LLMResponse
+
+
+def _register_and_login(client) -> tuple[str, str]:
+    suffix = uuid4().hex[:8]
+    email = f"obs1-{suffix}@email.com"
+    password = "StrongPass@123"
+    register = client.post(
+        "/auth/register",
+        json={"name": f"user-{suffix}", "email": email, "password": password},
+    )
+    assert register.status_code == 201
+    login = client.post("/auth/login", json={"email": email, "password": password})
+    assert login.status_code == 200
+    token = login.get_json()["token"]
+    from flask_jwt_extended import decode_token
+
+    return token, str(decode_token(token)["sub"])
+
+
+class TestTruncateSnapshot:
+    def test_returns_input_unchanged_when_below_cap(self) -> None:
+        snap = {
+            "schema_version": "financial_insight_snapshot.v1",
+            "current_period": {"paid": {"income_total": "0.00"}},
+            "comparisons": {},
+        }
+        out, info = truncate_snapshot(snap)
+        assert out == snap
+        assert info["truncated"] is False
+        assert info["snapshot_bytes_final"] == info["snapshot_bytes_original"]
+        assert info["dropped_sections"] == []
+
+    def test_trims_transactions_when_above_cap(self) -> None:
+        items = [
+            {"type": "expense", "amount": float(100 + i), "title": "x" * 60}
+            for i in range(200)
+        ]
+        snap = {
+            "schema_version": "financial_insight_snapshot.v1",
+            "current_period": {"paid": {"income_total": "0.00"}},
+            "comparisons": {},
+            "transactions": {"items": items},
+            "daily_series": [],
+            "credit_cards": [],
+            "categories": {"top_expense_categories": []},
+        }
+        out, info = truncate_snapshot(snap, max_bytes=2048)
+        assert info["truncated"] is True
+        assert "transactions.items" in info["dropped_sections"]
+        assert len(out["transactions"]["items"]) <= 15
+        assert info["snapshot_bytes_final"] < info["snapshot_bytes_original"]
+        # Structural backbone preserved.
+        assert out["schema_version"] == "financial_insight_snapshot.v1"
+        assert out["current_period"] == snap["current_period"]
+        assert out["comparisons"] == snap["comparisons"]
+
+    def test_trims_daily_series_to_last_seven(self) -> None:
+        # Use lots of large transactions to force step 1 then step 2 trimming.
+        items = [
+            {"type": "expense", "amount": float(i + 1), "title": "z" * 100}
+            for i in range(30)
+        ]
+        snap = {
+            "schema_version": "financial_insight_snapshot.v1",
+            "current_period": {},
+            "comparisons": {},
+            "transactions": {"items": items},
+            "daily_series": [
+                {"date": f"2026-05-{d:02d}", "expense": 100.0} for d in range(1, 30)
+            ],
+            "credit_cards": [],
+            "categories": {"top_expense_categories": []},
+        }
+        out, info = truncate_snapshot(snap, max_bytes=1024)
+        assert info["truncated"] is True
+        # Step 2 should kick in given how aggressive the cap is.
+        if "daily_series" in info["dropped_sections"]:
+            assert len(out["daily_series"]) == 7
+
+
+class TestMetadataPersistenceAndMetrics:
+    def test_generate_persists_metadata_json_and_increments_counter(
+        self, app, client
+    ) -> None:
+        token, user_id_str = _register_and_login(client)
+        user_id = UUID(user_id_str)
+
+        # Grant entitlement so Premium gate does not block.
+        from app.services.entitlement_service import grant_entitlement
+
+        with app.app_context():
+            grant_entitlement(
+                user_id=user_id,
+                feature_key="advanced_simulations",
+                source="trial",
+            )
+            db.session.commit()
+
+        provider = MagicMock()
+        provider.generate_with_usage.return_value = LLMResponse(
+            content=(
+                '{"summary":"Resumo.","items":[{"type":"saude_financeira",'
+                '"dimension":"general","title":"OK","message":"All good.",'
+                '"evidence":["current_period.paid.balance"]}]}'
+            ),
+            prompt_tokens=10,
+            completion_tokens=20,
+            total_tokens=30,
+            model="gpt-test",
+            latency_ms=50,
+        )
+
+        with app.app_context():
+            from app.services.ai_advisory_service import AIAdvisoryService
+
+            with patch(
+                "app.services.ai_advisory_service.record_ai_insight_generated"
+            ) as record:
+                service = AIAdvisoryService(user_id=user_id, llm_provider=provider)
+                result = service.generate_financial_insights(
+                    period_type="daily",
+                    anchor_date=date(2026, 5, 18),
+                )
+
+            # Counter called once with the dimensions captured by the LLM resp.
+            assert record.called
+            kwargs = record.call_args.kwargs
+            assert kwargs["period_type"] == "daily"
+            assert kwargs["dimensions"] == ["general"]
+            assert kwargs["tokens_used"] == 30
+            assert isinstance(kwargs["truncated"], bool)
+            assert kwargs["snapshot_bytes"] >= 0
+
+            # Persisted row has metadata_json populated with the snapshot stats.
+            row = (
+                db.session.query(AIInsight)
+                .filter_by(user_id=user_id)
+                .order_by(AIInsight.created_at.desc())
+                .first()
+            )
+            assert row is not None
+            md = row.metadata_dict
+            assert md["snapshot_version"] == "financial_insight_snapshot.v1"
+            assert md["dimensions_present"] == ["general"]
+            assert "snapshot_bytes_original" in md
+            assert "snapshot_bytes_final" in md
+            assert isinstance(md["truncated"], bool)
+            assert result["items"][0]["dimension"] == "general"
+
+
+class TestMaxBytesEnvOverride:
+    def test_default_constant_is_12kib(self) -> None:
+        # MAX_SNAPSHOT_BYTES may be overridden by env in CI; the default is
+        # 12 KiB. Just sanity-check the unit (multiple of 1024).
+        assert MAX_SNAPSHOT_BYTES > 0
+        assert MAX_SNAPSHOT_BYTES % 1024 == 0


### PR DESCRIPTION
## Summary

Entrega do **Sprint 5 do MVP-3** — observability stack para o motor de AI Insights. Última peça do roadmap backend MVP-3.

**Closes** #1289. Supersede parcial de #1271.

## Mudanças

### 1. `AIInsight.metadata_json` (migration `cc2_ai_insight_metadata`)
Nova coluna nullable Text JSON em `ai_insights`. Armazena snapshot/audit stats por geração:
- `snapshot_version`, `context_hash`
- `comparisons_available: list[str]`
- `dimensions_present: list[str]`
- `snapshot_bytes_original`, `snapshot_bytes_final`, `truncated`, `dropped_sections[]`

Property `AIInsight.metadata_dict` para encode/decode transparente. Legacy rows mantêm `NULL` (sem backfill).

### 2. `truncate_snapshot()` — guardrail 12 KiB
Em `FinancialInsightContextBuilder` (com `MAX_SNAPSHOT_BYTES` overridable via env). Quando o snapshot serializado excede o cap, reduz determinísticamente:
1. `transactions.items` → top 10 expense + top 5 income
2. `daily_series` → last 7 entries
3. `credit_cards` → drop zero/None utilization
4. `categories.top_expense_categories` → top 5

Sempre preserva: `schema_version`, `period_type`, `period`, `current_period`, `comparisons`, `data_quality`. Loga `ai_advisory.snapshot.truncated` com bytes original/final + dropped sections.

### 3. Prometheus metrics (3 instrumentos)
Em `app/extensions/prometheus_metrics.py`:

| Metric | Type | Labels |
|---|---|---|
| `auraxis_ai_insight_generated_total` | Counter | `period_type, dimension` |
| `auraxis_ai_insight_tokens` | Histogram | `period_type` |
| `auraxis_ai_insight_snapshot_bytes` | Histogram | `period_type, truncated` |

Emitidas via `record_ai_insight_generated()` chamado fire-and-forget em cada geração não-cached.

### 4. `AIAdvisoryService.generate_financial_insights` plug-in
Antes do prompt: `truncate_snapshot()`. Após resposta válida: persiste `metadata_json` + emite metrics. Falhas em metrics nunca abortam o fluxo do usuário.

### 5. ADR-0006
`docs/adr/0006-ai-insight-dimensions-and-observability.md` documenta:
- Closed enum dimension + `general` fallback
- Quota global (não per-scope)
- Cap 12 KiB + truncate ordering
- `metadata_json` em Text vs colunas dedicadas
- 3 Prometheus instruments
- Alternativas consideradas

## Stats

```
7 files changed, 627 insertions(+), 1 deletion(-)
```

## Test plan

- [x] `pytest tests/test_ai_insight_observability.py` → 5 passed (RED→GREEN TDD)
- [x] Full regression: **247 passed** (AI advisory + persistence + weekly recap + GraphQL + financial insight MVP-3 + credit cards + auth-everywhere + docs export)
- [x] Pre-commit gates (ruff format/check, mypy, bandit, secrets, alembic-single-head, sonar) green em todos os commits
- [ ] CI full quality gate (rodando)
- [ ] `bash scripts/test_migrations_local.sh` cc2 round-trip (CI valida)

## Resultado do MVP-3 backend

Com este merge, **todos os 3 sprints backend do MVP-3 ficam em master**:

| Sprint | Cards | PR |
|---|---|---|
| 1 (CreditCard hub) | `#1284 #1285 #1286` | #1294 ✅ merged |
| 3 (Insights extensions) | `#1287 #1288` | #1296 ✅ merged |
| 5 (Observability) | `#1289` | este PR |

Sprint 2 (web hub UI) e Sprint 4 (insights UI + parcelamento) ficam para Codex consumir os contratos REST + GraphQL agora completos.