### PR TITLE
feat(agent): telemetry capture in qa + watchdog workflows (R2/3.3b)

### DIFF
--- a/.github/workflows/agent-qa.yml
+++ b/.github/workflows/agent-qa.yml
@@ -118,3 +118,51 @@ jobs:
             - Only flag real issues: logic errors, missing tests, security problems, contract breaks
             - Don't flag style issues the linter already catches — that's noise
             - Coverage below 85% IS a blocking issue → create bug issue with agent:claude label
+
+      # ── Telemetry (Housekeeping R2/3.3 — mirror of agent-implement step) ─
+      - name: Capture agent run telemetry
+        if: always()
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          STATUS: ${{ job.status }}
+          RUN_ID: ${{ github.run_id }}
+          GH_TOKEN: ${{ secrets.TOKEN_GITHUB_ADMIN }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/agent-runs"
+          TS="$(date -u +%Y-%m-%dT%H:%M:%S+00:00)"
+          SAFE_TS="$(echo "$TS" | tr ':' '-')"
+          MERGED=$(gh pr view "$PR_NUMBER" --json merged --jq '.merged' 2>/dev/null || echo "false")
+          OUT="$RUNNER_TEMP/agent-runs/${SAFE_TS}-qa-${PR_NUMBER}.json"
+          TS="$TS" PR_NUMBER="$PR_NUMBER" REPO="$REPO" MERGED="$MERGED" \
+            STATUS="$STATUS" RUN_ID="$RUN_ID" OUT="$OUT" \
+            python3 - <<'PYEOF'
+          import json, os
+          data = {
+              "timestamp": os.environ["TS"],
+              "role": "qa",
+              "issue": int(os.environ["PR_NUMBER"]),
+              "repo": os.environ["REPO"],
+              "model": "claude-opus-4-7",
+              "input_tokens": 0,
+              "output_tokens": 0,
+              "pr_number": int(os.environ["PR_NUMBER"]),
+              "pr_merged": os.environ.get("MERGED") == "true",
+              "files_modified": [],
+              "job_status": os.environ.get("STATUS", "unknown"),
+              "run_id": os.environ.get("RUN_ID", ""),
+          }
+          with open(os.environ["OUT"], "w") as f:
+              json.dump(data, f, indent=2)
+          print(os.environ["OUT"])
+          PYEOF
+
+      - name: Upload telemetry artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: agent-telemetry-qa-${{ github.event.pull_request.number }}
+          path: ${{ runner.temp }}/agent-runs/
+          retention-days: 30
+          if-no-files-found: warn

--- a/.github/workflows/agent-watchdog.yml
+++ b/.github/workflows/agent-watchdog.yml
@@ -73,3 +73,52 @@ jobs:
             --body "CI still failing — commit \`${SHORT_SHA}\`. Run: ${WORKFLOW_URL}"
         env:
           GH_TOKEN: ${{ secrets.TOKEN_GITHUB_ADMIN }}
+
+      # ── Telemetry (Housekeeping R2/3.3 — mirror of agent-implement step) ─
+      # Identifier for watchdog is the upstream CI run id, since each invocation
+      # corresponds to a unique failed run.
+      - name: Capture agent run telemetry
+        if: always()
+        env:
+          UPSTREAM_RUN_ID: ${{ github.event.workflow_run.id }}
+          REPO: ${{ github.repository }}
+          STATUS: ${{ job.status }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/agent-runs"
+          TS="$(date -u +%Y-%m-%dT%H:%M:%S+00:00)"
+          SAFE_TS="$(echo "$TS" | tr ':' '-')"
+          OUT="$RUNNER_TEMP/agent-runs/${SAFE_TS}-watchdog-${UPSTREAM_RUN_ID}.json"
+          TS="$TS" UPSTREAM_RUN_ID="$UPSTREAM_RUN_ID" REPO="$REPO" \
+            STATUS="$STATUS" RUN_ID="$RUN_ID" OUT="$OUT" \
+            python3 - <<'PYEOF'
+          import json, os
+          data = {
+              "timestamp": os.environ["TS"],
+              "role": "watchdog",
+              "issue": f"ci-{os.environ['UPSTREAM_RUN_ID']}",
+              "repo": os.environ["REPO"],
+              "model": "claude-opus-4-7",
+              "input_tokens": 0,
+              "output_tokens": 0,
+              "pr_number": None,
+              "pr_merged": False,
+              "files_modified": [],
+              "job_status": os.environ.get("STATUS", "unknown"),
+              "run_id": os.environ.get("RUN_ID", ""),
+              "upstream_ci_run_id": os.environ["UPSTREAM_RUN_ID"],
+          }
+          with open(os.environ["OUT"], "w") as f:
+              json.dump(data, f, indent=2)
+          print(os.environ["OUT"])
+          PYEOF
+
+      - name: Upload telemetry artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: agent-telemetry-watchdog-${{ github.event.workflow_run.id }}
+          path: ${{ runner.temp }}/agent-runs/
+          retention-days: 30
+          if-no-files-found: warn


### PR DESCRIPTION
Follow-up de #1354 — espelha o piloto de agent-implement nos workflows restantes.

- agent-qa.yml: telemetry com identifier=PR number
- agent-watchdog.yml: telemetry com identifier=upstream CI run id (campo upstream_ci_run_id extra)

YAML validado. Closes nothing (pure follow-up).