### PR TITLE
fix(ai): honor user timezone for insight periods

### DIFF
--- a/app/controllers/ai/resources.py
+++ b/app/controllers/ai/resources.py
@@ -44,6 +44,7 @@ from app.services.analysis_ready_notification_service import (
 )
 from app.services.entitlement_service import has_entitlement
 from app.services.llm_provider import LLMProviderError
+from app.utils import timezone_utils
 from app.utils.typed_decorators import typed_doc as doc
 from app.utils.typed_decorators import typed_jwt_required as jwt_required
 
@@ -199,6 +200,19 @@ def _parse_ai_insight_generate_body(
     return None, period_type, anchor_date, preview_run_id
 
 
+def _raw_ai_insight_request_timezone(body: dict[str, Any]) -> object:
+    raw_timezone = request.headers.get(timezone_utils.USER_TIMEZONE_HEADER)
+    if raw_timezone in (None, ""):
+        raw_timezone = body.get("timezone")
+    return raw_timezone
+
+
+def _resolve_ai_insight_request_timezone(
+    body: dict[str, Any],
+) -> timezone_utils.UserTimezoneResolution:
+    return timezone_utils.resolve_user_timezone(_raw_ai_insight_request_timezone(body))
+
+
 class AIInsightGenerateResource(MethodResource):
     """POST /ai/insights/generate — period-aware AI financial insights."""
 
@@ -210,12 +224,25 @@ class AIInsightGenerateResource(MethodResource):
         ),
         tags=["AI Advisory"],
         security=[{"BearerAuth": []}],
+        params={
+            timezone_utils.USER_TIMEZONE_HEADER: {
+                "in": "header",
+                "description": (
+                    "Timezone IANA do usuário. Usado para calcular anchor_date "
+                    "quando a data âncora é omitida."
+                ),
+                "type": "string",
+                "required": False,
+                "example": "America/Sao_Paulo",
+            }
+        },
         requestBody=json_request_body(
             schema=AIInsightGenerateRequestSchema,
             description="Período que deve ser consolidado antes da chamada à IA.",
             example={
                 "period_type": "daily",
-                "anchor_date": "2026-05-17",
+                "anchor_date": None,
+                "timezone": "America/Sao_Paulo",
                 "preview_run_id": "550e8400-e29b-41d4-a716-446655440000",
             },
         ),
@@ -287,12 +314,25 @@ class AIInsightGenerateResource(MethodResource):
             return parse_error
         assert period_type is not None
 
+        timezone_resolution = _resolve_ai_insight_request_timezone(body)
+        anchor_was_omitted = anchor_date is None
+        if anchor_was_omitted:
+            anchor_date = timezone_utils.local_today(timezone_resolution)
+
         service = AIAdvisoryService(user_id=user_id)
+        timezone_kwargs: dict[str, Any] = {}
+        raw_timezone = _raw_ai_insight_request_timezone(body)
+        if raw_timezone not in (None, "") or anchor_was_omitted:
+            timezone_kwargs = {
+                "timezone_name": timezone_resolution.name,
+                "timezone_fallback": timezone_resolution.fallback_used,
+            }
         try:
             result = service.generate_financial_insights(
                 period_type=period_type,
                 anchor_date=anchor_date,
                 preview_run_id=preview_run_id,
+                **timezone_kwargs,
             )
         except AIConsentRequiredError as exc:
             return _ai_consent_required_response(exc)

--- a/app/graphql/mutations/ai_insight.py
+++ b/app/graphql/mutations/ai_insight.py
@@ -11,6 +11,7 @@ from datetime import date, datetime
 from typing import Any
 
 import graphene
+from flask import request
 
 from app.graphql.auth import get_current_user_required
 from app.graphql.errors import build_public_graphql_error
@@ -18,6 +19,7 @@ from app.graphql.observability import log_graphql_resolver
 from app.services.ai_advisory_service import AIAdvisoryService
 from app.services.financial_insight_context_builder import INSIGHT_DIMENSIONS
 from app.services.llm_provider import LLMProviderError
+from app.utils import timezone_utils
 
 _VALID_PERIOD_TYPES = ("daily", "weekly", "monthly")
 
