### PR TITLE
[AI] Governar custo dos insights com orçamento e circuit breaker

### DIFF
--- a/app/controllers/ai/resources.py
+++ b/app/controllers/ai/resources.py
@@ -34,7 +34,10 @@ from app.docs.openapi_helpers import (
 )
 from app.middleware.ai_rate_limit import ai_daily_limit
 from app.schemas.ai_insight_schema import AIInsightGenerateRequestSchema
-from app.services.ai_advisory_service import AIAdvisoryService
+from app.services.ai_advisory_service import (
+    AIAdvisoryService,
+    AIInsightCostBudgetExceededError,
+)
 from app.services.ai_lgpd import AIConsentRequiredError
 from app.services.analysis_ready_notification_service import (
     dispatch_analysis_ready_notification,
@@ -293,6 +296,13 @@ class AIInsightGenerateResource(MethodResource):
             )
         except AIConsentRequiredError as exc:
             return _ai_consent_required_response(exc)
+        except AIInsightCostBudgetExceededError as exc:
+            return compat_error_response(
+                legacy_payload={"error": str(exc)},
+                status_code=429,
+                message=str(exc),
+                error_code="AI_INSIGHT_BUDGET_EXCEEDED",
+            )
         except LLMProviderError as exc:
             return compat_error_response(
                 legacy_payload={"error": str(exc)},

--- a/app/services/ai_advisory_service.py
+++ b/app/services/ai_advisory_service.py
@@ -18,14 +18,15 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import os
 from calendar import monthrange
-from datetime import date, datetime
-from decimal import Decimal
+from datetime import date, datetime, time
+from decimal import Decimal, InvalidOperation
 from typing import Any
 from uuid import UUID
 
 from dateutil.relativedelta import relativedelta
-from sqlalchemy import case, func
+from sqlalchemy import case, func, or_
 
 from app.extensions.database import db
 from app.extensions.prometheus_metrics import record_ai_insight_generated
@@ -52,6 +53,7 @@ from app.services.goal_projection_service import GoalProjectionService
 from app.services.insight_evidence_validator import filter_valid_items
 from app.services.llm_provider import LLMProvider, LLMProviderError, get_llm_provider
 from app.services.weekly_summary import compute_weekly_summary
+from app.utils.datetime_utils import utc_now_naive
 
 log = logging.getLogger(__name__)
 
@@ -144,6 +146,31 @@ _FINANCIAL_INSIGHT_RESPONSE_SCHEMA: dict[str, Any] = {
 InsightItem = dict[str, str]
 FinancialInsightItem = dict[str, Any]
 
+_AI_INSIGHTS_DAILY_BUDGET_ENV = "AI_INSIGHTS_DAILY_BUDGET_USD"
+_AI_INSIGHTS_MONTHLY_BUDGET_ENV = "AI_INSIGHTS_MONTHLY_BUDGET_USD"
+_AI_INSIGHT_COST_ENDPOINTS = (
+    "financial_insights_daily",
+    "financial_insights_weekly",
+    "financial_insights_monthly",
+)
+
+
+class AIInsightCostBudgetExceededError(LLMProviderError):
+    """Raised when AI Insight generation is blocked by cost governance."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        scope: str,
+        limit_usd: Decimal,
+        spent_usd: Decimal,
+    ) -> None:
+        super().__init__(message)
+        self.scope = scope
+        self.limit_usd = limit_usd
+        self.spent_usd = spent_usd
+
 
 # ---------------------------------------------------------------------------
 # AIInsight persistence helpers
@@ -169,6 +196,31 @@ def _get_cached_insight(
     return insight
 
 
+def _get_cached_insight_for_snapshot(
+    *,
+    user_id: UUID,
+    insight_type: InsightType,
+    period_label: str,
+    snapshot_hash: str,
+) -> AIInsight | None:
+    """Return a cached insight only when the persisted context hash matches."""
+    candidates: list[AIInsight] = (
+        db.session.query(AIInsight)
+        .filter_by(
+            user_id=user_id,
+            insight_type=insight_type,
+            period_label=period_label,
+        )
+        .order_by(AIInsight.created_at.desc())
+        .all()
+    )
+    for candidate in candidates:
+        metadata = candidate.metadata_dict
+        if str(metadata.get("context_hash") or "") == snapshot_hash:
+            return candidate
+    return None
+
+
 def _get_latest_insight(*, user_id: UUID) -> AIInsight | None:
     """Return the most recently created AIInsight for this user, or None."""
     insight: AIInsight | None = (
@@ -178,6 +230,43 @@ def _get_latest_insight(*, user_id: UUID) -> AIInsight | None:
         .first()
     )
     return insight
+
+
+def _get_latest_insight_for_period_context(
+    *,
+    user_id: UUID,
+    insight_type: InsightType,
+    period_label: str,
+) -> AIInsight | None:
+    """Return latest prior insight excluding the period currently being generated."""
+    insight: AIInsight | None = (
+        db.session.query(AIInsight)
+        .filter(AIInsight.user_id == user_id)
+        .filter(
+            or_(
+                AIInsight.insight_type != insight_type,
+                AIInsight.period_label != period_label,
+            )
+        )
+        .order_by(AIInsight.created_at.desc())
+        .first()
+    )
+    return insight
+
+
+def _period_label_for_anchor(
+    *,
+    insight_type: InsightType,
+    anchor: date,
+) -> str:
+    if insight_type == InsightType.daily:
+        return anchor.isoformat()
+    if insight_type == InsightType.weekly:
+        iso = anchor.isocalendar()
+        return f"{iso.year}-W{iso.week:02d}"
+    if insight_type == InsightType.monthly:
+        return f"{anchor:%Y-%m}"
+    return anchor.isoformat()
 
 
 def _save_insight(
@@ -557,6 +646,175 @@ def _log_llm_call(
         db.session.rollback()
 
 
+def _read_ai_insight_budget_limit(env_name: str) -> Decimal | None:
+    raw = os.getenv(env_name)
+    if raw is None or not raw.strip():
+        return None
+    try:
+        limit = Decimal(raw.strip())
+    except InvalidOperation:
+        log.warning("ai_advisory.cost_budget.invalid_env name=%s", env_name)
+        return None
+    if limit <= 0:
+        return None
+    return limit
+
+
+def _ai_insight_spend_usd(*, start_at: datetime, end_at: datetime) -> Decimal:
+    total = (
+        db.session.query(func.coalesce(func.sum(LLMAuditLog.estimated_cost_usd), 0))
+        .filter(LLMAuditLog.endpoint.in_(_AI_INSIGHT_COST_ENDPOINTS))
+        .filter(LLMAuditLog.created_at >= start_at)
+        .filter(LLMAuditLog.created_at < end_at)
+        .scalar()
+    )
+    return Decimal(str(total or "0"))
+
+
+def _budget_exceeded_message(
+    *,
+    scope_label: str,
+    limit_usd: Decimal,
+    spent_usd: Decimal,
+) -> str:
+    return (
+        f"Orçamento {scope_label} de AI Insights atingido "
+        f"(limite_usd={limit_usd}, gasto_usd={spent_usd})."
+    )
+
+
+def _raise_if_budget_exceeded(
+    *,
+    scope: str,
+    scope_label: str,
+    limit_usd: Decimal | None,
+    spent_usd: Decimal,
+) -> None:
+    if limit_usd is None or spent_usd < limit_usd:
+        return
+    message = _budget_exceeded_message(
+        scope_label=scope_label,
+        limit_usd=limit_usd,
+        spent_usd=spent_usd,
+    )
+    raise AIInsightCostBudgetExceededError(
+        message,
+        scope=scope,
+        limit_usd=limit_usd,
+        spent_usd=spent_usd,
+    )
+
+
+def _enforce_ai_insight_cost_budget(*, now: datetime | None = None) -> None:
+    """Block GPT generation when configured AI Insight cost budgets are spent."""
+    current = now or utc_now_naive()
+    day_start = datetime.combine(current.date(), time.min)
+    day_end = day_start + relativedelta(days=1)
+    month_start = datetime(current.year, current.month, 1)
+    month_end = month_start + relativedelta(months=1)
+
+    daily_limit = _read_ai_insight_budget_limit(_AI_INSIGHTS_DAILY_BUDGET_ENV)
+    if daily_limit is not None:
+        daily_spend = _ai_insight_spend_usd(start_at=day_start, end_at=day_end)
+        _raise_if_budget_exceeded(
+            scope="daily",
+            scope_label="diário",
+            limit_usd=daily_limit,
+            spent_usd=daily_spend,
+        )
+
+    monthly_limit = _read_ai_insight_budget_limit(_AI_INSIGHTS_MONTHLY_BUDGET_ENV)
+    if monthly_limit is not None:
+        monthly_spend = _ai_insight_spend_usd(start_at=month_start, end_at=month_end)
+        _raise_if_budget_exceeded(
+            scope="monthly",
+            scope_label="mensal",
+            limit_usd=monthly_limit,
+            spent_usd=monthly_spend,
+        )
+
+
+def _mark_preview_run_cached(
+    *,
+    preview_run: AIInsightRun,
+    cached: AIInsight,
+) -> None:
+    preview_run.status = AIInsightRunStatus.cached
+    preview_run.ai_insight_id = cached.id
+    preview_run.model = cached.model
+    preview_run.tokens_in = 0
+    preview_run.tokens_out = 0
+    preview_run.tokens_total = 0
+    preview_run.cost_usd = Decimal("0")
+    db.session.commit()
+
+
+def _mark_preview_run_blocked(
+    *,
+    preview_run: AIInsightRun,
+    reason: str,
+) -> None:
+    preview_run.status = AIInsightRunStatus.blocked
+    preview_run.rejection_reasons_json = [reason]
+    db.session.commit()
+
+
+def _cached_financial_insight_payload_for_snapshot(
+    *,
+    user_id: UUID,
+    insight_type: InsightType,
+    period_label: str,
+    snapshot_hash: str,
+    normalized_period_type: str,
+    context_version: str,
+    preview_run: AIInsightRun | None,
+) -> dict[str, Any] | None:
+    cached = _get_cached_insight_for_snapshot(
+        user_id=user_id,
+        insight_type=insight_type,
+        period_label=period_label,
+        snapshot_hash=snapshot_hash,
+    )
+    if cached is None:
+        return None
+
+    cached_payload = _cached_financial_insight_payload(
+        cached=cached,
+        user_id=user_id,
+        normalized_period_type=normalized_period_type,
+        context_version=context_version,
+    )
+    if cached_payload is None:
+        return None
+
+    if preview_run is not None:
+        _mark_preview_run_cached(preview_run=preview_run, cached=cached)
+    return cached_payload
+
+
+def _enforce_financial_insight_generation_budget(
+    *,
+    user_id: UUID,
+    normalized_period_type: str,
+    preview_run: AIInsightRun | None,
+) -> None:
+    try:
+        _enforce_ai_insight_cost_budget()
+    except AIInsightCostBudgetExceededError as exc:
+        if preview_run is not None:
+            _mark_preview_run_blocked(preview_run=preview_run, reason=str(exc))
+        log.warning(
+            "ai_advisory.financial_insights.cost_blocked "
+            "user=%s period_type=%s scope=%s spent_usd=%s limit_usd=%s",
+            user_id,
+            normalized_period_type,
+            exc.scope,
+            exc.spent_usd,
+            exc.limit_usd,
+        )
+        raise
+
+
 # ---------------------------------------------------------------------------
 # Service
 # ---------------------------------------------------------------------------
@@ -624,7 +882,6 @@ class AIAdvisoryService:
         anchor = anchor_date or date.today()
         consent_version = ensure_ai_consent_granted(self._user_id)
 
-        previous = _get_latest_insight(user_id=self._user_id)
         preview_run: AIInsightRun | None = None
         if preview_run_id is not None:
             (
@@ -642,7 +899,21 @@ class AIAdvisoryService:
                 preview_run_id=preview_run_id,
             )
             snapshot = prompt_snapshot
+            previous = _get_latest_insight_for_period_context(
+                user_id=self._user_id,
+                insight_type=insight_type,
+                period_label=period_label,
+            )
         else:
+            period_label_hint = _period_label_for_anchor(
+                insight_type=insight_type,
+                anchor=anchor,
+            )
+            previous = _get_latest_insight_for_period_context(
+                user_id=self._user_id,
+                insight_type=insight_type,
+                period_label=period_label_hint,
+            )
             snapshot = _build_period_snapshot(
                 insight_type=insight_type,
                 user_id=self._user_id,
@@ -656,26 +927,29 @@ class AIAdvisoryService:
             period_end = date.fromisoformat(str(period["end"]))
             context_version = str(snapshot["schema_version"])
 
-            cached = _get_cached_insight(
-                user_id=self._user_id,
-                insight_type=insight_type,
-                period_label=period_label,
-            )
-            if cached is not None:
-                cached_payload = _cached_financial_insight_payload(
-                    cached=cached,
-                    user_id=self._user_id,
-                    normalized_period_type=normalized_period_type,
-                    context_version=context_version,
-                )
-                if cached_payload is not None:
-                    return cached_payload
-
             prompt_snapshot = minimize_prompt_data(snapshot)
             # Apply 12 KiB cap before hashing/prompting so context_hash matches
             # whatever we actually send to the LLM.
             prompt_snapshot, truncation_info = truncate_snapshot(prompt_snapshot)
             context_hash = _financial_context_hash(prompt_snapshot)
+
+        cached_payload = _cached_financial_insight_payload_for_snapshot(
+            user_id=self._user_id,
+            insight_type=insight_type,
+            period_label=period_label,
+            snapshot_hash=context_hash,
+            normalized_period_type=normalized_period_type,
+            context_version=context_version,
+            preview_run=preview_run,
+        )
+        if cached_payload is not None:
+            return cached_payload
+
+        _enforce_financial_insight_generation_budget(
+            user_id=self._user_id,
+            normalized_period_type=normalized_period_type,
+            preview_run=preview_run,
+        )
 
         prompt = _build_financial_insight_prompt(
             prompt_snapshot,

--- a/app/services/ai_insight_audit.py
+++ b/app/services/ai_insight_audit.py
@@ -14,7 +14,8 @@ from app.models.user import User
 from app.services.ai_advisory_service import (
     _build_period_snapshot,
     _financial_context_hash,
-    _get_latest_insight,
+    _get_latest_insight_for_period_context,
+    _period_label_for_anchor,
 )
 from app.services.ai_insight_runs import create_ai_insight_run
 from app.services.ai_lgpd import minimize_prompt_data
@@ -304,7 +305,15 @@ def build_ai_insight_preview(
 
     insight_type = _normalize_insight_type(period_type)
     anchor = anchor_date or date.today()
-    previous = _get_latest_insight(user_id=user_id)
+    period_label_hint = _period_label_for_anchor(
+        insight_type=insight_type,
+        anchor=anchor,
+    )
+    previous = _get_latest_insight_for_period_context(
+        user_id=user_id,
+        insight_type=insight_type,
+        period_label=period_label_hint,
+    )
     raw_snapshot = _build_period_snapshot(
         insight_type=insight_type,
         user_id=user_id,

--- a/docs/wiki/AI-Insights-Rate-Limit.md
+++ b/docs/wiki/AI-Insights-Rate-Limit.md
@@ -26,6 +26,26 @@ The daily counter is not consumed by:
 This avoids penalizing users for infrastructure, provider, or configuration
 failures where Auraxis did not produce a new AI insight.
 
+## Cost Circuit Breaker
+
+Manual financial insight generation also checks the configured USD budget
+before calling the LLM provider:
+
+- `AI_INSIGHTS_DAILY_BUDGET_USD`
+- `AI_INSIGHTS_MONTHLY_BUDGET_USD`
+
+Empty, missing, zero, or negative values disable the corresponding budget.
+When a positive limit is configured, the source of truth is
+`LLMAuditLog.estimated_cost_usd` for `financial_insights_daily`,
+`financial_insights_weekly`, and `financial_insights_monthly`. If the current
+daily or monthly spend is already at or above the configured limit, generation
+is blocked before GPT is called and the API returns HTTP `429` with error code
+`AI_INSIGHT_BUDGET_EXCEEDED`.
+
+Cached insights are returned before the budget check because they do not
+generate new LLM cost. Admin preview and dossier export are also unaffected:
+they never call the LLM provider and do not consume budget.
+
 ## Response Headers
 
 Successful and failed pass-through responses include `X-AI-Calls-Remaining`

--- a/tests/test_ai_advisory_service.py
+++ b/tests/test_ai_advisory_service.py
@@ -411,6 +411,7 @@ class TestAIAdvisoryServiceFinancialInsights:
     def test_financial_insights_return_cached_period_without_provider_call(
         self,
         app,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         with app.app_context():
             from app.services.ai_advisory_service import AIAdvisoryService
@@ -426,6 +427,7 @@ class TestAIAdvisoryServiceFinancialInsights:
                 period_type="daily",
                 anchor_date=date(2026, 5, 17),
             )
+            monkeypatch.setenv("AI_INSIGHTS_DAILY_BUDGET_USD", "0.000001")
             second = service.generate_financial_insights(
                 period_type="daily",
                 anchor_date=date(2026, 5, 17),
@@ -435,6 +437,169 @@ class TestAIAdvisoryServiceFinancialInsights:
             assert second["cached"] is True
             assert second["summary"] == "Resumo cache."
             provider.generate_with_usage.assert_called_once()
+
+    def test_financial_insights_regenerate_when_snapshot_hash_changes(
+        self,
+        app,
+    ) -> None:
+        with app.app_context():
+            from app.services.ai_advisory_service import AIAdvisoryService
+
+            user_id = uuid.uuid4()
+            provider = MagicMock()
+            provider.generate_with_usage.side_effect = [
+                _financial_llm_response(summary="Resumo inicial."),
+                _financial_llm_response(summary="Resumo atualizado."),
+            ]
+            first_snapshot = {
+                "schema_version": "financial_insight_snapshot.v1",
+                "period_type": "daily",
+                "period": {
+                    "label": "2026-05-17",
+                    "start": "2026-05-17",
+                    "end": "2026-05-17",
+                },
+                "current_period": {
+                    "paid": {
+                        "income_total": "1000.00",
+                        "expense_total": "250.00",
+                        "balance": "750.00",
+                        "transaction_count": 2,
+                    },
+                    "commitments": {
+                        "pending_expense_total": "0.00",
+                        "overdue_expense_total": "0.00",
+                        "transaction_count": 0,
+                    },
+                    "cancelled_transaction_count": 0,
+                },
+                "comparisons": {},
+                "transactions": {"included_count": 2, "sample": []},
+                "data_quality": {
+                    "has_transactions": True,
+                    "missing_comparison_periods": [],
+                },
+            }
+            changed_snapshot = {
+                **first_snapshot,
+                "current_period": {
+                    **first_snapshot["current_period"],
+                    "paid": {
+                        **first_snapshot["current_period"]["paid"],
+                        "balance": "700.00",
+                    },
+                },
+            }
+
+            service = AIAdvisoryService(user_id=user_id, llm_provider=provider)
+            with patch(
+                "app.services.ai_advisory_service._build_period_snapshot",
+                side_effect=[first_snapshot, changed_snapshot],
+            ):
+                first = service.generate_financial_insights(
+                    period_type="daily",
+                    anchor_date=date(2026, 5, 17),
+                )
+                second = service.generate_financial_insights(
+                    period_type="daily",
+                    anchor_date=date(2026, 5, 17),
+                )
+
+            assert first["cached"] is False
+            assert second["cached"] is False
+            assert second["summary"] == "Resumo atualizado."
+            assert first["context_hash"] != second["context_hash"]
+            assert provider.generate_with_usage.call_count == 2
+
+    def test_financial_insights_daily_budget_blocks_before_provider_call(
+        self,
+        app,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        with app.app_context():
+            from app.extensions.database import db
+            from app.models.llm_audit_log import LLMAuditLog
+            from app.services.ai_advisory_service import (
+                AIAdvisoryService,
+                AIInsightCostBudgetExceededError,
+            )
+
+            user_id = uuid.uuid4()
+            db.session.add(
+                LLMAuditLog(
+                    user_id=user_id,
+                    endpoint="financial_insights_daily",
+                    model="gpt-4o-mini",
+                    prompt="redacted",
+                    response_text="redacted",
+                    prompt_tokens=10,
+                    completion_tokens=10,
+                    total_tokens=20,
+                    estimated_cost_usd=Decimal("0.01000000"),
+                    latency_ms=50,
+                )
+            )
+            db.session.commit()
+            monkeypatch.setenv("AI_INSIGHTS_DAILY_BUDGET_USD", "0.01")
+            monkeypatch.delenv("AI_INSIGHTS_MONTHLY_BUDGET_USD", raising=False)
+            provider = MagicMock()
+
+            service = AIAdvisoryService(user_id=user_id, llm_provider=provider)
+            with pytest.raises(
+                AIInsightCostBudgetExceededError,
+                match="Orçamento diário de AI Insights atingido",
+            ):
+                service.generate_financial_insights(
+                    period_type="daily",
+                    anchor_date=date(2026, 5, 17),
+                )
+
+            provider.generate_with_usage.assert_not_called()
+
+    def test_financial_insights_monthly_budget_blocks_before_provider_call(
+        self,
+        app,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        with app.app_context():
+            from app.extensions.database import db
+            from app.models.llm_audit_log import LLMAuditLog
+            from app.services.ai_advisory_service import (
+                AIAdvisoryService,
+                AIInsightCostBudgetExceededError,
+            )
+
+            user_id = uuid.uuid4()
+            db.session.add(
+                LLMAuditLog(
+                    user_id=user_id,
+                    endpoint="financial_insights_weekly",
+                    model="gpt-4o-mini",
+                    prompt="redacted",
+                    response_text="redacted",
+                    prompt_tokens=10,
+                    completion_tokens=10,
+                    total_tokens=20,
+                    estimated_cost_usd=Decimal("0.02000000"),
+                    latency_ms=50,
+                )
+            )
+            db.session.commit()
+            monkeypatch.delenv("AI_INSIGHTS_DAILY_BUDGET_USD", raising=False)
+            monkeypatch.setenv("AI_INSIGHTS_MONTHLY_BUDGET_USD", "0.02")
+            provider = MagicMock()
+
+            service = AIAdvisoryService(user_id=user_id, llm_provider=provider)
+            with pytest.raises(
+                AIInsightCostBudgetExceededError,
+                match="Orçamento mensal de AI Insights atingido",
+            ):
+                service.generate_financial_insights(
+                    period_type="daily",
+                    anchor_date=date(2026, 5, 17),
+                )
+
+            provider.generate_with_usage.assert_not_called()
 
     def test_financial_insights_reject_invalid_payload_without_saving(
         self,
@@ -897,6 +1062,34 @@ class TestAIInsightGenerateEndpoint:
             "anchor_date": date(2026, 5, 17),
             "preview_run_id": preview_run_id,
         }
+
+    def test_post_generation_budget_exceeded_returns_429(self, app, client) -> None:
+        token = _register_and_login(client, prefix="ai-generate-budget")
+        user_id = _get_current_user_id(app, token)
+        _grant_entitlement(app, user_id, "advanced_simulations")
+
+        from app.services.ai_advisory_service import AIInsightCostBudgetExceededError
+
+        error = AIInsightCostBudgetExceededError(
+            "Orçamento diário de AI Insights atingido.",
+            scope="daily",
+            limit_usd=Decimal("0.01"),
+            spent_usd=Decimal("0.01"),
+        )
+
+        with patch(
+            "app.services.ai_advisory_service.AIAdvisoryService.generate_financial_insights",
+            side_effect=error,
+        ):
+            resp = client.post(
+                "/ai/insights/generate",
+                json={"period_type": "daily", "anchor_date": "2026-05-17"},
+                headers=_auth(token),
+            )
+
+        assert resp.status_code == 429
+        body = resp.get_json()
+        assert body["error"] == "Orçamento diário de AI Insights atingido."
 
 
 class TestAIGoalProjectionEndpoint:

--- a/tests/test_ai_insight_audit_preview.py
+++ b/tests/test_ai_insight_audit_preview.py
@@ -161,8 +161,30 @@ class TestAIInsightAuditPreviewAdmin:
         self,
         admin_preview_app,
         admin_preview_client,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         user_id = _create_user_with_transactions(admin_preview_app)
+        monkeypatch.setenv("AI_INSIGHTS_DAILY_BUDGET_USD", "0.01")
+        monkeypatch.setenv("AI_INSIGHTS_MONTHLY_BUDGET_USD", "0.01")
+        with admin_preview_app.app_context():
+            from app.extensions.database import db
+            from app.models.llm_audit_log import LLMAuditLog
+
+            db.session.add(
+                LLMAuditLog(
+                    user_id=user_id,
+                    endpoint="financial_insights_daily",
+                    model="gpt-4o-mini",
+                    prompt="redacted",
+                    response_text="redacted",
+                    prompt_tokens=10,
+                    completion_tokens=10,
+                    total_tokens=20,
+                    estimated_cost_usd=Decimal("0.01000000"),
+                    latency_ms=50,
+                )
+            )
+            db.session.commit()
 
         with (
             patch(
@@ -205,5 +227,5 @@ class TestAIInsightAuditPreviewAdmin:
             assert run.status == AIInsightRunStatus.previewed
             assert run.snapshot_hash == payload["snapshot_hash"]
             assert run.tokens_total == 0
-            assert LLMAuditLog.query.filter_by(user_id=user_id).count() == 0
+            assert LLMAuditLog.query.filter_by(user_id=user_id).count() == 1
             assert AIInsight.query.filter_by(user_id=user_id).count() == 0


### PR DESCRIPTION
## Summary
- adds hash-aware financial insight caching so unchanged snapshots return cached output before any budget or LLM call
- adds daily/monthly USD circuit breakers for financial insight generation using LLMAuditLog as the spend source of truth
- keeps admin preview/dossier paths LLM-free and documents the new cost budget env vars

## Validation
- /Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-api/.venv/bin/python -m pytest tests/test_ai_advisory_service.py::TestAIAdvisoryServiceFinancialInsights tests/test_ai_advisory_service.py::TestAIInsightGenerateEndpoint tests/test_ai_insight_audit_preview.py::TestAIInsightAuditPreviewAdmin::test_preview_creates_run_without_llm_or_quota -q
- TZ=UTC PYTHON_BIN=/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-api/.venv/bin/python DATABASE_URL=sqlite:////tmp/auraxis-quality-1313.sqlite3 bash scripts/run_ci_quality_local.sh --local

Closes #1313