### PR TITLE
feat(auth): SEC-AUD-07 #623 canary metric for cookie-only header

### DIFF
--- a/app/controllers/auth/login_resource.py
+++ b/app/controllers/auth/login_resource.py
@@ -17,7 +17,10 @@ from app.docs.openapi_helpers import (
 )
 from app.extensions.database import db
 from app.extensions.integration_metrics import increment_metric
-from app.extensions.prometheus_metrics import record_auth_login
+from app.extensions.prometheus_metrics import (
+    record_auth_login,
+    record_auth_login_cookie_only_header,
+)
 from app.http.request_context import get_request_context
 from app.schemas.auth_schema import AuthSchema
 from app.services.captcha_service import get_captcha_service
@@ -279,8 +282,16 @@ class AuthResource(MethodResource):
                 "email_confirmed": identity.user.email_verified_at is not None,
             }
             record_auth_login(status="success")
+            cookie_only_header_value = request.headers.get(COOKIE_ONLY_HEADER)
+            # SEC-AUD-07 / #623 canary — track whether successful logins
+            # are arriving with the X-Refresh-Cookie-Only header so we can
+            # confirm 2 weeks of header_present="no" near zero before flipping
+            # AURAXIS_REFRESH_COOKIE_ONLY=True.
+            record_auth_login_cookie_only_header(
+                header_present=cookie_only_header_value is not None,
+            )
             omit_refresh_in_body = should_omit_refresh_token_in_body(
-                header_value=request.headers.get(COOKIE_ONLY_HEADER),
+                header_value=cookie_only_header_value,
             )
             legacy_payload: dict[str, Any] = {
                 "message": "Login successful",

--- a/app/extensions/prometheus_metrics.py
+++ b/app/extensions/prometheus_metrics.py
@@ -40,6 +40,7 @@ except ImportError:  # pragma: no cover
 _HTTP_REQUESTS_TOTAL: Any = None
 _HTTP_REQUEST_DURATION: Any = None
 _AUTH_LOGINS_TOTAL: Any = None
+_AUTH_LOGIN_COOKIE_ONLY_HEADER_TOTAL: Any = None
 _AUDIT_EVENTS_PURGED_TOTAL: Any = None
 _CACHE_HITS_TOTAL: Any = None
 _CACHE_MISSES_TOTAL: Any = None
@@ -85,6 +86,7 @@ def _ensure_metrics_initialized() -> None:
         _HTTP_REQUESTS_TOTAL, \
         _HTTP_REQUEST_DURATION, \
         _AUTH_LOGINS_TOTAL, \
+        _AUTH_LOGIN_COOKIE_ONLY_HEADER_TOTAL, \
         _AUDIT_EVENTS_PURGED_TOTAL, \
         _CACHE_HITS_TOTAL, \
         _CACHE_MISSES_TOTAL, \
@@ -113,6 +115,24 @@ def _ensure_metrics_initialized() -> None:
             "auraxis_auth_logins_total",
             "Total login attempts (status: success | failure | mfa_required)",
             ["status"],
+        )
+
+    # SEC-AUD-07 / #623 — canary metric for the cookie-only refresh flip.
+    # Labels:
+    #   header_present: "yes" | "no" — whether the client sent
+    #     X-Refresh-Cookie-Only on the login request.
+    # When the global flag AURAXIS_REFRESH_COOKIE_ONLY is flipped to True,
+    # responses stop carrying refresh_token in the body. Before flipping we
+    # need 2 weeks of header_present="no" near zero to confirm every
+    # production client has migrated.
+    if _AUTH_LOGIN_COOKIE_ONLY_HEADER_TOTAL is None:
+        _AUTH_LOGIN_COOKIE_ONLY_HEADER_TOTAL = Counter(
+            "auraxis_auth_login_cookie_only_header_total",
+            (
+                "Successful logins by presence of X-Refresh-Cookie-Only "
+                "header (canary for SEC-AUD-07)"
+            ),
+            ["header_present"],
         )
 
     if _AUDIT_EVENTS_PURGED_TOTAL is None:
@@ -205,6 +225,24 @@ def record_auth_login(*, status: str) -> None:
         _AUTH_LOGINS_TOTAL.labels(status=status).inc()
 
 