@@ -98,10 +100,19 @@ class GenerateAiInsightMutation(graphene.Mutation):
                 ) from exc
 
         service = AIAdvisoryService(user_id=user.id)
+        raw_timezone = request.headers.get(timezone_utils.USER_TIMEZONE_HEADER)
+        timezone_kwargs: dict[str, Any] = {}
+        if raw_timezone not in (None, "") or parsed_anchor is None:
+            timezone_resolution = timezone_utils.resolve_user_timezone(raw_timezone)
+            timezone_kwargs = {
+                "timezone_name": timezone_resolution.name,
+                "timezone_fallback": timezone_resolution.fallback_used,
+            }
         try:
             result = service.generate_financial_insights(
                 period_type=normalized,
                 anchor_date=parsed_anchor,
+                **timezone_kwargs,
             )
         except LLMProviderError as exc:
             raise build_public_graphql_error(

--- a/app/schemas/ai_insight_schema.py
+++ b/app/schemas/ai_insight_schema.py
@@ -20,6 +20,17 @@ class AIInsightGenerateRequestSchema(Schema):
             "example": "2026-05-17",
         },
     )
+    timezone = fields.String(
+        required=False,
+        allow_none=True,
+        metadata={
+            "description": (
+                "Timezone IANA do usuário usado quando anchor_date é omitido. "
+                "Também pode ser enviado no header X-Auraxis-Timezone."
+            ),
+            "example": "America/Sao_Paulo",
+        },
+    )
     preview_run_id = fields.UUID(
         required=False,
         allow_none=True,

--- a/app/services/ai_advisory_service.py
+++ b/app/services/ai_advisory_service.py
@@ -53,6 +53,7 @@ from app.services.goal_projection_service import GoalProjectionService
 from app.services.insight_evidence_validator import filter_valid_items
 from app.services.llm_provider import LLMProvider, LLMProviderError, get_llm_provider
 from app.services.weekly_summary import compute_weekly_summary
+from app.utils import timezone_utils
 from app.utils.datetime_utils import utc_now_naive
 
 log = logging.getLogger(__name__)
@@ -826,6 +827,8 @@ def _build_period_snapshot(
     user_id: UUID,
     anchor: date,
     previous_generated_at: datetime | None = None,
+    timezone_name: str = timezone_utils.DEFAULT_USER_TIMEZONE,
+    timezone_fallback: bool = False,
 ) -> dict[str, Any]:
     """Dispatch to the period-specific snapshot builder."""
     builder = FinancialInsightContextBuilder()
@@ -834,18 +837,24 @@ def _build_period_snapshot(
             user_id=user_id,
             anchor_date=anchor,
             previous_generated_at=previous_generated_at,
+            timezone_name=timezone_name,
+            timezone_fallback=timezone_fallback,
         )
     if insight_type == InsightType.weekly:
         return builder.build_weekly(
             user_id=user_id,
             anchor_date=anchor,
             previous_generated_at=previous_generated_at,
+            timezone_name=timezone_name,
+            timezone_fallback=timezone_fallback,
         )
     if insight_type == InsightType.monthly:
         return builder.build_monthly(
             user_id=user_id,
             anchor_date=anchor,
             previous_generated_at=previous_generated_at,
+            timezone_name=timezone_name,
+            timezone_fallback=timezone_fallback,
         )
     raise ValueError("period_type must be daily, weekly or monthly")
 
@@ -875,11 +884,18 @@ class AIAdvisoryService:
         period_type: str,
         anchor_date: date | None = None,
         preview_run_id: UUID | None = None,
+        timezone_name: str | None = None,
+        timezone_fallback: bool = False,
     ) -> dict[str, Any]:
         """Generate period-aware financial insights with structured evidence."""
         normalized_period_type = period_type.strip().lower()
         insight_type = InsightType(normalized_period_type)
