### PR TITLE
[API] Email verification — 14d grace period + soft-block decorator (foundation)

### DIFF
--- a/app/application/services/authenticated_user_context_service.py
+++ b/app/application/services/authenticated_user_context_service.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, datetime
 from typing import SupportsFloat, cast
 from uuid import UUID
 
@@ -33,6 +33,11 @@ class AuthenticatedUserProfile:
     taxonomy_version: str | None
     entitlements_version: int
     avatar_url: str | None
+    # Email verification status (14d grace period soft-block)
+    email_verified: bool = False
+    email_verification_deadline_at: str | None = None
+    email_verification_required_now: bool = False
+    days_until_email_required: int | None = None
 
 
 @dataclass(frozen=True)
@@ -66,6 +71,10 @@ def _to_float_or_none(value: SupportsFloat | None) -> float | None:
 
 
 def _isoformat_or_none(value: date | None) -> str | None:
+    return value.isoformat() if value is not None else None
+
+
+def _datetime_isoformat_or_none(value: datetime | None) -> str | None:
     return value.isoformat() if value is not None else None
 
 
@@ -115,6 +124,12 @@ class AuthenticatedUserContextService:
             taxonomy_version=user.taxonomy_version,
             entitlements_version=int(user.entitlements_version or 0),
             avatar_url=user.avatar_url,
