### PR TITLE
[AI] Preview e dossiê auditável de insights

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -17,6 +17,7 @@ from app.cli.features import features as features_cli_group
 from app.cli.openapi_export import openapi_export_command
 from app.cli.worker_cli import worker_cli_group
 from app.controllers.account import account_bp
+from app.controllers.admin.ai_insights import admin_ai_insights_bp
 from app.controllers.admin.audit_trail import admin_audit_trail_bp
 from app.controllers.admin.feature_flags import admin_feature_flags_bp
 from app.controllers.advisory import advisory_bp
@@ -334,6 +335,7 @@ def create_app(*, enable_http_runtime: bool = True) -> Flask:
     app.register_blueprint(ai_bp)
     app.register_blueprint(consents_bp)
     app.register_blueprint(admin_feature_flags_bp, url_prefix="/admin")
+    app.register_blueprint(admin_ai_insights_bp, url_prefix="/admin")
     app.register_blueprint(admin_audit_trail_bp)
 
     # Registra os endpoints documentados no Swagger com base no mapa real de rotas.

--- a/app/cli/ai_insights_cli.py
+++ b/app/cli/ai_insights_cli.py
@@ -14,9 +14,13 @@ Both commands follow the same pattern:
 
 from __future__ import annotations
 
+import html as html_lib
+import json
 import sys
 import uuid
 from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
 
 import click
 from flask import Flask
@@ -27,6 +31,7 @@ from app.models.ai_insight import AIInsight, InsightType
 from app.models.entitlement import Entitlement
 from app.models.user import User
 from app.services.ai_advisory_service import AIAdvisoryService
+from app.services.ai_insight_audit import get_ai_insight_run_dossier
 
 ai_insights_cli = AppGroup("ai", help="Scheduled AI insights batch commands.")
 
@@ -94,6 +99,69 @@ def _already_has_insight(
         .first()
     )
     return exists is not None
