### PR TITLE
fix: repair refresh csrf and daily insight context

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -13,6 +13,15 @@ AURAXIS_PREMIUM_OVERRIDE_USER_IDS=
 #   https://www.auraxis.com.br   — marketing/landing page
 CORS_ALLOWED_ORIGINS=https://app.auraxis.com.br,https://pilot.auraxis.com.br,https://www.auraxis.com.br
 
+# Refresh cookie / CSRF double-submit
+# Refresh token remains HttpOnly and scoped to /auth/refresh. The CSRF cookie
+# must be readable by app.auraxis.com.br so the Web client can forward it as
+# X-CSRF-TOKEN on POST /auth/refresh.
+AURAXIS_CSRF_ENFORCE=true
+JWT_COOKIE_DOMAIN=.auraxis.com.br
+JWT_COOKIE_SAMESITE=Lax
+JWT_REFRESH_CSRF_COOKIE_PATH=/
+
 # Database (Docker prod plan A: postgres container)
 POSTGRES_DB=flaskdb
 POSTGRES_USER=flaskuser
@@ -149,4 +158,3 @@ AWS_REGION=us-east-1
 # AURAXIS_CW_LOG_GROUP=/auraxis/prod/containers
 AURAXIS_SSM_PATH=/auraxis/prod
 # AURAXIS_SECRETS_MANAGER_ID=auraxis/prod/app
-

--- a/app/services/ai_advisory_service.py
+++ b/app/services/ai_advisory_service.py
@@ -2014,7 +2014,10 @@ def _build_financial_insight_prompt(
         "daily": (
             "Para insight diário: compare hoje com ontem, com o mesmo dia do mês "
             "passado quando disponível, recapitule rapidamente o mês até agora e "
-            "resuma como o usuário está hoje."
+            "resuma como o usuário está hoje. Diferencie transações pagas hoje "
+            "de transações criadas hoje: dívidas em current_period.created_today "
+            "devem ser mencionadas mesmo quando ainda estiverem pendentes ou com "
+            "vencimento futuro."
         ),
         "weekly": (
             "Para insight semanal: resuma a semana, cite maiores e menores gastos, "
@@ -2071,9 +2074,12 @@ def _build_financial_insight_prompt(
         "orçamentos, rendas, despesas, nomes, datas ou valores ausentes. Quando uma "
         "comparação não existir, mencione a ausência apenas se ela for relevante.\n"
         "Cada item deve conter evidências que apontem para chaves conhecidas do "
-        "snapshot, como current_period.paid.balance, comparisons.yesterday.delta, "
-        "daily_series, extremes, categories, transactions.sample, budgets, goals, "
-        "credit_cards, wallet ou financial_health.\n"
+        "snapshot, como current_period.paid.balance, "
+        "current_period.created_today.pending_expense_total, "
+        "comparisons.yesterday.delta, daily_series, extremes, categories, "
+        "transactions.sample, budgets, goals, credit_cards, wallet ou "
+        "financial_health. Nunca diga que não houve transações hoje quando "
+        "current_period.created_today.transaction_count for maior que zero.\n"
         "Quando 'wallet' estiver presente e o ativo total for > 0, contextualize "
         "a rentabilidade e a alocação atual: compare com "
         "'wallet.benchmark.cdi_monthly_pct' e 'wallet.benchmark.ipca_monthly_pct' "

--- a/app/services/financial_insight_context_builder.py
+++ b/app/services/financial_insight_context_builder.py
@@ -718,9 +718,7 @@ class FinancialInsightContextBuilder:
             tx for tx in transactions if tx.status != TransactionStatus.CANCELLED
         ]
         due_non_cancelled = [
-            tx
-            for tx in due_transactions
-            if tx.status != TransactionStatus.CANCELLED
+            tx for tx in due_transactions if tx.status != TransactionStatus.CANCELLED
         ]
         paid = [tx for tx in due_non_cancelled if tx.status == TransactionStatus.PAID]
 

--- a/app/services/financial_insight_context_builder.py
+++ b/app/services/financial_insight_context_builder.py
@@ -700,13 +700,34 @@ class FinancialInsightContextBuilder:
         timezone_name: str = _TIMEZONE,
         timezone_fallback: bool = False,
     ) -> dict[str, Any]:
-        transactions = self._fetch_transactions(user_id=user_id, start=start, end=end)
+        due_transactions = self._fetch_transactions(
+            user_id=user_id,
+            start=start,
+            end=end,
+        )
+        created_transactions = self._fetch_transactions_created(
+            user_id=user_id,
+            start=start,
+            end=end,
+        )
+        transactions = self._merge_transactions(
+            due_transactions,
+            created_transactions,
+        )
         non_cancelled = [
             tx for tx in transactions if tx.status != TransactionStatus.CANCELLED
         ]
-        paid = [tx for tx in non_cancelled if tx.status == TransactionStatus.PAID]
+        due_non_cancelled = [
+            tx
+            for tx in due_transactions
+            if tx.status != TransactionStatus.CANCELLED
+        ]
+        paid = [tx for tx in due_non_cancelled if tx.status == TransactionStatus.PAID]
 
-        current_period = self._current_period_summary(transactions)
+        current_period = self._current_period_summary(
+            due_transactions,
+            created_transactions=created_transactions,
+        )
         goals_payload: list[dict[str, Any]] = []
         goal_data_quality: dict[str, Any] = {}
         if include_goals:
@@ -952,9 +973,45 @@ class FinancialInsightContextBuilder:
         )
         return cast(list[Transaction], rows)
 
