### PR TITLE
feat(ai): automatic end-of-month recap batch + cron (#1386 slice B)

### DIFF
--- a/app/middleware/ai_rate_limit.py
+++ b/app/middleware/ai_rate_limit.py
@@ -38,6 +38,14 @@ AI_DAILY_LIMIT_MESSAGE = (
     "Tente novamente amanhã."
 )
 
+AI_MONTHLY_LIMIT = 30
+AI_MONTHLY_LIMIT_ERROR_CODE = "AI_MONTHLY_LIMIT_EXCEEDED"
+AI_MONTHLY_LIMIT_MESSAGE = (
+    "Limite mensal de insights atingido. "
+    "Você pode gerar até 30 insights por mês. "
+    "O limite renova no primeiro dia do próximo mês."
+)
+
 _BRT = timezone(timedelta(hours=-3))
 
 # Module-level Redis client — initialised lazily, shared across requests.
@@ -55,6 +63,20 @@ def _seconds_until_midnight_brt() -> int:
 
 def _brt_date_str() -> str:
     return datetime.now(_BRT).strftime("%Y-%m-%d")
+
+
+def _brt_month_str() -> str:
+    return datetime.now(_BRT).strftime("%Y-%m")
+
+
+def _seconds_until_month_end_brt() -> int:
+    """Seconds from now until 00:00 BRT of the first day of next month."""
+    now = datetime.now(_BRT)
+    if now.month == 12:
+        next_month = datetime(now.year + 1, 1, 1, tzinfo=_BRT)
+    else:
+        next_month = datetime(now.year, now.month + 1, 1, tzinfo=_BRT)
+    return max(1, int((next_month - now).total_seconds()))
 
 
 def _get_redis() -> Any | None:
@@ -144,6 +166,38 @@ def record_ai_daily_success(user_id: UUID) -> tuple[int, int]:
     return _InMemoryAICounter.incr(key, ttl), ttl
 
 
+def _monthly_counter_key(user_id: UUID) -> str:
+    return f"auraxis:ai-monthly:{user_id}:{_brt_month_str()}"
+
+
+def get_ai_monthly_usage(user_id: UUID) -> tuple[int, int]:
+    """Return current monthly successful insight count without incrementing it."""
+    key = _monthly_counter_key(user_id)
+    ttl = _seconds_until_month_end_brt()
+
+    client = _get_redis()
+    if client is not None:
+        raw_count = client.get(key)
+        return int(raw_count or 0), ttl
+
+    return _InMemoryAICounter.get(key), ttl
+
+
+def record_ai_monthly_success(user_id: UUID) -> tuple[int, int]:
+    """Increment the monthly counter after a successful, non-cached AI insight."""
+    key = _monthly_counter_key(user_id)
+    ttl = _seconds_until_month_end_brt()
+
+    client = _get_redis()
+    if client is not None:
+        count = int(client.incr(key))
+        if count == 1:
+            client.expire(key, ttl)
+        return count, ttl
+
+    return _InMemoryAICounter.incr(key, ttl), ttl
+
+
 def check_ai_daily_limit(
     user_id: UUID,
     *,
@@ -214,12 +268,29 @@ def ai_daily_limit(
                 resp.headers["X-AI-Calls-Remaining"] = "0"
                 return resp
 
+            monthly_count, monthly_retry_after = get_ai_monthly_usage(user_id)
+            if monthly_count >= AI_MONTHLY_LIMIT:
+                resp = compat_error_response(
+                    legacy_payload={"error": AI_MONTHLY_LIMIT_MESSAGE},
+                    status_code=429,
+                    message=AI_MONTHLY_LIMIT_MESSAGE,
+                    error_code=AI_MONTHLY_LIMIT_ERROR_CODE,
+                )
+                resp.headers["Retry-After"] = str(monthly_retry_after)
+                resp.headers["X-AI-Calls-Remaining"] = "0"
+                resp.headers["X-AI-Calls-Remaining-Month"] = "0"
+                return resp
+
             response = cast(Response, fn(*args, **kwargs))
             if _is_countable_ai_success(response):
                 count, retry_after = record_ai_daily_success(user_id)
+                monthly_count, _ = record_ai_monthly_success(user_id)
 
             remaining = max(0, max_calls - count)
             response.headers["X-AI-Calls-Remaining"] = str(remaining)
+            response.headers["X-AI-Calls-Remaining-Month"] = str(
+                max(0, AI_MONTHLY_LIMIT - monthly_count)
+            )
             return response
 
         return wrapper  # type: ignore[return-value]
@@ -231,11 +302,18 @@ __all__ = [
     "AI_DAILY_LIMIT",
     "AI_DAILY_LIMIT_ERROR_CODE",
     "AI_DAILY_LIMIT_MESSAGE",
+    "AI_MONTHLY_LIMIT",
+    "AI_MONTHLY_LIMIT_ERROR_CODE",
+    "AI_MONTHLY_LIMIT_MESSAGE",
     "ai_daily_limit",
     "check_ai_daily_limit",
     "get_ai_daily_usage",
+    "get_ai_monthly_usage",
     "record_ai_daily_success",
+    "record_ai_monthly_success",
     "_InMemoryAICounter",
     "_brt_date_str",
+    "_brt_month_str",
     "_seconds_until_midnight_brt",
+    "_seconds_until_month_end_brt",
 ]

--- a/app/middleware/ai_rate_limit.py
+++ b/app/middleware/ai_rate_limit.py
@@ -30,11 +30,11 @@ from app.controllers.response_contract import compat_error_response
 
 _F = TypeVar("_F", bound=Callable[..., Any])
 
-AI_DAILY_LIMIT = 2
+AI_DAILY_LIMIT = 1
 AI_DAILY_LIMIT_ERROR_CODE = "AI_DAILY_LIMIT_EXCEEDED"
 AI_DAILY_LIMIT_MESSAGE = (
     "Limite diário de insights atingido. "
-    "Você pode gerar até 2 insights por dia. "
+    "Você pode gerar 1 insight por dia. "
     "Tente novamente amanhã."
 )
 
@@ -214,6 +214,20 @@ def check_ai_daily_limit(
     return record_ai_daily_success(user_id)
 
 
+def request_is_admin() -> bool:
+    """True when the active JWT carries the 'admin' role.
+
+    Admins bypass the AI insight rate limits and cost ceiling so the team can
+    exercise the feature end-to-end without burning a real user's allowance.
+    """
+    try:
+        from app.auth import get_active_auth_context
+
+        return "admin" in get_active_auth_context().roles
+    except Exception:
+        return False
+
+
 def _is_countable_ai_success(response: Response) -> bool:
     """Return True when this response represents a new AI generation."""
     if not 200 <= response.status_code < 300:
@@ -248,6 +262,11 @@ def ai_daily_limit(
             from app.services.entitlement_service import has_entitlement
 
             user_id = current_user_id()
+
+            # Admins bypass the rate limits entirely so the team can test the
+            # feature without consuming a user's daily/monthly allowance.
+            if request_is_admin():
+                return cast(Response, fn(*args, **kwargs))
 
             # Only Premium users (advanced_simulations) can make manual AI insights
             # calls. Skip the rate-limit counter for Free users — the handler will
@@ -306,6 +325,7 @@ __all__ = [
     "AI_MONTHLY_LIMIT_ERROR_CODE",
     "AI_MONTHLY_LIMIT_MESSAGE",
     "ai_daily_limit",
+    "request_is_admin",
     "check_ai_daily_limit",
     "get_ai_daily_usage",
     "get_ai_monthly_usage",

--- a/app/services/ai_advisory_service.py
+++ b/app/services/ai_advisory_service.py
@@ -905,6 +905,12 @@ def _enforce_financial_insight_generation_budget(
     normalized_period_type: str,
     preview_run: AIInsightRun | None,
 ) -> None:
+    # The monthly recap is a guaranteed end-of-month deliverable (+1/mês,
+    # automático) — exempt from the per-user cost ceiling so it always runs.
+    # Its cost is still logged and counts toward future daily/weekly checks.
+    if normalized_period_type == "monthly":
+        return
+
     # Admins bypass the cost ceiling so the team can exercise insight
     # generation end-to-end without being blocked by the per-user budget.
     from app.middleware.ai_rate_limit import request_is_admin

--- a/app/services/ai_advisory_service.py
+++ b/app/services/ai_advisory_service.py
@@ -905,6 +905,13 @@ def _enforce_financial_insight_generation_budget(
     normalized_period_type: str,
     preview_run: AIInsightRun | None,
 ) -> None:
+    # Admins bypass the cost ceiling so the team can exercise insight
+    # generation end-to-end without being blocked by the per-user budget.
+    from app.middleware.ai_rate_limit import request_is_admin
+
+    if request_is_admin():
+        return
+
     try:
         _enforce_ai_insight_cost_budget()
         _enforce_ai_insight_user_cost_budget(user_id=user_id)

--- a/app/services/ai_advisory_service.py
+++ b/app/services/ai_advisory_service.py
@@ -149,6 +149,10 @@ FinancialInsightItem = dict[str, Any]
 
 _AI_INSIGHTS_DAILY_BUDGET_ENV = "AI_INSIGHTS_DAILY_BUDGET_USD"
 _AI_INSIGHTS_MONTHLY_BUDGET_ENV = "AI_INSIGHTS_MONTHLY_BUDGET_USD"
+_AI_INSIGHTS_USER_BUDGET_PCT_ENV = "AI_INSIGHTS_USER_BUDGET_PCT"
+_AI_INSIGHTS_BRL_USD_FX_ENV = "AI_INSIGHTS_BRL_USD_FX"
+_DEFAULT_USER_BUDGET_PCT = Decimal("0.5")
+_DEFAULT_BRL_USD_FX = Decimal("5.50")
 _AI_INSIGHT_COST_ENDPOINTS = (
     "financial_insights_daily",
     "financial_insights_weekly",
@@ -772,6 +776,71 @@ def _enforce_ai_insight_cost_budget(*, now: datetime | None = None) -> None:
         )
 
 
+def _read_decimal_env(env_name: str, default: Decimal) -> Decimal:
+    raw = os.getenv(env_name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        value = Decimal(raw.strip())
+    except InvalidOperation:
+        log.warning("ai_advisory.cost_budget.invalid_env name=%s", env_name)
+        return default
+    return value
+
+
+def _user_ai_insight_monthly_budget_usd() -> Decimal:
+    """Per-user monthly LLM budget in USD: a share of the Premium plan price.
+
+    Hard rule (#1386): AI cost per user must never exceed 50% of the
+    subscription value. Derived from the canonical Premium monthly price
+    (R$29,90, ADR-669) × ``AI_INSIGHTS_USER_BUDGET_PCT`` (default 0.5),
+    converted to USD via ``AI_INSIGHTS_BRL_USD_FX`` (default 5.50).
+    """
+    from app.config.billing_plans import PREMIUM_MONTHLY_PLAN
+
+    pct = _read_decimal_env(_AI_INSIGHTS_USER_BUDGET_PCT_ENV, _DEFAULT_USER_BUDGET_PCT)
+    fx = _read_decimal_env(_AI_INSIGHTS_BRL_USD_FX_ENV, _DEFAULT_BRL_USD_FX)
+    if fx <= 0:
+        fx = _DEFAULT_BRL_USD_FX
+    if pct <= 0:
+        pct = _DEFAULT_USER_BUDGET_PCT
+    price_brl = Decimal(PREMIUM_MONTHLY_PLAN.price_cents) / Decimal(100)
+    return (price_brl * pct) / fx
+
+
+def _ai_insight_user_spend_usd(
+    *, user_id: UUID, start_at: datetime, end_at: datetime
+) -> Decimal:
+    total = (
+        db.session.query(func.coalesce(func.sum(LLMAuditLog.estimated_cost_usd), 0))
+        .filter(LLMAuditLog.user_id == user_id)
+        .filter(LLMAuditLog.endpoint.in_(_AI_INSIGHT_COST_ENDPOINTS))
+        .filter(LLMAuditLog.created_at >= start_at)
+        .filter(LLMAuditLog.created_at < end_at)
+        .scalar()
+    )
+    return Decimal(str(total or "0"))
+
+
+def _enforce_ai_insight_user_cost_budget(
+    *, user_id: UUID, now: datetime | None = None
+) -> None:
+    """Block generation when a single user's month-to-date AI cost hits the cap."""
+    current = now or utc_now_naive()
+    month_start = datetime(current.year, current.month, 1)
+    month_end = month_start + relativedelta(months=1)
+    limit = _user_ai_insight_monthly_budget_usd()
+    spent = _ai_insight_user_spend_usd(
+        user_id=user_id, start_at=month_start, end_at=month_end
+    )
+    _raise_if_budget_exceeded(
+        scope="user_monthly",
+        scope_label="mensal por usuário",
+        limit_usd=limit,
+        spent_usd=spent,
+    )
+
+
 def _mark_preview_run_cached(
     *,
     preview_run: AIInsightRun,
@@ -838,6 +907,7 @@ def _enforce_financial_insight_generation_budget(
 ) -> None:
     try:
         _enforce_ai_insight_cost_budget()
+        _enforce_ai_insight_user_cost_budget(user_id=user_id)
     except AIInsightCostBudgetExceededError as exc:
         if preview_run is not None:
             _mark_preview_run_blocked(preview_run=preview_run, reason=str(exc))

--- a/app/services/ai_monthly_report_service.py
+++ b/app/services/ai_monthly_report_service.py
@@ -247,6 +247,88 @@ def create_monthly_report_run(
     return _serialize_run(run, include_snapshot=True)
 
 
+def _previous_month_anchor(reference_date: date) -> date:
+    """First day of the month before ``reference_date`` (the month to recap)."""
+    if reference_date.month == 1:
+        return date(reference_date.year - 1, 12, 1)
+    return date(reference_date.year, reference_date.month - 1, 1)
+
+
+def _users_with_daily_insights(*, period_start: date, period_end: date) -> list[UUID]:
+    rows = (
+        db.session.query(AIInsight.user_id)
+        .filter(AIInsight.insight_type == InsightType.daily)
+        .filter(AIInsight.period_start >= period_start)
+        .filter(AIInsight.period_end <= period_end)
+        .distinct()
+        .all()
+    )
+    return [cast(UUID, row[0]) for row in rows]
+
+
+def _has_monthly_recap(*, user_id: UUID, period_label: str) -> bool:
+    return (
+        db.session.query(AIInsight.id)
+        .filter_by(
+            user_id=user_id,
+            insight_type=InsightType.monthly,
+            period_label=period_label,
+        )
+        .first()
+        is not None
+    )
+
+
+def generate_monthly_recaps_for_all(
+    *,
+    reference_date: date | None = None,
+    llm_provider: LLMProvider | None = None,
+) -> int:
+    """Generate the end-of-month recap for every user with activity.
+
+    Intended to run on the 1st of each month (cron): for the month that just
+    ended, every user that produced at least one daily insight gets a
+    consolidated monthly recap. Idempotent — users that already have a recap
+    for the period are skipped. The recap is exempt from the per-user daily/
+    monthly caps and cost ceiling (it does not go through the rate-limited
+    endpoint and ``monthly`` is exempt from the cost guard).
+    """
+    reference = reference_date or date.today()
+    anchor = _previous_month_anchor(reference)
+    period_start, period_end = _month_bounds(anchor)
+    period_label = f"{anchor:%Y-%m}"
+
+    user_ids = _users_with_daily_insights(
+        period_start=period_start, period_end=period_end
+    )
+    log.info(
+        "monthly_recap.batch start period=%s eligible_users=%d",
+        period_label,
+        len(user_ids),
+    )
+
+    generated = 0
+    for user_id in user_ids:
+        if _has_monthly_recap(user_id=user_id, period_label=period_label):
+            continue
+        try:
+            run = create_monthly_report_run(user_id=user_id, anchor_date=anchor)
+            process_monthly_report_run(
+                run_id=UUID(str(run["run_id"])), llm_provider=llm_provider
+            )
+            generated += 1
+        except Exception:
+            log.warning(
+                "monthly_recap.user_failed user_id=%s period=%s",
+                user_id,
+                period_label,
+                exc_info=True,
+            )
+
+    log.info("monthly_recap.batch done period=%s generated=%d", period_label, generated)
+    return generated
+
+
 def _app_deep_link(insight_id: UUID) -> str:
     base_url = os.getenv("AURAXIS_APP_URL", _DEFAULT_APP_URL).rstrip("/")
     return f"{base_url}/insights?open={insight_id}"

--- a/app/services/llm_provider.py
+++ b/app/services/llm_provider.py
@@ -42,7 +42,9 @@ class LLMResponse:
         Falls back to conservative defaults for unknown models.
         """
         _PRICES: dict[str, tuple[float, float]] = {
+            "gpt-4o": (2.50, 10.00),
             "gpt-4o-mini": (0.15, 0.60),
+            "gpt-4.1": (2.00, 8.00),
             "gpt-4.1-mini": (0.40, 1.60),
             "claude-haiku-4-5-20251001": (0.25, 1.25),
         }
@@ -123,7 +125,9 @@ class OpenAILLMProvider:
 
     def __init__(self) -> None:
         self._api_key = os.getenv("OPENAI_API_KEY", "")
-        self._model = os.getenv("OPENAI_ADVISORY_MODEL", "gpt-4o-mini")
+        # Strong model by default (#1386): richer, more assertive insights.
+        # Cost is bounded by the per-user monthly budget + 1/day cap.
+        self._model = os.getenv("OPENAI_ADVISORY_MODEL", "gpt-4o")
 
     def generate(self, prompt: str) -> str:
         return self.generate_with_usage(prompt).content

--- a/docs/wiki/AI-Insights-Cost-And-Recap.md
+++ b/docs/wiki/AI-Insights-Cost-And-Recap.md
@@ -1,0 +1,75 @@
+# AI Insights — Cost Governance, Model, Forecast & Monthly Recap
+
+Reference for the cost/model/limits policy and the automatic monthly recap
+(épico #814, issues #1385/#1386).
+
+## Model
+
+The advisory LLM defaults to a **strong model** — `gpt-4o` — for richer, more
+assertive insights. Override with `OPENAI_ADVISORY_MODEL`. Pricing per 1M
+tokens lives in `LLMResponse.estimated_cost_usd` (`gpt-4o`, `gpt-4o-mini`,
+`gpt-4.1`, `gpt-4.1-mini`, claude-haiku).
+
+Cost is bounded by the per-user ceiling + the daily/monthly caps, so a strong
+model is used without an automatic downgrade for now (product decision,
+2026-05-30). Revisit downgrade-on-budget if usage patterns require it.
+
+## Caps & cost ceiling
+
+| Control | Value | Where |
+|---|---|---|
+| Daily cap | 1/day per user (BRT) | `AI_DAILY_LIMIT` |
+| Monthly cap | 30/month per user (BRT) | `AI_MONTHLY_LIMIT` |
+| Per-user cost ceiling | ≤ 50% of plan price ≈ US$2,72/mês | `_enforce_ai_insight_user_cost_budget` |
+| Org-wide cost (optional) | env-driven | `AI_INSIGHTS_{DAILY,MONTHLY}_BUDGET_USD` |
+
+Admins (`admin` JWT role) and the monthly recap bypass all of the above. See
+[AI-Insights-Rate-Limit](AI-Insights-Rate-Limit.md).
+
+### Environment variables
+
+| Var | Default | Meaning |
+|---|---|---|
+| `OPENAI_ADVISORY_MODEL` | `gpt-4o` | Advisory model |
+| `AI_INSIGHTS_USER_BUDGET_PCT` | `0.5` | Share of plan price as the per-user cap |
+| `AI_INSIGHTS_BRL_USD_FX` | `5.50` | BRL→USD rate for the budget conversion |
+| `AI_INSIGHTS_DAILY_BUDGET_USD` | (unset) | Optional org-wide daily ceiling |
+| `AI_INSIGHTS_MONTHLY_BUDGET_USD` | (unset) | Optional org-wide monthly ceiling |
+
+## Forecast mode (#1385)
+
+When the requested period is entirely in the future (`period_start >
+local_today` in the user's timezone — e.g. generating July's insight while it
+is still May), generation switches to **forecast mode**: the prompt frames the
+snapshot's transactions as *scheduled* commitments/income (the recurring
+occurrences materialised by #1384), uses future tense, projects totals/balance,
+flags cash-flow risks and how to prepare. The response carries `forecast:
+true`.
+
+## Automatic monthly recap (#1386 slice B)
+
+On the 1st of each month a batch consolidates the month that just ended into a
+single recap per active user.
+
+- **Entry point:** `scripts/generate_monthly_recaps.py` →
+  `generate_monthly_recaps_for_all(reference_date=today)`.
+- **Eligibility:** users with ≥1 daily insight in the target month.
+- **Idempotent:** users that already have a `monthly` insight for the period
+  are skipped.
+- **Exempt** from the user daily/monthly caps and cost ceiling (runs off the
+  rate-limited endpoint; `monthly` is exempt from the cost guard).
+- Reuses `create_monthly_report_run` + `process_monthly_report_run`, which
+  aggregate the month's daily insights + the previous monthly recap and email a
+  deep link.
+
+### Cron (production)
+
+Schedule on the 1st of each month (BRT 06:00 → 09:00 UTC):
+
+```cron
+0 9 1 * * cd /app && python scripts/generate_monthly_recaps.py >> /var/log/auraxis/monthly_recap.log 2>&1
+```
+
+Mirror the install pattern of the recurring-transactions cron
+(`scripts/generate_recurring_transactions.py`). The job is safe to re-run
+(idempotent) and logs `monthly_recap.batch` start/done lines.

--- a/docs/wiki/AI-Insights-Rate-Limit.md
+++ b/docs/wiki/AI-Insights-Rate-Limit.md
@@ -1,7 +1,20 @@
 # AI Insights Rate Limit
 
-Manual AI insights are limited to 2 successful generations per user per BRT
-calendar day.
+Manual AI insights are limited per user, on the BRT calendar, to:
+
+- **1 successful generation per day** (`AI_DAILY_LIMIT`); and
+- **30 successful generations per month** (`AI_MONTHLY_LIMIT`).
+
+> The automatic end-of-month recap is **not** subject to these caps — it runs
+> via a batch job, not the rate-limited endpoint. See
+> [AI-Insights-Cost-And-Recap](AI-Insights-Cost-And-Recap.md).
+
+## Admin bypass
+
+Requests whose JWT carries the `admin` role bypass **both** caps and the cost
+ceiling entirely (`request_is_admin()` in `app/middleware/ai_rate_limit.py`).
+This lets the team exercise the feature end-to-end without consuming a real
+user's allowance. Admin generations still log cost to `LLMAuditLog`.
 
 ## What Counts
 
@@ -28,31 +41,39 @@ failures where Auraxis did not produce a new AI insight.
 
 ## Cost Circuit Breaker
 
-Manual financial insight generation also checks the configured USD budget
-before calling the LLM provider:
+Manual financial insight generation also checks USD budgets before calling the
+LLM provider. Two layers:
 
-- `AI_INSIGHTS_DAILY_BUDGET_USD`
-- `AI_INSIGHTS_MONTHLY_BUDGET_USD`
+1. **Org-wide (optional, env-driven):** `AI_INSIGHTS_DAILY_BUDGET_USD` /
+   `AI_INSIGHTS_MONTHLY_BUDGET_USD`. Empty/zero/negative disables the layer.
+2. **Per-user (#1386):** a user's month-to-date AI cost must never exceed
+   **50% of the Premium subscription price** (R$29,90, ADR-669). The limit is
+   `price × AI_INSIGHTS_USER_BUDGET_PCT (default 0.5) ÷ AI_INSIGHTS_BRL_USD_FX
+   (default 5.50)` ≈ **US$2,72/mês**. Source of truth is
+   `LLMAuditLog.estimated_cost_usd` filtered by `user_id`.
 
-Empty, missing, zero, or negative values disable the corresponding budget.
-When a positive limit is configured, the source of truth is
-`LLMAuditLog.estimated_cost_usd` for `financial_insights_daily`,
-`financial_insights_weekly`, and `financial_insights_monthly`. If the current
-daily or monthly spend is already at or above the configured limit, generation
-is blocked before GPT is called and the API returns HTTP `429` with error code
-`AI_INSIGHT_BUDGET_EXCEEDED`.
+Both layers cover the `financial_insights_daily/weekly/monthly` endpoints. When
+spend is at or above a limit, generation is blocked before GPT is called and
+the API returns HTTP `429` with error code `AI_INSIGHT_BUDGET_EXCEEDED`
+(per-user scope: `user_monthly`).
 
-Cached insights are returned before the budget check because they do not
-generate new LLM cost. Admin preview and dossier export are also unaffected:
-they never call the LLM provider and do not consume budget.
+Exemptions: cached insights (no new cost), admin requests, and the **monthly
+recap** (`period_type=monthly`, a guaranteed deliverable) are not blocked by
+the cost ceiling. Their cost is still logged.
+
+See [AI-Insights-Cost-And-Recap](AI-Insights-Cost-And-Recap.md) for the model
+choice, the full env reference, and the recap cron.
 
 ## Response Headers
 
 Successful and failed pass-through responses include `X-AI-Calls-Remaining`
-when they reach the AI daily-limit middleware. Requests blocked by the quota
-return:
+(daily) and `X-AI-Calls-Remaining-Month` (monthly) when they reach the AI
+limit middleware. Requests blocked by a quota return:
 
 - HTTP `429`;
-- error code `AI_DAILY_LIMIT_EXCEEDED`;
-- `Retry-After` with seconds until the next BRT day;
-- `X-AI-Calls-Remaining: 0`.
+- error code `AI_DAILY_LIMIT_EXCEEDED` (daily) or `AI_MONTHLY_LIMIT_EXCEEDED`
+  (monthly);
+- `Retry-After` with seconds until the next BRT day (daily) or first day of
+  next month (monthly);
+- `X-AI-Calls-Remaining: 0` (and `X-AI-Calls-Remaining-Month: 0` for the
+  monthly cap).

--- a/scripts/generate_monthly_recaps.py
+++ b/scripts/generate_monthly_recaps.py
@@ -1,0 +1,50 @@
+"""Generate end-of-month AI recap insights for all active users (#1386, slice B).
+
+Run on the 1st of each month (cron). For the month that just ended, every user
+with at least one daily insight gets a consolidated monthly recap. Idempotent:
+users that already have a recap for the period are skipped.
+
+The recap is exempt from the per-user daily/monthly caps and cost ceiling.
+
+Usage:
+    python scripts/generate_monthly_recaps.py
+"""
+
+import logging
+import sys
+from datetime import date
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app import create_app  # noqa: E402
+from app.services.ai_monthly_report_service import (  # noqa: E402
+    generate_monthly_recaps_for_all,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def main() -> int:
+    try:
+        app = create_app(enable_http_runtime=False)
+    except Exception:
+        logger.exception("monthly_recap: failed to initialise application factory")
+        return 1
+
+    with app.app_context():
+        try:
+            generated = generate_monthly_recaps_for_all(reference_date=date.today())
+        except Exception:
+            logger.exception("monthly_recap: unhandled error in batch generation")
+            return 1
+
+    logger.info("monthly_recap: done — recaps generated=%s", generated)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_ai_daily_rate_limit.py
+++ b/tests/test_ai_daily_rate_limit.py
@@ -219,9 +219,9 @@ class TestAIDailyRateLimitHTTP:
             resp = client.get("/ai/insights/spending", headers=_auth(token))
 
         assert resp.status_code == 200
-        assert resp.headers.get("X-AI-Calls-Remaining") == "1"
+        assert resp.headers.get("X-AI-Calls-Remaining") == "0"
 
-    def test_second_call_returns_200_remaining_zero(self, app, client) -> None:
+    def test_second_call_returns_429_at_daily_limit(self, app, client) -> None:
         token = _register_and_login(client, "ai-rl-2nd")
         _grant_premium(app, token)
 
@@ -236,9 +236,11 @@ class TestAIDailyRateLimitHTTP:
             },
         ):
             client.get("/ai/insights/spending", headers=_auth(token))
-            resp = client.get("/ai/insights/spending", headers=_auth(token))
+            resp = client.get("/ai/insights/spending", headers=_auth(token, v2=True))
 
-        assert resp.status_code == 200
+        # Daily limit is 1/day → the second call is blocked.
+        assert resp.status_code == 429
+        assert resp.get_json()["error"]["code"] == "AI_DAILY_LIMIT_EXCEEDED"
         assert resp.headers.get("X-AI-Calls-Remaining") == "0"
 
     def test_third_call_returns_429(self, app, client) -> None:
@@ -288,7 +290,7 @@ class TestAIDailyRateLimitHTTP:
 
         assert failed.status_code == 500
         assert recovered.status_code == 200
-        assert recovered.headers.get("X-AI-Calls-Remaining") == "1"
+        assert recovered.headers.get("X-AI-Calls-Remaining") == "0"
 
     def test_cached_spending_insight_does_not_consume_daily_limit(
         self, app, client
@@ -310,7 +312,7 @@ class TestAIDailyRateLimitHTTP:
             resp = client.get("/ai/insights/spending", headers=_auth(token))
 
         assert resp.status_code == 200
-        assert resp.headers.get("X-AI-Calls-Remaining") == "2"
+        assert resp.headers.get("X-AI-Calls-Remaining") == "1"
 
     def test_cached_period_generate_does_not_consume_daily_limit(
         self, app, client
@@ -341,7 +343,7 @@ class TestAIDailyRateLimitHTTP:
             )
 
         assert resp.status_code == 200
-        assert resp.headers.get("X-AI-Calls-Remaining") == "2"
+        assert resp.headers.get("X-AI-Calls-Remaining") == "1"
 
     def test_429_message_is_portuguese(self, app, client) -> None:
         token = _register_and_login(client, "ai-rl-ptbr")
@@ -393,7 +395,8 @@ class TestAIDailyRateLimitHTTP:
         assert resp.get_json()["error"]["code"] == "AI_DAILY_LIMIT_EXCEEDED"
 
     def test_spending_and_weekly_share_same_daily_counter(self, app, client) -> None:
-        """1 spending call + 1 weekly call = 2 calls total — next call is 429."""
+        """Spending and weekly share one daily counter — at 1/day the second
+        call (weekly) is already blocked."""
         token = _register_and_login(client, "ai-rl-shared")
         _grant_premium(app, token)
 
@@ -420,11 +423,13 @@ class TestAIDailyRateLimitHTTP:
             ),
         ):
             r1 = client.get("/ai/insights/spending", headers=_auth(token))
-            r2 = client.get("/ai/insights/weekly-summary", headers=_auth(token))
-            r3 = client.get("/ai/insights/spending", headers=_auth(token))
+            r2 = client.get(
+                "/ai/insights/weekly-summary", headers=_auth(token, v2=True)
+            )
+            r3 = client.get("/ai/insights/spending", headers=_auth(token, v2=True))
 
         assert r1.status_code == 200
-        assert r2.status_code == 200
+        assert r2.status_code == 429
         assert r3.status_code == 429
 
     def test_free_user_gets_403_not_429(self, app, client) -> None:
@@ -453,13 +458,14 @@ class TestAIDailyRateLimitHTTP:
                 "model": "stub",
             },
         ):
-            # Exhaust user_a
+            # Exhaust user_a (1/day → second call blocked)
             client.get("/ai/insights/spending", headers=_auth(token_a))
-            client.get("/ai/insights/spending", headers=_auth(token_a))
-            blocked = client.get("/ai/insights/spending", headers=_auth(token_a))
+            blocked = client.get(
+                "/ai/insights/spending", headers=_auth(token_a, v2=True)
+            )
             assert blocked.status_code == 429
 
             # user_b still has full quota
             resp_b = client.get("/ai/insights/spending", headers=_auth(token_b))
             assert resp_b.status_code == 200
-            assert resp_b.headers.get("X-AI-Calls-Remaining") == "1"
+            assert resp_b.headers.get("X-AI-Calls-Remaining") == "0"

--- a/tests/test_ai_insight_cost_and_limits.py
+++ b/tests/test_ai_insight_cost_and_limits.py
@@ -145,6 +145,23 @@ class TestUserCostEnforcement:
             # Must not raise.
             _enforce_ai_insight_user_cost_budget(user_id=user_id, now=now)
 
+    def test_monthly_recap_is_exempt_from_cost_ceiling(self, app) -> None:
+        with app.app_context():
+            from app.services.ai_advisory_service import (
+                _enforce_financial_insight_generation_budget,
+            )
+
+            user_id = uuid.uuid4()
+            _seed_llm_cost(
+                user_id, cost_usd="100.00", endpoint="financial_insights_daily"
+            )
+            # Monthly recap is a guaranteed deliverable → never blocked by budget.
+            _enforce_financial_insight_generation_budget(
+                user_id=user_id,
+                normalized_period_type="monthly",
+                preview_run=None,
+            )
+
     def test_spend_is_isolated_per_user(self, app) -> None:
         with app.app_context():
             from app.services.ai_advisory_service import (

--- a/tests/test_ai_insight_cost_and_limits.py
+++ b/tests/test_ai_insight_cost_and_limits.py
@@ -228,3 +228,77 @@ class TestMonthlyCapHTTP:
         assert resp.status_code == 429
         assert resp.get_json()["error"]["code"] == "AI_MONTHLY_LIMIT_EXCEEDED"
         assert resp.headers.get("X-AI-Calls-Remaining-Month") == "0"
+
+
+# ---------------------------------------------------------------------------
+# Admin bypass — admins are exempt from caps and cost ceiling (for testing)
+# ---------------------------------------------------------------------------
+
+
+class TestAdminBypass:
+    def setup_method(self) -> None:
+        _reset_ai_counter()
+
+    def test_request_is_admin_reads_roles_claim(self) -> None:
+        from app.middleware.ai_rate_limit import request_is_admin
+
+        admin_ctx = type("Ctx", (), {"roles": ["admin"]})()
+        user_ctx = type("Ctx", (), {"roles": ["user"]})()
+        with patch("app.auth.get_active_auth_context", return_value=admin_ctx):
+            assert request_is_admin() is True
+        with patch("app.auth.get_active_auth_context", return_value=user_ctx):
+            assert request_is_admin() is False
+
+    def test_admin_bypasses_daily_and_monthly_caps(self, app, client) -> None:
+        from app.middleware.ai_rate_limit import AI_MONTHLY_LIMIT
+
+        token = _register_and_login(client, "ai-admin")
+        user_id = _grant_premium(app, token)
+        # Pre-saturate both counters; an admin must still pass through.
+        from app.middleware.ai_rate_limit import record_ai_monthly_success
+
+        for _ in range(AI_MONTHLY_LIMIT):
+            record_ai_monthly_success(user_id)
+
+        with (
+            patch(
+                "app.middleware.ai_rate_limit.request_is_admin",
+                return_value=True,
+            ),
+            patch(
+                "app.services.ai_advisory_service.AIAdvisoryService.generate_spending_insights",
+                return_value={
+                    "insights": "ok",
+                    "tokens_used": 10,
+                    "cost_usd": 0.0,
+                    "month": "2026-05",
+                    "model": "stub",
+                },
+            ),
+        ):
+            first = client.get("/ai/insights/spending", headers=_auth(token, v2=True))
+            second = client.get("/ai/insights/spending", headers=_auth(token, v2=True))
+
+        assert first.status_code == 200
+        assert second.status_code == 200  # would be 429 for a non-admin
+
+    def test_admin_bypasses_cost_ceiling(self, app) -> None:
+        with app.app_context():
+            from app.services.ai_advisory_service import (
+                _enforce_financial_insight_generation_budget,
+            )
+
+            user_id = uuid.uuid4()
+            _seed_llm_cost(
+                user_id, cost_usd="100.00", endpoint="financial_insights_daily"
+            )
+            with patch(
+                "app.middleware.ai_rate_limit.request_is_admin",
+                return_value=True,
+            ):
+                # Far above budget, but an admin must not be blocked.
+                _enforce_financial_insight_generation_budget(
+                    user_id=user_id,
+                    normalized_period_type="daily",
+                    preview_run=None,
+                )

--- a/tests/test_ai_insight_cost_and_limits.py
+++ b/tests/test_ai_insight_cost_and_limits.py
@@ -1,0 +1,230 @@
+"""Cost ceiling + monthly cap enforcement for AI insights (#1386, slice A).
+
+Covers:
+- Per-user monthly LLM budget = 50% of the Premium plan price (FX-adjusted).
+- Per-user month-to-date cost enforcement (isolated per user).
+- Monthly generation counter (30/month) + HTTP 429 at the cap.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from decimal import Decimal
+from unittest.mock import patch
+
+import pytest
+
+
+def _register_and_login(client, prefix: str) -> str:
+    suffix = uuid.uuid4().hex[:8]
+    email = f"{prefix}-{suffix}@test.com"
+    password = "StrongPass@123"
+    reg = client.post(
+        "/auth/register",
+        json={"name": f"{prefix}-{suffix}", "email": email, "password": password},
+    )
+    assert reg.status_code == 201
+    login = client.post("/auth/login", json={"email": email, "password": password})
+    assert login.status_code == 200
+    return login.get_json()["token"]
+
+
+def _auth(token: str, v2: bool = False) -> dict[str, str]:
+    headers = {"Authorization": f"Bearer {token}"}
+    if v2:
+        headers["X-API-Contract"] = "v2"
+    return headers
+
+
+def _grant_premium(app, token: str) -> uuid.UUID:
+    with app.app_context():
+        from flask_jwt_extended import decode_token
+
+        from app.extensions.database import db
+        from app.models.entitlement import Entitlement, EntitlementSource
+
+        user_id = uuid.UUID(decode_token(token)["sub"])
+        db.session.add(
+            Entitlement(
+                user_id=user_id,
+                feature_key="advanced_simulations",
+                source=EntitlementSource.MANUAL,
+                expires_at=None,
+            )
+        )
+        db.session.commit()
+        return user_id
+
+
+def _reset_ai_counter() -> None:
+    from app.middleware.ai_rate_limit import _InMemoryAICounter
+
+    _InMemoryAICounter.reset()
+
+
+def _seed_llm_cost(user_id: uuid.UUID, *, cost_usd: str, endpoint: str) -> None:
+    from app.extensions.database import db
+    from app.models.llm_audit_log import LLMAuditLog
+
+    db.session.add(
+        LLMAuditLog(
+            user_id=user_id,
+            endpoint=endpoint,
+            model="gpt-4o-mini",
+            prompt="p",
+            response_text="r",
+            prompt_tokens=10,
+            completion_tokens=10,
+            total_tokens=20,
+            estimated_cost_usd=Decimal(cost_usd),
+            latency_ms=10,
+        )
+    )
+    db.session.commit()
+
+
+# ---------------------------------------------------------------------------
+# Per-user budget computation
+# ---------------------------------------------------------------------------
+
+
+class TestUserBudgetComputation:
+    def test_default_budget_is_half_plan_price_in_usd(self) -> None:
+        from app.services.ai_advisory_service import _user_ai_insight_monthly_budget_usd
+
+        # R$29,90 * 0.5 / 5.50 ≈ 2.7182 USD
+        budget = _user_ai_insight_monthly_budget_usd()
+        assert abs(budget - Decimal("2.718181818")) < Decimal("0.001")
+
+    def test_env_overrides_pct_and_fx(self) -> None:
+        from app.services.ai_advisory_service import _user_ai_insight_monthly_budget_usd
+
+        with patch.dict(
+            "os.environ",
+            {"AI_INSIGHTS_USER_BUDGET_PCT": "0.25", "AI_INSIGHTS_BRL_USD_FX": "5.00"},
+        ):
+            # 29.90 * 0.25 / 5.00 = 1.495
+            assert _user_ai_insight_monthly_budget_usd() == Decimal("1.495")
+
+
+# ---------------------------------------------------------------------------
+# Per-user cost enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestUserCostEnforcement:
+    def test_raises_when_user_month_spend_reaches_budget(self, app) -> None:
+        with app.app_context():
+            from app.services.ai_advisory_service import (
+                AIInsightCostBudgetExceededError,
+                _enforce_ai_insight_user_cost_budget,
+            )
+
+            user_id = uuid.uuid4()
+            now = datetime(2026, 5, 15, 12, 0, 0)
+            # Budget ≈ 2.72 USD; seed 3.00 this month.
+            _seed_llm_cost(
+                user_id, cost_usd="3.00", endpoint="financial_insights_daily"
+            )
+            with pytest.raises(AIInsightCostBudgetExceededError) as exc:
+                _enforce_ai_insight_user_cost_budget(user_id=user_id, now=now)
+            assert exc.value.scope == "user_monthly"
+
+    def test_does_not_raise_below_budget(self, app) -> None:
+        with app.app_context():
+            from app.services.ai_advisory_service import (
+                _enforce_ai_insight_user_cost_budget,
+            )
+
+            user_id = uuid.uuid4()
+            now = datetime(2026, 5, 15, 12, 0, 0)
+            _seed_llm_cost(
+                user_id, cost_usd="0.50", endpoint="financial_insights_daily"
+            )
+            # Must not raise.
+            _enforce_ai_insight_user_cost_budget(user_id=user_id, now=now)
+
+    def test_spend_is_isolated_per_user(self, app) -> None:
+        with app.app_context():
+            from app.services.ai_advisory_service import (
+                _enforce_ai_insight_user_cost_budget,
+            )
+
+            spender = uuid.uuid4()
+            other = uuid.uuid4()
+            now = datetime(2026, 5, 15, 12, 0, 0)
+            _seed_llm_cost(
+                spender, cost_usd="5.00", endpoint="financial_insights_daily"
+            )
+            # The other user has no spend → not blocked by spender's cost.
+            _enforce_ai_insight_user_cost_budget(user_id=other, now=now)
+
+
+# ---------------------------------------------------------------------------
+# Monthly generation cap (30/month)
+# ---------------------------------------------------------------------------
+
+
+class TestMonthlyCounter:
+    def setup_method(self) -> None:
+        _reset_ai_counter()
+
+    def test_record_and_get_monthly_usage(self) -> None:
+        from app.middleware.ai_rate_limit import (
+            get_ai_monthly_usage,
+            record_ai_monthly_success,
+        )
+
+        user_id = uuid.uuid4()
+        for _ in range(3):
+            record_ai_monthly_success(user_id)
+        count, ttl = get_ai_monthly_usage(user_id)
+        assert count == 3
+        assert ttl > 0
+
+    def test_monthly_usage_isolated_per_user(self) -> None:
+        from app.middleware.ai_rate_limit import (
+            get_ai_monthly_usage,
+            record_ai_monthly_success,
+        )
+
+        a, b = uuid.uuid4(), uuid.uuid4()
+        record_ai_monthly_success(a)
+        count_b, _ = get_ai_monthly_usage(b)
+        assert count_b == 0
+
+
+class TestMonthlyCapHTTP:
+    def setup_method(self) -> None:
+        _reset_ai_counter()
+
+    def test_returns_429_when_monthly_cap_reached(self, app, client) -> None:
+        from app.middleware.ai_rate_limit import (
+            AI_MONTHLY_LIMIT,
+            record_ai_monthly_success,
+        )
+
+        token = _register_and_login(client, "ai-monthly-cap")
+        user_id = _grant_premium(app, token)
+
+        # Saturate the monthly counter (daily stays at 0, so the monthly cap is
+        # the gate that trips).
+        for _ in range(AI_MONTHLY_LIMIT):
+            record_ai_monthly_success(user_id)
+
+        with patch(
+            "app.services.ai_advisory_service.AIAdvisoryService.generate_spending_insights",
+            return_value={
+                "insights": "ok",
+                "tokens_used": 10,
+                "cost_usd": 0.0,
+                "month": "2026-05",
+                "model": "stub",
+            },
+        ):
+            resp = client.get("/ai/insights/spending", headers=_auth(token, v2=True))
+
+        assert resp.status_code == 429
+        assert resp.get_json()["error"]["code"] == "AI_MONTHLY_LIMIT_EXCEEDED"
+        assert resp.headers.get("X-AI-Calls-Remaining-Month") == "0"

--- a/tests/test_ai_monthly_recap_batch.py
+++ b/tests/test_ai_monthly_recap_batch.py
@@ -1,0 +1,163 @@
+"""Automatic end-of-month recap batch (#1386, slice B).
+
+Covers generate_monthly_recaps_for_all: eligibility (users with activity in the
+month that just ended), idempotency, and recap persistence.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import date
+from decimal import Decimal
+
+from app.extensions.database import db
+from app.models.ai_insight import AIInsight, InsightType
+from app.models.user import User
+from app.services.ai_monthly_report_service import generate_monthly_recaps_for_all
+from app.services.llm_provider import LLMResponse
+
+
+def _create_user() -> uuid.UUID:
+    user = User(
+        name="Recap Tester",
+        email=f"recap-{uuid.uuid4().hex[:8]}@email.com",
+        password="hash",
+    )
+    db.session.add(user)
+    db.session.commit()
+    return user.id
+
+
+def _seed_daily_insight(user_id: uuid.UUID, *, period: date) -> None:
+    db.session.add(
+        AIInsight(
+            user_id=user_id,
+            content=json.dumps(
+                {
+                    "summary": "Daily",
+                    "items": [
+                        {
+                            "type": "saude_financeira",
+                            "dimension": "general",
+                            "title": "Resumo",
+                            "message": "Dia consolidado.",
+                            "evidence": ["current_period.paid.balance"],
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+            ),
+            insight_type=InsightType.daily,
+            period_label=period.isoformat(),
+            period_start=period,
+            period_end=period,
+            model="gpt-test",
+            tokens_used=50,
+            cost_usd=Decimal("0.00001"),
+        )
+    )
+    db.session.commit()
+
+
+def _seed_monthly_recap(user_id: uuid.UUID, *, period_label: str) -> None:
+    start = date.fromisoformat(f"{period_label}-01")
+    db.session.add(
+        AIInsight(
+            user_id=user_id,
+            content="{}",
+            insight_type=InsightType.monthly,
+            period_label=period_label,
+            period_start=start,
+            period_end=start,
+            model="gpt-test",
+            tokens_used=10,
+            cost_usd=Decimal("0.00001"),
+        )
+    )
+    db.session.commit()
+
+
+class _RecapProvider:
+    def generate_with_usage(self, prompt: str, response_schema=None) -> LLMResponse:
+        dimensions = [
+            "general",
+            "transactions",
+            "goals",
+            "budgets",
+            "credit_cards",
+            "wallet",
+        ]
+        return LLMResponse(
+            content=json.dumps(
+                {
+                    "summary": "Recap mensal consolidado.",
+                    "items": [
+                        {
+                            "type": "saude_financeira",
+                            "dimension": dim,
+                            "title": dim,
+                            "message": "Consolidado do mês.",
+                            "evidence": [
+                                f"data_quality.domain_presence.{dim}"
+                                if dim != "general"
+                                else "current_period.paid.balance"
+                            ],
+                        }
+                        for dim in dimensions
+                    ],
+                },
+                ensure_ascii=False,
+            ),
+            prompt_tokens=100,
+            completion_tokens=80,
+            total_tokens=180,
+            model="gpt-4o",
+            latency_ms=50,
+        )
+
+
+class TestMonthlyRecapBatch:
+    def test_generates_recap_for_user_with_activity(self, app) -> None:
+        with app.app_context():
+            user_id = _create_user()
+            _seed_daily_insight(user_id, period=date(2026, 4, 15))
+
+            generated = generate_monthly_recaps_for_all(
+                reference_date=date(2026, 5, 1),
+                llm_provider=_RecapProvider(),
+            )
+
+            assert generated == 1
+            recap = AIInsight.query.filter_by(
+                user_id=user_id,
+                insight_type=InsightType.monthly,
+                period_label="2026-04",
+            ).first()
+            assert recap is not None
+
+    def test_idempotent_skips_existing_recap(self, app) -> None:
+        with app.app_context():
+            user_id = _create_user()
+            _seed_daily_insight(user_id, period=date(2026, 4, 15))
+            _seed_monthly_recap(user_id, period_label="2026-04")
+
+            generated = generate_monthly_recaps_for_all(
+                reference_date=date(2026, 5, 1),
+                llm_provider=_RecapProvider(),
+            )
+
+            assert generated == 0
+
+    def test_skips_users_without_activity_in_target_month(self, app) -> None:
+        with app.app_context():
+            user_id = _create_user()
+            # Activity in March, not April → April batch must skip the user.
+            _seed_daily_insight(user_id, period=date(2026, 3, 10))
+
+            generated = generate_monthly_recaps_for_all(
+                reference_date=date(2026, 5, 1),
+                llm_provider=_RecapProvider(),
+            )
+
+            assert generated == 0

--- a/tests/test_llm_provider.py
+++ b/tests/test_llm_provider.py
@@ -93,14 +93,15 @@ class TestOpenAILLMProvider:
                 provider.generate("prompt")
 
     def test_uses_custom_model_from_env(self, monkeypatch):
-        monkeypatch.setenv("OPENAI_ADVISORY_MODEL", "gpt-4o")
-        provider = OpenAILLMProvider()
-        assert provider._model == "gpt-4o"
-
-    def test_default_model_is_gpt4o_mini(self, monkeypatch):
-        monkeypatch.delenv("OPENAI_ADVISORY_MODEL", raising=False)
+        monkeypatch.setenv("OPENAI_ADVISORY_MODEL", "gpt-4o-mini")
         provider = OpenAILLMProvider()
         assert provider._model == "gpt-4o-mini"
+
+    def test_default_model_is_strong(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_ADVISORY_MODEL", raising=False)
+        provider = OpenAILLMProvider()
+        # Strong model by default (#1386); overridable via OPENAI_ADVISORY_MODEL.
+        assert provider._model == "gpt-4o"
 
 
 class TestClaudeLLMProvider:


### PR DESCRIPTION
Closes #1386 (Frente C — Insights, épico #814) — **fatia B: recap mensal automático** (sobre a fatia A, #1390).

## O que entrega
- **Recap mensal automático** (`generate_monthly_recaps_for_all` + `scripts/generate_monthly_recaps.py`): no 1º dia do mês, consolida o mês que terminou em 1 recap por usuário com atividade (≥1 insight diário no mês). Idempotente (pula quem já tem recap do período). Reusa `create/process_monthly_report_run` (agrega diários + mês anterior + email com deep link).
- **Fora dos caps**: roda fora do endpoint rate-limited e o `monthly` é **isento do teto de custo per-user** — o recap é um entregável garantido ("+1/mês"). Custo ainda é logado.
- **Docs/Wiki**: `docs/wiki/AI-Insights-Cost-And-Recap.md` (modelo, envs, ceiling, forecast, cron) + atualização do `AI-Insights-Rate-Limit.md` (1/dia, 30/mês, ceiling per-user, admin bypass, headers).

## Cron (produção)
`0 9 1 * *` → `python scripts/generate_monthly_recaps.py` (espelha o cron de recorrência). Idempotente. Instalação via SSH/infra fica como passo operacional (documentado na wiki).

## Testes / qualidade
- `test_ai_monthly_recap_batch.py` (gera p/ usuário ativo, idempotência, pula sem atividade) + teste de isenção do `monthly` no ceiling. ruff + mypy limpos.

> Base nesta PR é a branch da fatia A (#1390) para diff limpo; re-aponta p/ master quando #1390 mergear.

Refs #814