+            email_verified=bool(user.email_verified),
+            email_verification_deadline_at=_datetime_isoformat_or_none(
+                user.email_verification_deadline_at
+            ),
+            email_verification_required_now=bool(user.email_verification_required_now),
+            days_until_email_required=user.days_until_email_required,
         )
 
     def build_wallet_entries(

--- a/app/controllers/transaction/create_resource.py
+++ b/app/controllers/transaction/create_resource.py
@@ -10,6 +10,7 @@ from app.application.services.transaction_application_service import (
     TransactionApplicationError,
 )
 from app.auth import current_user_id
+from app.decorators import require_email_verified
 from app.schemas.transaction_schema import TransactionSchema
 from app.utils.typed_decorators import typed_doc as doc
 from app.utils.typed_decorators import typed_jwt_required as jwt_required
@@ -49,6 +50,7 @@ class TransactionCreateMixin:
 
     @doc(**TRANSACTION_CREATE_DOC)
     @jwt_required()
+    @require_email_verified
     @use_kwargs(TransactionSchema, location="json")
     def post(self, **kwargs: Any) -> Response:
         token_error = _guard_revoked_token()

--- a/app/controllers/transaction/detail_resources.py
+++ b/app/controllers/transaction/detail_resources.py
@@ -6,6 +6,7 @@ from flask import Response
 from flask_apispec.views import MethodResource
 
 from app.auth import current_user_id
+from app.decorators import require_email_verified
 from app.extensions.database import db
 from app.models.transaction import Transaction
 from app.utils.typed_decorators import typed_doc as doc
@@ -73,6 +74,7 @@ class TransactionDetailResource(MethodResource):
 class TransactionForceDeleteResource(MethodResource):
     @doc(**TRANSACTION_FORCE_DELETE_DOC)
     @jwt_required()
+    @require_email_verified
     def delete(self, transaction_id: UUID) -> Response:
         token_error = _guard_revoked_token()
         if token_error is not None:
@@ -113,6 +115,7 @@ class TransactionForceDeleteResource(MethodResource):
 class TransactionRestoreResource(MethodResource):
     @doc(**TRANSACTION_RESTORE_DOC)
     @jwt_required()
+    @require_email_verified
     def patch(self, transaction_id: UUID) -> Response:
         token_error = _guard_revoked_token()
         if token_error is not None:

--- a/app/decorators/__init__.py
+++ b/app/decorators/__init__.py
@@ -1,0 +1,5 @@
+"""Decorators for endpoint-level enforcement."""
+
+from app.decorators.require_email_verified import require_email_verified
+
+__all__ = ["require_email_verified"]

--- a/app/decorators/require_email_verified.py
+++ b/app/decorators/require_email_verified.py
@@ -1,0 +1,74 @@
+"""Decorator that soft-blocks endpoints when the user has not confirmed their email
+within the grace period.
+
+Behavior:
+- If `EMAIL_VERIFICATION_ENFORCE=false` (config flag), the decorator is a no-op.
+- If the user has confirmed (User.email_verified_at is not None), proceeds.
+- If the user is within the grace period (created_at + grace_days), proceeds.
+- If the grace period has expired, returns HTTP 403 with code
+  `EMAIL_VERIFICATION_REQUIRED` and metadata for the frontend to open the
+  resend modal.
+
+Reads continue working — apply this decorator only on mutation endpoints
+(POST/PUT/PATCH/DELETE) so users can still see their data.
+
+References:
+- app/models/user.py — User.email_verification_required_now hybrid property
+- config/__init__.py — EMAIL_VERIFICATION_GRACE_PERIOD_DAYS, EMAIL_VERIFICATION_ENFORCE
+- .context/adr/email_verification_grace_period.md (TODO) — design rationale
+"""
+
+from collections.abc import Callable
+from functools import wraps
+from typing import Any
+
+from flask import current_app, jsonify
+
+from app.auth.identity import (
+    AuthContextError,
+    RevokedTokenError,
+    get_active_user,
+)
+
+
+def require_email_verified(view_func: Callable[..., Any]) -> Callable[..., Any]:
+    """Block endpoint with 403 when user is past grace period without email confirm."""
+
+    @wraps(view_func)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        if not current_app.config.get("EMAIL_VERIFICATION_ENFORCE", True):
+            return view_func(*args, **kwargs)
+
+        try:
+            resolved = get_active_user(optional=True)
+        except (AuthContextError, RevokedTokenError):
+            # auth_guard handles unauthenticated requests upstream; if we got here
+            # without a valid context, let the underlying handler decide.
+            return view_func(*args, **kwargs)
+
+        if resolved is None:
+            return view_func(*args, **kwargs)
+
+        _, user = resolved
+        if not user.email_verification_required_now:
+            return view_func(*args, **kwargs)
+
+        deadline = user.email_verification_deadline_at
+        payload = {
+            "error": "EMAIL_VERIFICATION_REQUIRED",
+            "message": (
+                "Confirme seu email para continuar usando o Auraxis. "
+                "Sua conta passou de 14 dias sem confirmação e entrou em modo "
+                "somente-leitura. Solicite um novo link de confirmação."
+            ),
+            "deadline_passed_at": deadline.isoformat()
+            if deadline is not None
+            else None,
+            "resend_endpoint": "/auth/email/resend",
+        }
+        return jsonify(payload), 403
+
+    return wrapper
+
+
+__all__ = ["require_email_verified"]

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,7 +1,9 @@
 # mypy: disable-error-code="name-defined,no-redef"
 
 import uuid
+from datetime import UTC, datetime, timedelta
 
+from flask import current_app
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.ext.hybrid import hybrid_property
 
@@ -88,3 +90,53 @@ class User(db.Model):
     @monthly_income.setter
     def monthly_income(self, value):
         self.monthly_income_net = value
+
+    @hybrid_property
+    def email_verified(self) -> bool:
+        """True se o email do usuário foi confirmado."""
+        return self.email_verified_at is not None
+
+    @hybrid_property
+    def email_verification_deadline_at(self) -> datetime | None:
+        """Timestamp limite para confirmar email; None se já verificado.
+
+        Após esse prazo, o usuário entra em modo soft-block (mutations bloqueadas
+        retornam 403 EMAIL_VERIFICATION_REQUIRED). Reads continuam liberados.
+        """
+        if self.email_verified_at is not None:
+            return None
+        if self.created_at is None:
+            return None
+        grace_days = int(
+            current_app.config.get("EMAIL_VERIFICATION_GRACE_PERIOD_DAYS", 14)
+        )
+        deadline: datetime = self.created_at + timedelta(days=grace_days)
+        return deadline
+
+    @hybrid_property
+    def email_verification_required_now(self) -> bool:
+        """True se o grace period expirou e o email ainda não foi confirmado.
+
+        Usado pelo decorator @require_email_verified para retornar 403 em
+        endpoints de mutation.
+        """
+        if self.email_verified_at is not None:
+            return False
+        deadline = self.email_verification_deadline_at
+        if deadline is None:
+            return False
+        return datetime.now(UTC).replace(tzinfo=None) > deadline
+
+    @hybrid_property
+    def days_until_email_required(self) -> int | None:
+        """Dias restantes até o grace period expirar; None se já verificado.
+
+        Pode ser <= 0 (já expirou — frontend usa para mostrar gate, não countdown).
+        """
+        if self.email_verified_at is not None:
+            return None
+        deadline = self.email_verification_deadline_at
+        if deadline is None:
+            return None
+        remaining = deadline - datetime.now(UTC).replace(tzinfo=None)
+        return remaining.days

--- a/app/services/authenticated_user_payloads.py
+++ b/app/services/authenticated_user_payloads.py
@@ -72,12 +72,20 @@ class AuthenticatedUserProductContextPayload(TypedDict):
     entitlements_version: int
 
 
+class AuthenticatedUserEmailVerificationPayload(TypedDict):
+    verified: bool
+    deadline_at: str | None
+    required_now: bool
+    days_remaining: int | None
+
+
 class AuthenticatedUserCanonicalPayload(TypedDict):
     identity: AuthenticatedUserIdentityPayload
     profile: AuthenticatedUserProfileDetailsPayload
     financial_profile: AuthenticatedUserFinancialProfilePayload
     investor_profile: AuthenticatedUserInvestorProfilePayload
     product_context: AuthenticatedUserProductContextPayload
+    email_verification: AuthenticatedUserEmailVerificationPayload
 
 
 class AuthenticatedUserTransactionsPreviewPayload(TypedDict):
@@ -153,6 +161,12 @@ def to_authenticated_user_canonical_payload(
         },
         "product_context": {
             "entitlements_version": profile.entitlements_version,
+        },
+        "email_verification": {
+            "verified": profile.email_verified,
+            "deadline_at": profile.email_verification_deadline_at,
+            "required_now": profile.email_verification_required_now,
+            "days_remaining": profile.days_until_email_required,
         },
     }
 

