### PR TITLE
[API] Email verification reminders cron D-7 / D-1

### DIFF
--- a/.github/workflows/reminder-job.yml
+++ b/.github/workflows/reminder-job.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   dispatch-reminders:
-    name: Dispatch Due-Date Reminders
+    name: Dispatch Reminders (due-date + email verification)
     runs-on: ubuntu-latest
     environment: prod
 
@@ -112,7 +112,7 @@ jobs:
           echo "Timed out waiting for container health check."
           exit 1
 
-      - name: Dispatch reminders via SSM
+      - name: Dispatch reminders via SSM (due-date + email verification)
         env:
           AWS_REGION: ${{ vars.AWS_REGION }}
           PROD_INSTANCE_ID: ${{ vars.AURAXIS_PROD_INSTANCE_ID }}
@@ -121,7 +121,7 @@ jobs:
             --region "${AWS_REGION}" \
             --instance-ids "${PROD_INSTANCE_ID}" \
             --document-name "AWS-RunShellScript" \
-            --parameters 'commands=["cd /opt/auraxis && docker compose exec -T web flask reminders dispatch-due-soon"]' \
+            --parameters 'commands=["cd /opt/auraxis && docker compose exec -T web flask reminders dispatch-due-soon && docker compose exec -T web flask reminders dispatch-email-verification"]' \
             --query "Command.CommandId" \
             --output text)
 

