### PR TITLE
fix(auth): harden email confirmation contract

### DIFF
--- a/app/application/services/email_confirmation_service.py
+++ b/app/application/services/email_confirmation_service.py
@@ -26,12 +26,15 @@ EMAIL_CONFIRMATION_SUCCESS_MESSAGE = "Email confirmed successfully."
 EMAIL_CONFIRMATION_INVALID_TOKEN_MESSAGE = (
     "Invalid or expired email confirmation token."
 )
+EMAIL_CONFIRMATION_INVALID_OR_REUSED_REASON = "invalid_or_reused"
+EMAIL_CONFIRMATION_TOKEN_EXPIRED_REASON = "expired"
 
 
 @dataclass(frozen=True)
 class EmailConfirmationResult:
     ok: bool
     message: str
+    reason: str | None = None
     # Populated when ok=True so the REST controller can mint a JWT and open
     # a session for the user (magic-link login pattern — #1338).
     user_id: UUID | None = None
@@ -122,6 +125,15 @@ def _dispatch_confirmation_email(*, email: str, token: str) -> None:
     )
 
 
+def _log_confirmation_failure(*, reason: str, user_id: UUID | None = None) -> None:
+    safe_user_id = str(user_id) if user_id is not None else "unknown"
+    runtime_logger().info(
+        "event=auth.email_confirmation_failed reason=%s user_id=%s",
+        reason,
+        safe_user_id,
+    )
+
+
 def issue_email_confirmation(user: User) -> EmailConfirmationResult:
     if user.email_verified_at is not None:
         return EmailConfirmationResult(
@@ -162,17 +174,24 @@ def confirm_email(*, token: str) -> EmailConfirmationResult:
     )
     now = _utcnow()
     if user is None or user.email_verification_token_expires_at is None:
+        _log_confirmation_failure(reason=EMAIL_CONFIRMATION_INVALID_OR_REUSED_REASON)
         return EmailConfirmationResult(
             ok=False,
             message=EMAIL_CONFIRMATION_INVALID_TOKEN_MESSAGE,
+            reason=EMAIL_CONFIRMATION_INVALID_OR_REUSED_REASON,
         )
     expires_at = user.email_verification_token_expires_at
     if expires_at.tzinfo is None:
         expires_at = expires_at.replace(tzinfo=UTC)
     if expires_at < now:
+        _log_confirmation_failure(
+            reason=EMAIL_CONFIRMATION_TOKEN_EXPIRED_REASON,
+            user_id=user.id,
+        )
         return EmailConfirmationResult(
             ok=False,
             message=EMAIL_CONFIRMATION_INVALID_TOKEN_MESSAGE,
+            reason=EMAIL_CONFIRMATION_TOKEN_EXPIRED_REASON,
         )
 
     user.email_verified_at = now

--- a/app/controllers/auth/confirm_email_resource.py
+++ b/app/controllers/auth/confirm_email_resource.py
@@ -11,6 +11,7 @@ from app.application.services.authenticated_user_context_service import (
     AuthenticatedUserContextService,
 )
 from app.application.services.email_confirmation_service import (
+    EMAIL_CONFIRMATION_INVALID_OR_REUSED_REASON,
     EMAIL_CONFIRMATION_INVALID_TOKEN_MESSAGE,
     EMAIL_CONFIRMATION_SUCCESS_MESSAGE,
 )