+    def _fetch_transactions_created(
+        self,
+        *,
+        user_id: UUID,
+        start: date,
+        end: date,
+    ) -> list[Transaction]:
+        start_dt = datetime.combine(start, datetime.min.time())
+        end_dt = datetime.combine(end + timedelta(days=1), datetime.min.time())
+        rows = (
+            Transaction.query.filter(
+                Transaction.user_id == user_id,
+                Transaction.deleted.is_(False),
+                Transaction.created_at >= start_dt,
+                Transaction.created_at < end_dt,
+            )
+            .order_by(Transaction.created_at.asc(), Transaction.due_date.asc())
+            .all()
+        )
+        return cast(list[Transaction], rows)
+
+    def _merge_transactions(
+        self,
+        *transaction_groups: list[Transaction],
+    ) -> list[Transaction]:
+        by_id: dict[UUID, Transaction] = {}
+        for group in transaction_groups:
+            for transaction in group:
+                by_id[transaction.id] = transaction
+        return sorted(
+            by_id.values(),
+            key=lambda tx: (tx.due_date, tx.created_at, _money(tx.amount)),
+        )
+
     def _current_period_summary(
         self,
         transactions: list[Transaction],
+        *,
+        created_transactions: list[Transaction] | None = None,
     ) -> dict[str, Any]:
         paid = [tx for tx in transactions if tx.status == TransactionStatus.PAID]
         pending = [tx for tx in transactions if tx.status == TransactionStatus.PENDING]
@@ -962,11 +1019,27 @@ class FinancialInsightContextBuilder:
         cancelled_count = sum(
             1 for tx in transactions if tx.status == TransactionStatus.CANCELLED
         )
+        created = [
+            tx
+            for tx in (created_transactions or [])
+            if tx.status != TransactionStatus.CANCELLED
+        ]
+        created_pending = [
+            tx
+            for tx in created
+            if tx.status in {TransactionStatus.PENDING, TransactionStatus.OVERDUE}
+        ]
 
         paid_income = self._sum(paid, TransactionType.INCOME)
         paid_expense = self._sum(paid, TransactionType.EXPENSE)
         pending_expense = self._sum(pending, TransactionType.EXPENSE)
         overdue_expense = self._sum(overdue, TransactionType.EXPENSE)
