### PR TITLE
feat(agent): telemetry capture + artifact upload in agent-implement workflow (R2/3.3a)

### DIFF
--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -210,3 +210,64 @@ jobs:
             --body "Agent run failed (CI timeout or unexpected error). Check workflow logs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
           GH_TOKEN: ${{ secrets.TOKEN_GITHUB_ADMIN }}
+
+      # ── Telemetry (Housekeeping R2/3.3) ──────────────────────────────────
+      # Writes a JSON entry consumed by `make agent-dashboard` in the
+      # platform repo. Schema must match `AgentRun.from_dict` in
+      # `auraxis-platform/scripts/agent_dashboard.py`. Inline (no platform
+      # dep) so we don't need a checkout of platform from this submodule
+      # workflow. Cross-repo aggregation cron is a follow-up.
+      - name: Capture agent run telemetry
+        if: always()
+        env:
+          ISSUE: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+          STATUS: ${{ job.status }}
+          RUN_ID: ${{ github.run_id }}
+          GH_TOKEN: ${{ secrets.TOKEN_GITHUB_ADMIN }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/agent-runs"
+          TS="$(date -u +%Y-%m-%dT%H:%M:%S+00:00)"
+          SAFE_TS="$(echo "$TS" | tr ':' '-')"
+          PR=$(gh pr list --search "head:feat/${ISSUE}" \
+            --json number --jq '.[0].number // empty' 2>/dev/null || echo "")
+          MERGED="false"
+          if [ -n "$PR" ]; then
+            MERGED=$(gh pr view "$PR" --json merged --jq '.merged' 2>/dev/null || echo "false")
+          fi
+          OUT="$RUNNER_TEMP/agent-runs/${SAFE_TS}-implement-${ISSUE}.json"
+          # Token counts are not surfaced by claude-code-action@beta — emit
+          # zeros and let the dashboard show "unknown cost". When the action
+          # gains a stats output, wire input_tokens/output_tokens here.
+          TS="$TS" ISSUE="$ISSUE" REPO="$REPO" PR="$PR" MERGED="$MERGED" \
+            STATUS="$STATUS" RUN_ID="$RUN_ID" OUT="$OUT" \
+            python3 - <<'PYEOF'
+          import json, os
+          data = {
+              "timestamp": os.environ["TS"],
+              "role": "implement",
+              "issue": int(os.environ["ISSUE"]),
+              "repo": os.environ["REPO"],
+              "model": "claude-opus-4-7",
+              "input_tokens": 0,
+              "output_tokens": 0,
+              "pr_number": int(os.environ["PR"]) if os.environ.get("PR") else None,
+              "pr_merged": os.environ.get("MERGED") == "true",
+              "files_modified": [],
+              "job_status": os.environ.get("STATUS", "unknown"),
+              "run_id": os.environ.get("RUN_ID", ""),
+          }
+          with open(os.environ["OUT"], "w") as f:
+              json.dump(data, f, indent=2)
+          print(os.environ["OUT"])
+          PYEOF
+
+      - name: Upload telemetry artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: agent-telemetry-implement-${{ github.event.issue.number }}
+          path: ${{ runner.temp }}/agent-runs/
+          retention-days: 30
+          if-no-files-found: warn


### PR DESCRIPTION
## Summary

Fase 3.3a (parte api piloto) do plano Housekeeping Round 2. Sibling platform PR #775 adicionou `.claude/agents/_telemetry.py` helper + docs. Esta PR conecta o primeiro workflow api (`agent-implement.yml`) ao pipeline de telemetria.

### Mudanças

2 novos steps em `.github/workflows/agent-implement.yml` (rodam sempre via `if: always()`):

1. **`Capture agent run telemetry`** — escreve `$RUNNER_TEMP/agent-runs/<ts>-implement-<issue>.json` com schema compatível com `AgentRun.from_dict` do `scripts/agent_dashboard.py`:
   - `timestamp`, `role`, `issue`, `repo`, `model`, `pr_number`, `pr_merged`, `files_modified`, `job_status`, `run_id`
   - `input_tokens`/`output_tokens` ficam em `0` até `claude-code-action@beta` expor stats (follow-up — quando o action add stats output, wireup é 1 linha)
   - Inline (sem dep no platform repo) para evitar checkout cross-repo neste workflow

2. **`Upload telemetry artifact`** — `actions/upload-artifact@v4 name=agent-telemetry-implement-<issue>` com retenção de 30 dias

## Test plan

- [x] YAML validado: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/agent-implement.yml'))"`
- [x] Schema bate com o que `agent_dashboard.py` espera (verificado contra os 6 testes de `.claude/agents/test_telemetry.py` do platform)
- [ ] Próximo run real de `agent-implement` no master vai produzir o artifact (verificável no Actions tab)

## Out of scope

- `agent-qa.yml` e `agent-watchdog.yml` — replicar é trivial após este piloto estabilizar
- Cron platform-level que agrega artifacts em `.context/reports/agent_runs/` (follow-up)
- Token counts reais do claude-code-action (depende do action expor stats)

## Closes

Closes #1354