--- a/app/application/services/email_verification_reminder_service.py
+++ b/app/application/services/email_verification_reminder_service.py
@@ -1,0 +1,178 @@
+"""Email verification reminders — D-7 and D-1 dispatch service.
+
+Mirrors the pattern of ``transaction_reminder_service`` but for the
+14-day email verification grace period introduced in #1325 / PR #1326.
+
+The reminder targets users whose grace-period deadline falls in
+``days_until_deadline`` days from ``today``:
+
+    target_creation_day = today - (grace_days - days_until_deadline)
+
+Idempotency uses the ``Alert`` table with ``entity_type='user'`` and
+``entity_id=user.id`` so we can safely run the job multiple times per day
+without duplicating emails.
+
+Unlike transaction reminders, this dispatch does **not** require the
+``email_reminders`` entitlement — verification is system-critical and
+every unverified user must receive it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from typing import Sequence, cast
+from uuid import UUID
+
+from flask import current_app
+
+from app.extensions.database import db
+from app.models.alert import Alert, AlertStatus
+from app.models.user import User
+from app.services.email_dlq import get_email_dlq
+from app.services.email_provider import (
+    EmailMessage,
+    EmailProviderError,
+    get_default_email_provider,
+)
+from app.services.email_templates.base import render_email_verification_reminder_email
+from app.utils.datetime_utils import utc_now_naive
+
+_REMINDER_WINDOWS = {
+    7: "email_verification_reminder_7d",
+    1: "email_verification_reminder_1d",
+}
+
+_USER_ENTITY_TYPE = "user"
+
+
+@dataclass(frozen=True)
+class EmailVerificationReminderResult:
+    scanned: int
+    sent: int
+    skipped: int
+    queued: int = 0
+
+
+def _start_of_day(day: date) -> datetime:
+    return datetime.combine(day, datetime.min.time())
+
+
+def _end_of_day(day: date) -> datetime:
+    return datetime.combine(day, datetime.max.time())
+
+
+def _existing_alert(*, user_id: UUID, category: str, day: date) -> Alert | None:
+    return cast(
+        Alert | None,
+        Alert.query.filter(
+            Alert.user_id == user_id,
+            Alert.category == category,
+            Alert.entity_type == _USER_ENTITY_TYPE,
+            Alert.entity_id == user_id,
+            Alert.triggered_at >= _start_of_day(day),
+            Alert.triggered_at <= _end_of_day(day),
+        ).first(),
+    )
+
+
+def _eligible_users(*, target_creation_day: date) -> Sequence[User]:
+    return cast(
+        Sequence[User],
+        User.query.filter(
+            User.email_verified_at.is_(None),
+            User.created_at >= _start_of_day(target_creation_day),
+            User.created_at <= _end_of_day(target_creation_day),
+            User.deleted_at.is_(None),
+        ).all(),
+    )
+
+
+def _build_subject(*, days_until_deadline: int) -> str:
+    if days_until_deadline == 1:
+        return "Último dia para confirmar seu email — Auraxis"
+    return f"Faltam {days_until_deadline} dias para confirmar seu email — Auraxis"
+
+
+def _send_or_queue(message: EmailMessage) -> AlertStatus:
+    try:
+        get_default_email_provider().send(message)
+        return AlertStatus.SENT
+    except EmailProviderError as exc:
+        get_email_dlq().push(message, reason=str(exc))
+        return AlertStatus.PENDING
+
+
+def dispatch_email_verification_reminders(
+    *, days_until_deadline: int, today: date | None = None
+) -> EmailVerificationReminderResult:
+    """Send verification reminders to users at the requested countdown window.
+
+    Args:
+        days_until_deadline: 7 (D-7) or 1 (D-1).
+        today: Override the reference day for tests.
+
+    Returns:
+        EmailVerificationReminderResult with scan/send/skip/queue counters.
+    """
+    category = _REMINDER_WINDOWS.get(days_until_deadline)
+    if category is None:
+        raise ValueError("Unsupported reminder window")
+
+    grace_days = int(current_app.config.get("EMAIL_VERIFICATION_GRACE_PERIOD_DAYS", 14))
+    reference_day = today or date.today()
+    target_creation_day = reference_day - timedelta(
+        days=grace_days - days_until_deadline
+    )
+
+    scanned = 0
+    sent = 0
+    skipped = 0
+    queued = 0
+
+    for user in _eligible_users(target_creation_day=target_creation_day):
+        scanned += 1
+        if _existing_alert(user_id=user.id, category=category, day=reference_day):
+            skipped += 1
+            continue
+
+        email_html, email_text = render_email_verification_reminder_email(
+            days_until_deadline=days_until_deadline,
+        )
+        message = EmailMessage(
+            to_email=str(user.email),
+            subject=_build_subject(days_until_deadline=days_until_deadline),
+            html=email_html,
+            text=email_text,
+            tag=category,
+        )
+        alert_status = _send_or_queue(message)
+        if alert_status == AlertStatus.SENT:
+            sent += 1
+            sent_at = utc_now_naive()
+        else:
+            queued += 1
+            sent_at = None
+
+        db.session.add(
+            Alert(
+                user_id=user.id,
+                category=category,
+                status=alert_status,
+                entity_type=_USER_ENTITY_TYPE,
+                entity_id=user.id,
+                triggered_at=_start_of_day(reference_day),
+                sent_at=sent_at,
+            )
+        )
+
+    db.session.commit()
+    return EmailVerificationReminderResult(
+        scanned=scanned, sent=sent, skipped=skipped, queued=queued
+    )
+
+
+__all__ = [
+    "EmailVerificationReminderResult",
+    "dispatch_email_verification_reminders",
+]

--- a/app/extensions/reminders_cli.py
+++ b/app/extensions/reminders_cli.py
@@ -1,11 +1,13 @@
-"""Flask CLI command — transaction due-date reminders.
+"""Flask CLI commands — transaction and email-verification reminders.
 
-Dispatches email reminders for transactions approaching their due date:
+Dispatches email reminders:
 
     flask reminders dispatch-due-soon [--dry-run]
+    flask reminders dispatch-email-verification [--dry-run]
 
-The underlying business logic lives in
-``app.application.services.transaction_reminder_service``.
+Business logic lives in
+``app.application.services.transaction_reminder_service`` and
+``app.application.services.email_verification_reminder_service``.
 """
 
 from __future__ import annotations
@@ -14,7 +16,7 @@ import click
 from flask import Flask
 from flask.cli import AppGroup
 
-reminders_cli = AppGroup("reminders", help="Transaction reminder commands.")
+reminders_cli = AppGroup("reminders", help="Reminder dispatch commands.")
 
 
 @reminders_cli.command("dispatch-due-soon")
@@ -49,6 +51,47 @@ def dispatch_due_soon(ctx: click.Context, dry_run: bool) -> None:
         except Exception as exc:  # noqa: BLE001
             click.echo(
                 f"ERROR {window}-day reminders: unexpected failure — {exc}",
+                err=True,
+            )
+            exit_code = 1
+
+    sys.exit(exit_code)
+
+
+@reminders_cli.command("dispatch-email-verification")
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Print what would be sent without dispatching emails.",
+)
+@click.pass_context
+def dispatch_email_verification(ctx: click.Context, dry_run: bool) -> None:
+    """Send D-7 and D-1 reminders for the email verification grace period."""
+    import sys
+
+    if dry_run:
+        click.echo(
+            "[dry-run] Would dispatch verification reminders for D-7 and D-1 windows."
+        )
+        return
+
+    from app.application.services.email_verification_reminder_service import (
+        dispatch_email_verification_reminders,
+    )
+
+    exit_code = 0
+    for window in (7, 1):
+        try:
+            result = dispatch_email_verification_reminders(days_until_deadline=window)
+            click.echo(
+                f"D-{window} verification reminders: "
+                f"scanned={result.scanned} sent={result.sent} "
+                f"skipped={result.skipped} queued={result.queued}"
+            )
+        except Exception as exc:  # noqa: BLE001
+            click.echo(
+                f"ERROR D-{window} verification reminders: unexpected failure — {exc}",
                 err=True,
             )
             exit_code = 1