-        anchor = anchor_date or date.today()
+        timezone_resolution = timezone_utils.resolve_user_timezone(timezone_name)
+        fallback_used = timezone_fallback or (
+            timezone_resolution.fallback_used
+            and (anchor_date is None or timezone_name is not None)
+        )
+        anchor = anchor_date or timezone_utils.local_today(timezone_resolution)
         consent_version = ensure_ai_consent_granted(self._user_id)
 
         preview_run: AIInsightRun | None = None
@@ -919,6 +935,8 @@ class AIAdvisoryService:
                 user_id=self._user_id,
                 anchor=anchor,
                 previous_generated_at=previous.created_at if previous else None,
+                timezone_name=timezone_resolution.name,
+                timezone_fallback=fallback_used,
             )
 
             period = snapshot["period"]

--- a/app/services/financial_insight_context_builder.py
+++ b/app/services/financial_insight_context_builder.py
@@ -466,6 +466,8 @@ class FinancialInsightContextBuilder:
         user_id: UUID,
         anchor_date: date,
         previous_generated_at: datetime | None = None,
+        timezone_name: str = _TIMEZONE,
+        timezone_fallback: bool = False,
     ) -> dict[str, Any]:
         """Return a daily snapshot with extended temporal comparisons."""
         current = self._period_snapshot(
@@ -476,6 +478,8 @@ class FinancialInsightContextBuilder:
             period_type="daily",
             include_credit_cards=True,
             previous_generated_at=previous_generated_at,
+            timezone_name=timezone_name,
+            timezone_fallback=timezone_fallback,
         )
         yesterday = anchor_date - timedelta(days=1)
         previous_week = anchor_date - timedelta(days=7)
@@ -541,6 +545,8 @@ class FinancialInsightContextBuilder:
         user_id: UUID,
         anchor_date: date,
         previous_generated_at: datetime | None = None,
+        timezone_name: str = _TIMEZONE,
+        timezone_fallback: bool = False,
     ) -> dict[str, Any]:
         """Return a weekly snapshot for the ISO week containing ``anchor_date``."""
         start, end = _week_bounds(anchor_date)
@@ -555,6 +561,8 @@ class FinancialInsightContextBuilder:
             include_credit_cards=True,
             include_wallet=True,
             previous_generated_at=previous_generated_at,
+            timezone_name=timezone_name,
+            timezone_fallback=timezone_fallback,
         )
         previous_start = start - timedelta(days=7)
         previous_end = start - timedelta(days=1)
@@ -578,6 +586,8 @@ class FinancialInsightContextBuilder:
         user_id: UUID,
         anchor_date: date,
         previous_generated_at: datetime | None = None,
+        timezone_name: str = _TIMEZONE,
+        timezone_fallback: bool = False,
     ) -> dict[str, Any]:
         """Return a monthly snapshot for the calendar month containing anchor."""
         start, end = _month_bounds(anchor_date)
@@ -593,6 +603,8 @@ class FinancialInsightContextBuilder:
             include_credit_cards=True,
             include_wallet=True,
             previous_generated_at=previous_generated_at,
+            timezone_name=timezone_name,
+            timezone_fallback=timezone_fallback,
         )
 
     def _comparison_snapshot(
@@ -643,6 +655,8 @@ class FinancialInsightContextBuilder:
         include_wallet: bool = False,
         market_rates: MarketRatesProvider | None = None,
         previous_generated_at: datetime | None = None,
+        timezone_name: str = _TIMEZONE,
+        timezone_fallback: bool = False,
     ) -> dict[str, Any]:
         transactions = self._fetch_transactions(user_id=user_id, start=start, end=end)
         non_cancelled = [
@@ -662,7 +676,7 @@ class FinancialInsightContextBuilder:
             "schema_version": _SNAPSHOT_VERSION,
             "period_type": period_type,
             "currency": _CURRENCY,
-            "timezone": _TIMEZONE,
+            "timezone": timezone_name,
             "anchor_date": end.isoformat(),
             "period": _date_period(start, end, label),
             "current_period": current_period,
@@ -690,6 +704,8 @@ class FinancialInsightContextBuilder:
                 "missing_comparison_periods": [],
             },
         }