--- a/app/services/authenticated_user_payloads.py
+++ b/app/services/authenticated_user_payloads.py
@@ -126,6 +126,12 @@ class WalletEntryPayload(TypedDict):
 def to_user_profile_payload(profile: AuthenticatedUserProfile) -> UserProfilePayload:
     payload = asdict(profile)
     payload.pop("entitlements_version", None)
+    # GraphQL UserType doesn't yet expose email_verification fields; surface them
+    # only via the REST canonical payload until the GraphQL parity PR lands.
+    payload.pop("email_verified", None)
+    payload.pop("email_verification_deadline_at", None)
+    payload.pop("email_verification_required_now", None)
+    payload.pop("days_until_email_required", None)
     return cast(UserProfilePayload, payload)
 
 

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -106,6 +106,15 @@ class Config:
         "AURAXIS_PREMIUM_OVERRIDE_USER_IDS", ""
     )
 
+    # Email verification grace period — after N days without confirmation,
+    # mutations are soft-blocked (reads continue). See:
+    # - app/models/user.py — User.email_verification_required_now
+    # - app/decorators/require_email_verified.py — endpoint decorator
+    EMAIL_VERIFICATION_GRACE_PERIOD_DAYS = int(
+        os.getenv("EMAIL_VERIFICATION_GRACE_PERIOD_DAYS", "14")
+    )
+    EMAIL_VERIFICATION_ENFORCE = _read_bool_env("EMAIL_VERIFICATION_ENFORCE", True)
+
     DEBUG = _read_bool_env("FLASK_DEBUG", False)
 
     # Database config

