### PR TITLE
[API] Fix email confirmation URL (n/a) + email templates v3 Market Pulse

### DIFF
--- a/app/application/services/email_confirmation_service.py
+++ b/app/application/services/email_confirmation_service.py
@@ -69,6 +69,9 @@ def _confirmation_outbox() -> list[dict[str, str]]:
     )
 
 
+_DEFAULT_CONFIRMATION_URL = "https://app.auraxis.com.br/confirm-email"
+
+
 def _confirmation_frontend_url() -> str:
     return str(runtime_config("EMAIL_CONFIRMATION_FRONTEND_URL", "")).strip()
 
@@ -78,10 +81,10 @@ def _build_confirmation_url(token: str) -> str:
     if not base_url:
         runtime_logger().warning(
             "event=auth.email_confirmation_url_missing "
-            "EMAIL_CONFIRMATION_FRONTEND_URL is not configured — "
-            "confirmation link will be 'n/a'. Set this variable in your environment."
+            "EMAIL_CONFIRMATION_FRONTEND_URL not configured — falling back to "
+            "canonical default. Set this variable in your environment."
         )
-        return "n/a"
+        base_url = _DEFAULT_CONFIRMATION_URL
     separator = "&" if "?" in base_url else "?"
     return f"{base_url}{separator}token={token}"
 