+
+
+def _parse_uuid_option(value: str | None, *, option_name: str) -> uuid.UUID | None:
+    if value in (None, ""):
+        return None
+    try:
+        return uuid.UUID(str(value))
+    except ValueError as exc:
+        raise click.ClickException(f"{option_name} deve ser UUID válido") from exc
+
+
+def _render_dossier_html(payload: dict[str, Any]) -> str:
+    title = f"AI Insight Dossier {payload['run']['id']}"
+    pretty = html_lib.escape(
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True)
+    )
+    return (
+        "<!doctype html>\n"
+        '<html lang="pt-BR">\n'
+        "<head>\n"
+        '  <meta charset="utf-8">\n'
+        f"  <title>{html_lib.escape(title)}</title>\n"
+        "  <style>"
+        "body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;"
+        "margin:32px;color:#111827;background:#f9fafb;}"
+        "main{max-width:1100px;margin:0 auto;}"
+        "pre{white-space:pre-wrap;background:#fff;border:1px solid #d1d5db;"
+        "border-radius:8px;padding:16px;overflow:auto;}"
+        "h1{font-size:22px;margin:0 0 16px;}"
+        "</style>\n"
+        "</head>\n"
+        "<body><main>\n"
+        f"<h1>{html_lib.escape(title)}</h1>\n"
+        f"<pre>{pretty}</pre>\n"
+        "</main></body>\n"
+        "</html>\n"
+    )
+
+
+def _write_dossier_files(
+    *,
+    payload: dict[str, Any],
+    output_dir: Path,
+    output_format: str,
+) -> list[Path]:
+    run_id = str(payload["run"]["id"])
+    output_dir.mkdir(parents=True, exist_ok=True)
+    written: list[Path] = []
+
+    if output_format in {"json", "both"}:
+        json_path = output_dir / f"ai-insight-dossier-{run_id}.json"
+        json_path.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True),
+            encoding="utf-8",
+        )
+        written.append(json_path)
+
+    if output_format in {"html", "both"}:
+        html_path = output_dir / f"ai-insight-dossier-{run_id}.html"
+        html_path.write_text(_render_dossier_html(payload), encoding="utf-8")
+        written.append(html_path)
+
+    return written
 
 
 def _run_batch(
@@ -231,6 +299,67 @@ def monthly_insights(month: str | None, dry_run: bool) -> None:
     if not dry_run:
         click.echo(f"monthly_insights month={month_label}")
     sys.exit(exit_code)
+
+
+@ai_insights_cli.command("export-dossier")
+@click.option("--run-id", default=None, help="AIInsightRun UUID to export.")
+@click.option("--user-id", default=None, help="Filter by user UUID.")
+@click.option(
+    "--period-type",
+    default=None,
+    type=click.Choice(["daily", "weekly", "monthly"]),
+    help="Filter by insight period type.",
+)
+@click.option("--period-label", default=None, help="Filter by period label.")
+@click.option("--insight-id", default=None, help="Filter by AIInsight UUID.")
+@click.option(
+    "--output-dir",
+    default=".",
+    type=click.Path(file_okay=False, path_type=Path),
+    help="Local directory where dossier files will be written.",
+)
+@click.option(
+    "--format",
+    "output_format",
+    default="json",
+    type=click.Choice(["json", "html", "both"]),
+    show_default=True,
+    help="Dossier output format.",
+)
+def export_dossier(
+    run_id: str | None,
+    user_id: str | None,
+    period_type: str | None,
+    period_label: str | None,
+    insight_id: str | None,
+    output_dir: Path,
+    output_format: str,
+) -> None:
+    """Export an auditable AI Insight dossier without calling an LLM."""
+
+    if not any((run_id, user_id, period_type, period_label, insight_id)):
+        raise click.ClickException(
+            "Informe ao menos um filtro: --run-id, --user-id, --period-type, "
+            "--period-label ou --insight-id."
+        )
+
+    payload = get_ai_insight_run_dossier(
+        run_id=_parse_uuid_option(run_id, option_name="--run-id"),
+        user_id=_parse_uuid_option(user_id, option_name="--user-id"),
+        period_type=period_type,
+        period_label=period_label,
+        insight_id=_parse_uuid_option(insight_id, option_name="--insight-id"),
+    )
+    paths = _write_dossier_files(
+        payload=payload,
+        output_dir=output_dir,
+        output_format=output_format,
+    )
+    click.echo(
+        "export_dossier: "
+        + " ".join(f"path={path}" for path in paths)
+        + f" run_id={payload['run']['id']}"
+    )
 
 
 def register_ai_insights_commands(app: Flask) -> None:

--- a/app/controllers/admin/ai_insights.py
+++ b/app/controllers/admin/ai_insights.py
@@ -1,0 +1,120 @@
+"""Admin endpoints for backend-only AI Insight audit preview."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date
+
+from flask import Blueprint, Response, request
+
+from app.auth import get_active_auth_context
+from app.controllers.response_contract import (
+    compat_error_response,
+    compat_success_response,
+)
+from app.services.ai_insight_audit import build_ai_insight_preview
+
+admin_ai_insights_bp = Blueprint("admin_ai_insights", __name__)
+
+
+def _is_admin() -> bool:
+    try:
+        ctx = get_active_auth_context()
+        return "admin" in ctx.roles
+    except Exception:
+        return False
+
+
+def _forbidden_response() -> Response:
+    return compat_error_response(
+        legacy_payload={
+            "message": "Forbidden",
+            "success": False,
+            "error": {"code": "FORBIDDEN", "details": {}},
+        },
+        status_code=403,
+        message="Forbidden",
+        error_code="FORBIDDEN",
+    )
+
+
+def _validation_response(message: str) -> Response:
+    return compat_error_response(
+        legacy_payload={"error": message},
+        status_code=400,
+        message=message,
+        error_code="VALIDATION_ERROR",
+    )
+
+
+def _parse_preview_body() -> (
+    tuple[Response, None, None, None]
+    | tuple[
+        None,
+        uuid.UUID,
+        str,
+        date | None,
+    ]
+):
+    body = request.get_json(silent=True) or {}
+
+    try:
+        user_id = uuid.UUID(str(body.get("user_id", "")))
+    except (TypeError, ValueError):
+        return _validation_response("user_id deve ser um UUID válido"), None, None, None
+
+    period_type = str(body.get("period_type", "")).strip().lower()
+    if period_type not in {"daily", "weekly", "monthly"}:
+        return (
+            _validation_response("period_type deve ser daily, weekly ou monthly"),
+            None,
+            None,
+            None,
+        )
+
+    raw_anchor_date = body.get("anchor_date")
+    if raw_anchor_date in (None, ""):
+        return None, user_id, period_type, None
+    try:
+        anchor_date = date.fromisoformat(str(raw_anchor_date))
+    except ValueError:
+        return (
+            _validation_response("anchor_date deve estar no formato YYYY-MM-DD"),
+            None,
+            None,
+            None,
+        )
+    return None, user_id, period_type, anchor_date
+
+
+@admin_ai_insights_bp.post("/ai-insights/preview")
+def create_ai_insight_preview() -> Response:
+    """Create a deterministic AI Insight preview without calling GPT."""
+
+    if not _is_admin():
+        return _forbidden_response()
+
+    error, user_id, period_type, anchor_date = _parse_preview_body()
+    if error is not None:
+        return error
+    assert user_id is not None
+    assert period_type is not None
+
+    try:
+        payload = build_ai_insight_preview(
+            user_id=user_id,
+            period_type=period_type,
+            anchor_date=anchor_date,
+        )
+    except ValueError as exc:
+        return _validation_response(str(exc))
+
+    return compat_success_response(
+        legacy_payload=payload,
+        status_code=201,
+        message="Preview de AI Insight criado com sucesso",
+        data=payload,
+    )
+
+
+__all__ = ["admin_ai_insights_bp"]

--- a/app/controllers/ai/resources.py
+++ b/app/controllers/ai/resources.py
@@ -137,7 +137,7 @@ def _parse_goal_projection_body(
 
 def _parse_ai_insight_generate_body(
     body: dict[str, Any],
-) -> tuple[Response, None, None] | tuple[None, str, date | None]:
+) -> tuple[Response, None, None, None] | tuple[None, str, date | None, UUID | None]:
     period_type = str(body.get("period_type", "")).strip().lower()
     if period_type not in _AI_INSIGHT_PERIOD_TYPES:
         return (
@@ -151,29 +151,49 @@ def _parse_ai_insight_generate_body(
             ),
             None,
             None,
+            None,
         )
 
     raw_anchor_date = body.get("anchor_date")
-    if raw_anchor_date in (None, ""):
-        return None, period_type, None
+    anchor_date: date | None = None
+    if raw_anchor_date not in (None, ""):
+        try:
+            anchor_date = date.fromisoformat(str(raw_anchor_date))
+        except ValueError:
+            return (
+                compat_error_response(
+                    legacy_payload={
+                        "error": "anchor_date deve estar no formato YYYY-MM-DD"
+                    },
+                    status_code=400,
+                    message="anchor_date deve estar no formato YYYY-MM-DD",
+                    error_code="VALIDATION_ERROR",
+                ),
+                None,
+                None,
+                None,
+            )
+
+    raw_preview_run_id = body.get("preview_run_id")
+    if raw_preview_run_id in (None, ""):
+        return None, period_type, anchor_date, None
 
     try:
-        anchor_date = date.fromisoformat(str(raw_anchor_date))
-    except ValueError:
+        preview_run_id = uuid.UUID(str(raw_preview_run_id))
+    except (TypeError, ValueError):
         return (
             compat_error_response(
-                legacy_payload={
-                    "error": "anchor_date deve estar no formato YYYY-MM-DD"
-                },
+                legacy_payload={"error": "preview_run_id deve ser um UUID válido"},
                 status_code=400,
-                message="anchor_date deve estar no formato YYYY-MM-DD",
+                message="preview_run_id deve ser um UUID válido",
                 error_code="VALIDATION_ERROR",
             ),
             None,
             None,
+            None,
         )
 
-    return None, period_type, anchor_date
+    return None, period_type, anchor_date, preview_run_id
 
 
 class AIInsightGenerateResource(MethodResource):
@@ -190,7 +210,11 @@ class AIInsightGenerateResource(MethodResource):
         requestBody=json_request_body(
             schema=AIInsightGenerateRequestSchema,
             description="Período que deve ser consolidado antes da chamada à IA.",
-            example={"period_type": "daily", "anchor_date": "2026-05-17"},
+            example={
+                "period_type": "daily",
+                "anchor_date": "2026-05-17",
+                "preview_run_id": "550e8400-e29b-41d4-a716-446655440000",
+            },
         ),
         responses={
             200: json_success_response(
@@ -253,7 +277,9 @@ class AIInsightGenerateResource(MethodResource):
             return entitlement_error
 
         body = request.get_json(silent=True) or {}
-        parse_error, period_type, anchor_date = _parse_ai_insight_generate_body(body)
+        parse_error, period_type, anchor_date, preview_run_id = (
+            _parse_ai_insight_generate_body(body)
+        )
         if parse_error is not None:
             return parse_error
         assert period_type is not None
@@ -263,6 +289,7 @@ class AIInsightGenerateResource(MethodResource):
             result = service.generate_financial_insights(
                 period_type=period_type,
                 anchor_date=anchor_date,
+                preview_run_id=preview_run_id,
             )
         except AIConsentRequiredError as exc:
             return _ai_consent_required_response(exc)

--- a/app/schemas/ai_insight_schema.py
+++ b/app/schemas/ai_insight_schema.py
@@ -20,6 +20,17 @@ class AIInsightGenerateRequestSchema(Schema):
             "example": "2026-05-17",
         },
     )
+    preview_run_id = fields.UUID(
+        required=False,
+        allow_none=True,
+        metadata={
+            "description": (
+                "Run de preview admin a ser reutilizado para manter o mesmo "
+                "snapshot_hash na geração."
+            ),
+            "example": "550e8400-e29b-41d4-a716-446655440000",
+        },
+    )
 
 
 __all__ = ["AIInsightGenerateRequestSchema"]

--- a/app/services/ai_advisory_service.py
+++ b/app/services/ai_advisory_service.py
@@ -30,6 +30,7 @@ from sqlalchemy import case, func
 from app.extensions.database import db
 from app.extensions.prometheus_metrics import record_ai_insight_generated
 from app.models.ai_insight import AIInsight, InsightType
+from app.models.ai_insight_run import AIInsightRun, AIInsightRunStatus
 from app.models.budget import Budget
 from app.models.goal import Goal
 from app.models.goal_contribution import GoalContribution
@@ -403,6 +404,112 @@ def _financial_context_hash(snapshot: dict[str, Any]) -> str:
     return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
 
 
+def _snapshot_byte_size(snapshot: dict[str, Any]) -> int:
+    return len(
+        json.dumps(snapshot, ensure_ascii=False, sort_keys=True, default=str).encode(
+            "utf-8"
+        )
+    )
+
+
+def _truncation_info_from_preview_run(
+    run: AIInsightRun,
+    snapshot: dict[str, Any],
+) -> dict[str, Any]:
+    info = (
+        run.truncation_flags_json if isinstance(run.truncation_flags_json, dict) else {}
+    )
+    snapshot_bytes = _snapshot_byte_size(snapshot)
+    return {
+        "snapshot_bytes_original": int(
+            info.get("snapshot_bytes_original", snapshot_bytes)
+        ),
+        "snapshot_bytes_final": int(info.get("snapshot_bytes_final", snapshot_bytes)),
+        "truncated": bool(info.get("truncated", False)),
+        "dropped_sections": list(info.get("dropped_sections") or []),
+        "max_bytes": int(info.get("max_bytes", snapshot_bytes)),
+    }
+
+
+def _load_preview_financial_context(
+    *,
+    user_id: UUID,
+    insight_type: InsightType,
+    preview_run_id: UUID,
+) -> tuple[
+    AIInsightRun,
+    dict[str, Any],
+    str,
+    date,
+    date,
+    str,
+    str,
+    dict[str, Any],
+]:
+    preview_run = db.session.get(AIInsightRun, preview_run_id)
+    if (
+        preview_run is None
+        or preview_run.user_id != user_id
+        or preview_run.period_type != insight_type
+    ):
+        raise LLMProviderError("preview_run_id inválido")
+    if preview_run.status != AIInsightRunStatus.previewed:
+        raise LLMProviderError("preview_run_id não está em preview")
+    if not isinstance(preview_run.snapshot_json, dict):
+        raise LLMProviderError("preview_run_id não possui snapshot auditável")
+
+    prompt_snapshot = dict(preview_run.snapshot_json)
+    return (
+        preview_run,
+        prompt_snapshot,
+        preview_run.period_label,
+        preview_run.period_start,
+        preview_run.period_end,
+        preview_run.snapshot_schema_version,
+        preview_run.snapshot_hash,
+        _truncation_info_from_preview_run(preview_run, prompt_snapshot),
+    )
+
+
+def _cached_financial_insight_payload(
+    *,
+    cached: AIInsight,
+    user_id: UUID,
+    normalized_period_type: str,
+    context_version: str,
+) -> dict[str, Any] | None:
+    try:
+        (
+            cached_summary,
+            cached_items,
+            cached_metadata,
+        ) = _coerce_financial_insight_response(cached.content)
+    except LLMProviderError:
+        log.warning(
+            "ai_advisory.financial_insights.cached_parse_failed user=%s insight=%s",
+            user_id,
+            cached.id,
+        )
+        return None
+
+    return {
+        "period_type": normalized_period_type,
+        "period_label": cached.period_label,
+        "period_start": cached.period_start.isoformat(),
+        "period_end": cached.period_end.isoformat(),
+        "summary": cached_summary,
+        "items": cached_items,
+        "context_version": cached_metadata.get(
+            "context_schema_version", context_version
+        ),
+        "context_hash": cached_metadata.get("context_hash"),
+        "tokens_used": cached.tokens_used,
+        "cost_usd": float(cached.cost_usd),
+        "model": cached.model,
+        "cached": True,
+    }
+
+
 def _log_llm_call(
     *,
     user_id: UUID,
@@ -509,6 +616,7 @@ class AIAdvisoryService:
         *,
         period_type: str,
         anchor_date: date | None = None,
+        preview_run_id: UUID | None = None,
     ) -> dict[str, Any]:
         """Generate period-aware financial insights with structured evidence."""
         normalized_period_type = period_type.strip().lower()
@@ -517,61 +625,58 @@ class AIAdvisoryService:
         consent_version = ensure_ai_consent_granted(self._user_id)
 
         previous = _get_latest_insight(user_id=self._user_id)
-        snapshot = _build_period_snapshot(
-            insight_type=insight_type,
-            user_id=self._user_id,
-            anchor=anchor,
-            previous_generated_at=previous.created_at if previous else None,
-        )
+        preview_run: AIInsightRun | None = None
+        if preview_run_id is not None:
+            (
+                preview_run,
+                prompt_snapshot,
+                period_label,
+                period_start,
+                period_end,
+                context_version,
+                context_hash,
+                truncation_info,
+            ) = _load_preview_financial_context(
+                user_id=self._user_id,
+                insight_type=insight_type,
+                preview_run_id=preview_run_id,
+            )
+            snapshot = prompt_snapshot
+        else:
+            snapshot = _build_period_snapshot(
+                insight_type=insight_type,
+                user_id=self._user_id,
+                anchor=anchor,
+                previous_generated_at=previous.created_at if previous else None,
+            )
 
-        period = snapshot["period"]
-        period_label = str(period["label"])
-        period_start = date.fromisoformat(str(period["start"]))
-        period_end = date.fromisoformat(str(period["end"]))
-        context_version = str(snapshot["schema_version"])
+            period = snapshot["period"]
+            period_label = str(period["label"])
+            period_start = date.fromisoformat(str(period["start"]))
+            period_end = date.fromisoformat(str(period["end"]))
+            context_version = str(snapshot["schema_version"])
 
-        cached = _get_cached_insight(
-            user_id=self._user_id,
-            insight_type=insight_type,
-            period_label=period_label,
-        )
-        if cached is not None:
-            try:
-                (
-                    cached_summary,
-                    cached_items,
-                    cached_metadata,
-                ) = _coerce_financial_insight_response(cached.content)
-            except LLMProviderError:
-                log.warning(
-                    "ai_advisory.financial_insights.cached_parse_failed "
-                    "user=%s insight=%s",
-                    self._user_id,
-                    cached.id,
+            cached = _get_cached_insight(
+                user_id=self._user_id,
+                insight_type=insight_type,
+                period_label=period_label,
+            )
+            if cached is not None:
+                cached_payload = _cached_financial_insight_payload(
+                    cached=cached,
+                    user_id=self._user_id,
+                    normalized_period_type=normalized_period_type,
+                    context_version=context_version,
                 )
-            else:
-                return {
-                    "period_type": normalized_period_type,
-                    "period_label": cached.period_label,
-                    "period_start": cached.period_start.isoformat(),
-                    "period_end": cached.period_end.isoformat(),
-                    "summary": cached_summary,
-                    "items": cached_items,
-                    "context_version": cached_metadata.get(
-                        "context_schema_version", context_version
-                    ),
-                    "context_hash": cached_metadata.get("context_hash"),
-                    "tokens_used": cached.tokens_used,
-                    "cost_usd": float(cached.cost_usd),
-                    "model": cached.model,
-                    "cached": True,
-                }
+                if cached_payload is not None:
+                    return cached_payload
 
-        prompt_snapshot = minimize_prompt_data(snapshot)
-        # Apply 12 KiB cap before hashing/prompting so context_hash matches
-        # whatever we actually send to the LLM.
-        prompt_snapshot, truncation_info = truncate_snapshot(prompt_snapshot)
-        context_hash = _financial_context_hash(prompt_snapshot)
+            prompt_snapshot = minimize_prompt_data(snapshot)
+            # Apply 12 KiB cap before hashing/prompting so context_hash matches
+            # whatever we actually send to the LLM.
+            prompt_snapshot, truncation_info = truncate_snapshot(prompt_snapshot)
+            context_hash = _financial_context_hash(prompt_snapshot)
+
         prompt = _build_financial_insight_prompt(
             prompt_snapshot,
             period_type=normalized_period_type,
@@ -629,7 +734,7 @@ class AIAdvisoryService:
                 truncation_info["dropped_sections"]
             )
 
-        _save_insight(
+        saved_insight = _save_insight(
             user_id=self._user_id,
             content=serialized_content,
             insight_type=insight_type,
@@ -642,6 +747,16 @@ class AIAdvisoryService:
             previous_insight_id=previous.id if previous else None,
             metadata=persist_metadata,
         )
+
+        if preview_run is not None:
+            preview_run.status = AIInsightRunStatus.generated
+            preview_run.ai_insight_id = saved_insight.id
+            preview_run.model = llm_resp.model
+            preview_run.tokens_in = int(llm_resp.prompt_tokens or 0)
+            preview_run.tokens_out = int(llm_resp.completion_tokens or 0)
+            preview_run.tokens_total = int(llm_resp.total_tokens or 0)
+            preview_run.cost_usd = Decimal(str(llm_resp.estimated_cost_usd))
+            db.session.commit()
 
         try:
             record_ai_insight_generated(

--- a/app/services/ai_insight_audit.py
+++ b/app/services/ai_insight_audit.py
@@ -1,0 +1,415 @@
+"""Backend-only audit helpers for AI Insight preview and dossier export."""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+from typing import Any
+from uuid import UUID
+
+from app.extensions.database import db
+from app.models.ai_insight import AIInsight, InsightType
+from app.models.ai_insight_run import AIInsightRun, AIInsightRunStatus
+from app.models.user import User
+from app.services.ai_advisory_service import (
+    _build_period_snapshot,
+    _financial_context_hash,
+    _get_latest_insight,
+)
+from app.services.ai_insight_runs import create_ai_insight_run
+from app.services.ai_lgpd import minimize_prompt_data
+from app.services.financial_insight_context_builder import truncate_snapshot
+
+PROMPT_TEMPLATE_VERSION = "financial-insight.v1.preview"
+EVIDENCE_MANIFEST_VERSION = "ai_insight_evidence_manifest.v1"
+
+_ALLOWED_PREVIEW_PERIODS = {
+    InsightType.daily,
+    InsightType.weekly,
+    InsightType.monthly,
+}
+
+
+def _normalize_insight_type(period_type: str) -> InsightType:
+    try:
+        insight_type = InsightType(period_type.strip().lower())
+    except (AttributeError, ValueError) as exc:
+        raise ValueError("period_type deve ser daily, weekly ou monthly") from exc
+    if insight_type not in _ALLOWED_PREVIEW_PERIODS:
+        raise ValueError("period_type deve ser daily, weekly ou monthly")
+    return insight_type
+
+
+def _date_iso(value: object) -> str | None:
+    return value.isoformat() if hasattr(value, "isoformat") else None
+
+
+def _json_safe(value: Any) -> Any:
+    return json.loads(json.dumps(value, ensure_ascii=False, default=str))
+
+
+def _json_safe_dict(value: dict[str, Any]) -> dict[str, Any]:
+    decoded = _json_safe(value)
+    return decoded if isinstance(decoded, dict) else {}
+
+
+def _get_path(payload: dict[str, Any], path: str) -> Any:
+    node: Any = payload
+    for part in path.split("."):
+        if not isinstance(node, dict) or part not in node:
+            return None
+        node = node[part]
+    return node
+
+
+def _safe_float(value: object) -> float:
+    try:
+        return float(value or 0)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _latest_snapshot_hash(
+    *,
+    user_id: UUID,
+    period_type: InsightType,
+) -> str | None:
+    previous_run = (
+        AIInsightRun.query.filter_by(user_id=user_id, period_type=period_type)
+        .order_by(AIInsightRun.created_at.desc())
+        .first()
+    )
+    return str(previous_run.snapshot_hash) if previous_run else None
+
+
+def _evidence_item(
+    *,
+    snapshot: dict[str, Any],
+    path: str,
+    label: str,
+    dimension: str,
+) -> dict[str, Any] | None:
+    value = _get_path(snapshot, path)
+    if value is None:
+        return None
+    return {
+        "path": path,
+        "label": label,
+        "dimension": dimension,
+        "value": value,
+    }
+
+
+def build_evidence_manifest(
+    *,
+    snapshot: dict[str, Any],
+    snapshot_hash: str,
+) -> dict[str, Any]:
+    """Return deterministic evidence pointers for an auditable snapshot."""
+
+    evidence_paths = (
+        (
+            "current_period.paid.income_total",
+            "Receitas pagas no período",
+            "transactions",
+        ),
+        (
+            "current_period.paid.expense_total",
+            "Despesas pagas no período",
+            "transactions",
+        ),
+        ("current_period.paid.balance", "Saldo pago no período", "general"),
+        (
+            "current_period.commitments.pending_expense_total",
+            "Compromissos pendentes",
+            "transactions",
+        ),
+        (
+            "current_period.commitments.overdue_expense_total",
+            "Despesas vencidas",
+            "transactions",
+        ),
+        ("transactions.included_count", "Transações consideradas", "transactions"),
+        ("wallet.total_value", "Valor total da carteira", "general"),
+    )
+    items = [
+        item
+        for path, label, dimension in evidence_paths
+        if (
+            item := _evidence_item(
+                snapshot=snapshot,
+                path=path,
+                label=label,
+                dimension=dimension,
+            )
+        )
+        is not None
+    ]
+
+    for index, budget in enumerate(snapshot.get("budgets") or []):
+        if isinstance(budget, dict):
+            items.append(
+                {
+                    "path": f"budgets.{index}",
+                    "label": str(budget.get("name") or "Orçamento"),
+                    "dimension": "budgets",
+                    "value": budget,
+                }
+            )
+
+    for index, goal in enumerate(snapshot.get("goals") or []):
+        if isinstance(goal, dict):
+            items.append(
+                {
+                    "path": f"goals.{index}",
+                    "label": str(goal.get("title") or "Meta"),
+                    "dimension": "goals",
+                    "value": goal,
+                }
+            )
+
+    for index, card in enumerate(snapshot.get("credit_cards") or []):
+        if isinstance(card, dict):
+            items.append(
+                {
+                    "path": f"credit_cards.{index}",
+                    "label": str(card.get("name") or "Cartão"),
+                    "dimension": "credit_cards",
+                    "value": card,
+                }
+            )
+
+    return {
+        "schema_version": EVIDENCE_MANIFEST_VERSION,
+        "snapshot_hash": snapshot_hash,
+        "items": items,
+    }
+
+
+def build_deterministic_risks(snapshot: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return deterministic risk flags derived from the snapshot."""
+
+    risks: list[dict[str, Any]] = []
+    data_quality = snapshot.get("data_quality") or {}
+    if isinstance(data_quality, dict) and data_quality.get("has_transactions") is False:
+        risks.append(
+            {
+                "code": "insufficient_transaction_data",
+                "severity": "info",
+                "dimension": "general",
+                "evidence": ["data_quality.has_transactions"],
+            }
+        )
+
+    balance = _safe_float(_get_path(snapshot, "current_period.paid.balance"))
+    if balance < 0:
+        risks.append(
+            {
+                "code": "negative_paid_balance",
+                "severity": "high",
+                "dimension": "general",
+                "evidence": ["current_period.paid.balance"],
+            }
+        )
+
+    overdue = _safe_float(
+        _get_path(snapshot, "current_period.commitments.overdue_expense_total")
+    )
+    if overdue > 0:
+        risks.append(
+            {
+                "code": "overdue_expenses",
+                "severity": "high",
+                "dimension": "transactions",
+                "evidence": ["current_period.commitments.overdue_expense_total"],
+            }
+        )
+
+    for index, budget in enumerate(snapshot.get("budgets") or []):
+        if isinstance(budget, dict) and bool(budget.get("exceeded")):
+            risks.append(
+                {
+                    "code": "budget_exceeded",
+                    "severity": "medium",
+                    "dimension": "budgets",
+                    "evidence": [f"budgets.{index}.exceeded"],
+                }
+            )
+
+    for index, card in enumerate(snapshot.get("credit_cards") or []):
+        if isinstance(card, dict) and _safe_float(card.get("utilization_pct")) >= 80:
+            risks.append(
+                {
+                    "code": "high_credit_card_utilization",
+                    "severity": "medium",
+                    "dimension": "credit_cards",
+                    "evidence": [f"credit_cards.{index}.utilization_pct"],
+                }
+            )
+
+    return risks
+
+
+def build_ai_insight_preview(
+    *,
+    user_id: UUID,
+    period_type: str,
+    anchor_date: date | None = None,
+) -> dict[str, Any]:
+    """Create an auditable preview run without calling the LLM provider."""
+
+    if db.session.get(User, user_id) is None:
+        raise ValueError("user_id não encontrado")
+
+    insight_type = _normalize_insight_type(period_type)
+    anchor = anchor_date or date.today()
+    previous = _get_latest_insight(user_id=user_id)
+    raw_snapshot = _build_period_snapshot(
+        insight_type=insight_type,
+        user_id=user_id,
+        anchor=anchor,
+        previous_generated_at=previous.created_at if previous else None,
+    )
+    prompt_snapshot = minimize_prompt_data(raw_snapshot)
+    prompt_snapshot, truncation_info = truncate_snapshot(prompt_snapshot)
+    snapshot_hash = _financial_context_hash(prompt_snapshot)
+    evidence_manifest = build_evidence_manifest(
+        snapshot=prompt_snapshot,
+        snapshot_hash=snapshot_hash,
+    )
+    risks = build_deterministic_risks(prompt_snapshot)
+
+    period = prompt_snapshot["period"]
+    period_label = str(period["label"])
+    period_start = date.fromisoformat(str(period["start"]))
+    period_end = date.fromisoformat(str(period["end"]))
+    data_quality = prompt_snapshot.get("data_quality") or {}
+
+    run = create_ai_insight_run(
+        user_id=user_id,
+        status=AIInsightRunStatus.previewed,
+        period_type=insight_type,
+        period_label=period_label,
+        period_start=period_start,
+        period_end=period_end,
+        snapshot_schema_version=str(prompt_snapshot["schema_version"]),
+        snapshot_hash=snapshot_hash,
+        previous_snapshot_hash=_latest_snapshot_hash(
+            user_id=user_id,
+            period_type=insight_type,
+        ),
+        prompt_template_version=PROMPT_TEMPLATE_VERSION,
+        snapshot_json=prompt_snapshot,
+        evidence_manifest_json=evidence_manifest,
+        data_quality_json=data_quality,
+        truncation_flags_json=truncation_info,
+    )
+
+    return {
+        "run_id": str(run.id),
+        "status": run.status.value,
+        "period_type": insight_type.value,
+        "period_label": period_label,
+        "period_start": period_start.isoformat(),
+        "period_end": period_end.isoformat(),
+        "snapshot_hash": snapshot_hash,
+        "previous_snapshot_hash": run.previous_snapshot_hash,
+        "prompt_template_version": run.prompt_template_version,
+        "snapshot": _json_safe(prompt_snapshot),
+        "comparisons": _json_safe(prompt_snapshot.get("comparisons") or {}),
+        "risks": _json_safe(risks),
+        "evidence_manifest": _json_safe(evidence_manifest),
+        "data_quality": _json_safe(data_quality),
+        "truncation": _json_safe(truncation_info),
+    }
+
+
+def serialize_ai_insight_run_dossier(run: AIInsightRun) -> dict[str, Any]:
+    """Serialize an AIInsightRun dossier without exposing raw prompts."""
+
+    insight = (
+        db.session.get(AIInsight, run.ai_insight_id) if run.ai_insight_id else None
+    )
+    payload: dict[str, Any] = {
+        "run": {
+            "id": str(run.id),
+            "user_id": str(run.user_id),
+            "ai_insight_id": str(run.ai_insight_id) if run.ai_insight_id else None,
+            "status": run.status.value,
+            "period_type": run.period_type.value,
+            "period_label": run.period_label,
+            "period_start": _date_iso(run.period_start),
+            "period_end": _date_iso(run.period_end),
+            "snapshot_schema_version": run.snapshot_schema_version,
+            "snapshot_hash": run.snapshot_hash,
+            "previous_snapshot_hash": run.previous_snapshot_hash,
+            "prompt_template_version": run.prompt_template_version,
+            "model": run.model,
+            "tokens_in": int(run.tokens_in or 0),
+            "tokens_out": int(run.tokens_out or 0),
+            "tokens_total": int(run.tokens_total or 0),
+            "cost_usd": float(run.cost_usd or 0),
+            "created_at": _date_iso(run.created_at),
+            "expires_at": _date_iso(run.expires_at),
+            "purged_at": _date_iso(run.purged_at),
+        },
+        "snapshot": run.snapshot_json or {},
+        "evidence_manifest": run.evidence_manifest_json or {},
+        "data_quality": run.data_quality_json or {},
+        "truncation": run.truncation_flags_json or {},
+        "rejection_reasons": run.rejection_reasons_json or [],
+        "insight": None,
+    }
+    if insight is not None:
+        payload["insight"] = {
+            "id": str(insight.id),
+            "insight_type": insight.insight_type.value,
+            "period_label": insight.period_label,
+            "model": insight.model,
+            "tokens_used": int(insight.tokens_used or 0),
+            "cost_usd": float(insight.cost_usd or 0),
+            "content": insight.content,
+            "metadata": insight.metadata_dict,
+            "created_at": _date_iso(insight.created_at),
+        }
+    return _json_safe_dict(payload)
+
+
+def get_ai_insight_run_dossier(
+    *,
+    run_id: UUID | None = None,
+    user_id: UUID | None = None,
+    period_type: str | None = None,
+    period_label: str | None = None,
+    insight_id: UUID | None = None,
+) -> dict[str, Any]:
+    """Return the most recent run dossier matching the supplied selector."""
+
+    query = AIInsightRun.query
+    if run_id is not None:
+        query = query.filter(AIInsightRun.id == run_id)
+    if user_id is not None:
+        query = query.filter(AIInsightRun.user_id == user_id)
+    if period_type:
+        query = query.filter(
+            AIInsightRun.period_type == _normalize_insight_type(period_type)
+        )
+    if period_label:
+        query = query.filter(AIInsightRun.period_label == period_label)
+    if insight_id is not None:
+        query = query.filter(AIInsightRun.ai_insight_id == insight_id)
+
+    run = query.order_by(AIInsightRun.created_at.desc()).first()
+    if run is None:
+        raise ValueError("AIInsightRun não encontrado")
+    return serialize_ai_insight_run_dossier(run)
+
+
+__all__ = [
+    "PROMPT_TEMPLATE_VERSION",
+    "build_ai_insight_preview",
+    "build_deterministic_risks",
+    "build_evidence_manifest",
+    "get_ai_insight_run_dossier",
+    "serialize_ai_insight_run_dossier",
+]

--- a/openapi.json
+++ b/openapi.json
@@ -655,6 +655,13 @@
             ],
             "example": "daily",
             "type": "string"