+        if timezone_fallback:
+            snapshot["data_quality"]["timezone_fallback"] = True
         snapshot["data_quality"].update(goal_data_quality)
         if include_wallet:
             wallet_payload, missing_rates = self._wallet_payload(

--- a/app/utils/timezone_utils.py
+++ b/app/utils/timezone_utils.py
@@ -1,0 +1,73 @@
+"""User timezone helpers for financial period resolution.
+
+The API stores canonical timestamps independently from user locale, but period
+selection for financial insights must follow the user's local calendar day.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+DEFAULT_USER_TIMEZONE = "America/Sao_Paulo"
+USER_TIMEZONE_HEADER = "X-Auraxis-Timezone"
+
+
+@dataclass(frozen=True)
+class UserTimezoneResolution:
+    """Validated timezone selected for a request."""
+
+    name: str
+    zone: ZoneInfo
+    fallback_used: bool
+    requested: str | None
+
+
+def utc_now() -> datetime:
+    """Return the current UTC datetime; kept injectable for deterministic tests."""
+    return datetime.now(UTC)
+
+
+def resolve_user_timezone(raw_timezone: object) -> UserTimezoneResolution:
+    """Resolve an IANA timezone name, falling back safely when absent/invalid."""
+    requested = str(raw_timezone or "").strip() or None
+    if requested is not None:
+        try:
+            return UserTimezoneResolution(
+                name=requested,
+                zone=ZoneInfo(requested),
+                fallback_used=False,
+                requested=requested,
+            )
+        except (ZoneInfoNotFoundError, ValueError):
+            pass
+
+    return UserTimezoneResolution(
+        name=DEFAULT_USER_TIMEZONE,
+        zone=ZoneInfo(DEFAULT_USER_TIMEZONE),
+        fallback_used=True,
+        requested=requested,
+    )
+
+
+def local_today(
+    resolution: UserTimezoneResolution,
+    *,
+    now_utc: datetime | None = None,
+) -> date:
+    """Return today's date in the resolved user timezone."""
+    now = now_utc or utc_now()
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=UTC)
+    return now.astimezone(resolution.zone).date()
+
+
+__all__ = [
+    "DEFAULT_USER_TIMEZONE",
+    "USER_TIMEZONE_HEADER",
+    "UserTimezoneResolution",
+    "local_today",
+    "resolve_user_timezone",
+    "utc_now",
+]

--- a/openapi.json
+++ b/openapi.json
@@ -662,6 +662,12 @@
             "format": "uuid",
             "nullable": true,
             "type": "string"