--- a/app/services/email_templates/base.py
+++ b/app/services/email_templates/base.py
@@ -1,8 +1,10 @@
 """Auraxis transactional email template system.
 
 All emails are rendered from a shared base layout that enforces brand
-consistency: dark background, amber/gold brand colour, Playfair Display
-headings, Raleway body — matching the web application's design tokens.
+consistency with the v3 "Market Pulse" design system: navy background,
+cyan brand colour, Inter sans-serif throughout — mirrored from the
+auraxis-web design tokens (dark variant, since emails are always rendered
+against a dark canvas).
 
 Usage::
 
@@ -17,19 +19,22 @@ from __future__ import annotations
 # Brand tokens (mirrored from auraxis-web design system)
 # ---------------------------------------------------------------------------
 
-_COLOR_BG_BASE = "#0b0909"
-_COLOR_BG_SURFACE = "#272020"
-_COLOR_BG_ELEVATED = "#413939"
-_COLOR_BRAND = "#ffab1a"
-_COLOR_BRAND_HOVER = "#ffbe4d"
-_COLOR_BRAND_DARK = "#f59600"
-_COLOR_TEXT_PRIMARY = "#faf9f9"
-_COLOR_TEXT_SECONDARY = "#d1c7c7"
-_COLOR_TEXT_MUTED = "#9b8888"
-_COLOR_BORDER = "rgba(65, 57, 57, 0.8)"
+# v3 "Market Pulse" tokens — mirrors auraxis-web design system (dark variant).
+# Emails are always rendered against a dark navy background regardless of the
+# recipient's client preference, so we lock to the dark-mode palette here.
+_COLOR_BG_BASE = "#05070d"
+_COLOR_BG_SURFACE = "#121a2a"
+_COLOR_BG_ELEVATED = "#0e1523"
+_COLOR_BRAND = "#44d4ff"
+_COLOR_BRAND_HOVER = "#7eddff"
+_COLOR_BRAND_DARK = "#087FA7"
+_COLOR_TEXT_PRIMARY = "#f1f5ff"
+_COLOR_TEXT_SECONDARY = "#c5cee0"
+_COLOR_TEXT_MUTED = "#8b95b1"
+_COLOR_BORDER = "rgba(30, 41, 59, 0.8)"
 
-_FONT_HEADING = "'Playfair Display', 'Georgia', 'Times New Roman', serif"
-_FONT_BODY = "'Raleway', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif"
+_FONT_HEADING = "'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif"
+_FONT_BODY = "'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif"
 
 _LOGO_URL = "https://app.auraxis.com.br/logo.png"
 _APP_URL = "https://app.auraxis.com.br"
@@ -59,7 +64,7 @@ def _base_layout(*, title: str, preview_text: str, body_html: str) -> str:
   </noscript>
   <![endif]-->
   <style>
-    @import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600;700&family=Raleway:wght@400;500;600&display=swap');
+    @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap');
     body, table, td, a {{ -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; }}
     table, td {{ mso-table-lspace: 0pt; mso-table-rspace: 0pt; }}
     img {{ -ms-interpolation-mode: bicubic; border: 0; height: auto; line-height: 100%; outline: none; text-decoration: none; }}

--- a/tests/test_email_confirmation_url.py
+++ b/tests/test_email_confirmation_url.py
@@ -1,0 +1,52 @@
+"""Tests for the confirmation URL builder + canonical fallback (#1334).
+
+Covers:
+- Fallback to canonical default when EMAIL_CONFIRMATION_FRONTEND_URL is empty
+- Respect of configured env var
+- Correct separator (`?` vs `&`) when base URL already has query params
+"""
+
+from __future__ import annotations
+
+from app.application.services.email_confirmation_service import (
+    _DEFAULT_CONFIRMATION_URL,
+    _build_confirmation_url,
+)
+
+
+def test_falls_back_to_canonical_default_when_env_empty(app, monkeypatch) -> None:
+    monkeypatch.setitem(app.config, "EMAIL_CONFIRMATION_FRONTEND_URL", "")
+    with app.app_context():
+        url = _build_confirmation_url(token="abc123")
+        assert url == f"{_DEFAULT_CONFIRMATION_URL}?token=abc123"
+
+
+def test_respects_configured_env_var(app, monkeypatch) -> None:
+    monkeypatch.setitem(
+        app.config,
+        "EMAIL_CONFIRMATION_FRONTEND_URL",
+        "https://staging.auraxis.com.br/confirm-email",
+    )
+    with app.app_context():
+        url = _build_confirmation_url(token="abc123")
+        assert url == "https://staging.auraxis.com.br/confirm-email?token=abc123"
+
+
+def test_uses_ampersand_when_base_url_already_has_query(app, monkeypatch) -> None:
+    monkeypatch.setitem(
+        app.config,
+        "EMAIL_CONFIRMATION_FRONTEND_URL",
+        "https://app.auraxis.com.br/confirm-email?utm_source=email",
+    )
+    with app.app_context():
+        url = _build_confirmation_url(token="xyz789")
+        assert (
+            url
+            == "https://app.auraxis.com.br/confirm-email?utm_source=email&token=xyz789"
+        )
+
+
+def test_canonical_default_targets_root_confirm_email_path() -> None:
+    # Guards against future regressions where someone "moves" the canonical URL
+    # back under /auth/ — the Nuxt page is at /confirm-email (root).
+    assert _DEFAULT_CONFIRMATION_URL == "https://app.auraxis.com.br/confirm-email"

--- a/tests/test_email_templates.py
+++ b/tests/test_email_templates.py
@@ -15,8 +15,8 @@ from app.services.email_templates import (
     render_password_reset_email,
 )
 
-CONFIRM_URL = "https://app.auraxis.com.br/auth/confirm-email?token=abc123"
-RESET_URL = "https://app.auraxis.com.br/auth/reset-password?token=xyz456"
+CONFIRM_URL = "https://app.auraxis.com.br/confirm-email?token=abc123"
+RESET_URL = "https://app.auraxis.com.br/reset-password?token=xyz456"
 
 
 class TestRenderConfirmationEmail:
@@ -35,20 +35,17 @@ class TestRenderConfirmationEmail:
 
     def test_html_contains_brand_colour(self) -> None:
         html, _ = render_confirmation_email(confirmation_url=CONFIRM_URL)
-        # Primary brand amber
-        assert "#ffab1a" in html
+        # Primary brand cyan (v3 Market Pulse)
+        assert "#44d4ff" in html
 
     def test_html_contains_brand_name(self) -> None:
         html, _ = render_confirmation_email(confirmation_url=CONFIRM_URL)
         assert "Auraxis" in html
 
-    def test_html_contains_heading_font(self) -> None:
+    def test_html_contains_inter_font(self) -> None:
+        # v3 Market Pulse uses Inter as a single sans-serif for headings and body.
         html, _ = render_confirmation_email(confirmation_url=CONFIRM_URL)
-        assert "Playfair Display" in html
-
-    def test_html_contains_body_font(self) -> None:
-        html, _ = render_confirmation_email(confirmation_url=CONFIRM_URL)
-        assert "Raleway" in html
+        assert "Inter" in html
 
     def test_html_contains_cta_button(self) -> None:
         html, _ = render_confirmation_email(confirmation_url=CONFIRM_URL)
@@ -99,7 +96,7 @@ class TestRenderPasswordResetEmail:
 
     def test_html_contains_brand_colour(self) -> None:
         html, _ = render_password_reset_email(reset_url=RESET_URL)
-        assert "#ffab1a" in html
+        assert "#44d4ff" in html
 
 
 class TestRenderDueSoonEmail:
@@ -120,7 +117,7 @@ class TestRenderDueSoonEmail:
         html, _ = render_due_soon_email(
             title="Aluguel", amount_formatted="1500.00", days_before_due=7
         )
-        assert "#ffab1a" in html
+        assert "#44d4ff" in html
 
     def test_html_contains_brand_name(self) -> None:
         html, _ = render_due_soon_email(


### PR DESCRIPTION
## Summary

Smoke E2E do flow Fase 1 (signup → email → click → /confirm-email) achou 2 bugs visíveis ao Italo:

1. **URL "http://n/a"** no email — `EMAIL_CONFIRMATION_FRONTEND_URL` não carregada no runtime e backend devolvia sentinel "n/a", quebrando o link.
2. **Layout v1 stale** — amber/brown + Playfair/Raleway em vez do v3 Market Pulse (cyan/navy/Inter) atual do auraxis-web.

Closes #1334

## Changes

### Backend — `email_confirmation_service.py`
- Novo `_DEFAULT_CONFIRMATION_URL = "https://app.auraxis.com.br/confirm-email"`
- Quando env var não setada, faz fallback (com warning de log) em vez de devolver "n/a"
- Defesa em profundidade: link sempre clicável, mesmo se deploy esquecer env

### Email templates — `email_templates/base.py`

Tokens compartilhados rotados para v3 Market Pulse (dark variant):

| Token | v1 (stale) | v3 |
|---|---|---|
| BG_BASE | `#0b0909` brown | `#05070d` navy |
| BG_SURFACE | `#272020` | `#121a2a` |
| BG_ELEVATED | `#413939` | `#0e1523` |
| BRAND | `#ffab1a` amber | `#44d4ff` cyan |
| TEXT_PRIMARY | `#faf9f9` taupe | `#f1f5ff` blue-grey |
| FONT | Playfair Display + Raleway | Inter |

Os 6 templates (confirmation, password_reset, account_deletion, due_soon, analysis_ready, email_verification_reminder) herdam via f-string — propagação automática.

### Tests

- `tests/test_email_confirmation_url.py` **(novo)** — 4 testes cobrem:
  - Fallback canônico quando env vazia
  - Respeito da env quando setada
  - Separador `?`/`&` correto quando base URL já tem query
  - Guard do path `/confirm-email` (regression test contra voltar para `/auth/`)
- `tests/test_email_templates.py` — assertions atualizadas para cyan (`#44d4ff`) e Inter (em vez de Playfair Display + Raleway). URLs de teste atualizadas para `/confirm-email` (sem o `/auth/` prefix errado).

## Test plan

- [x] **Full pytest suite local verde antes do push** (`pytest -m "not schemathesis" --no-cov -x` → exit 0)
- [x] Pre-commit hooks verdes (ruff, mypy, bandit, etc.)
- [x] Pre-push hooks verdes (pip-audit, security-evidence)
- [ ] CI verde
- [ ] Smoke E2E manual pós-merge: signup → email tem URL `/confirm-email?token=...` (não `n/a`) → click → mutation valida → user.email_verified_at = now()
- [ ] Verificação visual: abrir HTML renderizado no browser, paleta cyan/navy

## Manual TODO post-merge (NÃO trackeado em git — `.env` é secret e bloqueado pelo pre-tool-use hook)

Italo, atualizar nos seus `.env` locais:

```diff
# repos/auraxis-api/.env (linha 103)
-EMAIL_CONFIRMATION_FRONTEND_URL=https://app.auraxis.com.br/auth/confirm-email
+EMAIL_CONFIRMATION_FRONTEND_URL=https://app.auraxis.com.br/confirm-email

# repos/auraxis-api/.env.prod (linha 66)
-EMAIL_CONFIRMATION_FRONTEND_URL=https://app.auraxis.com.br/auth/confirm-email
+EMAIL_CONFIRMATION_FRONTEND_URL=https://app.auraxis.com.br/confirm-email
```

E sanity-check no deploy prod (SSM Parameter Store ou docker compose `.env` no EC2): `EMAIL_CONFIRMATION_FRONTEND_URL` carregada no container? Mesmo se não, o fallback canônico do código novo evita quebrar — mas é higiene.

## Out of scope

- Light/dark variants via `prefers-color-scheme` — emails sempre dark
- Reescrita estrutural de templates (mantém table-based layout para compat client)
- ADR (sem decisão arquitetural — só fix + visual update)
- Atualizar `.env*.example` (bloqueado pelo pre-tool-use hook — secrets policy)