### PR TITLE
feat(sentry): env-aware traces_sample_rate auto-default + dev guidance (R2/3.1c)

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -53,9 +53,23 @@ BILLING_WEBHOOK_ALLOW_UNSIGNED=true
 EMAIL_CONFIRMATION_FRONTEND_URL=http://localhost:3000/auth/confirm-email
 
 # Sentry error tracking and performance monitoring (opt-in — leave blank to disable)
+#
+# Para DEV LOCAL: crie um Sentry project SEPARADO ("auraxis-api-dev") e cole
+# o DSN dele aqui. Quando SENTRY_ENVIRONMENT=dev, traces_sample_rate e auto-
+# definido para 1.0 (capturar todas as traces) — nao use o DSN de producao
+# localmente para nao poluir o quota nem misturar alertas reais com bugs locais.
+#
+# Setup:
+#   1. https://sentry.io -> New Project -> Flask -> "auraxis-api-dev"
+#   2. Cole o DSN abaixo
+#   3. Suba o stack (docker-compose up) e force um erro
+#   4. Confirme que aparece no project dev (nao no prod)
+#
+# SENTRY_TRACES_RATE: deixe em branco para usar o auto-default por env
+# (dev=1.0, staging|preview=0.5, prod=0.0). Override manual tambem funciona.
 SENTRY_DSN=
 SENTRY_ENVIRONMENT=dev
-SENTRY_TRACES_RATE=0.0
+SENTRY_TRACES_RATE=
 SENTRY_PROFILES_RATE=0.0
 # SENTRY_RELEASE=
 

--- a/app/extensions/sentry.py
+++ b/app/extensions/sentry.py
@@ -35,6 +35,29 @@ if TYPE_CHECKING:
     from sentry_sdk.types import Event, Hint
 
 
+def _resolve_traces_rate(environment: str) -> float:
+    """Resolve the active ``traces_sample_rate``.
+
+    Honors an explicit ``SENTRY_TRACES_RATE`` env override; otherwise picks an
+    env-aware default that matches the web/app side defaults (see PRs
+    auraxis-web #928 and auraxis-app #451):
+
+    - ``dev``                 → 1.0 (capture every trace for local debugging)
+    - ``staging`` / ``preview`` → 0.5
+    - everything else         → 0.0 (baseline production rate)
+
+    Use a separate Sentry project for dev to keep prod quota clean.
+    """
+    explicit = os.getenv("SENTRY_TRACES_RATE")
+    if explicit is not None and explicit.strip() != "":
+        return float(explicit)
+    if environment == "dev":
+        return 1.0
+    if environment in ("staging", "preview"):
+        return 0.5
+    return 0.0
+
+
 def _before_send(event: Event, hint: Hint) -> Event | None:
     """Drop client errors (4xx) and apply error sampling to reduce quota use."""
     exc_info = hint.get("exc_info")
@@ -75,7 +98,7 @@ def init_sentry() -> None:
 
     environment = os.getenv("SENTRY_ENVIRONMENT", "dev")
     release = os.getenv("SENTRY_RELEASE", "")
-    traces_sample_rate = float(os.getenv("SENTRY_TRACES_RATE", "0.0"))
+    traces_sample_rate = _resolve_traces_rate(environment)
     profiles_sample_rate = float(os.getenv("SENTRY_PROFILES_RATE", "0.0"))
 
     sentry_sdk.init(

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -222,3 +222,58 @@ def test_before_send_passes_all_events_at_full_rate(
     event: dict = {"message": "error"}
     results = [mod._before_send(event, hint) for _ in range(20)]
     assert all(r is not None for r in results)
+
+
+# ---------------------------------------------------------------------------
+# _resolve_traces_rate — env-aware auto-default
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_traces_rate_dev_defaults_to_full(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """In dev with no explicit SENTRY_TRACES_RATE, return 1.0 to capture all."""
+    monkeypatch.delenv("SENTRY_TRACES_RATE", raising=False)
+    mod = _reload_sentry()
+    assert mod._resolve_traces_rate("dev") == 1.0
+
+
+def test_resolve_traces_rate_staging_and_preview_default_to_half(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """staging and preview return 0.5 when no explicit override."""
+    monkeypatch.delenv("SENTRY_TRACES_RATE", raising=False)
+    mod = _reload_sentry()
+    assert mod._resolve_traces_rate("staging") == 0.5
+    assert mod._resolve_traces_rate("preview") == 0.5
+
+
+def test_resolve_traces_rate_production_defaults_to_zero(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Production keeps baseline 0.0 — opt-in via explicit env."""
+    monkeypatch.delenv("SENTRY_TRACES_RATE", raising=False)
+    mod = _reload_sentry()
+    assert mod._resolve_traces_rate("production") == 0.0
+    assert mod._resolve_traces_rate("unknown") == 0.0
+
+
+def test_resolve_traces_rate_explicit_env_takes_precedence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit SENTRY_TRACES_RATE overrides env-aware default."""
+    monkeypatch.setenv("SENTRY_TRACES_RATE", "0.3")
+    mod = _reload_sentry()
+    # Even in dev (where default would be 1.0), explicit override wins.
+    assert mod._resolve_traces_rate("dev") == 0.3
+    assert mod._resolve_traces_rate("production") == 0.3
+
+
+def test_resolve_traces_rate_empty_env_uses_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Empty string SENTRY_TRACES_RATE falls back to env-aware default."""
+    monkeypatch.setenv("SENTRY_TRACES_RATE", "")
+    mod = _reload_sentry()
+    assert mod._resolve_traces_rate("dev") == 1.0
+    assert mod._resolve_traces_rate("production") == 0.0


### PR DESCRIPTION
## Summary

Fase 3.1c (parte api) do plano Housekeeping Round 2. Api Sentry aceita `SENTRY_TRACES_RATE` como override explícito mas não tinha defaults env-aware — dev local usava `0.0` (nada capturado), incompatível com web/app side (PRs auraxis-web #928, auraxis-app #451) que usam `1.0` em dev.

### Mudanças

- **`app/extensions/sentry.py`**: nova função pura `_resolve_traces_rate(env)`:
  - `dev` → 1.0 (capturar tudo localmente)
  - `staging` / `preview` → 0.5
  - production / outro → 0.0 (baseline atual mantida)
  - Override `SENTRY_TRACES_RATE` (explicit) continua tendo precedência
  - Empty string trata como não definido

- **`.env.dev.example`**: documenta setup do project Sentry SEPARADO `auraxis-api-dev` + instrução para deixar `SENTRY_TRACES_RATE=` vazio para auto-default

- **5 novos testes** (20/20 passam):
  - dev default 1.0
  - staging/preview 0.5
  - production/unknown 0.0
  - explicit override (e.g. 0.3) respected
  - empty string falls back to default

## Test plan

- [x] `bash scripts/repo_bin.sh pytest tests/test_sentry.py -x -q` → 20/20 passam
- [x] Existing 15 tests do test_sentry.py continuam verdes
- [x] LGPD send_default_pii=False preservado
- [x] before_send drop de 4xx preservado

## Out of scope (sibling siblings já merged)

- Web side: auraxis-web #928 (merged)
- App side: auraxis-app #451 (merged)

## Closes

Closes #1352