+          },
+          "timezone": {
+            "description": "Timezone IANA do usuário usado quando anchor_date é omitido. Também pode ser enviado no header X-Auraxis-Timezone.",
+            "example": "America/Sao_Paulo",
+            "nullable": true,
+            "type": "string"
           }
         },
         "required": [
@@ -1372,15 +1378,25 @@
     "/ai/insights/generate": {
       "post": {
         "description": "Gera insights financeiros com contexto daily, weekly ou monthly, incluindo evidências estruturadas extraídas do snapshot financeiro.",
-        "parameters": [],
+        "parameters": [
+          {
+            "description": "Timezone IANA do usuário. Usado para calcular anchor_date quando a data âncora é omitida.",
+            "example": "America/Sao_Paulo",
+            "in": "header",
+            "name": "X-Auraxis-Timezone",
+            "required": false,
+            "type": "string"
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
               "description": "Período que deve ser consolidado antes da chamada à IA.",
               "example": {
-                "anchor_date": "2026-05-17",
+                "anchor_date": null,
                 "period_type": "daily",
-                "preview_run_id": "550e8400-e29b-41d4-a716-446655440000"
+                "preview_run_id": "550e8400-e29b-41d4-a716-446655440000",
+                "timezone": "America/Sao_Paulo"
               },
               "schema": {
                 "$ref": "#/components/schemas/app_schemas_ai_insight_schema_AIInsightGenerateRequestSchema"

--- a/tests/test_ai_advisory_service.py
+++ b/tests/test_ai_advisory_service.py
@@ -18,7 +18,7 @@ Coverage areas:
 from __future__ import annotations
 
 import uuid
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from decimal import Decimal
 from unittest.mock import MagicMock, patch
 
@@ -1018,6 +1018,156 @@ class TestAIInsightGenerateEndpoint:
             "period_type": "daily",
             "anchor_date": date(2026, 5, 17),
             "preview_run_id": None,
+        }
+
+    def test_post_generation_uses_user_timezone_when_anchor_is_omitted(
+        self,
+        app,
+        client,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        token = _register_and_login(client, prefix="ai-generate-tz")
+        user_id = _get_current_user_id(app, token)
+        _grant_entitlement(app, user_id, "advanced_simulations")
+
+        generated = {
+            "period_type": "daily",
+            "period_label": "2026-05-21",
+            "period_start": "2026-05-21",
+            "period_end": "2026-05-21",
+            "summary": "Resumo do dia local.",
+            "items": [],
+            "context_version": "financial_insight_snapshot.v1",
+            "cached": False,
+            "model": "stub",
+            "tokens_used": 123,
+            "cost_usd": 0.00001,
+        }
+        monkeypatch.setattr(
+            "app.controllers.ai.resources.timezone_utils.utc_now",
+            lambda: datetime(2026, 5, 22, 2, 30, tzinfo=timezone.utc),
+        )
+
+        with patch(
+            "app.services.ai_advisory_service.AIAdvisoryService.generate_financial_insights",
+            return_value=generated,
+        ) as mocked_generate:
+            resp = client.post(
+                "/ai/insights/generate",
+                json={"period_type": "daily"},
+                headers={
+                    **_auth(token),
+                    "X-Auraxis-Timezone": "America/Sao_Paulo",
+                },
+            )
+
+        assert resp.status_code == 200
+        mocked_generate.assert_called_once()
+        assert mocked_generate.call_args.kwargs == {
+            "period_type": "daily",
+            "anchor_date": date(2026, 5, 21),
+            "preview_run_id": None,
+            "timezone_name": "America/Sao_Paulo",
+            "timezone_fallback": False,
+        }
+
+    def test_post_generation_falls_back_when_timezone_is_invalid(
+        self,
+        app,
+        client,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        token = _register_and_login(client, prefix="ai-generate-bad-tz")
+        user_id = _get_current_user_id(app, token)
+        _grant_entitlement(app, user_id, "advanced_simulations")
+
+        generated = {
+            "period_type": "daily",
+            "period_label": "2026-05-21",
+            "period_start": "2026-05-21",
+            "period_end": "2026-05-21",
+            "summary": "Resumo com fallback.",
+            "items": [],
+            "context_version": "financial_insight_snapshot.v1",
+            "cached": False,
+            "model": "stub",
+            "tokens_used": 123,
+            "cost_usd": 0.00001,
+        }
+        monkeypatch.setattr(
+            "app.controllers.ai.resources.timezone_utils.utc_now",
+            lambda: datetime(2026, 5, 22, 2, 30, tzinfo=timezone.utc),
+        )
+
+        with patch(
+            "app.services.ai_advisory_service.AIAdvisoryService.generate_financial_insights",
+            return_value=generated,
+        ) as mocked_generate:
+            resp = client.post(
+                "/ai/insights/generate",
+                json={"period_type": "daily"},
+                headers={
+                    **_auth(token),
+                    "X-Auraxis-Timezone": "Mars/Olympus_Mons",
+                },
+            )
+
+        assert resp.status_code == 200
+        mocked_generate.assert_called_once()
+        assert mocked_generate.call_args.kwargs == {
+            "period_type": "daily",
+            "anchor_date": date(2026, 5, 21),
+            "preview_run_id": None,
+            "timezone_name": "America/Sao_Paulo",
+            "timezone_fallback": True,
+        }
+
+    def test_post_generation_accepts_timezone_from_payload_when_header_is_absent(
+        self,
+        app,
+        client,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        token = _register_and_login(client, prefix="ai-generate-body-tz")
+        user_id = _get_current_user_id(app, token)
+        _grant_entitlement(app, user_id, "advanced_simulations")
+
+        generated = {
+            "period_type": "daily",
+            "period_label": "2026-05-21",
+            "period_start": "2026-05-21",
+            "period_end": "2026-05-21",
+            "summary": "Resumo com timezone no payload.",
+            "items": [],
+            "context_version": "financial_insight_snapshot.v1",
+            "cached": False,
+            "model": "stub",
+            "tokens_used": 123,
+            "cost_usd": 0.00001,
+        }
+        monkeypatch.setattr(
+            "app.controllers.ai.resources.timezone_utils.utc_now",
+            lambda: datetime(2026, 5, 21, 23, 30, tzinfo=timezone.utc),
+        )
+
+        with patch(
+            "app.services.ai_advisory_service.AIAdvisoryService.generate_financial_insights",
+            return_value=generated,
+        ) as mocked_generate:
+            resp = client.post(
+                "/ai/insights/generate",
+                json={"period_type": "daily", "timezone": "Pacific/Kiritimati"},
+                headers=_auth(token),
+            )
+
+        assert resp.status_code == 200
+        mocked_generate.assert_called_once()
+        assert mocked_generate.call_args.kwargs == {
+            "period_type": "daily",
+            "anchor_date": date(2026, 5, 22),
+            "preview_run_id": None,
+            "timezone_name": "Pacific/Kiritimati",
+            "timezone_fallback": False,
         }
 
     def test_post_generation_accepts_preview_run_id(self, app, client) -> None:

--- a/tests/test_financial_insight_context_builder.py
+++ b/tests/test_financial_insight_context_builder.py
@@ -321,6 +321,24 @@ class TestFinancialInsightContextBuilderDaily:
             "same_day_previous_month"
         ]
 
+    def test_daily_snapshot_records_user_timezone_and_fallback_quality(
+        self, app
+    ) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            anchor = date(2026, 5, 21)
+
+            snapshot = FinancialInsightContextBuilder().build_daily(
+                user_id=user_id,
+                anchor_date=anchor,
+                timezone_name="America/Sao_Paulo",
+                timezone_fallback=True,
+            )
+
+        assert snapshot["timezone"] == "America/Sao_Paulo"
+        assert snapshot["anchor_date"] == "2026-05-21"
+        assert snapshot["data_quality"]["timezone_fallback"] is True
+
     def test_snapshot_redacts_user_pii_and_sensitive_transaction_fields(
         self, app
     ) -> None:

--- a/tests/test_graphql_generate_ai_insight.py
+++ b/tests/test_graphql_generate_ai_insight.py
@@ -20,10 +20,12 @@ def _register_and_login(client, *, prefix: str) -> str:
     return login.get_json()["token"]
 
 
-def _gql(client, query, token=None, variables=None):
+def _gql(client, query, token=None, variables=None, extra_headers=None):
     headers = {"Content-Type": "application/json", "X-API-Contract": "v2"}
     if token:
         headers["Authorization"] = f"Bearer {token}"
+    if extra_headers:
+        headers.update(extra_headers)
     return client.post(
         "/graphql",
         json={"query": query, "variables": variables or {}},
@@ -134,3 +136,53 @@ class TestGenerateAiInsightMutation:
         assert len(data["items"]) == 1
         assert data["items"][0]["dimension"] == "credit_cards"
         assert data["items"][0]["evidence"] == ["credit_cards[0].utilization_pct"]
+
+    def test_passes_timezone_header_to_generation_service(self, app, client):
+        token = _register_and_login(client, prefix="gql-gen-tz")
+        from flask_jwt_extended import decode_token
+
+        from app.services.entitlement_service import grant_entitlement
+
+        with app.app_context():
+            user_id = UUID(decode_token(token)["sub"])
+            grant_entitlement(
+                user_id=user_id,
+                feature_key="advanced_simulations",
+                source="trial",
+            )
+            from app.extensions.database import db
+
+            db.session.commit()
+
+        fake_result = {
+            "period_type": "daily",
+            "period_label": "2026-05-22",
+            "period_start": "2026-05-22",
+            "period_end": "2026-05-22",
+            "summary": "Resumo com timezone.",
+            "items": [],
+            "context_version": "financial_insight_snapshot.v1",
+            "cached": False,
+            "model": "gpt-4o-mini",
+            "tokens_used": 50,
+            "cost_usd": 0.0001,
+        }
+        with patch("app.graphql.mutations.ai_insight.AIAdvisoryService") as MockSvc:
+            instance = MockSvc.return_value
+            instance.generate_financial_insights.return_value = fake_result
+            response = _gql(
+                client,
+                _GENERATE_MUTATION,
+                token,
+                variables={"periodType": "daily", "anchorDate": None},
+                extra_headers={"X-Auraxis-Timezone": "Pacific/Kiritimati"},
+            )
+
+        body = response.get_json()
+        assert "errors" not in body or not body["errors"], body
+        instance.generate_financial_insights.assert_called_once_with(
+            period_type="daily",
+            anchor_date=None,
+            timezone_name="Pacific/Kiritimati",
+            timezone_fallback=False,
+        )

--- a/tests/test_timezone_utils.py
+++ b/tests/test_timezone_utils.py
@@ -1,0 +1,34 @@
+"""Tests for user timezone resolution in financial period contracts."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from app.utils.timezone_utils import local_today, resolve_user_timezone
+
+
+def test_resolve_user_timezone_accepts_valid_iana_name() -> None:
+    resolution = resolve_user_timezone("Pacific/Kiritimati")
+
+    assert resolution.name == "Pacific/Kiritimati"
+    assert resolution.fallback_used is False
+    assert resolution.requested == "Pacific/Kiritimati"
+
+
+def test_resolve_user_timezone_falls_back_for_invalid_name() -> None:
+    resolution = resolve_user_timezone("Mars/Olympus_Mons")
+
+    assert resolution.name == "America/Sao_Paulo"
+    assert resolution.fallback_used is True
+    assert resolution.requested == "Mars/Olympus_Mons"
+
+
+def test_local_today_uses_resolved_timezone_calendar_day() -> None:
+    resolution = resolve_user_timezone("America/Sao_Paulo")
+
+    local_day = local_today(
+        resolution,
+        now_utc=datetime(2026, 5, 22, 2, 30, tzinfo=UTC),
+    )
+
+    assert local_day.isoformat() == "2026-05-21"


### PR DESCRIPTION
## Summary
- Resolves AI Insights period resolution with the user's IANA timezone when `anchor_date` is omitted.
- Accepts timezone via `X-Auraxis-Timezone` header or `timezone` request payload for `POST /ai/insights/generate`.
- Propagates the resolved timezone into daily/weekly/monthly financial snapshots and records `data_quality.timezone_fallback=true` when an invalid/missing timezone fallback determines the local period.
- Extends GraphQL AI insight generation to honor the same request timezone header.
- Updates the OpenAPI contract for the new header and payload field.

## Why
Financial insight periods cannot follow the server clock. A user in `America/Sao_Paulo`, `Pacific/Kiritimati`, or any other IANA timezone needs daily/monthly boundaries to reflect the calendar they see in the UI.

## Tests
- `pytest tests/test_timezone_utils.py tests/test_ai_advisory_service.py::TestAIInsightGenerateEndpoint tests/test_financial_insight_context_builder.py::TestFinancialInsightContextBuilderDaily tests/test_graphql_generate_ai_insight.py -q`
- `pytest tests/test_timezone_utils.py tests/test_ai_advisory_service.py tests/test_financial_insight_context_builder.py tests/test_graphql_generate_ai_insight.py tests/test_ai_daily_rate_limit.py -q`
- `ruff format --check .`
- `ruff check app tests config run.py run_without_db.py`
- `mypy app/controllers/ai/resources.py app/schemas/ai_insight_schema.py app/services/ai_advisory_service.py app/services/financial_insight_context_builder.py app/utils/timezone_utils.py`
- `bash scripts/check-openapi-drift.sh`
- `TZ=UTC PYTHON_BIN=/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-api/.venv/bin/python DATABASE_URL=sqlite:////tmp/auraxis-quality-1344.sqlite3 bash scripts/run_ci_quality_local.sh --local`

## Rollback
Revert this PR. Clients that omit `anchor_date` will return to server-local period resolution; OpenAPI will no longer advertise timezone input.

Closes #1344