+        created_income = self._sum(created, TransactionType.INCOME)
+        created_expense = self._sum(created, TransactionType.EXPENSE)
+        created_pending_expense = self._sum(
+            created_pending,
+            TransactionType.EXPENSE,
+        )
 
         return {
             "paid": {
@@ -979,6 +1052,13 @@ class FinancialInsightContextBuilder:
                 "pending_expense_total": _money_str(pending_expense),
                 "overdue_expense_total": _money_str(overdue_expense),
                 "transaction_count": len(pending) + len(overdue),
+            },
+            "created_today": {
+                "income_total": _money_str(created_income),
+                "expense_total": _money_str(created_expense),
+                "pending_expense_total": _money_str(created_pending_expense),
+                "transaction_count": len(created),
+                "items": self._transaction_event_payload(created)["items"],
             },
             "cancelled_transaction_count": cancelled_count,
         }

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -74,6 +74,7 @@ class Config:
     # body during the transition period.
     JWT_TOKEN_LOCATION = ["headers", "cookies"]
     JWT_HEADER_TYPE = "Bearer"
+    JWT_COOKIE_DOMAIN = os.getenv("JWT_COOKIE_DOMAIN") or None
     JWT_REFRESH_COOKIE_NAME = "auraxis_refresh"
     JWT_REFRESH_COOKIE_PATH = "/auth/refresh"
     # Secure flag is enabled in non-dev/test runtimes. HTTPS is required for
@@ -96,6 +97,8 @@ class Config:
     JWT_REFRESH_CSRF_HEADER_NAME = "X-CSRF-TOKEN"
     JWT_ACCESS_CSRF_COOKIE_NAME = "auraxis_csrf_access"
     JWT_REFRESH_CSRF_COOKIE_NAME = "auraxis_csrf_refresh"
+    JWT_ACCESS_CSRF_COOKIE_PATH = os.getenv("JWT_ACCESS_CSRF_COOKIE_PATH", "/")
+    JWT_REFRESH_CSRF_COOKIE_PATH = os.getenv("JWT_REFRESH_CSRF_COOKIE_PATH", "/")
     JWT_CSRF_IN_COOKIES = True
     # SEC-1 — close dual-mode: when True, login/refresh responses stop echoing
     # refresh_token in the JSON body; clients must rely on the httpOnly cookie.

--- a/tests/test_auth_refresh_csrf.py
+++ b/tests/test_auth_refresh_csrf.py
@@ -105,6 +105,29 @@ class TestCsrfEnforcementWhenEnabled:
         assert raw, "CSRF cookie must be emitted"
         assert "HttpOnly" not in raw, "CSRF cookie must be readable by client JS"
 
+    def test_refresh_csrf_cookie_is_readable_from_app_shell_path(self, app, client):
+        """The app shell at /dashboard must read the double-submit CSRF cookie."""
+        self._enable_csrf(app)
+        app.config["JWT_COOKIE_DOMAIN"] = ".auraxis.com.br"
+        app.config["JWT_COOKIE_SECURE"] = True
+        _create_user(app, email="csrf-on-cookie-scope@test.com")
+        resp = _login(client, email="csrf-on-cookie-scope@test.com")
+
+        csrf_raw = _find_set_cookie(resp, CSRF_REFRESH_COOKIE_NAME) or ""
+        refresh_raw = _find_set_cookie(resp, REFRESH_COOKIE_NAME) or ""
+
+        assert csrf_raw, "CSRF cookie must be emitted"
+        assert "HttpOnly" not in csrf_raw
+        assert "Path=/" in csrf_raw
+        assert "Domain=auraxis.com.br" in csrf_raw
+        assert "SameSite=Lax" in csrf_raw
+        assert "Secure" in csrf_raw
+
+        assert refresh_raw, "refresh cookie must still be emitted"
+        assert "HttpOnly" in refresh_raw
+        assert "Path=/auth/refresh" in refresh_raw
+        assert "Domain=auraxis.com.br" in refresh_raw
+
     def test_refresh_without_csrf_header_returns_401(self, app, client):
         self._enable_csrf(app)
         _create_user(app, email="csrf-on-missing-header@test.com")

