### PR TITLE
[API] /auth/email/confirm magic-link login (emit JWT + refresh cookie)

### DIFF
--- a/app/application/services/email_confirmation_service.py
+++ b/app/application/services/email_confirmation_service.py
@@ -6,6 +6,7 @@ import secrets
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import cast
+from uuid import UUID
 
 from app.extensions.database import db
 from app.http.runtime import (
@@ -31,6 +32,10 @@ EMAIL_CONFIRMATION_INVALID_TOKEN_MESSAGE = (
 class EmailConfirmationResult:
     ok: bool
     message: str
+    # Populated when ok=True so the REST controller can mint a JWT and open
+    # a session for the user (magic-link login pattern — #1338).
+    user_id: UUID | None = None
+    user_email: str | None = None
 
 
 def _utcnow() -> datetime:
@@ -179,4 +184,9 @@ def confirm_email(*, token: str) -> EmailConfirmationResult:
         "event=auth.email_confirmation_completed user_id=%s",
         str(user.id),
     )
-    return EmailConfirmationResult(ok=True, message=EMAIL_CONFIRMATION_SUCCESS_MESSAGE)
+    return EmailConfirmationResult(
+        ok=True,
+        message=EMAIL_CONFIRMATION_SUCCESS_MESSAGE,
+        user_id=user.id,
+        user_email=str(user.email),
+    )

--- a/app/controllers/auth/confirm_email_resource.py
+++ b/app/controllers/auth/confirm_email_resource.py
@@ -1,26 +1,39 @@
 from __future__ import annotations
 
 from typing import Any
+from uuid import UUID
 
-from flask import Response, current_app
+from flask import Response, current_app, request
 from flask_apispec.views import MethodResource
+from flask_jwt_extended import set_refresh_cookies
 
+from app.application.services.authenticated_user_context_service import (
+    AuthenticatedUserContextService,
+)
 from app.application.services.email_confirmation_service import (
     EMAIL_CONFIRMATION_INVALID_TOKEN_MESSAGE,
     EMAIL_CONFIRMATION_SUCCESS_MESSAGE,
 )
+from app.application.services.session_service import create_session
 from app.docs.openapi_helpers import (
     contract_header_param,
     json_error_response,
     json_request_body,
     json_success_response,
 )
+from app.extensions.database import db
+from app.http.request_context import get_request_context
+from app.models.user import User
 from app.schemas.auth_schema import ConfirmEmailSchema
+from app.services.authenticated_user_payloads import (
+    to_authenticated_user_canonical_payload,
+)
 from app.utils.typed_decorators import typed_doc as doc
 from app.utils.typed_decorators import typed_use_kwargs as use_kwargs
 
 from .contracts import compat_error, compat_success
-from .dependencies import get_auth_dependencies
+from .cookie_only_policy import COOKIE_ONLY_HEADER, should_omit_refresh_token_in_body
+from .dependencies import AuthDependencies, get_auth_dependencies
 
 
 class ConfirmEmailResource(MethodResource):
@@ -57,19 +70,19 @@ class ConfirmEmailResource(MethodResource):
     @use_kwargs(ConfirmEmailSchema, location="json")
     def post(self, **kwargs: Any) -> Response:
         try:
-            result = get_auth_dependencies().confirm_email(str(kwargs["token"]))
-            if not result.ok:
+            dependencies = get_auth_dependencies()
+            result = dependencies.confirm_email(str(kwargs["token"]))
+            if not result.ok or result.user_id is None:
                 return compat_error(
                     legacy_payload={"message": result.message},
                     status_code=400,
                     message=result.message,
                     error_code="VALIDATION_ERROR",
                 )
-            return compat_success(
-                legacy_payload={"message": result.message},
-                status_code=200,
+            return _build_magic_link_response(
+                user_id=result.user_id,
+                dependencies=dependencies,
                 message=result.message,
-                data={},
             )
         except Exception:
             current_app.logger.exception(
@@ -81,3 +94,73 @@ class ConfirmEmailResource(MethodResource):
                 message="Email confirmation failed",
                 error_code="INTERNAL_ERROR",
             )
+
+
+def _build_magic_link_response(
+    *,
+    user_id: UUID,
+    dependencies: AuthDependencies,
+    message: str,
+) -> Response:
+    """Mint a JWT pair for the verified user and return the canonical envelope.
+
+    The HMAC token already proved possession of the email address, so we treat
+    that as sufficient credential to open a session (#1338 magic-link login).
+    Mirrors the pattern used by /auth/login.
+    """
+    user = db.session.get(User, user_id)
+    if user is None:
+        return compat_error(
+            legacy_payload={"message": "Email confirmation failed"},
+            status_code=500,
+            message="Email confirmation failed",
+            error_code="INTERNAL_ERROR",
+        )
+
+    access_token = dependencies.create_access_token(str(user.id))
+    refresh_token = dependencies.create_refresh_token(str(user.id))
+    access_jti = dependencies.get_token_jti(access_token)
+    refresh_jti = dependencies.get_token_jti(refresh_token)
+
+    user.current_jti = access_jti
+    user.refresh_token_jti = refresh_jti
+    request_context = get_request_context()
+    create_session(
+        user_id=user.id,
+        raw_refresh_token=refresh_token,
+        refresh_jti=refresh_jti,
+        access_jti=access_jti,
+        user_agent=request_context.user_agent,
+        remote_addr=request_context.client_ip,
+    )
+    db.session.commit()
+
+    profile = AuthenticatedUserContextService.with_defaults().build_profile(user)
+    user_payload = to_authenticated_user_canonical_payload(profile)
+
+    omit_refresh_in_body = should_omit_refresh_token_in_body(
+        header_value=request.headers.get(COOKIE_ONLY_HEADER),
+    )
+    legacy_payload: dict[str, Any] = {
+        "message": message,
+        "token": access_token,
+        "user": user_payload,
+    }
+    data_payload: dict[str, Any] = {
+        "token": access_token,
+        "user": user_payload,
+    }
+    if not omit_refresh_in_body:
+        legacy_payload["refresh_token"] = refresh_token
+        data_payload["refresh_token"] = refresh_token
+
+    response = compat_success(
+        legacy_payload=legacy_payload,
+        status_code=200,
+        message=message,
+        data=data_payload,
+    )
+    # SEC-GAP-01 — refresh as httpOnly cookie; client can read access_token
+    # from response body and the refresh stays inaccessible to JavaScript.
+    set_refresh_cookies(response, refresh_token)
+    return response

--- a/tests/test_auth_contract.py
+++ b/tests/test_auth_contract.py
@@ -303,6 +303,7 @@ def test_auth_password_reset_v2_contract_revokes_existing_sessions(client) -> No
 
 
 def test_auth_email_confirm_v2_contract(client) -> None:
+    """Magic-link login (#1338): confirm returns access token + canonical user."""
     suffix = uuid.uuid4().hex[:8]
     payload = _register_payload(suffix)
     register = client.post("/auth/register", json=payload)
@@ -322,7 +323,50 @@ def test_auth_email_confirm_v2_contract(client) -> None:
     body = response.get_json()
     assert body["success"] is True
     assert body["message"] == EMAIL_CONFIRMATION_SUCCESS_MESSAGE
-    assert body["data"] == {}
+    # Magic-link login: response carries token + canonical user payload.
+    data = body["data"]
+    assert isinstance(data.get("token"), str) and len(data["token"]) > 0
+    user_payload = data["user"]
+    assert set(user_payload.keys()) >= {
+        "identity",
+        "profile",
+        "financial_profile",
+        "investor_profile",
+        "product_context",
+        "email_verification",
+    }
+    assert user_payload["identity"]["email"] == payload["email"]
+    # Backend just marked verified — the canonical block must reflect that.
+    assert user_payload["email_verification"]["verified"] is True
+    # Refresh cookie must be set so the client can refresh silently afterwards.
+    set_cookie = response.headers.get("Set-Cookie", "")
+    assert "auraxis_refresh" in set_cookie
+
+
+def test_auth_email_confirm_v2_contract_rejects_reused_token(client) -> None:
+    """Second click on the same magic-link must not mint a new session."""
+    suffix = uuid.uuid4().hex[:8]
+    payload = _register_payload(suffix)
+    client.post("/auth/register", json=payload)
+    outbox = client.application.extensions.get("email_confirmation_outbox", [])
+    token = outbox[0]["token"]
+
+    first = client.post(
+        "/auth/email/confirm",
+        headers=_v2_headers(),
+        json={"token": token},
+    )
+    assert first.status_code == 200
+
+    second = client.post(
+        "/auth/email/confirm",
+        headers=_v2_headers(),
+        json={"token": token},
+    )
+    assert second.status_code == 400
+    body = second.get_json()
+    assert body["success"] is False
+    assert body["error"]["code"] == "VALIDATION_ERROR"
 
 
 def test_auth_email_confirm_v2_contract_with_invalid_token(client) -> None:


### PR DESCRIPTION
## Summary

Smoke E2E em prod 2026-05-21 mostrou usuários logados sendo cuspidos pra `/login` ao clicar no link de confirmação de email — modal "Sessão expirada" hijack durante o fluxo. Italo + Claude debateram (2026-05-21) e aprovaram a solução de produto: token HMAC do email **é credencial** → endpoint `/auth/email/confirm` vira **passwordless login** (magic-link).

Spec completa: `auraxis-platform/.context/feature_specs/email-confirm-passwordless-login.md`

Closes #1338

## Changes

### `email_confirmation_service.py`
- `EmailConfirmationResult` ganha `user_id: UUID | None` + `user_email: str | None` (populated quando `ok=True`)

### `confirm_email_resource.py`
- Quando o service retorna sucesso, o controller:
  1. Carrega user via `db.session.get(User, user_id)`
  2. Mint access + refresh tokens via `AuthDependencies.create_access_token` / `create_refresh_token`
  3. Persiste sessão via `session_service.create_session()`
  4. Constrói canonical v3 user payload via `AuthenticatedUserContextService.build_profile`
  5. Retorna envelope v2 `{token, user, refresh_token?}` + `set_refresh_cookies(response, refresh_token)`
- Mirror do pattern de `/auth/login` (mesma sequência, sem password verification)

### Tests
- `test_auth_email_confirm_v2_contract` atualizado: valida shape `{token, user}` + bloco canonical v3 + `email_verification.verified === true` + cookie `auraxis_refresh` setado
- `test_auth_email_confirm_v2_contract_rejects_reused_token` (novo): garantia idempotência — segundo clique no link retorna 400, **não** emite nova sessão

## Test plan

- [x] `pytest -m "not schemathesis" --no-cov -x` verde local (suite completa)
- [x] Pre-commit + pre-push hooks verdes
- [ ] CI verde
- [ ] Smoke pós-deploy: signup → click email → response carries token + cookie set

## Definição de resposta (envelope v2)

```json
{
  "success": true,
  "message": "Email confirmed successfully.",
  "data": {
    "token": "eyJhbGc...",
    "user": {
      "identity": { "id": "...", "name": "...", "email": "..." },
      "profile": { ... },
      "financial_profile": { ... },
      "investor_profile": { ... },
      "product_context": { "entitlements_version": 1 },
      "email_verification": {
        "verified": true,
        "deadline_at": null,
        "required_now": false,
        "days_remaining": null
      }
    },
    "refresh_token": "..."
  }
}
```

Header: `Set-Cookie: auraxis_refresh=...; HttpOnly; Path=/auth/refresh; Secure`

## Acceptance criteria

- [x] Token HMAC válido → response carrega `{token, user}` canônico v3
- [x] Refresh cookie httpOnly setado
- [x] Token HMAC use-once preservado (segundo uso → 400 sem JWT)
- [x] Token HMAC expirado/inválido → 400 sem emitir JWT
- [x] `EmailConfirmationResult` ganha `user_id`/`user_email`
- [x] Audit log: evento `auth.email_confirmation_completed` com user_id

## Out of scope

- Flag `auth_method=email_link` no JWT
- TTL diferenciado pra magic-link
- Frontend (PR auraxis-web #916 em paralelo consome este contract)