### PR TITLE
[API] Register EMAIL_CONFIRMATION_FRONTEND_URL in Config class

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -114,6 +114,10 @@ class Config:
         os.getenv("EMAIL_VERIFICATION_GRACE_PERIOD_DAYS", "14")
     )
     EMAIL_VERIFICATION_ENFORCE = _read_bool_env("EMAIL_VERIFICATION_ENFORCE", True)
+    # URL base do frontend para o link de confirmação de email. Consumido por
+    # email_confirmation_service. Quando vazio, o serviço faz fallback para
+    # a URL canônica de prod com warning de log (PR #1335).
+    EMAIL_CONFIRMATION_FRONTEND_URL = os.getenv("EMAIL_CONFIRMATION_FRONTEND_URL", "")
 
     DEBUG = _read_bool_env("FLASK_DEBUG", False)
 


### PR DESCRIPTION
## Summary

Smoke E2E em prod (2026-05-21 14:00 UTC) mostrou que o backend logava `EMAIL_CONFIRMATION_FRONTEND_URL not configured — falling back to canonical default` mesmo com a env var setada no container (`docker exec auraxis-web-1 printenv` retornava o valor).

Root cause: `runtime_config()` lê de `current_app.config`, e Flask só carrega no config o que está explicitamente atribuído na classe `Config`. A env var não estava listada lá → ignorada.

Fix: 1 linha adicionando `EMAIL_CONFIRMATION_FRONTEND_URL = os.getenv("EMAIL_CONFIRMATION_FRONTEND_URL", "")` ao `Config` class. O fallback canônico do PR #1335 continua valendo quando vazio.

Closes #1336

## Test plan

- [x] Pytest local verde (10/10 nos tests de URL + resend)
- [x] Pre-commit + pre-push hooks verdes
- [ ] CI verde
- [ ] Smoke pós-deploy: logs do container web não devem mais ter `email_confirmation_url_missing` quando env var setada