--- a/tests/test_financial_insight_context_builder.py
+++ b/tests/test_financial_insight_context_builder.py
@@ -188,6 +188,40 @@ def _as_json(value: dict[str, Any]) -> str:
 
 
 class TestFinancialInsightContextBuilderDaily:
+    def test_daily_snapshot_includes_pending_expenses_created_today_even_when_due_later(
+        self, app
+    ) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            anchor = date(2026, 5, 26)
+            for index, amount in enumerate(("120.25", "2580.00", "45.90"), start=1):
+                _make_transaction(
+                    user_id,
+                    title=f"Dívida nova {index}",
+                    amount=amount,
+                    tx_type=TransactionType.EXPENSE,
+                    status=TransactionStatus.PENDING,
+                    due_date=date(2026, 6, index),
+                    created_at=datetime(2026, 5, 26, 9 + index, 0, 0),
+                )
+
+            snapshot = FinancialInsightContextBuilder().build_daily(
+                user_id=user_id,
+                anchor_date=anchor,
+            )
+
+        created_today = snapshot["current_period"]["created_today"]
+        assert created_today["transaction_count"] == 3
+        assert created_today["expense_total"] == "2746.15"
+        assert created_today["pending_expense_total"] == "2746.15"
+        assert [item["title"] for item in created_today["items"]] == [
+            "Dívida nova 1",
+            "Dívida nova 2",
+            "Dívida nova 3",
+        ]
+        assert snapshot["transactions"]["included_count"] == 3
+        assert snapshot["data_quality"]["domain_presence"]["transactions"] is True
+
     def test_daily_snapshot_compares_today_yesterday_previous_month_and_mtd(
         self, app
     ) -> None:


### PR DESCRIPTION
## Resumo
- Corrige o contrato de cookies do refresh para que o Web consiga ler `auraxis_csrf_refresh` e enviar `X-CSRF-TOKEN` depois de um F5.
- Mantém `auraxis_refresh` como cookie HttpOnly com `Path=/auth/refresh`, enquanto o CSRF fica em `Path=/` e domínio compartilhado quando `JWT_COOKIE_DOMAIN=.auraxis.com.br` estiver configurado.
- Expande o snapshot diário de AI Insights para incluir transações criadas no dia, mesmo quando ainda estão pendentes e com vencimento futuro.
- Reforça o prompt financeiro para diferenciar transações pagas hoje de dívidas criadas hoje.

## Detalhes técnicos
- Adiciona `JWT_COOKIE_DOMAIN`, `JWT_ACCESS_CSRF_COOKIE_PATH` e `JWT_REFRESH_CSRF_COOKIE_PATH` à configuração.
- Documenta no `.env.prod.example` a configuração esperada para produção: `AURAXIS_CSRF_ENFORCE=true`, `JWT_COOKIE_DOMAIN=.auraxis.com.br`, `JWT_REFRESH_CSRF_COOKIE_PATH=/`.
- O builder financeiro agora busca separadamente transações por vencimento e transações criadas no período; os totais pagos continuam baseados em vencimento, mas `current_period.created_today` expõe novas dívidas para a LLM.
- `transactions.included_count` e `transactions.sample` passam a considerar a união deduplicada de vencidas/no período e criadas/no período, garantindo que o `context_hash` mude quando novas dívidas relevantes forem cadastradas.

## Testes
- `python -m ruff check app/services/ai_advisory_service.py app/services/financial_insight_context_builder.py config/__init__.py tests/test_auth_refresh_csrf.py tests/test_financial_insight_context_builder.py`
- `python -m pytest tests/test_auth_refresh_csrf.py tests/test_auth_refresh_cookie.py tests/test_financial_insight_context_builder.py tests/test_ai_advisory_service.py::TestAIAdvisoryServiceFinancialInsights -q`
- `python -m pytest -q`

## Rollback
- Reverter este PR volta o refresh/CSRF e o snapshot diário ao comportamento anterior.
- Se necessário operacionalmente, `AURAXIS_CSRF_ENFORCE=false` desliga temporariamente a exigência do header enquanto o Web é validado.
