### PR TITLE
feat(transactions): configurable recurrence cadence + materialize future months

### DIFF
--- a/app/application/services/transaction/mutations.py
+++ b/app/application/services/transaction/mutations.py
@@ -29,6 +29,7 @@ from app.application.services.transaction.validators import (
     normalize_transaction_type,
 )
 from app.models.transaction import (
+    RecurrenceUnit,
     Transaction,
     TransactionCategory,
     TransactionStatus,
@@ -105,6 +106,9 @@ def build_transaction_kwargs(
     """Map a pre-normalised payload to ``Transaction`` constructor kwargs."""
     raw_category = normalized.get("category")
     category = TransactionCategory(raw_category) if raw_category else None
+    raw_unit = normalized.get("recurrence_unit")
+    recurrence_unit = RecurrenceUnit(raw_unit) if raw_unit else RecurrenceUnit.month
+    recurrence_interval = int(normalized.get("recurrence_interval") or 1)
     return {
         "user_id": user_id,
         "title": str(normalized.get("title", "")),
@@ -118,6 +122,8 @@ def build_transaction_kwargs(
         "is_recurring": bool(normalized.get("is_recurring", False)),
         "is_installment": bool(normalized.get("is_installment", False)),
         "installment_count": normalized.get("installment_count"),
+        "recurrence_interval": recurrence_interval,
+        "recurrence_unit": recurrence_unit,
         "category": category,
         "tag_id": normalized.get("tag_id"),
         "account_id": normalized.get("account_id"),

--- a/app/application/services/transaction/writes.py
+++ b/app/application/services/transaction/writes.py
@@ -7,6 +7,7 @@ focused on composition.
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Callable
 from uuid import UUID
 
@@ -33,7 +34,10 @@ from app.application.services.transaction.validators import (
 )
 from app.extensions.database import db
 from app.models.transaction import Transaction
+from app.services.recurrence_service import RecurrenceService
 from app.services.transaction_serialization import TransactionPayload
+
+logger = logging.getLogger(__name__)
 
 
 def execute_create_transaction(
@@ -127,6 +131,23 @@ def execute_create_transaction(
     except Exception:
         db.session.rollback()
         raise
+
+    # Populate future occurrences immediately so a recurring transaction shows
+    # up in upcoming months without waiting for the daily reconciliation cron.
+    # Best-effort: a failure here must not fail the create that already
+    # committed — the cron will reconcile.
+    if transaction.is_recurring:
+        try:
+            RecurrenceService.materialize_for_template(transaction)
+            invalidate_cache()
+        except Exception:
+            db.session.rollback()
+            logger.warning(
+                "recurrence: inline materialisation failed for transaction %s; "
+                "cron will reconcile",
+                transaction.id,
+                exc_info=True,
+            )
 
     return {
         "message": "Transação criada com sucesso",

--- a/app/graphql/mutations/transaction.py
+++ b/app/graphql/mutations/transaction.py
@@ -33,6 +33,8 @@ class CreateTransactionMutation(graphene.Mutation):
         is_recurring = graphene.Boolean(default_value=False)
         is_installment = graphene.Boolean(default_value=False)
         installment_count = graphene.Int()
+        recurrence_interval = graphene.Int()
+        recurrence_unit = graphene.String()
         currency = graphene.String(default_value="BRL")
         status = TransactionStatusEnum()
         start_date = graphene.String()

--- a/app/graphql/types.py
+++ b/app/graphql/types.py
@@ -53,6 +53,8 @@ class TransactionTypeObject(graphene.ObjectType):
     is_recurring = graphene.Boolean(required=True)
     is_installment = graphene.Boolean(required=True)
     installment_count = graphene.Int()
+    recurrence_interval = graphene.Int()
+    recurrence_unit = graphene.String()
     category = graphene.String()
     tag_id = graphene.String()
     account_id = graphene.String()

--- a/app/models/transaction.py
+++ b/app/models/transaction.py
@@ -38,6 +38,15 @@ class TransactionStatus(enum.Enum):
     OVERDUE = "overdue"
 
 
+class RecurrenceUnit(enum.Enum):
+    """Cadence unit for a recurring transaction (combined with an interval)."""
+
+    day = "day"
+    week = "week"
+    month = "month"
+    year = "year"
+
+
 class Transaction(db.Model):
     __tablename__ = "transactions"
 
@@ -50,6 +59,23 @@ class Transaction(db.Model):
     is_recurring = db.Column(db.Boolean, default=False)
     is_installment = db.Column(db.Boolean, default=False)
     installment_count = db.Column(db.Integer, nullable=True)
+    # Recurrence cadence: repeat every ``recurrence_interval`` ``recurrence_unit``s
+    # (e.g. interval=2 + unit=week → every two weeks). Legacy rows default to a
+    # monthly cadence so existing recurring transactions keep working.
+    recurrence_interval = db.Column(
+        db.Integer, nullable=False, default=1, server_default=db.text("1")
+    )
+    recurrence_unit = db.Column(
+        db.Enum(
+            RecurrenceUnit,
+            name="recurrence_unit_enum",
+            native_enum=False,
+            values_callable=lambda e: [m.value for m in e],
+        ),
+        nullable=False,
+        default=RecurrenceUnit.month,
+        server_default=RecurrenceUnit.month.value,
+    )
     amount = db.Column(db.Numeric(12, 2), nullable=False)
     currency = db.Column(db.String(3), default="BRL")
 

--- a/app/schemas/transaction_schema.py
+++ b/app/schemas/transaction_schema.py
@@ -56,6 +56,22 @@ class TransactionSchema(Schema):
             "example": 12,
         },
     )
+    recurrence_interval = fields.Int(
+        load_default=1,
+        validate=validate.Range(min=1, max=365),
+        metadata={
+            "description": "Intervalo da recorrência (a cada N unidades)",
+            "example": 1,
+        },
+    )
+    recurrence_unit = fields.Str(
+        load_default="month",
+        validate=validate.OneOf(["day", "week", "month", "year"]),
+        metadata={
+            "description": "Unidade da recorrência: day, week, month ou year",
+            "example": "month",
+        },
+    )
     amount = fields.Decimal(
         as_string=True,
         required=True,

--- a/app/services/recurrence_service.py
+++ b/app/services/recurrence_service.py
@@ -3,13 +3,17 @@ from __future__ import annotations
 import calendar
 import logging
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, timedelta
 from typing import Iterable
 
 from app.extensions.database import db
-from app.models.transaction import Transaction
+from app.models.transaction import RecurrenceUnit, Transaction
 
 logger = logging.getLogger(__name__)
+
+# Safety bound: when a recurring transaction has no usable end_date, materialise
+# at most this far ahead so a runaway cadence cannot flood the table.
+_MAX_HORIZON_DAYS = 366 * 2
 
 
 def _add_months(value: date, months: int) -> date:
@@ -18,6 +22,18 @@ def _add_months(value: date, months: int) -> date:
     month = month_index % 12 + 1
     day = min(value.day, calendar.monthrange(year, month)[1])
     return date(year, month, day)
+
+
+def _advance(value: date, unit: RecurrenceUnit, interval: int) -> date:
+    """Advance ``value`` by one cadence step (``interval`` × ``unit``)."""
+    step = max(int(interval or 1), 1)
+    if unit == RecurrenceUnit.day:
+        return value + timedelta(days=step)
+    if unit == RecurrenceUnit.week:
+        return value + timedelta(weeks=step)
+    if unit == RecurrenceUnit.year:
+        return _add_months(value, 12 * step)
+    return _add_months(value, step)
 
 
 @dataclass(frozen=True)
@@ -43,7 +59,12 @@ class RecurrenceService:
         if transaction.start_date > transaction.end_date:
             return None
 
-        window_end = min(transaction.end_date, reference_date)
+        # Materialise up to end_date — not capped at the reference date — so
+        # future months are populated. A rolling horizon bounds runaway windows
+        # (e.g. a daily cadence with an end_date years away); the cron extends
+        # the window on each run.
+        horizon = reference_date + timedelta(days=_MAX_HORIZON_DAYS)
+        window_end = min(transaction.end_date, horizon)
         if window_end < transaction.start_date:
             return None
 
@@ -54,14 +75,16 @@ class RecurrenceService:
         *,
         window: RecurrenceWindow,
         base_due_date: date,
+        unit: RecurrenceUnit,
+        interval: int,
     ) -> Iterable[date]:
         due_date = base_due_date
         while due_date < window.start:
-            due_date = _add_months(due_date, 1)
+            due_date = _advance(due_date, unit, interval)
 
         while due_date <= window.end:
             yield due_date
-            due_date = _add_months(due_date, 1)
+            due_date = _advance(due_date, unit, interval)
 
     @staticmethod
     def generate_missing_occurrences(reference_date: date | None = None) -> int:
@@ -82,55 +105,88 @@ class RecurrenceService:
             window = RecurrenceService._build_window(template, reference)
             if window is None:
                 continue
-
-            expected_dates = RecurrenceService._iter_expected_due_dates(
-                window=window,
-                base_due_date=template.due_date,
+            created.extend(
+                RecurrenceService._build_occurrences(template=template, window=window)
             )
-            for due in expected_dates:
-                if due == template.due_date:
-                    continue
 
-                exists = Transaction.query.filter_by(
+        return RecurrenceService._persist(created)
+
+    @staticmethod
+    def materialize_for_template(
+        template: Transaction, reference_date: date | None = None
+    ) -> int:
+        """Materialise future occurrences for a single recurring template.
+
+        Called right after a recurring transaction is created so its future
+        months are populated immediately, without waiting for the daily cron.
+        Idempotent: skips occurrences that already exist.
+        """
+        reference = reference_date or date.today()
+        window = RecurrenceService._build_window(template, reference)
+        if window is None:
+            return 0
+        return RecurrenceService._persist(
+            RecurrenceService._build_occurrences(template=template, window=window)
+        )
+
+    @staticmethod
+    def _build_occurrences(
+        *, template: Transaction, window: RecurrenceWindow
+    ) -> list[Transaction]:
+        occurrences: list[Transaction] = []
+        expected_dates = RecurrenceService._iter_expected_due_dates(
+            window=window,
+            base_due_date=template.due_date,
+            unit=template.recurrence_unit or RecurrenceUnit.month,
+            interval=template.recurrence_interval or 1,
+        )
+        for due in expected_dates:
+            if due == template.due_date:
+                continue
+
+            exists = Transaction.query.filter_by(
+                user_id=template.user_id,
+                title=template.title,
+                amount=template.amount,
+                type=template.type,
+                due_date=due,
+                is_recurring=True,
+                start_date=template.start_date,
+                end_date=template.end_date,
+                deleted=False,
+            ).first()
+            if exists:
+                continue
+
+            occurrences.append(
+                Transaction(
                     user_id=template.user_id,
                     title=template.title,
+                    description=template.description,
+                    observation=template.observation,
+                    is_recurring=True,
+                    is_installment=False,
+                    installment_count=None,
+                    recurrence_interval=template.recurrence_interval or 1,
+                    recurrence_unit=template.recurrence_unit or RecurrenceUnit.month,
                     amount=template.amount,
+                    currency=template.currency,
+                    status=template.status,
                     type=template.type,
                     due_date=due,
-                    is_recurring=True,
                     start_date=template.start_date,
                     end_date=template.end_date,
-                    deleted=False,
-                ).first()
-                if exists:
-                    continue
-
-                created.append(
-                    Transaction(
-                        user_id=template.user_id,
-                        title=template.title,
-                        description=template.description,
-                        observation=template.observation,
-                        is_recurring=True,
-                        is_installment=False,
-                        installment_count=None,
-                        amount=template.amount,
-                        currency=template.currency,
-                        status=template.status,
-                        type=template.type,
-                        due_date=due,
-                        start_date=template.start_date,
-                        end_date=template.end_date,
-                        tag_id=template.tag_id,
-                        account_id=template.account_id,
-                        credit_card_id=template.credit_card_id,
-                        installment_group_id=(
-                            template.installment_group_id or template.id
-                        ),
-                        paid_at=None,
-                    )
+                    tag_id=template.tag_id,
+                    account_id=template.account_id,
+                    credit_card_id=template.credit_card_id,
+                    installment_group_id=(template.installment_group_id or template.id),
+                    paid_at=None,
                 )
+            )
+        return occurrences
 
+    @staticmethod
+    def _persist(created: list[Transaction]) -> int:
         if not created:
             logger.info("recurrence: no new occurrences to create")
             return 0

--- a/app/services/transaction_serialization.py
+++ b/app/services/transaction_serialization.py
@@ -18,6 +18,8 @@ class TransactionPayload(TypedDict):
     is_recurring: bool
     is_installment: bool
     installment_count: int | None
+    recurrence_interval: int
+    recurrence_unit: str
     category: str | None
     tag_id: str | None
     account_id: str | None
@@ -52,6 +54,12 @@ def serialize_transaction_payload(transaction: Transaction) -> TransactionPayloa
         "is_recurring": transaction.is_recurring,
         "is_installment": transaction.is_installment,
         "installment_count": transaction.installment_count,
+        "recurrence_interval": getattr(transaction, "recurrence_interval", 1) or 1,
+        "recurrence_unit": (
+            transaction.recurrence_unit.value
+            if getattr(transaction, "recurrence_unit", None)
+            else "month"
+        ),
         "category": (
             transaction.category.value
             if getattr(transaction, "category", None)

--- a/graphql.introspection.json
+++ b/graphql.introspection.json
@@ -8166,6 +8166,30 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "recurrenceInterval",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "recurrenceUnit",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "category",
               "type": {
                 "kind": "SCALAR",
@@ -10324,6 +10348,30 @@
                   "description": null,
                   "isDeprecated": false,
                   "name": "observation",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "recurrenceInterval",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "recurrenceUnit",
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",

--- a/migrations/versions/rec1_recurrence_cadence.py
+++ b/migrations/versions/rec1_recurrence_cadence.py
@@ -1,0 +1,57 @@
+"""recurrence_cadence
+
+Adds configurable recurrence cadence to `transactions`:
+
+- recurrence_interval (INT, NOT NULL, default 1)
+- recurrence_unit     (VARCHAR, NOT NULL, default 'month')
+
+Together they express "repeat every N units" (e.g. interval=2 + unit=week →
+every two weeks). Legacy recurring rows default to a monthly cadence so they
+keep materialising as before.
+
+`recurrence_unit` is stored as VARCHAR (matching the model's
+`Enum(..., native_enum=False)`) — no native PG enum / CREATE TYPE, per the
+repo migration conventions.
+
+Revision ID: rec1_recurrence_cadence
+Revises: ai6_add_ai_insight_runs
+Create Date: 2026-05-30 00:00:00.000000
+
+Refs: #1384 (auraxis-api).
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "rec1_recurrence_cadence"
+down_revision = "ai6_add_ai_insight_runs"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "transactions",
+        sa.Column(
+            "recurrence_interval",
+            sa.Integer(),
+            nullable=False,
+            server_default="1",
+        ),
+    )
+    op.add_column(
+        "transactions",
+        sa.Column(
+            "recurrence_unit",
+            sa.String(length=10),
+            nullable=False,
+            server_default="month",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("transactions", "recurrence_unit")
+    op.drop_column("transactions", "recurrence_interval")

--- a/schema.graphql
+++ b/schema.graphql
@@ -642,6 +642,8 @@ type TransactionTypeObject {
   isRecurring: Boolean!
   isInstallment: Boolean!
   installmentCount: Int
+  recurrenceInterval: Int
+  recurrenceUnit: String
   category: String
   tagId: String
   accountId: String
@@ -788,7 +790,7 @@ type Mutation {
   resetPassword(newPassword: String!, token: String!): AuthPayloadType
   confirmEmail(token: String!): AuthPayloadType
   updateUserProfile(birthDate: String, financialObjectives: String, gender: String, initialInvestment: DecimalScalar, investmentGoalDate: String, investorProfile: String, investorProfileSuggested: String, monthlyExpenses: DecimalScalar, monthlyIncome: DecimalScalar, monthlyIncomeNet: DecimalScalar, monthlyInvestment: DecimalScalar, netWorth: DecimalScalar, occupation: String, profileQuizScore: Int, stateUf: String, taxonomyVersion: String): UpdateUserProfileMutation
-  createTransaction(accountId: UUID, amount: String!, category: String, creditCardId: UUID, currency: String = "BRL", description: String, dueDate: String!, endDate: String, installmentCount: Int, isInstallment: Boolean = false, isRecurring: Boolean = false, observation: String, startDate: String, status: TransactionStatus, tagId: UUID, title: String!, type: TransactionType!): CreateTransactionMutation @deprecated(reason: "ADR-0002: use POST /transactions")
+  createTransaction(accountId: UUID, amount: String!, category: String, creditCardId: UUID, currency: String = "BRL", description: String, dueDate: String!, endDate: String, installmentCount: Int, isInstallment: Boolean = false, isRecurring: Boolean = false, observation: String, recurrenceInterval: Int, recurrenceUnit: String, startDate: String, status: TransactionStatus, tagId: UUID, title: String!, type: TransactionType!): CreateTransactionMutation @deprecated(reason: "ADR-0002: use POST /transactions")
   updateTransaction(accountId: UUID, amount: String, category: String, creditCardId: UUID, currency: String, description: String, dueDate: String, endDate: String, installmentCount: Int, isInstallment: Boolean, isRecurring: Boolean, observation: String, paidAt: String, startDate: String, status: TransactionStatus, tagId: UUID, title: String, transactionId: UUID!, type: TransactionType): UpdateTransactionMutation @deprecated(reason: "ADR-0002: use PATCH /transactions/{id}")
   deleteTransaction(transactionId: UUID!): DeleteTransactionMutation @deprecated(reason: "ADR-0002: use DELETE /transactions/{id}")
   createGoal(category: String, currentAmount: String, description: String, priority: Int, status: GoalStatus, targetAmount: String!, targetDate: String, title: String!): CreateGoalMutation @deprecated(reason: "ADR-0002: use POST /goals")

--- a/tests/test_recurrence_service.py
+++ b/tests/test_recurrence_service.py
@@ -5,7 +5,12 @@ from unittest.mock import patch
 import pytest
 
 from app.extensions.database import db
-from app.models.transaction import Transaction, TransactionStatus, TransactionType
+from app.models.transaction import (
+    RecurrenceUnit,
+    Transaction,
+    TransactionStatus,
+    TransactionType,
+)
 from app.models.user import User
 from app.services.recurrence_service import RecurrenceService
 
@@ -55,6 +60,90 @@ def test_generate_missing_occurrences_is_idempotent(app) -> None:
             date(2026, 3, 5),
             date(2026, 4, 5),
         ]
+
+
+def test_generate_materializes_future_occurrences_until_end_date(app) -> None:
+    """Occurrences must be created up to end_date even when it is in the future
+    relative to the reference date — this is the fix for recurring transactions
+    not showing up in future months."""
+    with app.app_context():
+        user = _create_user()
+        template = Transaction(
+            user_id=user.id,
+            title="Aluguel",
+            amount=Decimal("1000.00"),
+            type=TransactionType.EXPENSE,
+            status=TransactionStatus.PENDING,
+            due_date=date(2026, 1, 5),
+            is_recurring=True,
+            start_date=date(2026, 1, 5),
+            end_date=date(2026, 4, 5),
+            currency="BRL",
+        )
+        db.session.add(template)
+        db.session.commit()
+
+        # Reference date is early January, but occurrences through April must
+        # still be materialised.
+        created = RecurrenceService.generate_missing_occurrences(
+            reference_date=date(2026, 1, 10)
+        )
+
+        due_dates = [
+            item.due_date
+            for item in Transaction.query.filter_by(
+                user_id=user.id, deleted=False
+            ).order_by(Transaction.due_date.asc())
+        ]
+
+        assert created == 3
+        assert due_dates == [
+            date(2026, 1, 5),
+            date(2026, 2, 5),
+            date(2026, 3, 5),
+            date(2026, 4, 5),
+        ]
+
+
+def test_generate_respects_weekly_interval(app) -> None:
+    with app.app_context():
+        user = _create_user()
+        template = Transaction(
+            user_id=user.id,
+            title="Feira",
+            amount=Decimal("100.00"),
+            type=TransactionType.EXPENSE,
+            status=TransactionStatus.PENDING,
+            due_date=date(2026, 1, 1),
+            is_recurring=True,
+            start_date=date(2026, 1, 1),
+            end_date=date(2026, 1, 29),
+            currency="BRL",
+            recurrence_interval=1,
+            recurrence_unit=RecurrenceUnit.week,
+        )
+        db.session.add(template)
+        db.session.commit()
+
+        created = RecurrenceService.generate_missing_occurrences(
+            reference_date=date(2026, 1, 1)
+        )
+
+        occurrences = Transaction.query.filter_by(
+            user_id=user.id, deleted=False
+        ).order_by(Transaction.due_date.asc())
+        due_dates = [item.due_date for item in occurrences]
+
+        assert due_dates == [
+            date(2026, 1, 1),
+            date(2026, 1, 8),
+            date(2026, 1, 15),
+            date(2026, 1, 22),
+            date(2026, 1, 29),
+        ]
+        assert created == 4
+        # New occurrences inherit the cadence so subsequent runs stay idempotent.
+        assert all(item.recurrence_unit == RecurrenceUnit.week for item in occurrences)
 
 
 def test_generate_missing_occurrences_skips_invalid_or_installment(app) -> None:

--- a/tests/test_transaction_recurrence_cadence.py
+++ b/tests/test_transaction_recurrence_cadence.py
@@ -1,0 +1,143 @@
+"""Integration tests for configurable recurrence cadence (#1384).
+
+Covers the end-to-end create flow: REST + GraphQL accept ``recurrence_interval``
+and ``recurrence_unit``, persist them, and materialise future occurrences up to
+``end_date`` immediately on create (the fix for recurring transactions not
+appearing in future months).
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from flask_jwt_extended import decode_token
+
+from app.extensions.database import db
+from app.models.transaction import RecurrenceUnit, Transaction
+
+
+def _register_and_login(client, prefix: str = "tx-rec") -> str:
+    suffix = uuid.uuid4().hex[:8]
+    email = f"{prefix}-{suffix}@test.com"
+    client.post(
+        "/auth/register",
+        json={"name": prefix, "email": email, "password": "StrongPass@123"},
+    )
+    login = client.post(
+        "/auth/login", json={"email": email, "password": "StrongPass@123"}
+    )
+    return login.get_json()["token"]
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}", "X-API-Contract": "v2"}
+
+
+def _graphql(client, query: str, token: str | None = None) -> Any:
+    headers = {"Authorization": f"Bearer {token}"} if token else {}
+    return client.post("/graphql", json={"query": query}, headers=headers)
+
+
+def test_rest_create_recurring_materialises_future_months(client, app) -> None:
+    token = _register_and_login(client)
+    resp = client.post(
+        "/transactions",
+        json={
+            "title": "Aluguel",
+            "amount": 1000.0,
+            "type": "expense",
+            "due_date": "2026-05-05",
+            "is_recurring": True,
+            "start_date": "2026-05-05",
+            "end_date": "2026-08-05",
+            "recurrence_interval": 1,
+            "recurrence_unit": "month",
+        },
+        headers=_auth(token),
+    )
+    assert resp.status_code in (200, 201), resp.get_json()
+
+    user_id = uuid.UUID(decode_token(token)["sub"])
+    with app.app_context():
+        rows = (
+            db.session.query(Transaction)
+            .filter_by(user_id=user_id, title="Aluguel", deleted=False)
+            .order_by(Transaction.due_date.asc())
+            .all()
+        )
+        due_dates = [row.due_date.isoformat() for row in rows]
+        assert due_dates == ["2026-05-05", "2026-06-05", "2026-07-05", "2026-08-05"]
+        assert all(row.recurrence_unit == RecurrenceUnit.month for row in rows)
+        assert all(row.recurrence_interval == 1 for row in rows)
+
+
+def test_rest_create_recurring_weekly_interval(client, app) -> None:
+    token = _register_and_login(client)
+    resp = client.post(
+        "/transactions",
+        json={
+            "title": "Feira",
+            "amount": 100.0,
+            "type": "expense",
+            "due_date": "2026-05-01",
+            "is_recurring": True,
+            "start_date": "2026-05-01",
+            "end_date": "2026-05-29",
+            "recurrence_interval": 1,
+            "recurrence_unit": "week",
+        },
+        headers=_auth(token),
+    )
+    assert resp.status_code in (200, 201), resp.get_json()
+
+    user_id = uuid.UUID(decode_token(token)["sub"])
+    with app.app_context():
+        rows = (
+            db.session.query(Transaction)
+            .filter_by(user_id=user_id, title="Feira", deleted=False)
+            .order_by(Transaction.due_date.asc())
+            .all()
+        )
+        due_dates = [row.due_date.isoformat() for row in rows]
+        assert due_dates == [
+            "2026-05-01",
+            "2026-05-08",
+            "2026-05-15",
+            "2026-05-22",
+            "2026-05-29",
+        ]
+
+
+def test_graphql_create_accepts_recurrence_cadence(client) -> None:
+    token = _register_and_login(client)
+    resp = _graphql(
+        client,
+        """
+        mutation {
+          createTransaction(
+            title: "Internet"
+            amount: "99.90"
+            type: EXPENSE
+            dueDate: "2026-05-10"
+            isRecurring: true
+            startDate: "2026-05-10"
+            endDate: "2026-07-10"
+            recurrenceInterval: 1
+            recurrenceUnit: "month"
+          ) {
+            message
+            items { title recurrenceUnit recurrenceInterval isRecurring }
+          }
+        }
+        """,
+        token=token,
+    )
+    body = resp.get_json()
+    assert "errors" not in body, body
+    items = body["data"]["createTransaction"]["items"]
+    assert items
+    first = items[0]
+    assert first["recurrenceUnit"] == "month"
+    assert first["recurrenceInterval"] == 1
+    assert first["isRecurring"] is True


### PR DESCRIPTION
Closes #1384 (Frente B — Recorrência, épico #814).

## Bug
Transações recorrentes não apareciam em meses futuros. Raiz: `RecurrenceService.generate_missing_occurrences` só materializava ocorrências **até `today`** (`min(end_date, reference_date)`) e **só mensalmente** (`_add_months(.., 1)` fixo). O model só tinha `is_recurring`/`start_date`/`end_date`, sem cadência.

## O que entrega
- **Model**: `RecurrenceUnit` enum + `recurrence_interval` (INT, default 1) e `recurrence_unit` (default `month`, backward-compatible). Migration `rec1_recurrence_cadence` (VARCHAR + server_default, sem CREATE TYPE; validada up/down em Postgres real).
- **`RecurrenceService`**: cadência configurável (`_advance` por dia/semana/mês/ano × intervalo) e **materialização até `end_date`** (não mais capada em `today`), com horizonte rolante de segurança (`today + 2 anos`) para evitar flood; cron diário reconcilia.
- **Trigger no create**: `materialize_for_template` roda inline ao criar uma transação recorrente → meses futuros populados na hora (best-effort; cron reconcilia em falha).
- **Paridade REST + GraphQL**: `recurrence_interval`/`recurrence_unit` aceitos no schema Marshmallow e na mutation GraphQL, serializados na saída e no `TransactionTypeObject`. Bundle GraphQL (`schema.graphql`, introspection) regenerado.

## Testes / qualidade
- `tests/test_recurrence_service.py`: + materialização futura + cadência semanal (5 testes).
- `tests/test_transaction_recurrence_cadence.py`: create REST mensal/semanal + GraphQL (3 testes).
- Suíte completa: **2391 passed**, coverage **91.13%** (≥85). ruff + mypy limpos. Migration up/down ✓ em Postgres efêmero.

> Edição de cadência em transações já materializadas ("esta e futuras") fica como follow-up (não em `_MUTABLE_TRANSACTION_FIELDS`), conforme spec.

Refs #814