--- a/tests/test_email_verification_grace_period.py
+++ b/tests/test_email_verification_grace_period.py
@@ -1,0 +1,232 @@
+"""Tests for the 14-day email verification grace period + soft-block decorator.
+
+Coverage:
+- User.email_verified hybrid property (verified vs unverified)
+- User.email_verification_deadline_at (computed from created_at + grace_days)
+- User.email_verification_required_now (False within grace, True after)
+- User.days_until_email_required (countdown)
+- @require_email_verified decorator behavior:
+  - allows verified users
+  - allows users within grace period
+  - blocks users past grace period (403 EMAIL_VERIFICATION_REQUIRED)
+  - no-op when EMAIL_VERIFICATION_ENFORCE=false
+- /user/me exposes email_verification block in canonical payload
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+from app.extensions.database import db
+from app.models.user import User
+
+# ---------------------------------------------------------------------------
+# Hybrid property tests
+# ---------------------------------------------------------------------------
+
+
+def _make_user(
+    *,
+    app,
+    created_at: datetime | None = None,
+    email_verified_at: datetime | None = None,
+) -> User:
+    """Persist a User with controlled timestamps for grace-period testing."""
+    suffix = uuid.uuid4().hex[:8]
+    with app.app_context():
+        user = User(
+            name=f"Test {suffix}",
+            email=f"grace-{suffix}@test.com",
+            password="hashed-not-real",
+            created_at=created_at or datetime.now(UTC).replace(tzinfo=None),
+            email_verified_at=email_verified_at,
+        )
+        db.session.add(user)
+        db.session.commit()
+        db.session.refresh(user)
+        return user
+
+
+def test_email_verified_true_when_email_verified_at_is_set(app):
+    user = _make_user(app=app, email_verified_at=datetime.now(UTC).replace(tzinfo=None))
+    with app.app_context():
+        assert user.email_verified is True
+        assert user.email_verification_required_now is False
+        assert user.email_verification_deadline_at is None
+        assert user.days_until_email_required is None
+
+
+def test_email_verified_false_when_unconfirmed(app):
+    user = _make_user(app=app)
+    with app.app_context():
+        assert user.email_verified is False
+
+
+def test_deadline_within_grace_period_does_not_require_verification(app):
+    # Created 1 hour ago — well within 14-day grace period
+    recent = datetime.now(UTC).replace(tzinfo=None) - timedelta(hours=1)
+    user = _make_user(app=app, created_at=recent)
+    with app.app_context():
+        assert user.email_verification_required_now is False
+        assert user.email_verification_deadline_at is not None
+        # Deadline should be ~14 days from created_at
+        days_remaining = (
+            user.email_verification_deadline_at - datetime.now(UTC).replace(tzinfo=None)
+        ).days
+        assert days_remaining >= 13
+
+
+def test_deadline_past_grace_period_requires_verification(app):
+    # Created 15 days ago — past 14-day grace
+    old = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=15)
+    user = _make_user(app=app, created_at=old)
+    with app.app_context():
+        assert user.email_verification_required_now is True
+        assert user.days_until_email_required is not None
+        assert user.days_until_email_required < 0
+
+
+def test_days_until_email_required_counts_down(app):
+    # Created 10 days ago — should have ~4 days remaining
+    created = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=10)
+    user = _make_user(app=app, created_at=created)
+    with app.app_context():
+        days = user.days_until_email_required
+        assert days is not None
+        assert 3 <= days <= 4
+
+
+# ---------------------------------------------------------------------------
+# Decorator integration tests (via existing endpoint)
+# ---------------------------------------------------------------------------
+
+
+def _register_and_login(client) -> tuple[str, str, str]:
+    """Register a fresh user, return (email, jwt_token, user_id)."""
+    suffix = uuid.uuid4().hex[:8]
+    email = f"gate-{suffix}@test.com"
+    password = "StrongPass@123"
+    reg_resp = client.post(
+        "/auth/register",
+        json={"name": f"Gate User {suffix}", "email": email, "password": password},
+    )
+    assert reg_resp.status_code == 201, f"Register failed: {reg_resp.get_json()}"
+    user_id = reg_resp.get_json().get("data", {}).get("user", {}).get(
+        "id"
+    ) or reg_resp.get_json().get("user_id")
+    resp = client.post("/auth/login", json={"email": email, "password": password})
+    assert resp.status_code == 200
+    body = resp.get_json()
+    token = body.get("token") or body.get("data", {}).get("token")
+    return email, token, user_id
+
+
+def _force_user_created_at(app, email: str, *, days_ago: int) -> None:
+    """Force user.created_at to N days in the past for grace-period testing."""
+    with app.app_context():
+        user = User.query.filter_by(email=email).first()
+        assert user is not None
+        user.created_at = datetime.now(UTC).replace(tzinfo=None) - timedelta(
+            days=days_ago
+        )
+        db.session.commit()
+
+
+def test_create_transaction_blocked_for_unverified_user_past_grace(app, client):
+    email, token, _ = _register_and_login(client)
+    _force_user_created_at(app, email, days_ago=15)
+
+    resp = client.post(
+        "/transactions",
+        json={
+            "name": "Test",
+            "amount": 100.0,
+            "type": "expense",
+            "category": "outros",
+            "due_date": "2026-12-31",
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 403
+    body = resp.get_json()
+    assert body.get("error") == "EMAIL_VERIFICATION_REQUIRED"
+    assert body.get("resend_endpoint") == "/auth/email/resend"
+
+
+def test_create_transaction_allowed_within_grace_period(app, client):
+    email, token, _ = _register_and_login(client)
+    # Default created_at is now() — well within grace
+    resp = client.post(
+        "/transactions",
+        json={
+            "name": "Allowed",
+            "amount": 50.0,
+            "type": "expense",
+            "category": "outros",
+            "due_date": "2026-12-31",
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    # Should NOT be 403 (may be 201 or other status depending on validation)
+    assert resp.status_code != 403
+
+
+def test_decorator_is_noop_when_enforce_disabled(app, client, monkeypatch):
+    monkeypatch.setattr(
+        app.config,
+        "get",
+        lambda key, default=None: (
+            False
+            if key == "EMAIL_VERIFICATION_ENFORCE"
+            else app.config[key]
+            if key in app.config
+            else default
+        ),
+    )
+    email, token, _ = _register_and_login(client)
+    _force_user_created_at(app, email, days_ago=20)
+
+    resp = client.post(
+        "/transactions",
+        json={
+            "name": "Test",
+            "amount": 100.0,
+            "type": "expense",
+            "category": "outros",
+            "due_date": "2026-12-31",
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    # When ENFORCE=false, should not block on email verification
+    assert (
+        resp.status_code != 403
+        or resp.get_json().get("error") != "EMAIL_VERIFICATION_REQUIRED"
+    )
+
+
+# ---------------------------------------------------------------------------
+# /user/me exposure
+# ---------------------------------------------------------------------------
+
+
+def test_user_me_exposes_email_verification_block(app, client):
+    email, token, _ = _register_and_login(client)
+    resp = client.get(
+        "/user/me",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "X-API-Contract": "v3",
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    user_payload = body.get("data", {}).get("user", {})
+    email_block = user_payload.get("email_verification")
+    assert email_block is not None
+    assert "verified" in email_block
+    assert "deadline_at" in email_block
+    assert "required_now" in email_block
+    assert "days_remaining" in email_block
+    assert email_block["verified"] is False  # Fresh user, not yet confirmed
+    assert email_block["required_now"] is False  # Within grace period

--- a/tests/test_user_bootstrap_contract.py
+++ b/tests/test_user_bootstrap_contract.py
@@ -100,6 +100,7 @@ def test_user_bootstrap_v2_contract_returns_aggregated_payload(client, app) -> N
         "financial_profile",
         "investor_profile",
         "product_context",
+        "email_verification",
     }
     assert body["data"]["transactions_preview"]["limit"] == 2
     assert body["data"]["transactions_preview"]["returned_items"] == 2

--- a/tests/test_user_contract.py
+++ b/tests/test_user_contract.py
@@ -75,6 +75,14 @@ CANONICAL_USER_KEYS = {
     "financial_profile",
     "investor_profile",
     "product_context",
+    "email_verification",
+}
+
+EMAIL_VERIFICATION_FIELDS = {
+    "verified",
+    "deadline_at",
+    "required_now",
+    "days_remaining",
 }
 
 IDENTITY_FIELDS = {"id", "name", "email"}
@@ -345,6 +353,10 @@ def test_user_me_v3_contract_returns_canonical_context_only(client) -> None:
         set(body["data"]["user"]["investor_profile"].keys()) == INVESTOR_PROFILE_FIELDS
     )
     assert set(body["data"]["user"]["product_context"].keys()) == PRODUCT_CONTEXT_FIELDS
+    assert (
+        set(body["data"]["user"]["email_verification"].keys())
+        == EMAIL_VERIFICATION_FIELDS
+    )
     assert "monthly_income" not in body["data"]["user"]["financial_profile"]
     assert "transactions" not in body["data"]["user"]
     assert "wallet" not in body["data"]["user"]


### PR DESCRIPTION
## Summary

Foundation do gate de confirmação de email após 14 dias.

- **Soft-block**: mutations retornam `403 EMAIL_VERIFICATION_REQUIRED` quando grace expirou
- **Reads continuam liberados** — preserva UX para usuários que esquecem do email
- **Flag `EMAIL_VERIFICATION_ENFORCE`** permite desligar em staging/testes sem mudar código
- **Sem migration** — `User.email_verified_at` (já existente) + hybrid properties computed

Closes #1325

## Changes

### Modelo
- `User.email_verified` — hybrid_property derivada de `email_verified_at IS NOT NULL`
- `User.email_verification_deadline_at` — `created_at + grace_days`; `None` se já verificado
- `User.email_verification_required_now` — `True` quando grace expirou sem confirmação
- `User.days_until_email_required` — countdown em dias (pode ser negativo)

### Config
- `EMAIL_VERIFICATION_GRACE_PERIOD_DAYS` (default `14`)
- `EMAIL_VERIFICATION_ENFORCE` (default `true`)

### Decorator (`app/decorators/require_email_verified.py` — novo)
- Wrap em endpoints de mutation
- Lê `User` via `get_active_user()` do `app/auth/identity`
- Retorna 403 com payload `{error, message, deadline_passed_at, resend_endpoint}`
- Aplicado em:
  - `transaction/create_resource.py` → `POST /transactions`
  - `transaction/detail_resources.py` → `DELETE /transactions/<id>/force`, `PATCH /transactions/<id>/restore`

### `/user/me` canonical payload (v3)
- Novo bloco `email_verification` com `{verified, deadline_at, required_now, days_remaining}`

### Tests
- `tests/test_email_verification_grace_period.py`:
  - 5 testes de hybrid properties (verified, unverified, dentro/fora do grace, countdown)
  - 3 testes de decorator via `/transactions POST` (bloqueio após 14d, allow dentro do grace, no-op quando enforce=false)
  - 1 teste de exposição em `/user/me`

## Out of scope deste PR (próximas levas)

- Apply decorator em `goal/`, `wallet/`, `budget/`, `simulation/`, `credit_card/` controllers
- GraphQL parity (query `me` com novos campos + mutations bloqueadas via resolver helper)
- Job cron de lembretes D-7/D-1 (workflow GHA + templates)
- Frontend web (PR separado em `auraxis-web` consumindo este contract)
- Frontend mobile (após TestFlight pipeline)

## Test plan

- [x] Pre-commit hooks verdes (ruff, mypy, bandit, controller contract, alembic, sonar)
- [x] Pre-push hooks verdes (pip-audit, security-evidence)
- [ ] CI verde (aguardar pipeline)
- [ ] Smoke E2E manual após merge: registrar conta → forçar `created_at` -15d via DB → tentar criar transação → ver 403 → confirmar email → retry → 200

## Decisão de gate

**Soft-block** justifica-se por:
1. Fintech retém dados — usuário pode ver mas não criar/editar
2. Filtra base sem trauma ("perdi minha conta")
3. Decorator granular permite escolher endpoint por endpoint, sem efeito-borboleta