@@ -51,13 +52,25 @@ class ConfirmEmailResource(MethodResource):
             200: json_success_response(
                 description="Email confirmado com sucesso",
                 message=EMAIL_CONFIRMATION_SUCCESS_MESSAGE,
-                data_example={},
+                data_example={
+                    "token": "access-token-issued-after-email-confirmation",
+                    "refresh_token": "refresh-token-issued-after-email-confirmation",
+                    "session_created": True,
+                    "user": {
+                        "identity": {
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "email": "usuario@auraxis.com.br",
+                        },
+                        "email_verification": {"verified": True},
+                    },
+                },
             ),
             400: json_error_response(
                 description="Token inválido, expirado ou payload inválido",
                 message=EMAIL_CONFIRMATION_INVALID_TOKEN_MESSAGE,
                 error_code="VALIDATION_ERROR",
                 status_code=400,
+                details_example={"reason": "expired"},
             ),
             500: json_error_response(
                 description="Erro interno ao confirmar email",
@@ -72,12 +85,27 @@ class ConfirmEmailResource(MethodResource):
         try:
             dependencies = get_auth_dependencies()
             result = dependencies.confirm_email(str(kwargs["token"]))
-            if not result.ok or result.user_id is None:
+            if not result.ok:
                 return compat_error(
                     legacy_payload={"message": result.message},
                     status_code=400,
                     message=result.message,
                     error_code="VALIDATION_ERROR",
+                    details={
+                        "reason": result.reason
+                        or EMAIL_CONFIRMATION_INVALID_OR_REUSED_REASON
+                    },
+                )
+            if result.user_id is None:
+                current_app.logger.info(
+                    "event=auth.email_confirmation_completed "
+                    "status=success_without_session"
+                )
+                return compat_success(
+                    legacy_payload={"message": result.message},
+                    status_code=200,
+                    message=result.message,
+                    data={"session_created": False},
                 )
             return _build_magic_link_response(
                 user_id=result.user_id,
@@ -149,6 +177,7 @@ def _build_magic_link_response(
     data_payload: dict[str, Any] = {
         "token": access_token,
         "user": user_payload,
+        "session_created": True,
     }
     if not omit_refresh_in_body:
         legacy_payload["refresh_token"] = refresh_token

--- a/openapi.json
+++ b/openapi.json
@@ -2160,7 +2160,20 @@
             "content": {
               "application/json": {
                 "example": {
-                  "data": {},
+                  "data": {
+                    "refresh_token": "refresh-token-issued-after-email-confirmation",
+                    "session_created": true,
+                    "token": "access-token-issued-after-email-confirmation",
+                    "user": {
+                      "email_verification": {
+                        "verified": true
+                      },
+                      "identity": {
+                        "email": "usuario@auraxis.com.br",
+                        "id": "00000000-0000-0000-0000-000000000000"
+                      }
+                    }
+                  },
                   "message": "Email confirmed successfully."
                 },
                 "schema": {
@@ -2199,6 +2212,9 @@
               "application/json": {
                 "example": {
                   "code": "VALIDATION_ERROR",
+                  "details": {
+                    "reason": "expired"
+                  },
                   "message": "Invalid or expired email confirmation token.",
                   "status_code": 400
                 },

--- a/tests/test_auth_contract.py
+++ b/tests/test_auth_contract.py
@@ -1,17 +1,27 @@
+import logging
 import uuid
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
 from typing import Dict
 
 from app.application.services.email_confirmation_service import (
     EMAIL_CONFIRMATION_INVALID_TOKEN_MESSAGE,
     EMAIL_CONFIRMATION_NEUTRAL_MESSAGE,
     EMAIL_CONFIRMATION_SUCCESS_MESSAGE,
+    EmailConfirmationResult,
 )
 from app.application.services.password_reset_service import (
     PASSWORD_RESET_INVALID_TOKEN_MESSAGE,
     PASSWORD_RESET_NEUTRAL_MESSAGE,
     PASSWORD_RESET_SUCCESS_MESSAGE,
 )
+from app.controllers.auth.dependencies import AUTH_DEPENDENCIES_EXTENSION_KEY
+from app.extensions.database import db
 from app.extensions.integration_metrics import snapshot_metrics
+from app.models.user import User
+
+EMAIL_CONFIRMATION_INVALID_OR_REUSED_REASON = "invalid_or_reused"
+EMAIL_CONFIRMATION_TOKEN_EXPIRED_REASON = "expired"
 
 
 def _register_payload(suffix: str, password: str = "StrongPass@123") -> Dict[str, str]:
@@ -343,6 +353,38 @@ def test_auth_email_confirm_v2_contract(client) -> None:
     assert "auraxis_refresh" in set_cookie
 
 
+def test_auth_email_confirm_v2_contract_allows_success_without_session(
+    client,
+    monkeypatch,
+) -> None:
+    """Compatibility path: a valid confirmation can succeed without minting JWTs."""
+    dependencies = client.application.extensions[AUTH_DEPENDENCIES_EXTENSION_KEY]
+    monkeypatch.setitem(
+        client.application.extensions,
+        AUTH_DEPENDENCIES_EXTENSION_KEY,
+        replace(
+            dependencies,
+            confirm_email=lambda _token: EmailConfirmationResult(
+                ok=True,
+                message=EMAIL_CONFIRMATION_SUCCESS_MESSAGE,
+            ),
+        ),
+    )
+
+    response = client.post(
+        "/auth/email/confirm",
+        headers=_v2_headers(),
+        json={"token": "valid-token-value-with-sufficient-length-123456"},
+    )
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["success"] is True
+    assert body["message"] == EMAIL_CONFIRMATION_SUCCESS_MESSAGE
+    assert body["data"] == {"session_created": False}
+    assert "auraxis_refresh" not in response.headers.get("Set-Cookie", "")
+
+
 def test_auth_email_confirm_v2_contract_rejects_reused_token(client) -> None:
     """Second click on the same magic-link must not mint a new session."""
     suffix = uuid.uuid4().hex[:8]
@@ -367,6 +409,46 @@ def test_auth_email_confirm_v2_contract_rejects_reused_token(client) -> None:
     body = second.get_json()
     assert body["success"] is False
     assert body["error"]["code"] == "VALIDATION_ERROR"
+    assert (
+        body["error"]["details"]["reason"]
+        == EMAIL_CONFIRMATION_INVALID_OR_REUSED_REASON
+    )
+
+
+def test_auth_email_confirm_v2_contract_rejects_expired_token_without_leaking_token(
+    app,
+    caplog,
+    client,
+) -> None:
+    suffix = uuid.uuid4().hex[:8]
+    payload = _register_payload(suffix)
+    client.post("/auth/register", json=payload)
+    outbox = client.application.extensions.get("email_confirmation_outbox", [])
+    token = outbox[0]["token"]
+
+    with app.app_context():
+        user = User.query.filter_by(email=payload["email"]).first()
+        assert user is not None
+        user.email_verification_token_expires_at = datetime.now(UTC).replace(
+            tzinfo=None
+        ) - timedelta(minutes=1)
+        db.session.commit()
+
+    caplog.set_level(logging.INFO)
+    response = client.post(
+        "/auth/email/confirm",
+        headers=_v2_headers(),
+        json={"token": token},
+    )
+
+    assert response.status_code == 400
+    body = response.get_json()
+    assert body["success"] is False
+    assert body["error"]["code"] == "VALIDATION_ERROR"
+    assert body["error"]["details"]["reason"] == EMAIL_CONFIRMATION_TOKEN_EXPIRED_REASON
+    assert "event=auth.email_confirmation_failed" in caplog.text
+    assert f"reason={EMAIL_CONFIRMATION_TOKEN_EXPIRED_REASON}" in caplog.text
+    assert token not in caplog.text
 
 
 def test_auth_email_confirm_v2_contract_with_invalid_token(client) -> None:
@@ -381,6 +463,10 @@ def test_auth_email_confirm_v2_contract_with_invalid_token(client) -> None:
     assert body["success"] is False
     assert body["error"]["code"] == "VALIDATION_ERROR"
     assert body["message"] == EMAIL_CONFIRMATION_INVALID_TOKEN_MESSAGE
+    assert (
+        body["error"]["details"]["reason"]
+        == EMAIL_CONFIRMATION_INVALID_OR_REUSED_REASON
+    )
 
 
 def test_auth_email_resend_v2_contract_requires_jwt(client) -> None:


### PR DESCRIPTION
## Resumo

Closes #1341

Endurece o contrato de `POST /auth/email/confirm` para que o Web consiga encerrar o fluxo de confirmação de e-mail de forma determinística, sem spinner infinito e sem depender de inferência frágil.

## O que mudou

- Adiciona `reason` estruturado nos erros v2 de confirmação:
  - `invalid_or_reused` para token inválido ou token já consumido.
  - `expired` para token expirado.
- Registra falhas de confirmação com `event=auth.email_confirmation_failed`, `reason` e `user_id` quando seguro, sem logar o token bruto.
- Mantém o fluxo magic-link atual com access token, refresh cookie e payload canônico de usuário.
- Adiciona `session_created=true` no payload de sucesso com sessão.
- Adiciona caminho de compatibilidade `session_created=false` para confirmação bem-sucedida sem sessão, permitindo que o Web mostre sucesso e CTA de login sem tratar isso como erro.
- Atualiza o `openapi.json` para refletir o payload real de sucesso e o `details.reason` nos erros.

## Como testei

- RED test inicial falhou em sucesso sem sessão retornando 400.
- `pytest` alvo de confirmação de e-mail:
  - `test_auth_email_confirm_v2_contract`
  - `test_auth_email_confirm_v2_contract_allows_success_without_session`
  - `test_auth_email_confirm_v2_contract_rejects_reused_token`
  - `test_auth_email_confirm_v2_contract_rejects_expired_token_without_leaking_token`
  - `test_auth_email_confirm_v2_contract_with_invalid_token`
- Suite relacionada:
  - `tests/test_auth_contract.py`
  - `tests/test_email_confirmation_resend.py`
  - `tests/test_graphql_api.py::test_graphql_confirm_email_flow`
  - `tests/test_graphql_api.py::test_graphql_confirm_email_with_invalid_token_returns_public_validation_error`
- `bash scripts/check-openapi-drift.sh`
- Quality gate completo:
  - `TZ=UTC PYTHON_BIN=.venv/bin/python DATABASE_URL=sqlite:////tmp/auraxis-quality-1341-final.sqlite3 bash scripts/run_ci_quality_local.sh --local`
  - Resultado: `2350 passed, 1 skipped`, cobertura `91.04%`.
- Hooks de commit e push passaram com o venv da API no PATH, incluindo gitleaks, mypy, Postman contract, security evidence e pip-audit.

## Rollback

Reverter este PR volta o endpoint ao contrato anterior: sucesso magic-link continua existindo, mas erros deixam de carregar `details.reason` e sucesso sem sessão volta a ser tratado como 400.
