### PR TITLE
[API] Expand @require_email_verified to remaining mutation endpoints

### DIFF
--- a/app/controllers/budget/resources.py
+++ b/app/controllers/budget/resources.py
@@ -7,6 +7,7 @@ from flask import request
 from flask_apispec.views import MethodResource
 
 from app.auth import current_user_id
+from app.decorators import require_email_verified
 from app.services.budget_service import BudgetService, BudgetServiceError
 from app.utils.typed_decorators import typed_doc as doc
 from app.utils.typed_decorators import typed_jwt_required as jwt_required
@@ -53,6 +54,7 @@ class BudgetCollectionResource(MethodResource):
         },
     )
     @jwt_required()
+    @require_email_verified
     def post(self) -> Any:
         service = _get_service()
         payload = request.get_json() or {}
@@ -139,6 +141,7 @@ class BudgetResource(MethodResource):
         },
     )
     @jwt_required()
+    @require_email_verified
     def patch(self, budget_id: UUID) -> Any:
         service = _get_service()
         payload = request.get_json() or {}
@@ -171,6 +174,7 @@ class BudgetResource(MethodResource):
         },
     )
     @jwt_required()
+    @require_email_verified
     def delete(self, budget_id: UUID) -> Any:
         service = _get_service()
         try:

--- a/app/controllers/credit_card/resources.py
+++ b/app/controllers/credit_card/resources.py
@@ -11,6 +11,7 @@ from flask import request
 
 from app.auth import current_user_id
 from app.controllers.response_contract import compat_error_tuple, compat_success_tuple
+from app.decorators import require_email_verified
 from app.extensions.database import db
 from app.models.credit_card import CreditCard
 from app.utils.typed_decorators import typed_jwt_required as jwt_required
@@ -188,6 +189,7 @@ def _validate_card_payload(
 
 @credit_card_bp.route("", methods=["POST"])
 @jwt_required()
+@require_email_verified
 def create_credit_card() -> tuple[dict[str, Any], int]:
     """Create a new credit card for the authenticated user."""
     user_id = current_user_id()
@@ -308,6 +310,7 @@ def _apply_card_updates(card: CreditCard, payload: dict[str, Any]) -> None:
 
 @credit_card_bp.route("/<uuid:credit_card_id>", methods=["PUT"])
 @jwt_required()
+@require_email_verified
 def update_credit_card(credit_card_id: UUID) -> tuple[dict[str, Any], int]:
     """Update an existing credit card belonging to the authenticated user."""
     user_id = current_user_id()
@@ -359,6 +362,7 @@ def update_credit_card(credit_card_id: UUID) -> tuple[dict[str, Any], int]:
 
 @credit_card_bp.route("/<uuid:credit_card_id>", methods=["DELETE"])
 @jwt_required()
+@require_email_verified
 def delete_credit_card(credit_card_id: UUID) -> tuple[dict[str, Any], int]:
     """Delete a credit card belonging to the authenticated user."""
     user_id = current_user_id()

--- a/app/controllers/goal/resources.py
+++ b/app/controllers/goal/resources.py
@@ -10,6 +10,7 @@ from marshmallow import fields
 from app.application.services.goal_application_service import GoalApplicationError
 from app.auth import current_user_id
 from app.controllers.response_contract import compat_success_response_deprecated
+from app.decorators import require_email_verified
 from app.docs.openapi_helpers import deprecated_headers_doc
 from app.utils.typed_decorators import typed_doc as doc
 from app.utils.typed_decorators import typed_jwt_required as jwt_required
@@ -68,6 +69,7 @@ class GoalCollectionResource(MethodResource):
         },
     )
     @jwt_required()
+    @require_email_verified
     def post(self) -> Any:
         user_id = current_user_id()
         payload = request.get_json() or {}
@@ -203,6 +205,7 @@ class GoalResource(MethodResource):
         },
     )
     @jwt_required()
+    @require_email_verified
     def put(self, goal_id: UUID) -> Any:
         payload = request.get_json() or {}
         try:
@@ -226,6 +229,7 @@ class GoalResource(MethodResource):
         },
     )
     @jwt_required()
+    @require_email_verified
     def patch(self, goal_id: UUID) -> Any:
         payload = request.get_json() or {}
         try:
@@ -248,6 +252,7 @@ class GoalResource(MethodResource):
         },
     )
     @jwt_required()
+    @require_email_verified
     def delete(self, goal_id: UUID) -> Any:
         user_id = current_user_id()
         dependencies = get_goal_dependencies()

