### PR TITLE
[AI] Persistir AIInsightRun e dossie auditavel com retencao LGPD

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -79,6 +79,7 @@ from app.middleware.docs_access import register_docs_access_guard
 from app.middleware.security_headers import register_security_headers
 from app.models.account import Account  # noqa: F401
 from app.models.ai_insight import AIInsight  # noqa: F401
+from app.models.ai_insight_run import AIInsightRun  # noqa: F401
 from app.models.audit_event import AuditEvent  # noqa: F401
 from app.models.budget import Budget  # noqa: F401
 from app.models.consent import Consent  # noqa: F401

--- a/app/lgpd/registry.py
+++ b/app/lgpd/registry.py
@@ -95,6 +95,7 @@ def _build_registry() -> list[EntityRule]:
     """
     from app.models.account import Account
     from app.models.ai_insight import AIInsight
+    from app.models.ai_insight_run import AIInsightRun
     from app.models.alert import Alert, AlertPreference
     from app.models.audit_event import AuditEvent
     from app.models.budget import Budget
@@ -317,6 +318,16 @@ def _build_registry() -> list[EntityRule]:
             retention_reason=RetentionReason.NONE,
             retention_days=None,
             description="AI-generated financial insights",
+        ),
+        EntityRule(
+            model=AIInsightRun,
+            user_id_field="user_id",
+            table_name="ai_insight_runs",
+            deletion_strategy=DeletionStrategy.DELETE,
+            export_included=True,
+            retention_reason=RetentionReason.AUDIT,
+            retention_days=30,
+            description=("Sanitized AI insight run snapshots and evidence manifests"),
         ),
         EntityRule(
             model=LLMAuditLog,

--- a/app/models/ai_insight_run.py
+++ b/app/models/ai_insight_run.py
@@ -1,0 +1,125 @@
+# mypy: disable-error-code=name-defined
+
+from __future__ import annotations
+
+import enum
+from datetime import datetime, timedelta
+from uuid import uuid4
+
+from sqlalchemy.dialects.postgresql import UUID
+
+from app.extensions.database import db
+from app.models.ai_insight import InsightType
+from app.utils.datetime_utils import utc_now_naive
+
+DEFAULT_AI_INSIGHT_RUN_RETENTION_DAYS = 30
+
+
+def _enum_values(e: type[enum.Enum]) -> list[str]:
+    return [m.value for m in e]
+
+
+def _default_expires_at() -> datetime:
+    return utc_now_naive() + timedelta(days=DEFAULT_AI_INSIGHT_RUN_RETENTION_DAYS)
+
+
+class AIInsightRunStatus(enum.Enum):
+    """Lifecycle state for an auditable AI insight execution run."""
+
+    previewed = "previewed"
+    generated = "generated"
+    cached = "cached"
+    rejected = "rejected"
+    blocked = "blocked"
+    failed = "failed"
+    purged = "purged"
+
+
+class AIInsightRun(db.Model):
+    """Auditable execution record for an AI Insight.
+
+    ``AIInsight`` remains the display store and ``LLMAuditLog`` remains the
+    token/cost call ledger. This model keeps the sanitized snapshot and evidence
+    manifest needed to audit which deterministic facts supported a given run.
+    """
+
+    __tablename__ = "ai_insight_runs"
+
+    id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    user_id = db.Column(
+        UUID(as_uuid=True),
+        db.ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    ai_insight_id = db.Column(
+        UUID(as_uuid=True),
+        db.ForeignKey("ai_insights.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    status = db.Column(
+        db.Enum(
+            AIInsightRunStatus,
+            name="ai_insight_run_status_enum",
+            native_enum=False,
+            values_callable=_enum_values,
+        ),
+        nullable=False,
+        default=AIInsightRunStatus.previewed,
+    )
+    period_type = db.Column(
+        db.Enum(
+            InsightType,
+            name="ai_insight_run_period_type_enum",
+            native_enum=False,
+            values_callable=_enum_values,
+        ),
+        nullable=False,
+    )
+    period_label = db.Column(db.String(30), nullable=False)
+    period_start = db.Column(db.Date, nullable=False)
+    period_end = db.Column(db.Date, nullable=False)
+    snapshot_schema_version = db.Column(db.String(80), nullable=False)
+    snapshot_hash = db.Column(db.String(96), nullable=False)
+    previous_snapshot_hash = db.Column(db.String(96), nullable=True)
+    prompt_template_version = db.Column(db.String(80), nullable=False)
+    snapshot_json = db.Column(db.JSON, nullable=True)
+    evidence_manifest_json = db.Column(db.JSON, nullable=True)
+    data_quality_json = db.Column(db.JSON, nullable=True)
+    rejection_reasons_json = db.Column(db.JSON, nullable=True, default=list)
+    truncation_flags_json = db.Column(db.JSON, nullable=True, default=dict)
+    model = db.Column(db.String(80), nullable=True)
+    tokens_in = db.Column(db.Integer, nullable=False, default=0)
+    tokens_out = db.Column(db.Integer, nullable=False, default=0)
+    tokens_total = db.Column(db.Integer, nullable=False, default=0)
+    cost_usd = db.Column(db.Numeric(10, 8), nullable=False, default=0)
+    created_at = db.Column(db.DateTime, default=utc_now_naive, nullable=False)
+    expires_at = db.Column(db.DateTime, default=_default_expires_at, nullable=False)
+    purged_at = db.Column(db.DateTime, nullable=True)
+
+    __table_args__ = (
+        db.Index("ix_ai_insight_runs_user_id", "user_id"),
+        db.Index("ix_ai_insight_runs_ai_insight_id", "ai_insight_id"),
+        db.Index("ix_ai_insight_runs_snapshot_hash", "snapshot_hash"),
+        db.Index("ix_ai_insight_runs_expires", "expires_at", "purged_at"),
+        db.Index(
+            "ix_ai_insight_runs_user_period",
+            "user_id",
+            "period_type",
+            "period_label",
+        ),
+        db.Index("ix_ai_insight_runs_status", "status"),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<AIInsightRun id={self.id} user_id={self.user_id} "
+            f"status={self.status.value!r} period={self.period_label!r} "
+            f"snapshot_hash={self.snapshot_hash!r}>"
+        )
+
+
+__all__ = [
+    "AIInsightRun",
+    "AIInsightRunStatus",
+    "DEFAULT_AI_INSIGHT_RUN_RETENTION_DAYS",
+]

--- a/app/services/ai_insight_runs.py
+++ b/app/services/ai_insight_runs.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import re
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Any
+from uuid import UUID
+
+from app.extensions.database import db
+from app.models.ai_insight import InsightType
+from app.models.ai_insight_run import (
+    DEFAULT_AI_INSIGHT_RUN_RETENTION_DAYS,
+    AIInsightRun,
+    AIInsightRunStatus,
+)
+from app.utils.datetime_utils import utc_now_naive
+
+_EMAIL_RE = re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.IGNORECASE)
+_CPF_RE = re.compile(r"\b\d{3}\.\d{3}\.\d{3}-\d{2}\b")
+_LONG_NUMBER_RE = re.compile(r"\b\d{8,}\b")
+_FORBIDDEN_SNAPSHOT_KEYS = frozenset(
+    {
+        "id",
+        "user_id",
+        "owner_id",
+        "from_user_id",
+        "to_user_id",
+        "external_id",
+        "email",
+        "phone",
+        "telefone",
+        "document",
+        "documento",
+        "cpf",
+        "cnpj",
+        "bank",
+        "bank_name",
+        "raw_bank_name",
+        "account_id",
+        "credit_card_id",
+        "transaction_id",
+    }
+)
+
+
+def _is_forbidden_snapshot_key(key: object) -> bool:
+    normalized = str(key).strip().lower()
+    if normalized in _FORBIDDEN_SNAPSHOT_KEYS:
+        return True
+    return normalized.endswith("_id")
+
+
+def _sanitize_text(value: str, *, max_length: int = 160) -> str:
+    text = " ".join(value.split())
+    text = _EMAIL_RE.sub("[email]", text)
+    text = _CPF_RE.sub("[cpf]", text)
+    text = _LONG_NUMBER_RE.sub("[number]", text)
+    if len(text) > max_length:
+        return text[: max_length - 1].rstrip() + "..."
+    return text
+
+
+def sanitize_audit_snapshot(value: Any) -> Any:
+    """Return a recursively sanitized snapshot suitable for AIInsightRun.
+
+    The financial snapshot is allowed to keep deterministic facts such as
+    amounts, dates, status and categories. It must not persist identifiers or
+    free-text PII in the auditable run payload.
+    """
+
+    if isinstance(value, dict):
+        return {
+            key: sanitize_audit_snapshot(child)
+            for key, child in value.items()
+            if not _is_forbidden_snapshot_key(key)
+        }
+    if isinstance(value, list):
+        return [sanitize_audit_snapshot(item) for item in value]
+    if isinstance(value, str):
+        return _sanitize_text(value)
+    return value
+
+
+def create_ai_insight_run(
+    *,
+    user_id: UUID,
+    status: AIInsightRunStatus,
+    period_type: InsightType,
+    period_label: str,
+    period_start: date,
+    period_end: date,
+    snapshot_schema_version: str,
+    snapshot_hash: str,
+    prompt_template_version: str,
+    ai_insight_id: UUID | None = None,
+    previous_snapshot_hash: str | None = None,
+    snapshot_json: Any | None = None,
+    evidence_manifest_json: Any | None = None,
+    data_quality_json: Any | None = None,
+    rejection_reasons_json: Any | None = None,
+    truncation_flags_json: Any | None = None,
+    model: str | None = None,
+    tokens_in: int = 0,
+    tokens_out: int = 0,
+    tokens_total: int = 0,
+    cost_usd: Decimal | float | str = Decimal("0"),
+    commit: bool = True,
+) -> AIInsightRun:
+    """Persist an AIInsightRun with sanitized audit payloads."""
+
+    run = AIInsightRun(
+        user_id=user_id,
+        ai_insight_id=ai_insight_id,
+        status=status,
+        period_type=period_type,
+        period_label=period_label,
+        period_start=period_start,
+        period_end=period_end,
+        snapshot_schema_version=snapshot_schema_version,
+        snapshot_hash=snapshot_hash,
+        previous_snapshot_hash=previous_snapshot_hash,
+        prompt_template_version=prompt_template_version,
+        snapshot_json=sanitize_audit_snapshot(snapshot_json),
+        evidence_manifest_json=sanitize_audit_snapshot(evidence_manifest_json),
+        data_quality_json=data_quality_json,
+        rejection_reasons_json=rejection_reasons_json or [],
+        truncation_flags_json=truncation_flags_json or {},
+        model=model,
+        tokens_in=tokens_in,
+        tokens_out=tokens_out,
+        tokens_total=tokens_total,
+        cost_usd=Decimal(str(cost_usd)),
+    )
+    db.session.add(run)
+    if commit:
+        db.session.commit()
+    return run
+
+
+def purge_expired_ai_insight_runs(*, now: datetime | None = None) -> int:
+    """Purge retained snapshot payloads whose audit retention window expired.
+
+    The run row remains as a lightweight audit marker. Account deletion still
+    hard-deletes the whole row through the LGPD registry.
+    """
+
+    purge_at = now or utc_now_naive()
+    rows = (
+        AIInsightRun.query.filter(AIInsightRun.expires_at <= purge_at)
+        .filter(AIInsightRun.purged_at.is_(None))
+        .all()
+    )
+    for row in rows:
+        row.snapshot_json = None
+        row.evidence_manifest_json = None
+        row.status = AIInsightRunStatus.purged
+        row.purged_at = purge_at
+    db.session.commit()
+    return len(rows)
+
+
+__all__ = [
+    "DEFAULT_AI_INSIGHT_RUN_RETENTION_DAYS",
+    "create_ai_insight_run",
+    "purge_expired_ai_insight_runs",
+    "sanitize_audit_snapshot",
+]

--- a/migrations/versions/ai6_add_ai_insight_runs.py
+++ b/migrations/versions/ai6_add_ai_insight_runs.py
@@ -1,0 +1,127 @@
+"""ai6 — create ai_insight_runs table
+
+Revision ID: ai6_add_ai_insight_runs
+Revises: cc2_ai_insight_metadata
+Create Date: 2026-05-18
+
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "ai6_add_ai_insight_runs"
+down_revision = "cc2_ai_insight_metadata"
+branch_labels = None
+depends_on = None
+
+
+def _jsonb_column(name: str) -> sa.Column:
+    return sa.Column(
+        name,
+        postgresql.JSONB(astext_type=sa.Text()),
+        nullable=True,
+    )
+
+
+def upgrade() -> None:
+    op.create_table(
+        "ai_insight_runs",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "ai_insight_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("ai_insights.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "status",
+            sa.String(length=30),
+            sa.CheckConstraint(
+                "status IN ('previewed','generated','cached','rejected',"
+                "'blocked','failed','purged')",
+                name="ck_ai_insight_runs_status",
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            "period_type",
+            sa.String(length=20),
+            sa.CheckConstraint(
+                "period_type IN ('daily','weekly','monthly','recap')",
+                name="ck_ai_insight_runs_period_type",
+            ),
+            nullable=False,
+        ),
+        sa.Column("period_label", sa.String(length=30), nullable=False),
+        sa.Column("period_start", sa.Date(), nullable=False),
+        sa.Column("period_end", sa.Date(), nullable=False),
+        sa.Column("snapshot_schema_version", sa.String(length=80), nullable=False),
+        sa.Column("snapshot_hash", sa.String(length=96), nullable=False),
+        sa.Column("previous_snapshot_hash", sa.String(length=96), nullable=True),
+        sa.Column("prompt_template_version", sa.String(length=80), nullable=False),
+        _jsonb_column("snapshot_json"),
+        _jsonb_column("evidence_manifest_json"),
+        _jsonb_column("data_quality_json"),
+        _jsonb_column("rejection_reasons_json"),
+        _jsonb_column("truncation_flags_json"),
+        sa.Column("model", sa.String(length=80), nullable=True),
+        sa.Column("tokens_in", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("tokens_out", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("tokens_total", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column(
+            "cost_usd",
+            sa.Numeric(precision=10, scale=8),
+            nullable=False,
+            server_default="0",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column("expires_at", sa.DateTime(), nullable=False),
+        sa.Column("purged_at", sa.DateTime(), nullable=True),
+    )
+
+    op.create_index("ix_ai_insight_runs_user_id", "ai_insight_runs", ["user_id"])
+    op.create_index(
+        "ix_ai_insight_runs_ai_insight_id",
+        "ai_insight_runs",
+        ["ai_insight_id"],
+    )
+    op.create_index(
+        "ix_ai_insight_runs_snapshot_hash",
+        "ai_insight_runs",
+        ["snapshot_hash"],
+    )
+    op.create_index(
+        "ix_ai_insight_runs_expires",
+        "ai_insight_runs",
+        ["expires_at", "purged_at"],
+    )
+    op.create_index(
+        "ix_ai_insight_runs_user_period",
+        "ai_insight_runs",
+        ["user_id", "period_type", "period_label"],
+    )
+    op.create_index("ix_ai_insight_runs_status", "ai_insight_runs", ["status"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_ai_insight_runs_status", table_name="ai_insight_runs")
+    op.drop_index("ix_ai_insight_runs_user_period", table_name="ai_insight_runs")
+    op.drop_index("ix_ai_insight_runs_expires", table_name="ai_insight_runs")
+    op.drop_index("ix_ai_insight_runs_snapshot_hash", table_name="ai_insight_runs")
+    op.drop_index("ix_ai_insight_runs_ai_insight_id", table_name="ai_insight_runs")
+    op.drop_index("ix_ai_insight_runs_user_id", table_name="ai_insight_runs")
+    op.drop_table("ai_insight_runs")

--- a/tests/lgpd/test_registry.py
+++ b/tests/lgpd/test_registry.py
@@ -108,6 +108,7 @@ def test_known_critical_models_present() -> None:
         "users",
         "transactions",
         "llm_audit_logs",
+        "ai_insight_runs",
         "ai_insights",
         "refresh_tokens",
         "push_subscriptions",

--- a/tests/test_ai_insight_run_model.py
+++ b/tests/test_ai_insight_run_model.py
@@ -1,0 +1,192 @@
+"""Tests for AIInsightRun audit persistence and retention (#1310)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date, timedelta
+from decimal import Decimal
+
+from app.extensions.database import db
+from app.models.ai_insight import AIInsight, InsightType
+from app.models.ai_insight_run import AIInsightRun, AIInsightRunStatus
+from app.services.ai_insight_runs import (
+    DEFAULT_AI_INSIGHT_RUN_RETENTION_DAYS,
+    create_ai_insight_run,
+    purge_expired_ai_insight_runs,
+    sanitize_audit_snapshot,
+)
+from app.utils.datetime_utils import utc_now_naive
+
+
+def _insight(user_id: uuid.UUID) -> AIInsight:
+    return AIInsight(
+        user_id=user_id,
+        content='{"summary":"Resumo","items":[]}',
+        insight_type=InsightType.daily,
+        period_label="2026-05-18",
+        period_start=date(2026, 5, 18),
+        period_end=date(2026, 5, 18),
+        model="gpt-4o-mini",
+        tokens_used=150,
+        cost_usd=Decimal("0.000123"),
+    )
+
+
+def _run_payload(user_id: uuid.UUID) -> dict[str, object]:
+    return {
+        "user_id": user_id,
+        "status": AIInsightRunStatus.generated,
+        "period_type": InsightType.daily,
+        "period_label": "2026-05-18",
+        "period_start": date(2026, 5, 18),
+        "period_end": date(2026, 5, 18),
+        "snapshot_schema_version": "financial_insight_snapshot.v2",
+        "snapshot_hash": "sha256:current",
+        "previous_snapshot_hash": "sha256:previous",
+        "prompt_template_version": "financial-insight.v2.2026-05-18",
+        "snapshot_json": {
+            "schema_version": "financial_insight_snapshot.v2",
+            "dimensions": {"transactions": {"balance": "100.00"}},
+        },
+        "evidence_manifest_json": {
+            "evidence": {
+                "dimensions.transactions.balance": {
+                    "label": "Saldo",
+                    "value": "100.00",
+                }
+            }
+        },
+        "data_quality_json": {"has_transactions": True},
+        "rejection_reasons_json": [],
+        "truncation_flags_json": {"truncated": False},
+        "model": "gpt-4o-mini",
+        "tokens_in": 100,
+        "tokens_out": 50,
+        "tokens_total": 150,
+        "cost_usd": Decimal("0.000123"),
+    }
+
+
+class TestAIInsightRunModel:
+    def test_create_generated_run_links_to_insight_and_defaults_retention(
+        self, app
+    ) -> None:
+        with app.app_context():
+            user_id = uuid.uuid4()
+            insight = _insight(user_id)
+            db.session.add(insight)
+            db.session.flush()
+
+            run_payload = _run_payload(user_id)
+            run_payload["snapshot_json"] = {
+                "user_id": str(user_id),
+                "dimensions": {
+                    "transactions": {
+                        "balance": "100.00",
+                        "sample": [
+                            {
+                                "transaction_id": str(uuid.uuid4()),
+                                "title": "Pagamento maria@example.com",
+                            }
+                        ],
+                    }
+                },
+            }
+            run = create_ai_insight_run(
+                **run_payload,
+                ai_insight_id=insight.id,
+            )
+
+            fetched = db.session.get(AIInsightRun, run.id)
+            assert fetched is not None
+            assert fetched.ai_insight_id == insight.id
+            assert fetched.status == AIInsightRunStatus.generated
+            assert fetched.period_type == InsightType.daily
+            assert fetched.snapshot_hash == "sha256:current"
+            assert fetched.previous_snapshot_hash == "sha256:previous"
+            assert fetched.prompt_template_version == "financial-insight.v2.2026-05-18"
+            assert fetched.snapshot_json["dimensions"]["transactions"]["balance"] == (
+                "100.00"
+            )
+            assert "user_id" not in fetched.snapshot_json
+            sample = fetched.snapshot_json["dimensions"]["transactions"]["sample"][0]
+            assert "transaction_id" not in sample
+            assert sample["title"] == "Pagamento [email]"
+            assert fetched.evidence_manifest_json["evidence"]
+            assert fetched.tokens_in == 100
+            assert fetched.tokens_out == 50
+            assert fetched.tokens_total == 150
+            assert fetched.cost_usd == Decimal("0.000123")
+            assert fetched.expires_at is not None
+            retention_delta = fetched.expires_at - fetched.created_at
+            assert (
+                timedelta(days=29, hours=23)
+                <= retention_delta
+                <= timedelta(days=30, hours=1)
+            )
+            assert DEFAULT_AI_INSIGHT_RUN_RETENTION_DAYS == 30
+
+    def test_sanitize_audit_snapshot_removes_identifiers_and_redacts_free_text(
+        self,
+    ) -> None:
+        raw = {
+            "user_id": str(uuid.uuid4()),
+            "email": "cliente@example.com",
+            "external_id": "bank-tx-123",
+            "dimensions": {
+                "transactions": {
+                    "sample": [
+                        {
+                            "transaction_id": str(uuid.uuid4()),
+                            "title": "Consulta CPF 123.456.789-10",
+                            "description": "Pagamento para maria@example.com",
+                            "amount": "100.00",
+                        }
+                    ]
+                }
+            },
+        }
+
+        sanitized = sanitize_audit_snapshot(raw)
+
+        assert "user_id" not in sanitized
+        assert "email" not in sanitized
+        assert "external_id" not in sanitized
+        sample = sanitized["dimensions"]["transactions"]["sample"][0]
+        assert "transaction_id" not in sample
+        assert sample["title"] == "Consulta CPF [cpf]"
+        assert sample["description"] == "Pagamento para [email]"
+        assert sample["amount"] == "100.00"
+
+    def test_purge_expired_runs_clears_audit_payload_but_keeps_metadata(
+        self, app
+    ) -> None:
+        with app.app_context():
+            user_id = uuid.uuid4()
+            now = utc_now_naive()
+            expired = AIInsightRun(
+                **_run_payload(user_id),
+                expires_at=now - timedelta(seconds=1),
+            )
+            fresh_payload = _run_payload(user_id)
+            fresh_payload["snapshot_hash"] = "sha256:fresh"
+            fresh = AIInsightRun(
+                **fresh_payload,
+                expires_at=now + timedelta(days=1),
+            )
+            db.session.add_all([expired, fresh])
+            db.session.commit()
+
+            deleted = purge_expired_ai_insight_runs(now=now)
+
+            assert deleted == 1
+            db.session.refresh(expired)
+            db.session.refresh(fresh)
+            assert expired.status == AIInsightRunStatus.purged
+            assert expired.snapshot_json is None
+            assert expired.evidence_manifest_json is None
+            assert expired.purged_at == now
+            assert expired.snapshot_hash == "sha256:current"
+            assert fresh.snapshot_json is not None
+            assert fresh.evidence_manifest_json is not None
+            assert fresh.purged_at is None

--- a/tests/test_lgpd_deletion.py
+++ b/tests/test_lgpd_deletion.py
@@ -35,6 +35,8 @@ from uuid import UUID
 
 from flask.testing import FlaskClient
 
+from app.models.ai_insight import InsightType
+from app.models.ai_insight_run import AIInsightRun, AIInsightRunStatus
 from app.utils.datetime_utils import utc_now_naive
 
 # ---------------------------------------------------------------------------
@@ -199,6 +201,42 @@ class TestDeleteStrategy:
 
         deleted = _extract_report(resp)["summary"]["deleted"]
         assert deleted.get("goals", 0) == 1
+
+    def test_ai_insight_runs_are_hard_deleted(
+        self, client: FlaskClient, app: Any
+    ) -> None:
+        from app.extensions.database import db
+
+        token, _ = _register_and_login(client)
+        uid = _user_id(client, token)
+
+        with app.app_context():
+            db.session.add(
+                AIInsightRun(
+                    user_id=uid,
+                    status=AIInsightRunStatus.generated,
+                    period_type=InsightType.daily,
+                    period_label="2026-05-18",
+                    period_start=date(2026, 5, 18),
+                    period_end=date(2026, 5, 18),
+                    snapshot_schema_version="financial_insight_snapshot.v2",
+                    snapshot_hash="sha256:delete-me",
+                    prompt_template_version="financial-insight.v2.2026-05-18",
+                    snapshot_json={"dimensions": {"transactions": {}}},
+                    evidence_manifest_json={"evidence": {}},
+                )
+            )
+            db.session.commit()
+            assert AIInsightRun.query.filter_by(user_id=uid).count() == 1
+
+        resp = _delete_me(client, token)
+        assert resp.status_code == 200
+
+        with app.app_context():
+            assert AIInsightRun.query.filter_by(user_id=uid).count() == 0
+
+        deleted = _extract_report(resp)["summary"]["deleted"]
+        assert deleted.get("ai_insight_runs", 0) == 1
 
     def test_refresh_tokens_and_push_subscriptions_are_revoked(
         self, client: FlaskClient, app: Any

--- a/tests/test_lgpd_export.py
+++ b/tests/test_lgpd_export.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 import re
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from decimal import Decimal
 from enum import Enum
 from uuid import UUID
@@ -36,6 +36,8 @@ from app.application.services.lgpd_export_service import (
     _serialize_value,
     build_user_export,
 )
+from app.models.ai_insight import InsightType
+from app.models.ai_insight_run import AIInsightRun, AIInsightRunStatus
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -169,6 +171,38 @@ class TestEntityCoverage:
         assert isinstance(consents, list)
         kinds = {row["kind"] for row in consents}
         assert {"terms", "privacy"} <= kinds
+
+    def test_export_includes_ai_insight_runs(self, app: Flask, client: FlaskClient):
+        from app.extensions.database import db as _db
+
+        token = _register_and_login(client)
+        user_id = _resolve_user_id(client, token)
+
+        with app.app_context():
+            _db.session.add(
+                AIInsightRun(
+                    user_id=user_id,
+                    status=AIInsightRunStatus.previewed,
+                    period_type=InsightType.monthly,
+                    period_label="2026-05",
+                    period_start=date(2026, 5, 1),
+                    period_end=date(2026, 5, 31),
+                    snapshot_schema_version="financial_insight_snapshot.v2",
+                    snapshot_hash="sha256:export-me",
+                    prompt_template_version="financial-insight.v2.2026-05-18",
+                    snapshot_json={"dimensions": {"transactions": {}}},
+                    evidence_manifest_json={"evidence": {}},
+                )
+            )
+            _db.session.commit()
+
+        package = _export(client, token)
+
+        runs = package["ai_insight_runs"]
+        assert isinstance(runs, list)
+        assert len(runs) == 1
+        assert runs[0]["snapshot_hash"] == "sha256:export-me"
+        assert runs[0]["snapshot_json"] == {"dimensions": {"transactions": {}}}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `AIInsightRun` persistence with status, period, snapshot hashes, template version, token/cost metadata, and optional `AIInsight` linkage.
- Adds sanitized run creation plus retention purge support for short-lived auditable snapshots and evidence manifests.
- Registers `ai_insight_runs` in the LGPD registry for export and hard delete, with focused creation, purge, deletion, and export coverage.

## Validation
- `bash scripts/run_ci_quality_local.sh --local` (2309 passed, 1 skipped, coverage 91.25%)
- `pytest tests/test_ai_insight_run_model.py tests/lgpd/test_registry.py tests/test_lgpd_deletion.py tests/test_lgpd_export.py -q` (56 passed)
- Commit hooks passed with `PYTHON_BIN=/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-api/.venv/bin/python`
- Pre-push hooks passed, including `security-evidence` and `pip-audit`

## Notes
- `bash scripts/test_migrations_local.sh` could not run locally because Docker is not available at `/Users/italochagas/.docker/run/docker.sock`; `alembic-single-head-check` passed in the quality gate.

Closes #1310
