### PR TITLE
fix(tests): force stub market rates provider in conftest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,12 @@ TEST_ENV_OVERRIDES = {
     "CORS_ALLOWED_ORIGINS": "https://frontend.local",
     "GRAPHQL_ALLOW_INTROSPECTION": "true",
     "BRAPI_CACHE_TTL_SECONDS": "0",
+    # Force the deterministic stub provider for market rates (BCB SGS data)
+    # so AI advisory tests don't flake on real BCB API timeouts. The default
+    # is BcbMarketRatesProvider which hits the public BCB API and returns
+    # different values on each call when the network is slow — that breaks
+    # snapshot hashing and cache-hit behaviour in tests.
+    "AI_MARKET_RATES_PROVIDER": "stub",
 }
 
 for key, value in TEST_ENV_OVERRIDES.items():
@@ -37,6 +43,29 @@ def isolate_test_env() -> Generator[None, None, None]:
             os.environ.pop(key, None)
         else:
             os.environ[key] = value
+
+
+@pytest.fixture(autouse=True)
+def reset_market_rates_provider_singleton() -> Generator[None, None, None]:
+    """Reset the BCB market-rates singleton so each test gets the stub.
+
+    The provider is a process-level singleton picked the first time it is
+    needed. If a test (or app import) instantiates it before our env var
+    `AI_MARKET_RATES_PROVIDER=stub` is read, subsequent tests inherit the
+    real BCB adapter and start flaking on timeouts. Resetting before each
+    test forces re-evaluation with our test env.
+    """
+    try:
+        from app.services.market_rates_provider import (
+            reset_market_rates_provider_for_tests,
+        )
+    except ImportError:
+        yield
+        return
+
+    reset_market_rates_provider_for_tests()
+    yield
+    reset_market_rates_provider_for_tests()
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Fix do test flaky `test_financial_insights_return_cached_period_without_provider_call` que está bloqueando merges em master há dias.

## Root cause

O teste depende de cache HIT na segunda chamada. Cache key inclui hash do snapshot, que inclui market rates do **BCB API real**. Em CI o BCB timeouta intermitente → snapshots diferentes entre calls → hash diferente → cache miss → budget enforcement dispara `AIInsightCostBudgetExceededError`.

**Não é bug em `ai_advisory_service.py`** — cache lookup está corretamente ANTES do budget enforcement (linha 991-1004). É problema de não-determinismo no test setup: testes usam BcbMarketRatesProvider (default) em vez do StubMarketRatesProvider determinístico.

## Fix

`tests/conftest.py`:
1. `TEST_ENV_OVERRIDES["AI_MARKET_RATES_PROVIDER"] = "stub"` → factory devolve `StubMarketRatesProvider`
2. Autouse fixture `reset_market_rates_provider_singleton` reseta o singleton process-level antes/depois de cada teste para garantir que o env var entre em efeito

## Test plan

- [x] Test específico passa local: `1 passed in 1.84s`
- [x] AI advisory suite passa: `56 passed in 7.24s`
- [x] Full suite (-m "not schemathesis"): **2388 passed, 1 skipped, 0 failed** em 306s
- [ ] CI verde no PR

## Impacto

Desbloqueia 3 PRs em vôo:
- #1380 (RDS migration step 1 — docker-compose)
- #1381 (RDS migration step 2 — migration script)
- #1375 (governance retire)

E qualquer PR futuro do auraxis-api.

## Rollback

`git revert`. Volta ao test flaky.

Closes #1382