+          },
+          "preview_run_id": {
+            "description": "Run de preview admin a ser reutilizado para manter o mesmo snapshot_hash na geração.",
+            "example": "550e8400-e29b-41d4-a716-446655440000",
+            "format": "uuid",
+            "nullable": true,
+            "type": "string"
           }
         },
         "required": [
@@ -1372,7 +1379,8 @@
               "description": "Período que deve ser consolidado antes da chamada à IA.",
               "example": {
                 "anchor_date": "2026-05-17",
-                "period_type": "daily"
+                "period_type": "daily",
+                "preview_run_id": "550e8400-e29b-41d4-a716-446655440000"
               },
               "schema": {
                 "$ref": "#/components/schemas/app_schemas_ai_insight_schema_AIInsightGenerateRequestSchema"
@@ -1393,6 +1401,7 @@
                     "cost_usd": 6.3e-05,
                     "items": [
                       {
+                        "dimension": "general",
                         "evidence": [
                           "current_period.paid.balance"
                         ],

--- a/tests/test_ai_advisory_service.py
+++ b/tests/test_ai_advisory_service.py
@@ -504,6 +504,98 @@ class TestAIAdvisoryServiceFinancialInsights:
             assert saved.insight_type == InsightType(period_type)
             assert saved.period_label == period_label
 
+    def test_generate_financial_insights_can_reuse_preview_run_snapshot(
+        self,
+        app,
+    ) -> None:
+        with app.app_context():
+            from app.extensions.database import db
+            from app.models.ai_insight import AIInsight, InsightType
+            from app.models.ai_insight_run import AIInsightRunStatus
+            from app.models.user import User
+            from app.services.ai_advisory_service import AIAdvisoryService
+            from app.services.ai_insight_runs import create_ai_insight_run
+
+            user_id = uuid.uuid4()
+            db.session.add(
+                User(
+                    id=user_id,
+                    name="Preview User",
+                    email=f"preview-{user_id.hex[:8]}@test.com",
+                    password="x",
+                )
+            )
+            db.session.commit()
+
+            snapshot = {
+                "schema_version": "financial_insight_snapshot.v1",
+                "period_type": "daily",
+                "period": {
+                    "label": "2026-05-17",
+                    "start": "2026-05-17",
+                    "end": "2026-05-17",
+                },
+                "current_period": {
+                    "paid": {
+                        "income_total": "1000.00",
+                        "expense_total": "250.00",
+                        "balance": "750.00",
+                        "transaction_count": 2,
+                    },
+                    "commitments": {
+                        "pending_expense_total": "0.00",
+                        "overdue_expense_total": "0.00",
+                        "transaction_count": 0,
+                    },
+                    "cancelled_transaction_count": 0,
+                },
+                "comparisons": {},
+                "transactions": {"included_count": 2, "sample": []},
+                "data_quality": {
+                    "has_transactions": True,
+                    "missing_comparison_periods": [],
+                },
+            }
+            preview_run = create_ai_insight_run(
+                user_id=user_id,
+                status=AIInsightRunStatus.previewed,
+                period_type=InsightType.daily,
+                period_label="2026-05-17",
+                period_start=date(2026, 5, 17),
+                period_end=date(2026, 5, 17),
+                snapshot_schema_version="financial_insight_snapshot.v1",
+                snapshot_hash="preview-hash-123",
+                prompt_template_version="financial-insight.v1.preview",
+                snapshot_json=snapshot,
+                evidence_manifest_json={"items": []},
+                data_quality_json=snapshot["data_quality"],
+            )
+
+            provider = MagicMock()
+            provider.generate_with_usage.return_value = _financial_llm_response(
+                summary="Resumo a partir do preview."
+            )
+
+            service = AIAdvisoryService(user_id=user_id, llm_provider=provider)
+            with patch(
+                "app.services.ai_advisory_service._build_period_snapshot",
+                side_effect=AssertionError("snapshot should come from preview run"),
+            ):
+                result = service.generate_financial_insights(
+                    period_type="daily",
+                    anchor_date=date(2026, 5, 17),
+                    preview_run_id=preview_run.id,
+                )
+
+            assert result["context_hash"] == "preview-hash-123"
+            assert result["cached"] is False
+            saved = AIInsight.query.filter_by(user_id=user_id).one()
+            db.session.refresh(preview_run)
+            assert preview_run.status == AIInsightRunStatus.generated
+            assert preview_run.ai_insight_id == saved.id
+            assert preview_run.snapshot_hash == "preview-hash-123"
+            assert preview_run.tokens_total == 140
+
     def test_audit_log_created_on_success(self, app) -> None:
         with app.app_context():
             user_id = uuid.uuid4()
@@ -760,6 +852,50 @@ class TestAIInsightGenerateEndpoint:
         assert mocked_generate.call_args.kwargs == {
             "period_type": "daily",
             "anchor_date": date(2026, 5, 17),
+            "preview_run_id": None,
+        }
+
+    def test_post_generation_accepts_preview_run_id(self, app, client) -> None:
+        token = _register_and_login(client, prefix="ai-generate-preview")
+        user_id = _get_current_user_id(app, token)
+        _grant_entitlement(app, user_id, "advanced_simulations")
+        preview_run_id = uuid.uuid4()
+
+        generated = {
+            "period_type": "daily",
+            "period_label": "2026-05-17",
+            "period_start": "2026-05-17",
+            "period_end": "2026-05-17",
+            "summary": "Resumo do preview.",
+            "items": [],
+            "context_version": "financial_insight_snapshot.v1",
+            "context_hash": "preview-hash-123",
+            "cached": False,
+            "model": "stub",
+            "tokens_used": 123,
+            "cost_usd": 0.00001,
+        }
+
+        with patch(
+            "app.services.ai_advisory_service.AIAdvisoryService.generate_financial_insights",
+            return_value=generated,
+        ) as mocked_generate:
+            resp = client.post(
+                "/ai/insights/generate",
+                json={
+                    "period_type": "daily",
+                    "anchor_date": "2026-05-17",
+                    "preview_run_id": str(preview_run_id),
+                },
+                headers=_auth(token),
+            )
+
+        assert resp.status_code == 200
+        mocked_generate.assert_called_once()
+        assert mocked_generate.call_args.kwargs == {
+            "period_type": "daily",
+            "anchor_date": date(2026, 5, 17),
+            "preview_run_id": preview_run_id,
         }
 
 

--- a/tests/test_ai_insight_audit_preview.py
+++ b/tests/test_ai_insight_audit_preview.py
@@ -1,0 +1,184 @@
+"""Tests for AI Insight audit preview admin endpoints (#1311)."""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+from typing import Generator
+from unittest.mock import patch
+
+import pytest
+
+_TEST_ENV = {
+    "SECRET_KEY": "test-secret-key-with-64-chars-minimum-for-jwt-signing-0001",
+    "JWT_SECRET_KEY": "test-jwt-secret-key-with-64-chars-minimum-for-signing-0002",
+    "FLASK_TESTING": "true",
+    "SECURITY_ENFORCE_STRONG_SECRETS": "false",
+    "DOCS_EXPOSURE_POLICY": "public",
+    "CORS_ALLOWED_ORIGINS": "https://frontend.local",
+    "GRAPHQL_ALLOW_INTROSPECTION": "true",
+}
+
+
+@pytest.fixture()
+def admin_preview_app(tmp_path: Path):
+    os.environ["DATABASE_URL"] = f"sqlite:///{tmp_path / 'test.sqlite3'}"
+    for key, value in _TEST_ENV.items():
+        os.environ[key] = value
+
+    from app import create_app
+    from app.extensions.database import db
+
+    flask_app = create_app(enable_http_runtime=False)
+    flask_app.config["TESTING"] = True
+
+    with flask_app.app_context():
+        db.drop_all()
+        db.create_all()
+
+    yield flask_app
+
+    with flask_app.app_context():
+        db.session.remove()
+        db.drop_all()
+        db.engine.dispose()
+
+
+@pytest.fixture()
+def admin_preview_client(admin_preview_app) -> Generator:
+    with admin_preview_app.test_client() as client:
+        yield client
+
+
+def _create_user_with_transactions(app) -> uuid.UUID:
+    with app.app_context():
+        from app.extensions.database import db
+        from app.models.account import Account
+        from app.models.transaction import (
+            Transaction,
+            TransactionCategory,
+            TransactionStatus,
+            TransactionType,
+        )
+        from app.models.user import User
+
+        user_id = uuid.uuid4()
+        user = User(
+            id=user_id,
+            name="Audit Preview User",
+            email=f"audit-preview-{user_id.hex[:8]}@test.com",
+            password="x",
+        )
+        db.session.add(user)
+        account = Account(
+            user_id=user_id,
+            name="Conta principal",
+            account_type="checking",
+        )
+        db.session.add(account)
+        db.session.flush()
+        db.session.add_all(
+            [
+                Transaction(
+                    user_id=user_id,
+                    account_id=account.id,
+                    title="Salário",
+                    amount=Decimal("4000.00"),
+                    status=TransactionStatus.PAID,
+                    type=TransactionType.INCOME,
+                    due_date=date(2026, 5, 17),
+                    category=TransactionCategory.outros,
+                ),
+                Transaction(
+                    user_id=user_id,
+                    account_id=account.id,
+                    title="Mercado",
+                    amount=Decimal("600.00"),
+                    status=TransactionStatus.PAID,
+                    type=TransactionType.EXPENSE,
+                    due_date=date(2026, 5, 17),
+                    category=TransactionCategory.alimentacao,
+                ),
+            ]
+        )
+        db.session.commit()
+        return user_id
+
+
+def _data(payload: dict) -> dict:
+    return payload.get("data") or payload
+
+
+class TestAIInsightAuditPreviewAdmin:
+    def test_preview_returns_403_for_non_admin(self, admin_preview_client) -> None:
+        with patch(
+            "app.controllers.admin.ai_insights._is_admin",
+            return_value=False,
+        ):
+            resp = admin_preview_client.post(
+                "/admin/ai-insights/preview",
+                json={
+                    "user_id": str(uuid.uuid4()),
+                    "period_type": "daily",
+                    "anchor_date": "2026-05-17",
+                },
+            )
+
+        assert resp.status_code == 403
+        body = resp.get_json()
+        assert body["success"] is False
+        assert body["error"]["code"] == "FORBIDDEN"
+
+    def test_preview_creates_run_without_llm_or_quota(
+        self,
+        admin_preview_app,
+        admin_preview_client,
+    ) -> None:
+        user_id = _create_user_with_transactions(admin_preview_app)
+
+        with (
+            patch(
+                "app.controllers.admin.ai_insights._is_admin",
+                return_value=True,
+            ),
+            patch(
+                "app.services.ai_advisory_service.get_llm_provider",
+                side_effect=AssertionError("preview must not initialize LLM provider"),
+            ),
+        ):
+            resp = admin_preview_client.post(
+                "/admin/ai-insights/preview",
+                json={
+                    "user_id": str(user_id),
+                    "period_type": "daily",
+                    "anchor_date": "2026-05-17",
+                },
+            )
+
+        assert resp.status_code == 201
+        payload = _data(resp.get_json())
+        assert payload["run_id"]
+        assert payload["period_type"] == "daily"
+        assert payload["period_label"] == "2026-05-17"
+        assert payload["snapshot_hash"]
+        assert payload["snapshot"]["period"]["label"] == "2026-05-17"
+        assert "comparisons" in payload
+        assert isinstance(payload["risks"], list)
+        assert isinstance(payload["evidence_manifest"], dict)
+        assert payload["data_quality"]["has_transactions"] is True
+
+        with admin_preview_app.app_context():
+            from app.models.ai_insight import AIInsight
+            from app.models.ai_insight_run import AIInsightRun, AIInsightRunStatus
+            from app.models.llm_audit_log import LLMAuditLog
+
+            run = AIInsightRun.query.filter_by(user_id=user_id).one()
+            assert str(run.id) == payload["run_id"]
+            assert run.status == AIInsightRunStatus.previewed
+            assert run.snapshot_hash == payload["snapshot_hash"]
+            assert run.tokens_total == 0
+            assert LLMAuditLog.query.filter_by(user_id=user_id).count() == 0
+            assert AIInsight.query.filter_by(user_id=user_id).count() == 0

--- a/tests/test_ai_insight_dossier_cli.py
+++ b/tests/test_ai_insight_dossier_cli.py
@@ -1,0 +1,131 @@
+"""Tests for AI Insight audit dossier export CLI (#1311)."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import date
+from pathlib import Path
+
+from click.testing import CliRunner
+
+
+def _create_dossier_run(app) -> uuid.UUID:
+    with app.app_context():
+        from app.extensions.database import db
+        from app.models.ai_insight import AIInsight, InsightType
+        from app.models.ai_insight_run import AIInsightRunStatus
+        from app.models.user import User
+        from app.services.ai_insight_runs import create_ai_insight_run
+
+        user_id = uuid.uuid4()
+        db.session.add(
+            User(
+                id=user_id,
+                name="Dossier User",
+                email=f"dossier-{user_id.hex[:8]}@test.com",
+                password="x",
+            )
+        )
+        insight = AIInsight(
+            user_id=user_id,
+            content='{"summary":"Resumo salvo","items":[]}',
+            insight_type=InsightType.daily,
+            period_label="2026-05-17",
+            period_start=date(2026, 5, 17),
+            period_end=date(2026, 5, 17),
+            model="stub",
+            tokens_used=20,
+            cost_usd=0,
+        )
+        db.session.add(insight)
+        db.session.flush()
+        run = create_ai_insight_run(
+            user_id=user_id,
+            ai_insight_id=insight.id,
+            status=AIInsightRunStatus.generated,
+            period_type=InsightType.daily,
+            period_label="2026-05-17",
+            period_start=date(2026, 5, 17),
+            period_end=date(2026, 5, 17),
+            snapshot_schema_version="financial_insight_snapshot.v1",
+            snapshot_hash="dossier-hash-123",
+            prompt_template_version="financial-insight.v1.preview",
+            snapshot_json={
+                "schema_version": "financial_insight_snapshot.v1",
+                "period_type": "daily",
+                "period": {
+                    "label": "2026-05-17",
+                    "start": "2026-05-17",
+                    "end": "2026-05-17",
+                },
+                "current_period": {"paid": {"balance": "100.00"}},
+                "comparisons": {},
+                "data_quality": {"has_transactions": True},
+            },
+            evidence_manifest_json={
+                "items": [
+                    {
+                        "path": "current_period.paid.balance",
+                        "label": "Saldo pago",
+                    }
+                ]
+            },
+            data_quality_json={"has_transactions": True},
+        )
+        db.session.commit()
+        return run.id
+
+
+def _invoke(app, *args: str):
+    from app.cli.ai_insights_cli import ai_insights_cli
+
+    runner = CliRunner()
+    with app.app_context():
+        return runner.invoke(ai_insights_cli, ["export-dossier", *args])
+
+
+class TestAIInsightDossierCLI:
+    def test_export_dossier_json_by_run_id(self, app, tmp_path: Path) -> None:
+        run_id = _create_dossier_run(app)
+
+        result = _invoke(
+            app,
+            "--run-id",
+            str(run_id),
+            "--output-dir",
+            str(tmp_path),
+            "--format",
+            "json",
+        )
+
+        assert result.exit_code == 0
+        output_path = tmp_path / f"ai-insight-dossier-{run_id}.json"
+        assert output_path.exists()
+        payload = json.loads(output_path.read_text(encoding="utf-8"))
+        assert payload["run"]["id"] == str(run_id)
+        assert payload["run"]["snapshot_hash"] == "dossier-hash-123"
+        assert payload["snapshot"]["period"]["label"] == "2026-05-17"
+        assert payload["evidence_manifest"]["items"][0]["path"] == (
+            "current_period.paid.balance"
+        )
+
+    def test_export_dossier_html_by_run_id(self, app, tmp_path: Path) -> None:
+        run_id = _create_dossier_run(app)
+
+        result = _invoke(
+            app,
+            "--run-id",
+            str(run_id),
+            "--output-dir",
+            str(tmp_path),
+            "--format",
+            "html",
+        )
+
+        assert result.exit_code == 0
+        output_path = tmp_path / f"ai-insight-dossier-{run_id}.html"
+        assert output_path.exists()
+        html = output_path.read_text(encoding="utf-8")
+        assert "dossier-hash-123" in html
+        assert "current_period.paid.balance" in html

--- a/tests/test_postman_collection_contract.py
+++ b/tests/test_postman_collection_contract.py
@@ -153,6 +153,8 @@ OPENAPI_GAPS: set[tuple[str, str]] = {
     ("DELETE", "/admin/feature-flags/{param}"),
     # Admin audit trail (#1052)
     ("GET", "/admin/audit-trail/{param}/{param}"),
+    # Admin AI Insight audit preview (#1311)
+    ("POST", "/admin/ai-insights/preview"),
     # Bank statements
     ("POST", "/bank-statements/preview"),
     ("POST", "/bank-statements/confirm"),


### PR DESCRIPTION
## Summary
- adds an admin-only AI Insight preview endpoint that persists a preview `AIInsightRun` without initializing or calling an LLM provider
- adds backend dossier export through `flask ai export-dossier` in JSON/HTML formats, selectable by run/user/period/insight
- lets `POST /ai/insights/generate` accept `preview_run_id` and reuse the persisted snapshot/hash when generating
- updates OpenAPI schema for `preview_run_id` and route-contract coverage gaps for the internal admin endpoint

## Validation
- `/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-api/.venv/bin/python -m pytest tests/test_ai_advisory_service.py tests/test_ai_insight_audit_preview.py tests/test_ai_insight_dossier_cli.py tests/test_ai_weekly_insights_cli.py tests/test_ai_daily_rate_limit.py tests/test_graphql_generate_ai_insight.py tests/test_ai_insight_observability.py`
- `TZ=UTC PYTHON_BIN=/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-api/.venv/bin/python DATABASE_URL=sqlite:////tmp/auraxis-quality-1311.sqlite3 bash scripts/run_ci_quality_local.sh --local`

Closes #1311