--- a/app/controllers/simulation/installment_vs_cash_resources.py
+++ b/app/controllers/simulation/installment_vs_cash_resources.py
@@ -11,6 +11,7 @@ from app.application.services.installment_vs_cash_application_service import (
 )
 from app.auth import current_user_id
 from app.controllers.response_contract import compat_success_response_deprecated
+from app.decorators import require_email_verified
 from app.docs.openapi_helpers import deprecated_headers_doc
 from app.schemas.installment_vs_cash_schema import (
     InstallmentVsCashCalculationSchema,
@@ -120,6 +121,7 @@ class InstallmentVsCashCanonicalResource(MethodResource):
         },
     )
     @jwt_required()
+    @require_email_verified
     @use_kwargs(InstallmentVsCashSaveSchema, location="json")
     def post(self, **kwargs: object) -> ResponseReturnValue:
         try:
@@ -151,6 +153,7 @@ class InstallmentVsCashSaveResource(MethodResource):
         },
     )
     @jwt_required()
+    @require_email_verified
     @use_kwargs(InstallmentVsCashSaveSchema, location="json")
     def post(self, **kwargs: object) -> Response:
         try:
@@ -175,6 +178,7 @@ class SimulationGoalBridgeResource(MethodResource):
         },
     )
     @jwt_required()
+    @require_email_verified
     @require_entitlement("advanced_simulations")
     @use_kwargs(InstallmentVsCashGoalBridgeSchema, location="json")
     def post(self, simulation_id: UUID, **kwargs: object) -> ResponseReturnValue:
@@ -213,6 +217,7 @@ class SimulationPlannedExpenseBridgeResource(MethodResource):
         },
     )
     @jwt_required()
+    @require_email_verified
     @require_entitlement("advanced_simulations")
     @use_kwargs(InstallmentVsCashPlannedExpenseBridgeSchema, location="json")
     def post(self, simulation_id: UUID, **kwargs: object) -> ResponseReturnValue:

--- a/app/controllers/simulation/resources.py
+++ b/app/controllers/simulation/resources.py
@@ -12,6 +12,7 @@ from app.application.services.simulation_application_service import (
 )
 from app.auth import current_user_id
 from app.controllers.response_contract import compat_error_response
+from app.decorators import require_email_verified
 from app.utils.typed_decorators import typed_doc as doc
 from app.utils.typed_decorators import typed_jwt_required as jwt_required
 from app.utils.typed_decorators import typed_use_kwargs as use_kwargs
@@ -67,6 +68,7 @@ class SimulationCollectionResource(MethodResource):
         },
     )
     @jwt_required()
+    @require_email_verified
     def post(self) -> Any:
         oversized = _enforce_body_size_cap()
         if oversized is not None:
@@ -176,6 +178,7 @@ class SimulationResource(MethodResource):
         },
     )
     @jwt_required()
+    @require_email_verified
     def delete(self, simulation_id: UUID) -> Any:
         user_id = current_user_id()
         dependencies = get_simulation_dependencies()

--- a/app/controllers/wallet/entry_resources.py
+++ b/app/controllers/wallet/entry_resources.py
@@ -8,6 +8,7 @@ from marshmallow import fields
 
 from app.application.services.wallet_application_service import WalletApplicationError
 from app.auth import current_user_id
