### PR TITLE
feat(ai): return persisted insight id on generation (REST + GraphQL) (#1400)

### DIFF
--- a/app/graphql/mutations/ai_insight.py
+++ b/app/graphql/mutations/ai_insight.py
@@ -45,6 +45,7 @@ class AIInsightItemType(graphene.ObjectType):
 
 class GenerateAiInsightPayload(graphene.ObjectType):
     ok = graphene.Boolean(required=True)
+    id = graphene.String()
     period_type = graphene.String()
     period_label = graphene.String()
     period_start = graphene.String()
@@ -141,6 +142,7 @@ class GenerateAiInsightMutation(graphene.Mutation):
 
         return GenerateAiInsightPayload(
             ok=True,
+            id=result.get("id"),
             period_type=result.get("period_type"),
             period_label=result.get("period_label"),
             period_start=result.get("period_start"),

--- a/app/services/ai_advisory_service.py
+++ b/app/services/ai_advisory_service.py
@@ -624,6 +624,7 @@ def _cached_financial_insight_payload(
         return None
 
     return {
+        "id": str(cached.id),
         "period_type": normalized_period_type,
         "period_label": cached.period_label,
         "period_start": cached.period_start.isoformat(),
@@ -1200,6 +1201,7 @@ class AIAdvisoryService:
             )
 
         return {
+            "id": str(saved_insight.id),
             "period_type": normalized_period_type,
             "period_label": period_label,
             "period_start": period_start.isoformat(),

--- a/graphql.introspection.json
+++ b/graphql.introspection.json
@@ -16415,6 +16415,18 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "id",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "periodType",
               "type": {
                 "kind": "SCALAR",

--- a/schema.graphql
+++ b/schema.graphql
@@ -1276,6 +1276,7 @@ type FiscalDocumentPayload {
 
 type GenerateAiInsightPayload {
   ok: Boolean!
+  id: String
   periodType: String
   periodLabel: String
   periodStart: String

--- a/tests/test_ai_advisory_service.py
+++ b/tests/test_ai_advisory_service.py
@@ -372,6 +372,7 @@ class TestAIAdvisoryServiceFinancialInsights:
             )
 
             saved = db.session.query(AIInsight).filter_by(user_id=user_id).one()
+            assert result["id"] == str(saved.id)
             assert saved.insight_type == InsightType.daily
             assert saved.period_label == "2026-05-17"
             assert "current_period.paid.balance" in saved.content

--- a/tests/test_graphql_generate_ai_insight.py
+++ b/tests/test_graphql_generate_ai_insight.py
@@ -37,6 +37,7 @@ _GENERATE_MUTATION = """
 mutation Gen($periodType: String!, $anchorDate: String) {
   generateAiInsight(periodType: $periodType, anchorDate: $anchorDate) {
     ok
+    id
     periodType
     summary
     items { type dimension title message evidence }
@@ -99,6 +100,7 @@ class TestGenerateAiInsightMutation:
             db.session.commit()
 
         fake_result = {
+            "id": "cccccccc-cccc-cccc-cccc-cccccccccccc",
             "period_type": "daily",
             "period_label": "2026-05-18",
             "period_start": "2026-05-18",
@@ -133,6 +135,7 @@ class TestGenerateAiInsightMutation:
         assert "errors" not in body or not body["errors"], body
         data = body["data"]["generateAiInsight"]
         assert data["ok"] is True
+        assert data["id"] == "cccccccc-cccc-cccc-cccc-cccccccccccc"
         assert data["summary"] == "Resumo do dia."
         assert len(data["items"]) == 1
         assert data["items"][0]["dimension"] == "credit_cards"


### PR DESCRIPTION
## Summary
The generation endpoints persist an `AIInsight` but did not surface its `id`,
so the frontend could not target `POST /ai/insights/<id>/feedback` for a
freshly generated insight (only history items carried an id).

- Include `id` in the `generate_financial_insights` result — both the fresh
  path (`saved_insight.id`) and the cache path (`cached.id`).
- Expose `id` on `GenerateAiInsightPayload` (GraphQL parity) and map it.
- Regenerated `schema.graphql` + `graphql.introspection.json`.
- Tests: service returns the persisted id; GraphQL mutation returns it.

Enables the feedback UI in web #958 / app #465.

## Refs
Closes #1400