### PR TITLE
[AI] Calcular saúde financeira determinística dos insights

### DIFF
--- a/app/services/ai_advisory_service.py
+++ b/app/services/ai_advisory_service.py
@@ -1707,7 +1707,7 @@ def _build_financial_insight_prompt(
         "Cada item deve conter evidências que apontem para chaves conhecidas do "
         "snapshot, como current_period.paid.balance, comparisons.yesterday.delta, "
         "daily_series, extremes, categories, transactions.sample, budgets, goals, "
-        "credit_cards ou wallet.\n"
+        "credit_cards, wallet ou financial_health.\n"
         "Quando 'wallet' estiver presente e o ativo total for > 0, contextualize "
         "a rentabilidade e a alocação atual: compare com "
         "'wallet.benchmark.cdi_monthly_pct' e 'wallet.benchmark.ipca_monthly_pct' "

--- a/app/services/ai_insight_audit.py
+++ b/app/services/ai_insight_audit.py
@@ -69,6 +69,18 @@ def _safe_float(value: object) -> float:
         return 0.0
 
 
+def _financial_health_risk_flags(
+    snapshot: dict[str, Any],
+) -> list[dict[str, Any]] | None:
+    financial_health = snapshot.get("financial_health")
+    if not isinstance(financial_health, dict):
+        return None
+    risk_flags = financial_health.get("risk_flags")
+    if not isinstance(risk_flags, list):
+        return None
+    return [flag for flag in risk_flags if isinstance(flag, dict)]
+
+
 def _latest_snapshot_hash(
     *,
     user_id: UUID,
@@ -108,6 +120,16 @@ def build_evidence_manifest(
     """Return deterministic evidence pointers for an auditable snapshot."""
 
     evidence_paths = (
+        (
+            "financial_health.score",
+            "Score determinístico de saúde financeira",
+            "general",
+        ),
+        (
+            "financial_health.risk_flags",
+            "Flags determinísticas de risco",
+            "general",
+        ),
         (
             "current_period.paid.income_total",
             "Receitas pagas no período",
@@ -189,6 +211,10 @@ def build_evidence_manifest(
 def build_deterministic_risks(snapshot: dict[str, Any]) -> list[dict[str, Any]]:
     """Return deterministic risk flags derived from the snapshot."""
 
+    risk_flags = _financial_health_risk_flags(snapshot)
+    if risk_flags is not None:
+        return risk_flags
+
     risks: list[dict[str, Any]] = []
     data_quality = snapshot.get("data_quality") or {}
     if isinstance(data_quality, dict) and data_quality.get("has_transactions") is False:
@@ -222,6 +248,21 @@ def build_deterministic_risks(snapshot: dict[str, Any]) -> list[dict[str, Any]]:
                 "severity": "high",
                 "dimension": "transactions",
                 "evidence": ["current_period.commitments.overdue_expense_total"],
+            }
+        )
+
+    pending = _safe_float(
+        _get_path(snapshot, "current_period.commitments.pending_expense_total")
+    )
+    if pending > 0:
+        risks.append(
+            {
+                "code": "future_commitments_open",
+                "severity": "low",
+                "dimension": "transactions",
+                "evidence": [
+                    "current_period.commitments.pending_expense_total",
+                ],
             }
         )
 

--- a/app/services/financial_insight_context_builder.py
+++ b/app/services/financial_insight_context_builder.py
@@ -20,6 +20,7 @@ from uuid import UUID
 from app.models.budget import Budget
 from app.models.credit_card import CreditCard
 from app.models.goal import Goal
+from app.models.goal_contribution import GoalContribution
 from app.models.transaction import (
     Transaction,
     TransactionStatus,
@@ -54,6 +55,7 @@ surface it belongs to so contextual pages can filter, while the global
 _SNAPSHOT_VERSION = "financial_insight_snapshot.v1"
 _CURRENCY = "BRL"
 _TIMEZONE = "America/Sao_Paulo"
+_GOAL_PACE_WINDOW_DAYS = 90
 
 # Hard cap on serialized snapshot size sent to the LLM (Sprint 5 obs-1).
 # When exceeded, `truncate_snapshot()` reduces large lists deterministically
@@ -73,6 +75,7 @@ _EMAIL_LOCAL_SYMBOLS = "._%+-"
 _EMAIL_DOMAIN_SYMBOLS = "-_"
 _CPF_RE = re.compile(r"\b\d{3}\.\d{3}\.\d{3}-\d{2}\b")
 _LONG_NUMBER_RE = re.compile(r"\b\d{8,}\b")
+_RiskPenalty = tuple[int, dict[str, Any]]
 
 
 def _money(value: object) -> Decimal:
@@ -264,6 +267,196 @@ def _date_period(start: date, end: date, label: str) -> dict[str, str]:
     }
 
 
+def _risk_flag(
+    *,
+    code: str,
+    severity: str,
+    dimension: str,
+    evidence: list[str],
+) -> dict[str, Any]:
+    return {
+        "code": code,
+        "severity": severity,
+        "dimension": dimension,
+        "evidence": evidence,
+    }
+
+
+def _financial_health_grade(score: int) -> str:
+    if score >= 80:
+        return "healthy"
+    if score >= 60:
+        return "attention"
+    return "critical"
+
+
+def _goal_pace_assessment(
+    *,
+    remaining: Decimal,
+    required_monthly_pace: Decimal | None,
+    observed_monthly_pace: Decimal,
+    has_target_date: bool,
+    has_contribution_history: bool,
+) -> tuple[str, str]:
+    if remaining <= 0:
+        return "completed", "goal_total"
+    if not has_target_date:
+        return "insufficient_data", "missing_target_date"
+    if not has_contribution_history:
+        return "insufficient_data", "no_contribution_history"
+    if required_monthly_pace is None:
+        return "insufficient_data", "missing_required_pace"
+    if observed_monthly_pace >= required_monthly_pace:
+        return "on_track", "goal_total_and_90d_contributions"
+    return "behind", "goal_total_and_90d_contributions"
+
+
+def _transaction_risk_penalties(
+    *,
+    balance: Decimal,
+    income: Decimal,
+    pending: Decimal,
+    overdue: Decimal,
+) -> list[_RiskPenalty]:
+    penalties: list[_RiskPenalty] = []
+    if balance < 0:
+        penalties.append(
+            (
+                30,
+                _risk_flag(
+                    code="negative_paid_balance",
+                    severity="high",
+                    dimension="general",
+                    evidence=["current_period.paid.balance"],
+                ),
+            )
+        )
+    if overdue > 0:
+        penalties.append(
+            (
+                25,
+                _risk_flag(
+                    code="overdue_expenses",
+                    severity="high",
+                    dimension="transactions",
+                    evidence=["current_period.commitments.overdue_expense_total"],
+                ),
+            )
+        )
+    if pending > 0:
+        penalty, code, severity = (
+            (20, "future_commitment_pressure", "medium")
+            if income == 0 or pending > max(balance, Decimal("0.00"))
+            else (5, "future_commitments_open", "low")
+        )
+        penalties.append(
+            (
+                penalty,
+                _risk_flag(
+                    code=code,
+                    severity=severity,
+                    dimension="transactions",
+                    evidence=[
+                        "current_period.commitments.pending_expense_total",
+                        "current_period.paid.balance",
+                    ],
+                ),
+            )
+        )
+    return penalties
+
+
+def _budget_risk_penalties(budgets: object) -> list[_RiskPenalty]:
+    if not isinstance(budgets, list):
+        return []
+    penalties: list[_RiskPenalty] = []
+    for index, budget in enumerate(budgets):
+        if not isinstance(budget, dict):
+            continue
+        utilization = _money(budget.get("utilization_pct"))
+        if bool(budget.get("exceeded")):
+            penalties.append(
+                (
+                    15,
+                    _risk_flag(
+                        code="budget_exceeded",
+                        severity="medium",
+                        dimension="budgets",
+                        evidence=[f"budgets.{index}.exceeded"],
+                    ),
+                )
+            )
+        elif utilization >= 90:
+            penalties.append(
+                (
+                    8,
+                    _risk_flag(
+                        code="budget_near_limit",
+                        severity="low",
+                        dimension="budgets",
+                        evidence=[f"budgets.{index}.utilization_pct"],
+                    ),
+                )
+            )
+    return penalties
+
+
+def _credit_card_risk_penalties(cards: object) -> list[_RiskPenalty]:
+    if not isinstance(cards, list):
+        return []
+    penalties: list[_RiskPenalty] = []
+    for index, card in enumerate(cards):
+        if not isinstance(card, dict):
+            continue
+        utilization = _money(card.get("utilization_pct"))
+        if utilization >= 95:
+            penalty, code, severity = (
+                25,
+                "credit_card_utilization_critical",
+                "high",
+            )
+        elif utilization >= 80:
+            penalty, code, severity = 15, "high_credit_card_utilization", "medium"
+        else:
+            continue
+        penalties.append(
+            (
+                penalty,
+                _risk_flag(
+                    code=code,
+                    severity=severity,
+                    dimension="credit_cards",
+                    evidence=[f"credit_cards.{index}.utilization_pct"],
+                ),
+            )
+        )
+    return penalties
+
+
+def _goal_risk_penalties(goals: object) -> list[_RiskPenalty]:
+    if not isinstance(goals, list):
+        return []
+    penalties: list[_RiskPenalty] = []
+    for index, goal in enumerate(goals):
+        if not isinstance(goal, dict) or goal.get("pace_assessment") != "behind":
+            continue
+        penalties.append(
+            (
+                10,
+                _risk_flag(
+                    code="goal_pace_gap",
+                    severity="medium",
+                    dimension="goals",
+                    evidence=[
+                        f"goals.{index}.required_monthly_pace",
+                        f"goals.{index}.observed_monthly_pace_90d",
+                    ],
+                ),
+            )
+        )
+    return penalties
+
+
 class FinancialInsightContextBuilder:
     """Build sanitized financial snapshots for daily, weekly and monthly insights."""
 
@@ -358,6 +551,7 @@ class FinancialInsightContextBuilder:
             label=f"{anchor_date.isocalendar().year}-W{anchor_date.isocalendar().week:02d}",
             period_type="weekly",
             include_daily_series=True,
+            include_goals=True,
             include_credit_cards=True,
             include_wallet=True,
             previous_generated_at=previous_generated_at,
@@ -457,6 +651,13 @@ class FinancialInsightContextBuilder:
         paid = [tx for tx in non_cancelled if tx.status == TransactionStatus.PAID]
 
         current_period = self._current_period_summary(transactions)
+        goals_payload: list[dict[str, Any]] = []
+        goal_data_quality: dict[str, Any] = {}
+        if include_goals:
+            goals_payload, goal_data_quality = self._goals_payload(
+                user_id=user_id,
+                anchor=end,
+            )
         snapshot: dict[str, Any] = {
             "schema_version": _SNAPSHOT_VERSION,
             "period_type": period_type,
@@ -480,7 +681,7 @@ class FinancialInsightContextBuilder:
             "budgets": self._budgets_payload(user_id=user_id, start=start, end=end)
             if include_budgets
             else [],
-            "goals": self._goals_payload(user_id=user_id) if include_goals else [],
+            "goals": goals_payload,
             "credit_cards": self._credit_cards_payload(user_id=user_id, anchor=end)
             if include_credit_cards
             else [],
@@ -489,6 +690,7 @@ class FinancialInsightContextBuilder:
                 "missing_comparison_periods": [],
             },
         }
+        snapshot["data_quality"].update(goal_data_quality)
         if include_wallet:
             wallet_payload, missing_rates = self._wallet_payload(
                 user_id=user_id,
@@ -500,6 +702,10 @@ class FinancialInsightContextBuilder:
                 snapshot["data_quality"]["missing_external_rates"] = missing_rates
         else:
             snapshot["wallet"] = {"items": [], "total_value": "0.00"}
+        snapshot["financial_health"] = self._financial_health_payload(snapshot)
+        snapshot["data_quality"]["insufficient_financial_health_data"] = (
+            snapshot["financial_health"]["grade"] == "insufficient_data"
+        )
         return snapshot
 
     def _credit_cards_payload(
@@ -986,7 +1192,12 @@ class FinancialInsightContextBuilder:
             )
         return result
 
-    def _goals_payload(self, *, user_id: UUID) -> list[dict[str, Any]]:
+    def _goals_payload(
+        self,
+        *,
+        user_id: UUID,
+        anchor: date,
+    ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
         rows = (
             Goal.query.filter(
                 Goal.user_id == user_id,
@@ -996,11 +1207,68 @@ class FinancialInsightContextBuilder:
             .all()
         )
         goals = cast(list[Goal], rows)
+        if not goals:
+            return [], {
+                "has_active_goals": False,
+                "insufficient_goal_pace_data": False,
+                "goal_pace_window_days": _GOAL_PACE_WINDOW_DAYS,
+            }
+
+        cutoff = datetime(
+            anchor.year, anchor.month, anchor.day, 23, 59, 59
+        ) - timedelta(days=_GOAL_PACE_WINDOW_DAYS)
+        contributions = cast(
+            list[GoalContribution],
+            GoalContribution.query.filter(
+                GoalContribution.user_id == user_id,
+                GoalContribution.created_at >= cutoff,
+            )
+            .order_by(GoalContribution.created_at.asc())
+            .all(),
+        )
+        recent_by_goal: dict[str, Decimal] = {}
+        for contribution in contributions:
+            goal_key = str(contribution.goal_id)
+            recent_by_goal[goal_key] = recent_by_goal.get(
+                goal_key, Decimal("0.00")
+            ) + _money(contribution.amount)
 
         result: list[dict[str, Any]] = []
+        goals_without_deadline = 0
+        goals_without_observed_pace = 0
         for goal in goals:
             current = _money(goal.current_amount)
             target = _money(goal.target_amount)
+            remaining = max(target - current, Decimal("0.00"))
+            days_remaining: int | None = None
+            required_monthly_pace: Decimal | None = None
+            if goal.target_date is None:
+                goals_without_deadline += 1
+            else:
+                days_remaining = max((goal.target_date - anchor).days, 0)
+                months_remaining = max((days_remaining + 29) // 30, 1)
+                required_monthly_pace = (
+                    remaining / Decimal(months_remaining)
+                    if remaining > 0
+                    else Decimal("0.00")
+                )
+
+            recent_90d = max(
+                recent_by_goal.get(str(goal.id), Decimal("0.00")),
+                Decimal("0.00"),
+            )
+            observed_monthly_pace = recent_90d / (
+                Decimal(_GOAL_PACE_WINDOW_DAYS) / Decimal(30)
+            )
+            if recent_90d == 0 and remaining > 0:
+                goals_without_observed_pace += 1
+            pace_assessment, pace_basis = _goal_pace_assessment(
+                remaining=remaining,
+                required_monthly_pace=required_monthly_pace,
+                observed_monthly_pace=observed_monthly_pace,
+                has_target_date=goal.target_date is not None,
+                has_contribution_history=recent_90d > 0,
+            )
             result.append(
                 {
                     "title": _sanitize_text(goal.title) or "Meta",
@@ -1010,9 +1278,76 @@ class FinancialInsightContextBuilder:
                     "target_date": goal.target_date.isoformat()
                     if goal.target_date
                     else None,
+                    "remaining_amount": _money_str(remaining),
+                    "days_remaining": days_remaining,
+                    "required_monthly_pace": _money_str(required_monthly_pace)
+                    if required_monthly_pace is not None
+                    else None,
+                    "observed_monthly_pace_90d": _money_str(observed_monthly_pace),
+                    "pace_assessment": pace_assessment,
+                    "pace_basis": pace_basis,
                 }
             )
-        return result
+        return result, {
+            "has_active_goals": True,
+            "insufficient_goal_pace_data": any(
+                goal.get("pace_assessment") == "insufficient_data" for goal in result
+            ),
+            "goals_without_deadline_count": goals_without_deadline,
+            "goals_without_observed_pace_count": goals_without_observed_pace,
+            "goal_pace_window_days": _GOAL_PACE_WINDOW_DAYS,
+        }
+
+    def _financial_health_payload(self, snapshot: dict[str, Any]) -> dict[str, Any]:
+        data_quality = snapshot.get("data_quality") or {}
+        has_transactions = bool(
+            isinstance(data_quality, dict) and data_quality.get("has_transactions")
+        )
+        if not has_transactions:
+            return {
+                "score": 50,
+                "grade": "insufficient_data",
+                "risk_flags": [
+                    _risk_flag(
+                        code="insufficient_transaction_data",
+                        severity="info",
+                        dimension="general",
+                        evidence=["data_quality.has_transactions"],
+                    )
+                ],
+            }
+
+        paid = snapshot["current_period"]["paid"]
+        commitments = snapshot["current_period"]["commitments"]
+        balance = _money(paid["balance"])
+        income = _money(paid["income_total"])
+        pending = _money(commitments["pending_expense_total"])
+        overdue = _money(commitments["overdue_expense_total"])
+        penalties = [
+            *_transaction_risk_penalties(
+                balance=balance,
+                income=income,
+                pending=pending,
+                overdue=overdue,
+            ),
+            *_budget_risk_penalties(snapshot.get("budgets")),
+            *_credit_card_risk_penalties(snapshot.get("credit_cards")),
+            *_goal_risk_penalties(snapshot.get("goals")),
+        ]
+        risk_flags = [flag for _penalty, flag in penalties]
+        score = 100 - sum(penalty for penalty, _flag in penalties)
+        score = max(0, min(100, score))
+        return {
+            "score": score,
+            "grade": _financial_health_grade(score),
+            "risk_flags": risk_flags,
+            "inputs": {
+                "paid_balance": _money_str(balance),
+                "paid_income_total": _money_str(income),
+                "pending_expense_total": _money_str(pending),
+                "overdue_expense_total": _money_str(overdue),
+            },
+        }
 
     def _sum(
         self,

--- a/app/services/insight_evidence_validator.py
+++ b/app/services/insight_evidence_validator.py
@@ -48,6 +48,7 @@ _KNOWN_SNAPSHOT_PREFIXES: frozenset[str] = frozenset(
         "goals",
         "credit_cards",
         "wallet",
+        "financial_health",
         "data_quality",
     }
 )

--- a/tests/test_ai_insight_audit_preview.py
+++ b/tests/test_ai_insight_audit_preview.py
@@ -112,6 +112,31 @@ def _data(payload: dict) -> dict:
     return payload.get("data") or payload
 
 
+def test_deterministic_risks_use_snapshot_financial_health_flags() -> None:
+    from app.services.ai_insight_audit import build_deterministic_risks
+
+    snapshot = {
+        "financial_health": {
+            "risk_flags": [
+                {
+                    "code": "future_commitment_pressure",
+                    "severity": "medium",
+                    "dimension": "transactions",
+                    "evidence": [
+                        "current_period.commitments.pending_expense_total",
+                        "current_period.paid.balance",
+                    ],
+                }
+            ]
+        }
+    }
+
+    assert (
+        build_deterministic_risks(snapshot)
+        == snapshot["financial_health"]["risk_flags"]
+    )
+
+
 class TestAIInsightAuditPreviewAdmin:
     def test_preview_returns_403_for_non_admin(self, admin_preview_client) -> None:
         with patch(

--- a/tests/test_financial_insight_context_builder.py
+++ b/tests/test_financial_insight_context_builder.py
@@ -11,7 +11,9 @@ from typing import Any
 
 from app.extensions.database import db
 from app.models.budget import Budget
+from app.models.credit_card import CreditCard
 from app.models.goal import Goal
+from app.models.goal_contribution import GoalContribution
 from app.models.transaction import (
     Transaction,
     TransactionCategory,
@@ -52,6 +54,7 @@ def _make_transaction(
     created_at: datetime | None = None,
     updated_at: datetime | None = None,
     paid_at: datetime | None = None,
+    credit_card_id: uuid.UUID | None = None,
 ) -> Transaction:
     tx = Transaction(
         user_id=user_id,
@@ -66,6 +69,7 @@ def _make_transaction(
         due_date=due_date,
         category=category,
         paid_at=paid_at,
+        credit_card_id=credit_card_id,
     )
     if created_at is not None:
         tx.created_at = created_at
@@ -97,6 +101,26 @@ def _make_budget(
     return budget
 
 
+def _make_credit_card(
+    user_id: uuid.UUID,
+    *,
+    name: str = "Cartão principal",
+    limit_amount: str = "1000.00",
+    closing_day: int = 20,
+    due_day: int = 28,
+) -> CreditCard:
+    card = CreditCard(
+        user_id=user_id,
+        name=name,
+        limit_amount=Decimal(limit_amount),
+        closing_day=closing_day,
+        due_day=due_day,
+    )
+    db.session.add(card)
+    db.session.commit()
+    return card
+
+
 def _make_goal(
     user_id: uuid.UUID,
     *,
@@ -116,6 +140,24 @@ def _make_goal(
     db.session.add(goal)
     db.session.commit()
     return goal
+
+
+def _make_goal_contribution(
+    user_id: uuid.UUID,
+    goal_id: uuid.UUID,
+    *,
+    amount: str,
+    created_at: datetime,
+) -> GoalContribution:
+    contribution = GoalContribution(
+        user_id=user_id,
+        goal_id=goal_id,
+        amount=Decimal(amount),
+        created_at=created_at,
+    )
+    db.session.add(contribution)
+    db.session.commit()
+    return contribution
 
 
 def _as_json(value: dict[str, Any]) -> str:
@@ -592,12 +634,155 @@ class TestFinancialInsightContextBuilderMonthly:
                 "exceeded": True,
             }
         ]
-        assert snapshot["goals"] == [
-            {
-                "title": "Comprar carro",
-                "current_amount": "1200.00",
-                "target_amount": "5000.00",
-                "progress_pct": "24.00",
-                "target_date": "2026-12-31",
-            }
-        ]
+        assert len(snapshot["goals"]) == 1
+        goal = snapshot["goals"][0]
+        assert goal["title"] == "Comprar carro"
+        assert goal["current_amount"] == "1200.00"
+        assert goal["target_amount"] == "5000.00"
+        assert goal["progress_pct"] == "24.00"
+        assert goal["target_date"] == "2026-12-31"
+        assert goal["remaining_amount"] == "3800.00"
+        assert goal["days_remaining"] == 214
+        assert goal["required_monthly_pace"] == "475.00"
+        assert goal["observed_monthly_pace_90d"] == "0.00"
+        assert goal["pace_assessment"] == "insufficient_data"
+        assert goal["pace_basis"] == "no_contribution_history"
+
+    def test_monthly_snapshot_includes_deterministic_health_and_risk_flags(
+        self, app
+    ) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            anchor = date(2026, 5, 17)
+            card = _make_credit_card(user_id, limit_amount="1000.00")
+            _make_budget(
+                user_id,
+                name="Alimentação",
+                amount="1000.00",
+                category=TransactionCategory.alimentacao,
+            )
+            _make_transaction(
+                user_id,
+                title="Receita baixa",
+                amount="500.00",
+                tx_type=TransactionType.INCOME,
+                status=TransactionStatus.PAID,
+                due_date=date(2026, 5, 2),
+            )
+            _make_transaction(
+                user_id,
+                title="Mercado alto",
+                amount="1200.00",
+                tx_type=TransactionType.EXPENSE,
+                status=TransactionStatus.PAID,
+                due_date=date(2026, 5, 10),
+                category=TransactionCategory.alimentacao,
+            )
+            _make_transaction(
+                user_id,
+                title="Fatura do ciclo",
+                amount="850.00",
+                tx_type=TransactionType.EXPENSE,
+                status=TransactionStatus.PENDING,
+                due_date=date(2026, 5, 25),
+                credit_card_id=card.id,
+            )
+            _make_transaction(
+                user_id,
+                title="Boleto vencido",
+                amount="100.00",
+                tx_type=TransactionType.EXPENSE,
+                status=TransactionStatus.OVERDUE,
+                due_date=date(2026, 5, 11),
+            )
+
+            snapshot = FinancialInsightContextBuilder().build_monthly(
+                user_id=user_id,
+                anchor_date=anchor,
+            )
+
+        health = snapshot["financial_health"]
+        assert health["score"] == 0
+        assert health["grade"] == "critical"
+        codes = {flag["code"] for flag in health["risk_flags"]}
+        assert {
+            "negative_paid_balance",
+            "overdue_expenses",
+            "future_commitment_pressure",
+            "budget_exceeded",
+            "high_credit_card_utilization",
+        }.issubset(codes)
+        assert snapshot["data_quality"]["insufficient_financial_health_data"] is False
+
+    def test_weekly_goal_pace_uses_deadline_and_contribution_history(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            anchor = date(2026, 5, 17)
+            goal = _make_goal(
+                user_id,
+                title="Reserva",
+                current_amount="1200.00",
+                target_amount="5000.00",
+                target_date=date(2026, 12, 31),
+            )
+            _make_goal_contribution(
+                user_id,
+                goal.id,
+                amount="300.00",
+                created_at=datetime(2026, 5, 10, 10, 0, 0),
+            )
+            _make_goal_contribution(
+                user_id,
+                goal.id,
+                amount="150.00",
+                created_at=datetime(2026, 4, 20, 10, 0, 0),
+            )
+            _make_goal_contribution(
+                user_id,
+                goal.id,
+                amount="999.00",
+                created_at=datetime(2026, 1, 1, 10, 0, 0),
+            )
+
+            snapshot = FinancialInsightContextBuilder().build_weekly(
+                user_id=user_id,
+                anchor_date=anchor,
+            )
+
+        assert len(snapshot["goals"]) == 1
+        goal_payload = snapshot["goals"][0]
+        assert goal_payload["remaining_amount"] == "3800.00"
+        assert goal_payload["days_remaining"] == 228
+        assert goal_payload["required_monthly_pace"] == "475.00"
+        assert goal_payload["observed_monthly_pace_90d"] == "150.00"
+        assert goal_payload["pace_assessment"] == "behind"
+        assert goal_payload["pace_basis"] == "goal_total_and_90d_contributions"
+        assert snapshot["data_quality"]["insufficient_goal_pace_data"] is False
+
+    def test_weekly_snapshot_marks_insufficient_data_without_transactions_or_goal_pace(
+        self, app
+    ) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            _make_goal(
+                user_id,
+                title="Meta sem prazo",
+                current_amount="0.00",
+                target_amount="1000.00",
+                target_date=None,
+            )
+
+            snapshot = FinancialInsightContextBuilder().build_weekly(
+                user_id=user_id,
+                anchor_date=date(2026, 5, 17),
+            )
+
+        assert snapshot["financial_health"]["score"] == 50
+        assert snapshot["financial_health"]["grade"] == "insufficient_data"
+        assert snapshot["financial_health"]["risk_flags"][0]["code"] == (
+            "insufficient_transaction_data"
+        )
+        assert snapshot["data_quality"]["insufficient_financial_health_data"] is True
+        assert snapshot["data_quality"]["insufficient_goal_pace_data"] is True
+        assert snapshot["goals"][0]["pace_assessment"] == "insufficient_data"
+        assert snapshot["goals"][0]["pace_basis"] == "missing_target_date"

--- a/tests/test_insight_evidence_validator.py
+++ b/tests/test_insight_evidence_validator.py
@@ -43,6 +43,7 @@ class TestKnownPrefixes:
             "comparisons.yesterday.delta",
             "daily_series",
             "data_quality.missing_external_rates",
+            "financial_health.risk_flags[0].code",
         ],
     )
     def test_accepts_known_prefix(self, path) -> None:


### PR DESCRIPTION
## Summary
- adiciona `financial_health` ao snapshot financeiro com score determinístico e flags de risco
- amplia metas com valor restante, prazo, ritmo mensal necessário e ritmo observado em 90 dias
- reaproveita as flags determinísticas no preview/dossiê e permite evidências em `financial_health`

## Validation
- `PYTHON_BIN=/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-api/.venv/bin/python /Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-api/.venv/bin/python -m pytest tests/test_financial_insight_context_builder.py tests/test_ai_insight_audit_preview.py tests/test_insight_evidence_validator.py -q`
- `PYTHON_BIN=/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-api/.venv/bin/python /Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-api/.venv/bin/python -m pytest tests/test_ai_advisory_service.py tests/test_graphql_generate_ai_insight.py tests/test_financial_insight_mvp3_extensions.py tests/test_wallet_insights_recap.py tests/test_ai_insight_goals_budget_context.py tests/test_ai_insight_run_model.py tests/test_ai_insight_dossier_cli.py -q`
- `TZ=UTC PYTHON_BIN=/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-api/.venv/bin/python DATABASE_URL=sqlite:////tmp/auraxis-quality-1312.sqlite3 bash scripts/run_ci_quality_local.sh --local`

Closes #1312