+from app.decorators import require_email_verified
 from app.schemas.openapi.wallet.docs import (
     WALLET_ADD_DOC,
     WALLET_DELETE_DOC,
@@ -36,6 +37,7 @@ from .dependencies import get_wallet_dependencies
 @wallet_bp.route("", methods=["POST"])
 @doc(**WALLET_ADD_DOC)
 @jwt_required()
+@require_email_verified
 def add_wallet_entry() -> tuple[dict[str, Any], int]:
     user_id = current_user_id()
     payload = request.get_json() or {}
@@ -178,6 +180,7 @@ def _update_wallet_entry_data(
 @wallet_bp.route("/<uuid:investment_id>", methods=["PATCH"])
 @doc(**WALLET_PATCH_DOC)
 @jwt_required()
+@require_email_verified
 def patch_wallet_entry(investment_id: UUID) -> tuple[dict[str, Any], int]:
     try:
         investment_data = _update_wallet_entry_data(
@@ -201,6 +204,7 @@ def patch_wallet_entry(investment_id: UUID) -> tuple[dict[str, Any], int]:
 @wallet_bp.route("/<uuid:investment_id>", methods=["PUT"])
 @doc(**WALLET_PUT_DOC)
 @jwt_required()
+@require_email_verified
 def update_wallet_entry(investment_id: UUID) -> Response | tuple[dict[str, Any], int]:
     try:
         investment_data = _update_wallet_entry_data(
@@ -226,6 +230,7 @@ def update_wallet_entry(investment_id: UUID) -> Response | tuple[dict[str, Any],
 @wallet_bp.route("/<uuid:investment_id>", methods=["DELETE"])
 @doc(**WALLET_DELETE_DOC)
 @jwt_required()
+@require_email_verified
 def delete_wallet_entry(investment_id: UUID) -> tuple[dict[str, Any], int]:
     user_id = current_user_id()
     dependencies = get_wallet_dependencies()

--- a/app/controllers/wallet/operation_resources.py
+++ b/app/controllers/wallet/operation_resources.py
@@ -11,6 +11,7 @@ from app.application.services.investment_application_service import (
     InvestmentApplicationError,
 )
 from app.auth import current_user_id
+from app.decorators import require_email_verified
 from app.utils.typed_decorators import typed_doc as doc
 from app.utils.typed_decorators import typed_jwt_required as jwt_required
 from app.utils.typed_decorators import typed_use_kwargs as use_kwargs
@@ -45,6 +46,7 @@ from .dependencies import get_wallet_dependencies
     },
 )
 @jwt_required()
+@require_email_verified
 def add_investment_operation(investment_id: UUID) -> tuple[dict[str, Any], int]:
     user_id: UUID = current_user_id()
     payload: dict[str, Any] = request.get_json() or {}
@@ -163,6 +165,7 @@ def list_investment_operations(
     },
 )
 @jwt_required()
+@require_email_verified
 def update_investment_operation(
     investment_id: UUID, operation_id: UUID
 ) -> tuple[dict[str, Any], int]:
@@ -212,6 +215,7 @@ def update_investment_operation(
     },
 )
 @jwt_required()
+@require_email_verified
 def delete_investment_operation(
     investment_id: UUID, operation_id: UUID
 ) -> tuple[dict[str, Any], int]:


### PR DESCRIPTION
## Summary

Follow-up do PR #1326 (closes #1325). Aplica o decorator soft-block em **22 mutation endpoints** restantes — goal, wallet (entry + operations), budget, simulation, credit_card.

Closes #1327

## Endpoints decorados

| Controller | Endpoints |
|---|---|
| `goal/resources.py` | POST `/goals`, PUT/PATCH/DELETE `/goals/<id>` |
| `wallet/entry_resources.py` | POST `/wallet`, PATCH/PUT/DELETE `/wallet/<id>` |
| `wallet/operation_resources.py` | POST `/wallet/<id>/operations`, PUT/DELETE `/wallet/<id>/operations/<op_id>` |
| `budget/resources.py` | POST `/budgets`, PATCH/DELETE `/budgets/<id>` |
| `simulation/resources.py` | POST `/simulations`, DELETE `/simulations/<id>` |
| `simulation/installment_vs_cash_resources.py` | POST canonical save, POST legacy save, POST goal bridge, POST planned expense bridge |
| `credit_card/resources.py` | POST `/credit-cards`, PUT/DELETE `/credit-cards/<id>` |

## Não aplicado em

- GETs (reads continuam liberados — princípio soft-block: ver mas não criar)
- Endpoints **públicos** sem auth (e.g. `POST /simulations/installment-vs-cash` calculation)
- `/auth/email/*`, `/user/me`, `/healthz`, `/readiness`
- `subscription_controller` — premium checkout precisa funcionar para usuário conseguir pagar e resolver bloqueio
- `goal` plan generation (POST stateless, é GET-with-body para projeção; bloquear quebraria preview)

## Test plan

- [x] **Suite pytest completa rodada local antes do push** (`pytest -m "not schemathesis" --no-cov -x` → exit 0)
- [x] Pre-commit hooks verdes (ruff, mypy, bandit, controller-response-contract-check, alembic, sonar)
- [x] Pre-push hooks verdes (pip-audit, security-evidence)
- [ ] CI verde

## Out of scope (próximas levas, plan sequência)

- **Fase 1.6** — Job cron D-7/D-1 lembretes
- **Fase 1.7** — GraphQL parity (UserType expor 4 campos + resolver helper para mutations bloqueadas)
- **Fase 2 web** — countdown banner + modal de gate + interceptor 403