--- a/app/services/email_templates/base.py
+++ b/app/services/email_templates/base.py
@@ -568,10 +568,125 @@ def render_analysis_ready_email(
     return html, text
 
 
+def render_email_verification_reminder_email(
+    *, days_until_deadline: int
+) -> tuple[str, str]:
+    """Render the D-7 / D-1 verification reminder email.
+
+    Args:
+        days_until_deadline: 7 (mild urgency) or 1 (high urgency).
+
+    Returns:
+        (html, text) tuple ready to pass to EmailMessage.
+    """
+    resend_url = f"{_APP_URL}/resend-confirmation"
+
+    if days_until_deadline == 1:
+        email_title = "Último dia para confirmar seu email"
+        preview = (
+            "Amanhã sua conta entra em modo somente-leitura. "
+            "Confirme seu email para manter o acesso total."
+        )
+        heading = "Último dia para confirmar seu email"
+        urgency_copy = (
+            f"Sua conta foi criada há quase 14 dias. "
+            f'Se você não confirmar seu email <strong style="color: {_COLOR_BRAND};">'
+            f"até amanhã</strong>, ela entrará em modo somente-leitura — "
+            f"você ainda poderá ver seus dados, mas não criar ou editar nada."
+        )
+        cta_label = "Confirmar agora"
+    else:
+        email_title = "Faltam 7 dias para confirmar seu email"
+        preview = (
+            "Confirme seu email no Auraxis dentro de 7 dias para evitar bloqueio "
+            "de novas transações."
+        )
+        heading = f"Faltam {days_until_deadline} dias para confirmar seu email"
+        urgency_copy = (
+            f"Você criou sua conta no Auraxis recentemente, mas ainda não "
+            f'confirmou seu email. Em <strong style="color: {_COLOR_BRAND};">'
+            f"{days_until_deadline} dias</strong> sua conta entrará em modo "
+            f"somente-leitura caso o email não seja confirmado."
+        )
+        cta_label = "Confirmar email"
+
+    body_html = f"""
+      <h1 style="font-family: {_FONT_HEADING}; font-size: 26px; font-weight: 700;
+                 color: {_COLOR_TEXT_PRIMARY}; margin: 0 0 8px; line-height: 1.2;">
+        {heading}
+      </h1>
+      <p style="font-family: {_FONT_BODY}; font-size: 13px; font-weight: 600;
+                color: {_COLOR_BRAND}; margin: 0 0 24px; text-transform: uppercase;
+                letter-spacing: 1px;">
+        Auraxis &mdash; Finanças pessoais
+      </p>
+
+      <div style="border-top: 1px solid {_COLOR_BG_ELEVATED}; margin: 0 0 28px;"></div>
+
+      <p style="font-family: {_FONT_BODY}; font-size: 15px; color: {_COLOR_TEXT_SECONDARY};
+                line-height: 1.65; margin: 0 0 24px;">
+        {urgency_copy}
+      </p>
+
+      <!-- CTA -->
+      <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin: 8px 0 32px;">
+        <tr>
+          <td align="left" style="border-radius: 8px; background-color: {_COLOR_BRAND};">
+            <a href="{resend_url}" class="btn"
+               style="background-color: {_COLOR_BRAND}; color: {_COLOR_BG_BASE};
+                      font-family: {_FONT_BODY}; font-size: 15px; font-weight: 600;
+                      text-decoration: none; display: inline-block;
+                      padding: 14px 32px; border-radius: 8px;">
+              {cta_label}
+            </a>
+          </td>
+        </tr>
+      </table>
+
+      <div style="border-top: 1px solid {_COLOR_BG_ELEVATED}; margin: 0 0 20px;"></div>
+
+      <p style="font-family: {_FONT_BODY}; font-size: 12px; color: {_COLOR_TEXT_MUTED};
+                line-height: 1.6; margin: 0;">
+        Não recebeu o email de confirmação original? Acesse
+        <a href="{resend_url}" style="color: {_COLOR_BRAND};">{resend_url}</a>
+        para reenviar.
+      </p>
+    """
+
+    html = _base_layout(
+        title=email_title,
+        preview_text=preview,
+        body_html=body_html,
+    )
+
+    if days_until_deadline == 1:
+        text = (
+            "Último dia para confirmar seu email — Auraxis\n"
+            "=============================================\n\n"
+            "Sua conta foi criada há quase 14 dias. Se você não confirmar seu "
+            "email até amanhã, ela entrará em modo somente-leitura.\n\n"
+            f"Confirme agora: {resend_url}\n\n"
+            "— Equipe Auraxis\n"
+        )
+    else:
+        text = (
+            f"Faltam {days_until_deadline} dias para confirmar seu email — Auraxis\n"
+            "========================================================\n\n"
+            f"Você criou sua conta no Auraxis recentemente. Em "
+            f"{days_until_deadline} dias sua conta entrará em modo "
+            "somente-leitura se o email não for confirmado.\n\n"
+            f"Confirme agora: {resend_url}\n\n"
+            "— Equipe Auraxis\n"
+        )
+
+    return html, text
+
+
 __all__ = [
     "render_account_deletion_email",
     "render_analysis_ready_email",
     "render_confirmation_email",
     "render_due_soon_email",
+    "render_email_verification_reminder_email",
     "render_password_reset_email",
 ]

--- a/tests/test_email_verification_reminder_service.py
+++ b/tests/test_email_verification_reminder_service.py
@@ -1,0 +1,202 @@
+"""Tests for email_verification_reminder_service.
+
+Covers:
+- Happy path D-7 dispatch for unverified user created 7 days into grace
+- Happy path D-1 dispatch for unverified user created 13 days into grace
+- Idempotency: running twice on the same day does not duplicate emails
+- Skip already-verified users
+- Skip soft-deleted users
+- Skip when creation_date doesn't match the target window
+- Invalid window raises ValueError
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime, timedelta
+
+import pytest
+
+from app.application.services.email_verification_reminder_service import (
+    EmailVerificationReminderResult,
+    dispatch_email_verification_reminders,
+)
+from app.extensions.database import db
+from app.models.user import User
+from app.services.email_provider import get_email_outbox
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_user(
+    *,
+    app,
+    created_at: datetime,
+    email_verified_at: datetime | None = None,
+    deleted_at: datetime | None = None,
+    email_suffix: str = "",
+) -> User:
+    suffix = email_suffix or uuid.uuid4().hex[:8]
+    user = User(
+        id=uuid.uuid4(),
+        name=f"Test {suffix}",
+        email=f"verify-{suffix}@test.com",
+        password="hash",
+        created_at=created_at,
+        email_verified_at=email_verified_at,
+        deleted_at=deleted_at,
+    )
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+def _drain_outbox() -> None:
+    """Clear the in-memory outbox between assertions."""
+    outbox = get_email_outbox()
+    outbox.clear()
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_dispatches_d7_reminder_for_unverified_user_at_grace_minus_7(app) -> None:
+    today = date(2030, 6, 15)
+    # grace is 14d, so user created 7 days ago lands in the D-7 window
+    with app.app_context():
+        _make_user(
+            app=app,
+            created_at=datetime.combine(today - timedelta(days=7), datetime.min.time())
+            + timedelta(hours=10),
+        )
+        result = dispatch_email_verification_reminders(
+            days_until_deadline=7, today=today
+        )
+
+        assert isinstance(result, EmailVerificationReminderResult)
+        assert result.scanned == 1
+        assert result.sent == 1
+        outbox = get_email_outbox()
+        assert len(outbox) == 1
+        assert outbox[0]["tag"] == "email_verification_reminder_7d"
+        _drain_outbox()
+
+
+def test_dispatches_d1_reminder_for_unverified_user_at_grace_minus_1(app) -> None:
+    today = date(2030, 6, 15)
+    with app.app_context():
+        _make_user(
+            app=app,
+            created_at=datetime.combine(today - timedelta(days=13), datetime.min.time())
+            + timedelta(hours=10),
+        )
+        result = dispatch_email_verification_reminders(
+            days_until_deadline=1, today=today
+        )
+
+        assert result.scanned == 1
+        assert result.sent == 1
+        outbox = get_email_outbox()
+        assert outbox[0]["tag"] == "email_verification_reminder_1d"
+        _drain_outbox()
+
+
+# ---------------------------------------------------------------------------
+# Idempotency
+# ---------------------------------------------------------------------------
+
+
+def test_is_idempotent_per_day(app) -> None:
+    today = date(2030, 6, 15)
+    with app.app_context():
+        _make_user(
+            app=app,
+            created_at=datetime.combine(today - timedelta(days=7), datetime.min.time())
+            + timedelta(hours=10),
+        )
+        first = dispatch_email_verification_reminders(
+            days_until_deadline=7, today=today
+        )
+        second = dispatch_email_verification_reminders(
+            days_until_deadline=7, today=today
+        )
+
+        assert first.sent == 1
+        assert second.sent == 0
+        assert second.skipped == 1
+        # outbox holds only the first dispatch
+        outbox = get_email_outbox()
+        assert len(outbox) == 1
+        _drain_outbox()
+
+
+# ---------------------------------------------------------------------------
+# Skip cases
+# ---------------------------------------------------------------------------
+
+
+def test_skips_verified_user(app) -> None:
+    today = date(2030, 6, 15)
+    with app.app_context():
+        _make_user(
+            app=app,
+            created_at=datetime.combine(today - timedelta(days=7), datetime.min.time())
+            + timedelta(hours=10),
+            email_verified_at=datetime.combine(
+                today - timedelta(days=6), datetime.min.time()
+            ),
+        )
+        result = dispatch_email_verification_reminders(
+            days_until_deadline=7, today=today
+        )
+
+        assert result.scanned == 0
+        assert result.sent == 0
+
+
+def test_skips_soft_deleted_user(app) -> None:
+    today = date(2030, 6, 15)
+    with app.app_context():
+        _make_user(
+            app=app,
+            created_at=datetime.combine(today - timedelta(days=7), datetime.min.time())
+            + timedelta(hours=10),
+            deleted_at=datetime.combine(today - timedelta(days=2), datetime.min.time()),
+        )
+        result = dispatch_email_verification_reminders(
+            days_until_deadline=7, today=today
+        )
+
+        assert result.scanned == 0
+        assert result.sent == 0
+
+
+def test_skips_user_outside_target_creation_window(app) -> None:
+    today = date(2030, 6, 15)
+    with app.app_context():
+        # Created 5 days ago — not in D-7 window (would need exactly 7)
+        _make_user(
+            app=app,
+            created_at=datetime.combine(today - timedelta(days=5), datetime.min.time())
+            + timedelta(hours=10),
+        )
+        result = dispatch_email_verification_reminders(
+            days_until_deadline=7, today=today
+        )
+
+        assert result.scanned == 0
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_window_raises_value_error(app) -> None:
+    with app.app_context():
+        with pytest.raises(ValueError):
+            dispatch_email_verification_reminders(days_until_deadline=42)


### PR DESCRIPTION
## Summary

Lembretes por email D-7 e D-1 antes do prazo de 14 dias da grace period (introduzida em #1326). Reduz conversão perdida por usuários que esquecem de confirmar.

Closes #1329

## Changes

### Service
`app/application/services/email_verification_reminder_service.py`
- `dispatch_email_verification_reminders(days_until_deadline, today=None)`
- Query users com `email_verified_at IS NULL` AND `deleted_at IS NULL` cujo `created_at` caiu em `today - (grace_days - days_until_deadline)`
- Idempotência via Alert (`entity_type='user'`, `entity_id=user.id`, `triggered_at` ancorado ao start-of-day)
- **Não requer entitlement** — sistema-crítico, todos os unverified recebem

### Email template
`app/services/email_templates/base.py::render_email_verification_reminder_email`
- D-7: urgência média ("faltam 7 dias")
- D-1: urgência alta ("último dia")
- CTA aponta para `/resend-confirmation`

### CLI
`app/extensions/reminders_cli.py`
- Novo comando `flask reminders dispatch-email-verification [--dry-run]`
- Roda D-7 e D-1 em sequência, exit code 1 se qualquer falhar

### Workflow
`.github/workflows/reminder-job.yml`
- SSM command roda `dispatch-due-soon && dispatch-email-verification` encadeados
- Mesmo cron diário existente (`0 7 * * *` — 04:00 BRT)

### Tests
`tests/test_email_verification_reminder_service.py` — 7 testes
- Happy path D-7 + D-1
- Idempotência (rodar 2x no mesmo dia não duplica)
- Skip: verified user, soft-deleted user, fora da janela
- Validation: janela inválida → ValueError

## Test plan

- [x] **Full pytest suite local antes do push** (`pytest -m "not schemathesis" --no-cov -x` → exit 0)
- [x] Pre-commit hooks verdes
- [x] Pre-push hooks verdes
- [ ] CI verde

## Out of scope

- GraphQL parity (Fase 1.7) — UserType expor 4 campos + resolver helper
- Frontend web (Fase 2) — countdown banner + gate modal