### PR TITLE
[API] GraphQL parity for email verification fields

### DIFF
--- a/app/graphql/authenticated_user_presenters.py
+++ b/app/graphql/authenticated_user_presenters.py
@@ -1,21 +1,26 @@
 from __future__ import annotations
 
+from dataclasses import asdict
+from typing import Any
+
 from app.application.services.authenticated_user_context_service import (
     AuthenticatedUserProfile,
 )
 from app.graphql.types import UserType
-from app.services.authenticated_user_payloads import (
-    UserProfilePayload,
-    to_user_profile_payload,
-)
 
-AuthenticatedUserGraphQLPayload = UserProfilePayload
+# The GraphQL UserType exposes the legacy v2 fields **plus** the new email
+# verification fields. The legacy REST v2 contract stays frozen and pops those
+# 4 fields in ``to_user_profile_payload``; GraphQL needs them, so we build the
+# payload directly from the dataclass here.
+AuthenticatedUserGraphQLPayload = dict[str, Any]
 
 
 def to_authenticated_user_graphql_payload(
     profile: AuthenticatedUserProfile,
 ) -> AuthenticatedUserGraphQLPayload:
-    return to_user_profile_payload(profile)
+    payload = asdict(profile)
+    payload.pop("entitlements_version", None)
+    return payload
 
 
 def to_authenticated_user_type(profile: AuthenticatedUserProfile) -> UserType:

--- a/app/graphql/types.py
+++ b/app/graphql/types.py
@@ -27,6 +27,11 @@ class UserType(graphene.ObjectType):
     profile_quiz_score = graphene.Int()
     taxonomy_version = graphene.String()
     avatar_url = graphene.String()
+    # #1325 / #1331: 14-day email verification grace period
+    email_verified = graphene.Boolean()
+    email_verification_deadline_at = graphene.String()
+    email_verification_required_now = graphene.Boolean()
+    days_until_email_required = graphene.Int()
 
 
 class AuthPayloadType(graphene.ObjectType):

--- a/app/services/authenticated_user_payloads.py
+++ b/app/services/authenticated_user_payloads.py
@@ -124,10 +124,15 @@ class WalletEntryPayload(TypedDict):
 
 
 def to_user_profile_payload(profile: AuthenticatedUserProfile) -> UserProfilePayload:
+    """Build the legacy v2 flat user payload.
+
+    The v2 contract is **frozen**: it does not include the new
+    email-verification fields. Clients on v2 read verification status
+    from a separate header/endpoint; v3 surfaces it inside the canonical
+    ``email_verification`` block.
+    """
     payload = asdict(profile)
     payload.pop("entitlements_version", None)
-    # GraphQL UserType doesn't yet expose email_verification fields; surface them
-    # only via the REST canonical payload until the GraphQL parity PR lands.
     payload.pop("email_verified", None)
     payload.pop("email_verification_deadline_at", None)
     payload.pop("email_verification_required_now", None)

--- a/graphql.introspection.json
+++ b/graphql.introspection.json
@@ -9648,6 +9648,54 @@
                 "name": "String",
                 "ofType": null
               }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "emailVerified",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "emailVerificationDeadlineAt",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "emailVerificationRequiredNow",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "daysUntilEmailRequired",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
             }
           ],
           "inputFields": null,

--- a/schema.graphql
+++ b/schema.graphql
@@ -773,6 +773,10 @@ type UserType {
   profileQuizScore: Int
   taxonomyVersion: String
   avatarUrl: String
+  emailVerified: Boolean
+  emailVerificationDeadlineAt: String
+  emailVerificationRequiredNow: Boolean
+  daysUntilEmailRequired: Int
 }
 
 type Mutation {

--- a/tests/test_graphql_api.py
+++ b/tests/test_graphql_api.py
@@ -126,6 +126,34 @@ def test_graphql_me_remains_user_context_only(client) -> None:
     assert "transactions" not in UserType._meta.fields
 
 
+def test_graphql_me_exposes_email_verification_fields(client) -> None:
+    token = _register_and_login_graphql(client)
+
+    response = _graphql(
+        client,
+        """
+        query Me {
+          me {
+            emailVerified
+            emailVerificationDeadlineAt
+            emailVerificationRequiredNow
+            daysUntilEmailRequired
+          }
+        }
+        """,
+        token=token,
+    )
+    assert response.status_code == 200
+    body = response.get_json()
+    assert "errors" not in body
+    payload = body["data"]["me"]
+    # Fresh user — not yet verified, within grace period
+    assert payload["emailVerified"] is False
+    assert payload["emailVerificationDeadlineAt"] is not None
+    assert payload["emailVerificationRequiredNow"] is False
+    assert payload["daysUntilEmailRequired"] is not None
+
+
 def test_graphql_forgot_password_is_neutral(client) -> None:
     mutation = """
     mutation ForgotPassword($email: String!) {


### PR DESCRIPTION
## Summary

Adiciona os 4 campos de email verification no GraphQL UserType para paridade com o canonical payload REST v3 (entregue em #1326).

Closes #1331

## Changes

### UserType (graphene)
```graphql
type UserType {
  ...
  emailVerified: Boolean
  emailVerificationDeadlineAt: String
  emailVerificationRequiredNow: Boolean
  daysUntilEmailRequired: Int
}
```

### Payload split
- `to_user_profile_payload` (REST v2 **frozen**): continua fazendo pop dos 4 campos.
- `to_authenticated_user_graphql_payload` (GraphQL): agora gera payload via `asdict(profile)` direto, expondo todos os campos.

### Tests
- `test_graphql_me_exposes_email_verification_fields`: query `me { emailVerified emailVerificationDeadlineAt emailVerificationRequiredNow daysUntilEmailRequired }` retorna shape correto para um usuário fresh (dentro da grace period).

## Test plan

- [x] **Full pytest suite local antes do push** (`pytest -m "not schemathesis" --no-cov -x` → exit 0)
- [x] Pre-commit hooks verdes (ruff, mypy, bandit, etc.)
- [x] Pre-push hooks verdes
- [ ] CI verde

## Out of scope

- `require_email_verified_resolver` helper para mutations GraphQL — PR separado quando mobile começar a consumir mutations sensíveis via GraphQL.
- Frontend web (Fase 2)