### PR TITLE
refactor(sonar): resolve 9 issues introduced by #1243 wallet insights

### DIFF
--- a/app/services/ai_advisory_service.py
+++ b/app/services/ai_advisory_service.py
@@ -446,6 +446,23 @@ def _log_llm_call(
 # ---------------------------------------------------------------------------
 
 
+def _build_period_snapshot(
+    *,
+    insight_type: InsightType,
+    user_id: UUID,
+    anchor: date,
+) -> dict[str, Any]:
+    """Dispatch to the period-specific snapshot builder."""
+    builder = FinancialInsightContextBuilder()
+    if insight_type == InsightType.daily:
+        return builder.build_daily(user_id=user_id, anchor_date=anchor)
+    if insight_type == InsightType.weekly:
+        return builder.build_weekly(user_id=user_id, anchor_date=anchor)
+    if insight_type == InsightType.monthly:
+        return builder.build_monthly(user_id=user_id, anchor_date=anchor)
+    raise ValueError("period_type must be daily, weekly or monthly")
+
+
 class AIAdvisoryService:
     """Central service for LLM-powered financial insights.
 
@@ -477,24 +494,11 @@ class AIAdvisoryService:
         anchor = anchor_date or date.today()
         consent_version = ensure_ai_consent_granted(self._user_id)
 
-        snapshot_builder = FinancialInsightContextBuilder()
-        if insight_type == InsightType.daily:
-            snapshot = snapshot_builder.build_daily(
-                user_id=self._user_id,
-                anchor_date=anchor,
-            )
-        elif insight_type == InsightType.weekly:
-            snapshot = snapshot_builder.build_weekly(
-                user_id=self._user_id,
-                anchor_date=anchor,
-            )
-        elif insight_type == InsightType.monthly:
-            snapshot = snapshot_builder.build_monthly(
-                user_id=self._user_id,
-                anchor_date=anchor,
-            )
-        else:
-            raise ValueError("period_type must be daily, weekly or monthly")
+        snapshot = _build_period_snapshot(
+            insight_type=insight_type,
+            user_id=self._user_id,
+            anchor=anchor,
+        )
 
         period = snapshot["period"]
         period_label = str(period["label"])

--- a/app/services/market_rates_provider.py
+++ b/app/services/market_rates_provider.py
@@ -27,7 +27,6 @@ import os
 from datetime import date, datetime
 from decimal import Decimal, InvalidOperation
 from typing import Protocol, runtime_checkable
-from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
@@ -41,6 +40,7 @@ _SGS_IPCA_MONTHLY = 433
 _BCB_BASE = "https://api.bcb.gov.br/dados/serie/bcdata.sgs.{series}/dados"
 _HTTP_TIMEOUT_SECONDS = 5.0
 _CACHE_TTL_SECONDS = 24 * 60 * 60
+_BR_DATE_FMT = "%d/%m/%Y"
 
 
 @runtime_checkable
@@ -82,17 +82,18 @@ class StubMarketRatesProvider:
         self._cdi = cdi
         self._ipca = ipca
 
-    def cdi_monthly(self, *, year: int, month: int) -> Decimal | None:  # noqa: ARG002
+    def cdi_monthly(self, *, year: int, month: int) -> Decimal | None:
+        # Stub ignores period intentionally; values are configured globally.
+        del year, month
         if self._cdi is not None:
             return self._cdi
-        raw = os.getenv("AI_MARKET_RATE_CDI_MONTHLY")
-        return _decimal_or_none(raw)
+        return _decimal_or_none(os.getenv("AI_MARKET_RATE_CDI_MONTHLY"))
 
-    def ipca_monthly(self, *, year: int, month: int) -> Decimal | None:  # noqa: ARG002
+    def ipca_monthly(self, *, year: int, month: int) -> Decimal | None:
+        del year, month
         if self._ipca is not None:
             return self._ipca
-        raw = os.getenv("AI_MARKET_RATE_IPCA_MONTHLY")
-        return _decimal_or_none(raw)
+        return _decimal_or_none(os.getenv("AI_MARKET_RATE_IPCA_MONTHLY"))
 
 
 def _decimal_or_none(raw: str | None) -> Decimal | None:
@@ -120,8 +121,8 @@ def _fetch_sgs_series_value(
     last_day = _last_day_of_month(year, month)
     params = {
         "formato": "json",
-        "dataInicial": target.strftime("%d/%m/%Y"),
-        "dataFinal": last_day.strftime("%d/%m/%Y"),
+        "dataInicial": target.strftime(_BR_DATE_FMT),
+        "dataFinal": last_day.strftime(_BR_DATE_FMT),
     }
     url = _BCB_BASE.format(series=series_id) + "?" + urlencode(params)
     request = Request(  # noqa: S310 — fixed-host BCB public API
@@ -132,7 +133,7 @@ def _fetch_sgs_series_value(
     try:
         with urlopen(request, timeout=_HTTP_TIMEOUT_SECONDS) as response:  # noqa: S310
             payload = json.loads(response.read().decode("utf-8"))
-    except (HTTPError, URLError, TimeoutError, ValueError, OSError) as exc:
+    except (OSError, ValueError) as exc:
         log.warning(
             "ai_advisory.market_rates.fetch_failed series=%s ym=%04d-%02d error=%s",
             series_id,
@@ -164,7 +165,7 @@ def _parse_sgs_payload(
         if not (isinstance(date_str, str) and isinstance(value_str, str)):
             continue
         try:
-            parsed = datetime.strptime(date_str, "%d/%m/%Y").date()
+            parsed = datetime.strptime(date_str, _BR_DATE_FMT).date()
         except ValueError:
             continue
         if parsed.year == target_year and parsed.month == target_month:


### PR DESCRIPTION
## Summary

Follow-up para o PR #1298 (wallet insights MVP-3). O Sonar policy reprovou o run de master pós-merge com 2 critical/blocker + 9 code smells novos introduzidos pela própria PR. Limpa todos.

## Mudanças

### market_rates_provider.py
- **S1192**: extrai `_BR_DATE_FMT = "%d/%m/%Y"` (duplicado 3x)
- **S5713 ×3**: `except (HTTPError, URLError, TimeoutError, ValueError, OSError)` → `(OSError, ValueError)`. HTTPError ⊂ URLError ⊂ OSError; TimeoutError ⊂ OSError. Imports limpos.
- **S1172 ×4**: `StubMarketRatesProvider.cdi_monthly/ipca_monthly` ignoram `year/month` por design — `del year, month` silencia linter sem mudar a assinatura (preserva compat com `BcbMarketRatesProvider`).

### ai_advisory_service.py
- **S3776**: `generate_financial_insights` tinha cognitive complexity 16 (limite 15) por causa do dispatch `if/elif/elif/else` por `insight_type`. Extraído em `_build_period_snapshot` helper module-level. Sem mudança de comportamento.

## Test plan

- [x] `pytest tests/test_wallet_insights_recap.py tests/test_ai_advisory_service.py tests/test_financial_insight_mvp3_extensions.py tests/test_ai_insight_observability.py tests/test_ai_insight_persistence.py` → 92 passed
- [x] `ruff check`: All checks passed
- [x] `mypy`: Success
- [ ] CI Sonar custom policy: `Open Critical/Blocker: 0` esperado