### PR TITLE
feat(ai): forecast mode for future-month financial insights

### DIFF
--- a/app/services/ai_advisory_service.py
+++ b/app/services/ai_advisory_service.py
@@ -1006,9 +1006,15 @@ class AIAdvisoryService:
             preview_run=preview_run,
         )
 
+        # Forecast mode: the requested period lies entirely in the future
+        # (e.g. generating an insight for June while it is still May). The
+        # snapshot's transactions are scheduled commitments/income — recurring
+        # occurrences materialised ahead of time — not realised history.
+        forecast = period_start > timezone_utils.local_today(timezone_resolution)
         prompt = _build_financial_insight_prompt(
             prompt_snapshot,
             period_type=normalized_period_type,
+            forecast=forecast,
         )
 
         try:
@@ -1119,6 +1125,7 @@ class AIAdvisoryService:
             "cost_usd": llm_resp.estimated_cost_usd,
             "model": llm_resp.model,
             "cached": False,
+            "forecast": forecast,
         }
 
     def generate_spending_insights(self, month: str | None = None) -> dict[str, Any]:
@@ -2008,28 +2015,42 @@ def _build_financial_insight_prompt(
     snapshot: dict[str, Any],
     *,
     period_type: str,
+    forecast: bool = False,
 ) -> str:
     context = json.dumps(snapshot, ensure_ascii=False, default=str)
-    period_instruction = {
-        "daily": (
-            "Para insight diário: compare hoje com ontem, com o mesmo dia do mês "
-            "passado quando disponível, recapitule rapidamente o mês até agora e "
-            "resuma como o usuário está hoje. Diferencie transações pagas hoje "
-            "de transações criadas hoje: dívidas em current_period.created_today "
-            "devem ser mencionadas mesmo quando ainda estiverem pendentes ou com "
-            "vencimento futuro."
-        ),
-        "weekly": (
-            "Para insight semanal: resuma a semana, cite maiores e menores gastos, "
-            "maiores e menores recebimentos, e identifique dias da semana com mais "
-            "e menos consumo/recebimento quando os dados permitirem."
-        ),
-        "monthly": (
-            "Para insight mensal: mostre o dia de maior gasto, maior recebimento, "
-            "menor gasto com atividade, menor recebimento com atividade e faça um "
-            "panorama geral do mês."
-        ),
-    }[period_type]
+    if forecast:
+        period_instruction = (
+            "MODO PREVISÃO: o período solicitado está inteiramente no futuro. As "
+            "transações do snapshot são compromissos e recebimentos já AGENDADOS "
+            "(ocorrências recorrentes materializadas e lançamentos futuros), não "
+            "fatos consumados — NUNCA afirme que já ocorreram e use sempre verbos "
+            "no futuro. Faça uma prévia acionável: projete o total de despesas e "
+            "receitas previstas, o saldo esperado, destaque o que aumentou em "
+            "relação a períodos anteriores, aponte riscos de caixa (ex.: despesas "
+            "previstas acima da receita prevista) e oriente como o usuário pode se "
+            "preparar. Trate cada dimensão obrigatória nessa ótica de previsão."
+        )
+    else:
+        period_instruction = {
+            "daily": (
+                "Para insight diário: compare hoje com ontem, com o mesmo dia do mês "
+                "passado quando disponível, recapitule rapidamente o mês até agora e "
+                "resuma como o usuário está hoje. Diferencie transações pagas hoje "
+                "de transações criadas hoje: dívidas em current_period.created_today "
+                "devem ser mencionadas mesmo quando ainda estiverem pendentes ou com "
+                "vencimento futuro."
+            ),
+            "weekly": (
+                "Para insight semanal: resuma a semana, cite maiores e menores gastos, "
+                "maiores e menores recebimentos, e identifique dias da semana com mais "
+                "e menos consumo/recebimento quando os dados permitirem."
+            ),
+            "monthly": (
+                "Para insight mensal: mostre o dia de maior gasto, maior recebimento, "
+                "menor gasto com atividade, menor recebimento com atividade e faça um "
+                "panorama geral do mês."
+            ),
+        }[period_type]
 
     insight_types = ", ".join(_SPENDING_INSIGHT_TYPES)
     contract = snapshot.get("insight_contract")

