### PR TITLE
feat(ai-insights): enforce dimension↔evidence consistency per item (#1300)

### DIFF
--- a/app/services/ai_advisory_service.py
+++ b/app/services/ai_advisory_service.py
@@ -48,6 +48,7 @@ from app.services.financial_insight_context_builder import (
     truncate_snapshot,
 )
 from app.services.goal_projection_service import GoalProjectionService
+from app.services.insight_evidence_validator import filter_valid_items
 from app.services.llm_provider import LLMProvider, LLMProviderError, get_llm_provider
 from app.services.weekly_summary import compute_weekly_summary
 
@@ -358,6 +359,14 @@ def _coerce_financial_insight_response(
         raise LLMProviderError("Invalid financial insight items.")
 
     items = [_coerce_financial_insight_item(item) for item in candidate_items]
+    # Issue #1300: drop items whose evidence paths disagree with the declared
+    # dimension (or point to unknown snapshot prefixes). Surviving items keep
+    # their order. When every item is rejected, surface as a provider error.
+    items = filter_valid_items(items)
+    if not items:
+        raise LLMProviderError(
+            "All financial insight items rejected by evidence validation."
+        )
     metadata = _coerce_financial_insight_metadata(parsed)
 
     return summary.strip(), items, metadata

--- a/app/services/insight_evidence_validator.py
+++ b/app/services/insight_evidence_validator.py
@@ -1,0 +1,165 @@
+"""Evidence path validation for AI insight items (issue #1300).
+
+LLMs may produce items whose ``dimension`` label disagrees with the actual
+``evidence`` paths (e.g. a "budgets" item supported only by
+``current_period.paid.expense_total``). This module enforces the domain
+contract: each ``dimension`` requires at least one evidence path matching
+the canonical prefixes of its snapshot section.
+
+Decisions (chat 2026-05-18)
+---------------------------
+- Reject offending items silently, log a structured warning, keep the rest.
+- When **every** item is rejected, the caller raises ``LLMProviderError``.
+- Whitelist of canonical path prefixes per dimension below.
+- ``general`` accepts any KNOWN prefix (so multi-surface narrative still works).
+
+The module exports two callables: :func:`is_known_evidence_prefix` and
+:func:`validate_item_evidence`. Callers integrate them in the LLM response
+coercion pipeline.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+
+# Canonical snapshot path prefixes recognised by the validator. A path
+# matches a prefix when it equals the prefix or begins with ``prefix + '.'``
+# or ``prefix + '['``. The set below is intentionally additive — when the
+# snapshot schema grows a new section, add the prefix here.
+_KNOWN_SNAPSHOT_PREFIXES: frozenset[str] = frozenset(
+    {
+        "schema_version",
+        "period_type",
+        "currency",
+        "timezone",
+        "anchor_date",
+        "period",
+        "current_period",
+        "comparisons",
+        "daily_series",
+        "extremes",
+        "categories",
+        "transactions",
+        "budgets",
+        "goals",
+        "credit_cards",
+        "wallet",
+        "data_quality",
+    }
+)
+
+
+# Map dimension → tuple of allowed prefixes. ``None`` means "any known prefix".
+_DIMENSION_EVIDENCE_PREFIXES: dict[str, tuple[str, ...] | None] = {
+    "general": None,
+    "transactions": (
+        "transactions",
+        "daily_series",
+        "extremes",
+        "categories",
+        "current_period.paid",
+        "current_period.commitments",
+        "comparisons",
+    ),
+    "credit_cards": ("credit_cards",),
+    "goals": ("goals",),
+    "budgets": ("budgets",),
+}
+
+
+def is_known_evidence_prefix(path: str) -> bool:
+    """Return True when ``path`` begins with a canonical snapshot prefix."""
+    if not isinstance(path, str) or not path.strip():
+        return False
+    candidate = path.strip()
+    root = candidate.split(".", 1)[0].split("[", 1)[0]
+    return root in _KNOWN_SNAPSHOT_PREFIXES
+
+
+def _matches_prefix(path: str, prefix: str) -> bool:
+    """A path matches a prefix when equal, or starts with ``prefix.`` / ``prefix[``."""
+    candidate = path.strip()
+    if candidate == prefix:
+        return True
+    return candidate.startswith(prefix + ".") or candidate.startswith(prefix + "[")
+
+
+def validate_item_evidence(item: dict[str, Any]) -> tuple[bool, str | None]:
+    """Validate that ``item.evidence`` is consistent with ``item.dimension``.
+
+    Returns ``(True, None)`` when valid; ``(False, reason)`` otherwise.
+    Reasons are stable strings suitable for structured logs/metrics.
+
+    Rules:
+    - ``dimension`` must be a known key in ``_DIMENSION_EVIDENCE_PREFIXES``.
+    - ``evidence`` must be a non-empty list of strings.
+    - Every evidence path must begin with a known snapshot prefix
+      (rejects fabricated paths like ``inventado.algo``).
+    - For specific dimensions, at least one evidence path must match the
+      dimension's allowed prefixes. ``general`` skips this check.
+    """
+    dimension = item.get("dimension")
+    if not isinstance(dimension, str) or dimension not in _DIMENSION_EVIDENCE_PREFIXES:
+        return False, "invalid_dimension"
+
+    evidence = item.get("evidence")
+    if not isinstance(evidence, list) or not evidence:
+        return False, "missing_evidence"
+
+    paths = [str(p).strip() for p in evidence if isinstance(p, str) and p.strip()]
+    if not paths:
+        return False, "empty_evidence"
+
+    unknown = [p for p in paths if not is_known_evidence_prefix(p)]
+    if unknown:
+        return False, "unknown_path_prefix"
+
+    allowed = _DIMENSION_EVIDENCE_PREFIXES[dimension]
+    if allowed is None:
+        return True, None
+
+    has_match = any(_matches_prefix(p, prefix) for p in paths for prefix in allowed)
+    if not has_match:
+        return False, "dimension_evidence_mismatch"
+
+    return True, None
+
+
+def filter_valid_items(
+    items: list[dict[str, Any]],
+    *,
+    user_id: Any = None,
+) -> list[dict[str, Any]]:
+    """Return only items whose evidence is valid for their declared dimension.
+
+    Rejected items are logged at WARNING with reason + sanitized item fields
+    (no PII). Empty result is the caller's responsibility to surface as an
+    LLM error — this helper does not raise.
+    """
+    accepted: list[dict[str, Any]] = []
+    for item in items:
+        ok, reason = validate_item_evidence(item)
+        if ok:
+            accepted.append(item)
+            continue
+        log.warning(
+            "ai_advisory.evidence_validation.rejected user=%s reason=%s "
+            "dimension=%s type=%s evidence=%s",
+            user_id,
+            reason,
+            item.get("dimension"),
+            item.get("type"),
+            item.get("evidence"),
+        )
+    return accepted
+
+
+__all__ = [
+    "filter_valid_items",
+    "is_known_evidence_prefix",
+    "validate_item_evidence",
+]

--- a/tests/test_insight_evidence_validator.py
+++ b/tests/test_insight_evidence_validator.py
@@ -1,0 +1,217 @@
+"""Tests for evidence validation pipeline (issue #1300).
+
+Covers:
+- per-dimension whitelist enforcement (budgets/goals/credit_cards/transactions)
+- general dimension accepts any KNOWN prefix
+- unknown prefixes rejected outright
+- missing/empty/non-list evidence rejected
+- filter_valid_items keeps survivors and logs rejected items
+- partial rejection in the full pipeline (coerce → filter)
+- all-rejected scenario raises LLMProviderError at service layer
+"""
+
+from __future__ import annotations
+
+import json
+from uuid import uuid4
+
+import pytest
+
+from app.services.ai_advisory_service import _coerce_financial_insight_response
+from app.services.insight_evidence_validator import (
+    filter_valid_items,
+    is_known_evidence_prefix,
+    validate_item_evidence,
+)
+from app.services.llm_provider import LLMProviderError
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Whitelist of snapshot prefixes
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestKnownPrefixes:
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "current_period.paid.balance",
+            "transactions.items[0]",
+            "credit_cards[1].utilization_pct",
+            "wallet.benchmark.cdi_monthly_pct",
+            "budgets.envelope.alimentacao",
+            "goals.viagem.progress",
+            "comparisons.yesterday.delta",
+            "daily_series",
+            "data_quality.missing_external_rates",
+        ],
+    )
+    def test_accepts_known_prefix(self, path) -> None:
+        assert is_known_evidence_prefix(path)
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "inventado.coisa",
+            "user.email",
+            "external.cdi",
+            "",
+            "   ",
+        ],
+    )
+    def test_rejects_unknown_or_empty(self, path) -> None:
+        assert not is_known_evidence_prefix(path)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# validate_item_evidence
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _item(dimension: str, evidence: list[str], type_: str = "saude_financeira") -> dict:
+    return {
+        "type": type_,
+        "dimension": dimension,
+        "title": "x",
+        "message": "y",
+        "evidence": evidence,
+    }
+
+
+class TestValidateItemEvidence:
+    def test_general_accepts_any_known_path(self) -> None:
+        ok, reason = validate_item_evidence(
+            _item(
+                "general",
+                ["current_period.paid.balance", "goals.viagem.progress"],
+            )
+        )
+        assert ok is True
+        assert reason is None
+
+    def test_budgets_requires_budgets_prefix(self) -> None:
+        ok, reason = validate_item_evidence(
+            _item("budgets", ["current_period.paid.expense_total"])
+        )
+        assert ok is False
+        assert reason == "dimension_evidence_mismatch"
+
+    def test_budgets_accepts_when_at_least_one_budgets_path(self) -> None:
+        ok, reason = validate_item_evidence(
+            _item(
+                "budgets",
+                ["current_period.paid.expense_total", "budgets.alimentacao.used"],
+            )
+        )
+        assert ok is True
+        assert reason is None
+
+    def test_goals_dimension_with_goals_evidence_accepted(self) -> None:
+        ok, _ = validate_item_evidence(_item("goals", ["goals.viagem.progress"]))
+        assert ok
+
+    def test_credit_cards_dimension_requires_credit_cards_path(self) -> None:
+        ok, reason = validate_item_evidence(
+            _item("credit_cards", ["transactions.items[0]"])
+        )
+        assert not ok
+        assert reason == "dimension_evidence_mismatch"
+        ok2, _ = validate_item_evidence(
+            _item("credit_cards", ["credit_cards[0].utilization_pct"])
+        )
+        assert ok2
+
+    def test_transactions_accepts_extremes_and_categories(self) -> None:
+        for path in ("extremes.max_expense_day", "categories.top_expense_categories"):
+            ok, _ = validate_item_evidence(_item("transactions", [path]))
+            assert ok, f"path {path!r} should be accepted for transactions"
+
+    def test_rejects_unknown_dimension(self) -> None:
+        ok, reason = validate_item_evidence(_item("investments", ["wallet.items"]))
+        assert not ok
+        assert reason == "invalid_dimension"
+
+    def test_rejects_missing_evidence(self) -> None:
+        ok, reason = validate_item_evidence(_item("general", []))
+        assert not ok
+        assert reason == "missing_evidence"
+
+    def test_rejects_non_list_evidence(self) -> None:
+        item = _item("general", [])
+        item["evidence"] = "current_period.paid.balance"
+        ok, reason = validate_item_evidence(item)
+        assert not ok
+        assert reason == "missing_evidence"
+
+    def test_rejects_unknown_prefix_path(self) -> None:
+        ok, reason = validate_item_evidence(_item("general", ["inventado.algo"]))
+        assert not ok
+        assert reason == "unknown_path_prefix"
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# filter_valid_items
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestFilterValidItems:
+    def test_drops_invalid_keeps_valid(self, caplog) -> None:
+        items = [
+            _item("budgets", ["current_period.paid.expense_total"]),  # invalid
+            _item("transactions", ["transactions.items[0]"]),  # valid
+            _item("goals", ["goals.x"]),  # valid
+        ]
+        caplog.set_level("WARNING")
+        accepted = filter_valid_items(items, user_id=uuid4())
+        assert len(accepted) == 2
+        assert any("evidence_validation.rejected" in m for m in caplog.messages)
+
+    def test_empty_input_returns_empty(self) -> None:
+        assert filter_valid_items([], user_id=None) == []
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Integration with the coercion pipeline
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _llm_response(*items: dict, summary: str = "Resumo.") -> str:
+    return json.dumps({"summary": summary, "items": list(items)})
+
+
+class TestPipelineIntegration:
+    def test_coerce_keeps_only_valid_items(self) -> None:
+        content = _llm_response(
+            {
+                "type": "saude_financeira",
+                "dimension": "budgets",
+                "title": "Estouro",
+                "message": "...",
+                # Misuse: budget claim with only generic evidence
+                "evidence": ["current_period.paid.expense_total"],
+            },
+            {
+                "type": "saude_financeira",
+                "dimension": "goals",
+                "title": "Meta",
+                "message": "...",
+                "evidence": ["goals.viagem.progress"],
+            },
+        )
+        summary, items, _meta = _coerce_financial_insight_response(content)
+        assert summary == "Resumo."
+        # Invalid item dropped
+        assert len(items) == 1
+        assert items[0]["dimension"] == "goals"
+
+    def test_all_rejected_raises_llm_provider_error(self) -> None:
+        content = _llm_response(
+            {
+                "type": "saude_financeira",
+                "dimension": "budgets",
+                "title": "x",
+                "message": "y",
+                "evidence": ["current_period.paid.expense_total"],
+            }
+        )
+        with pytest.raises(LLMProviderError):
+            _coerce_financial_insight_response(content)


### PR DESCRIPTION
## Summary

Fecha #1300. LLM podia produzir item com `dimension="budgets"` mas evidência só em `current_period.paid.expense_total` — sem nenhuma evidência da seção budgets do snapshot. API agora endurece a validação.

## Decisões do PO (chat 2026-05-18)

1. **Estratégia**: rejeitar item inválido silenciosamente, log WARNING, manter o resto. 0 válidos → `LLMProviderError`.
2. **Paths**: whitelist canônica de prefixos por dimension. `general` aceita qualquer prefixo CONHECIDO; rejeita paths fabricados (`inventado.algo`).

## Mudanças

### Novo módulo: `app/services/insight_evidence_validator.py`

```python
_DIMENSION_EVIDENCE_PREFIXES = {
  "general": None,  # any KNOWN prefix
  "transactions": ("transactions", "daily_series", "extremes", "categories",
                   "current_period.paid", "current_period.commitments", "comparisons"),
  "credit_cards": ("credit_cards",),
  "goals": ("goals",),
  "budgets": ("budgets",),
}
```

APIs públicas:
- `is_known_evidence_prefix(path) -> bool`
- `validate_item_evidence(item) -> (ok, reason)`. Reasons estáveis: `invalid_dimension`, `missing_evidence`, `empty_evidence`, `unknown_path_prefix`, `dimension_evidence_mismatch`.
- `filter_valid_items(items, user_id=None) -> list[item]` — mantém válidos, loga WARNING `ai_advisory.evidence_validation.rejected` para rejeitados.

### Integração
`ai_advisory_service._coerce_financial_insight_response`:
1. Coerce cada item (validação de schema já existente).
2. **NOVO**: `filter_valid_items(items)` filtra itens com evidência inconsistente.
3. Se 0 itens sobram → `LLMProviderError`.
4. Retorna restante.

Legacy AIInsight rows (pré-#1300) sem evidência ainda passam (não invocadas pelo coerce do novo response — só impacta novas gerações).

## Test plan

- [x] `tests/test_insight_evidence_validator.py` → 28 cases (TDD)
  - TestKnownPrefixes ×2 (parametrize ×14)
  - TestValidateItemEvidence ×9
  - TestFilterValidItems ×2
  - TestPipelineIntegration ×2
- [x] Regression: **124 passed** (AI advisory + persistence + observability + financial insight MVP-3 + wallet + GraphQL parity)
- [x] `ruff check`: passed
- [x] `mypy app/services/`: Success

## Critérios de aceite do #1300

- [x] `current_period.paid.expense_total` sozinho NÃO sustenta afirmação de orçamento ou meta
- [x] Item com domínio incompatível é rejeitado antes de persistir
- [x] Resposta inválida do modelo não vira insight válido silenciosamente (WARNING + drop ou LLMProviderError)
- [x] Testes cobrem orçamento, meta, cartão e transação pura

## Próximos

Métricas Prometheus para taxa de rejeição (eventual follow-up).

Closes #1300.