+def record_auth_login_cookie_only_header(*, header_present: bool) -> None:
+    """Canary for SEC-AUD-07 / #623.
+
+    Increment ``auraxis_auth_login_cookie_only_header_total`` to track
+    whether successful logins are arriving with the ``X-Refresh-Cookie-Only``
+    header set. Call this **only on successful logins** so the denominator
+    reflects real client traffic, not failed attempts.
+
+    When the rate of ``header_present="no"`` is effectively zero for 2
+    weeks in production, the global ``AURAXIS_REFRESH_COOKIE_ONLY`` flag
+    can be flipped safely.
+    """
+    _ensure_metrics_initialized()
+    if _AUTH_LOGIN_COOKIE_ONLY_HEADER_TOTAL is not None:
+        label = "yes" if header_present else "no"
+        _AUTH_LOGIN_COOKIE_ONLY_HEADER_TOTAL.labels(header_present=label).inc()
+
+
 def record_ai_insight_generated(
     *,
     period_type: str,
@@ -286,6 +324,7 @@ __all__ = [
     "record_ai_insight_generated",
     "record_audit_purge",
     "record_auth_login",
+    "record_auth_login_cookie_only_header",
     "record_cache_hit",
     "record_cache_invalidation",
     "record_cache_miss",

--- a/tests/test_api23_prometheus_metrics.py
+++ b/tests/test_api23_prometheus_metrics.py
@@ -18,6 +18,7 @@ import app.extensions.prometheus_metrics as prom_mod
 from app.extensions.prometheus_metrics import (
     generate_latest_metrics,
     record_auth_login,
+    record_auth_login_cookie_only_header,
     record_http_request,
 )
 
@@ -182,6 +183,45 @@ def test_record_auth_login_increments_failure_counter() -> None:
     after = auth_counter.labels(status="failure")._value.get()
 
     assert after == before + 1.0
+
+
+# ---------------------------------------------------------------------------
+# SEC-AUD-07 / #623 canary metric
+# ---------------------------------------------------------------------------
+
+
+def test_record_auth_login_cookie_only_header_yes_branch() -> None:
+    """header_present=True maps to the `yes` label."""
+    prom_mod._ensure_metrics_initialized()
+    counter = prom_mod._AUTH_LOGIN_COOKIE_ONLY_HEADER_TOTAL
+    assert counter is not None
+
+    before = counter.labels(header_present="yes")._value.get()
+    record_auth_login_cookie_only_header(header_present=True)
+    after = counter.labels(header_present="yes")._value.get()
+
+    assert after == before + 1.0
+
+
+def test_record_auth_login_cookie_only_header_no_branch() -> None:
+    """header_present=False maps to `no` (target for zero before flip)."""
+    prom_mod._ensure_metrics_initialized()
+    counter = prom_mod._AUTH_LOGIN_COOKIE_ONLY_HEADER_TOTAL
+    assert counter is not None
+
+    before = counter.labels(header_present="no")._value.get()
+    record_auth_login_cookie_only_header(header_present=False)
+    after = counter.labels(header_present="no")._value.get()
+
+    assert after == before + 1.0
+
+
+def test_cookie_only_header_metric_exposed_in_export() -> None:
+    """Counter name appears in /ops/metrics output once incremented."""
+    prom_mod._ensure_metrics_initialized()
+    record_auth_login_cookie_only_header(header_present=True)
+    body, _ = generate_latest_metrics()
+    assert b"auraxis_auth_login_cookie_only_header_total" in body
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adiciona métrica Prometheus `auraxis_auth_login_cookie_only_header_total` para medir, em prod, quantos logins bem-sucedidos chegam **sem** o header `X-Refresh-Cookie-Only`. Esse é o canary que precisa ficar zero por **2 semanas** antes do flip de `AURAXIS_REFRESH_COOKIE_ONLY=true` (que remove `refresh_token` do body do response permanentemente).

Fecha o primeiro item de [italofelipe/auraxis-platform#623](https://github.com/italofelipe/auraxis-platform/issues/623): "Instrumentar métrica `auth.login.cookie_only_header_missing` por 2 semanas." A clock dos 2 semanas começa quando este PR mergear + deployar em prod.

## Mudanças

### `app/extensions/prometheus_metrics.py`

- Novo singleton `_AUTH_LOGIN_COOKIE_ONLY_HEADER_TOTAL` declarado no bloco de globals + adicionado ao `global` statement de `_ensure_metrics_initialized()`.
- Novo Counter `auraxis_auth_login_cookie_only_header_total` com label `header_present: yes|no`.
- Nova função `record_auth_login_cookie_only_header(*, header_present)` exportada no `__all__`. Docstring explica o ciclo de 2 semanas e sinaliza para chamar SÓ em logins bem-sucedidos (denominador representa tráfego real).

### `app/controllers/auth/login_resource.py`

- Importa a nova função.
- Após `record_auth_login(status="success")`, chama `record_auth_login_cookie_only_header(header_present=...)` baseado em `request.headers.get(COOKIE_ONLY_HEADER)`.

### Tests

3 testes novos em `tests/test_api23_prometheus_metrics.py`:

- `test_record_auth_login_cookie_only_header_yes_branch` — header_present=True → label "yes"
- `test_record_auth_login_cookie_only_header_no_branch` — header_present=False → label "no" (target = zero)
- `test_cookie_only_header_metric_exposed_in_export` — counter aparece no /ops/metrics

17/17 prometheus + 22/22 cookie_only policy tests passando.

## Como ler a métrica no Prometheus

\`\`\`promql
# Logins sem header (denominador para flip decision)
auraxis_auth_login_cookie_only_header_total{header_present="no"}

# Razão de logins sem header
sum(rate(auraxis_auth_login_cookie_only_header_total{header_present="no"}[5m]))
/
sum(rate(auraxis_auth_login_cookie_only_header_total[5m]))
\`\`\`

Aceito flipar `AURAXIS_REFRESH_COOKIE_ONLY=true` quando a primeira query retornar 0 (ou < 1/dia ruído) por 2 semanas consecutivas.

## Out of scope

- O flip propriamente dito (depois das 2 semanas)
- Atualização do schema OpenAPI removendo `refresh_token` do body (depende do flip)

## Refs

Refs italofelipe/auraxis-platform#623