--- a/tests/test_ai_advisory_service.py
+++ b/tests/test_ai_advisory_service.py
@@ -385,6 +385,54 @@ class TestAIAdvisoryServiceFinancialInsights:
             assert audit.model == "gpt-4o-mini"
             assert audit.total_tokens == 140
 
+    def test_build_prompt_forecast_mode_frames_as_preview(self) -> None:
+        from app.services.ai_advisory_service import _build_financial_insight_prompt
+
+        snapshot = {"schema_version": "financial_insight_snapshot.v1"}
+        forecast_prompt = _build_financial_insight_prompt(
+            snapshot, period_type="monthly", forecast=True
+        )
+        normal_prompt = _build_financial_insight_prompt(
+            snapshot, period_type="monthly", forecast=False
+        )
+
+        assert "MODO PREVISÃO" in forecast_prompt
+        assert "MODO PREVISÃO" not in normal_prompt
+        assert "panorama geral do mês" in normal_prompt
+
+    def test_generate_financial_insights_flags_future_month_as_forecast(
+        self,
+        app,
+    ) -> None:
+        with app.app_context():
+            from app.services.ai_advisory_service import AIAdvisoryService
+
+            user_id = uuid.uuid4()
+            provider = MagicMock()
+            provider.generate_with_usage.return_value = _financial_llm_response(
+                summary="Prévia de julho."
+            )
+            service = AIAdvisoryService(user_id=user_id, llm_provider=provider)
+
+            with patch(
+                "app.services.ai_advisory_service.timezone_utils.local_today",
+                return_value=date(2026, 5, 30),
+            ):
+                future = service.generate_financial_insights(
+                    period_type="monthly",
+                    anchor_date=date(2026, 7, 15),
+                )
+                current = service.generate_financial_insights(
+                    period_type="monthly",
+                    anchor_date=date(2026, 5, 15),
+                )
+
+            assert future["forecast"] is True
+            assert current["forecast"] is False
+            # Future-month generation must frame the prompt as a forecast.
+            future_prompt = provider.generate_with_usage.call_args_list[0].args[0]
+            assert "MODO PREVISÃO" in future_prompt
+
     def test_financial_insights_reject_missing_required_dimensions(
         self,
         app,


### PR DESCRIPTION
Closes #1385 (Frente C — Insights, épico #814).

## Contexto
Auditoria do backend confirmou que **C1 (relatórios por dimensão + comparativos) já está implementado**: `_build_financial_insight_prompt` exige cobertura das 5 dimensões (`general, transactions, credit_cards, goals, budgets`), `_ensure_financial_insight_dimension_coverage` **rejeita** respostas com dimensão faltando, e o snapshot já carrega os comparativos (ontem, semana anterior, mesmo dia do mês/ano anterior). O exemplo "1 item genérico" relatado era do build antigo em prod, não do código atual.

O que faltava era **C2 — modo previsão (forecast)**.

## O que entrega (C2 — forecast)
- **Detecção**: quando o período solicitado está inteiramente no futuro (`period_start > local_today` no fuso do usuário — ex.: gerar insight de julho ainda em maio), `generate_financial_insights` ativa o modo previsão. As ocorrências do mês futuro já existem graças à materialização de recorrências (#1384).
- **Prompt**: branch "MODO PREVISÃO" instrui a LLM a tratar as transações como compromissos/recebimentos **agendados** (verbos no futuro), projetar despesas/receitas/saldo previstos, destacar o que subiu vs. períodos anteriores, apontar riscos de caixa e orientar preparação — por dimensão.
- **Resposta**: novo campo `forecast: boolean` no payload, para o frontend renderizar o painel de previsão (#958/#465).

## Testes / qualidade
- `test_build_prompt_forecast_mode_frames_as_preview` (prompt determinístico) e `test_generate_financial_insights_flags_future_month_as_forecast` (mês futuro → `forecast=true` + prompt em modo previsão; mês atual → `false`).
- Suíte AI advisory + observability + GraphQL generate verdes; ruff + mypy limpos.

## Follow-up
Paridade GraphQL do campo `forecast` no tipo de insight (REST já expõe; frontends consomem REST conforme spec). Enriquecimento opcional de comparativos *dentro* de cada dimensão pode ser iterado com base no feedback (#1387).

Refs #814 #1384
