### PR TITLE
fix(ai): exec weekly/monthly insights in running web container (#1249)

### DIFF
--- a/scripts/aws_ai_insights_job.py
+++ b/scripts/aws_ai_insights_job.py
@@ -321,7 +321,15 @@ for SERVICE in "${{SERVICE_START_ARGS[@]}}"; do
   fi
 done
 
-docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" run --rm --no-deps \\
+# Issue #1249: exec the CLI inside the *running* web container instead of
+# `docker compose run`. The prod ENTRYPOINT (scripts/entrypoint_prod.sh) always
+# `exec gunicorn ...` and ignores any passed command, so `run web <cmd>` booted
+# a web server that never exited and the SSM wait timed out (~30 min) on every
+# scheduled run. `exec` runs the command in the live container — which also
+# carries the correct DATABASE_URL / LLM_PROVIDER the API actually serves with
+# (the `run` path used .env.prod, still pointing at the decommissioned RDS) —
+# and exits cleanly when the batch finishes.
+docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" exec -T \\
   -e FLASK_APP=run.py \\
   web {flask_cmd}
 """

--- a/tests/test_aws_ai_insights_job.py
+++ b/tests/test_aws_ai_insights_job.py
@@ -27,11 +27,15 @@ def test_build_script_waits_only_for_services_started_by_the_job() -> None:
     assert "redis container was not created" not in script
 
 
-def test_build_script_still_runs_weekly_command_inside_web_without_deps() -> None:
+def test_build_script_execs_weekly_command_in_running_web_container() -> None:
+    # Issue #1249: must `exec` into the live web container, not `run` a fresh
+    # one — the prod entrypoint always launches gunicorn and ignores the passed
+    # command, so `run` left the SSM job hanging until the ~30 min timeout.
     script = aws_ai_insights_job._build_script(env_name="prod", mode="weekly")
 
-    assert "run --rm --no-deps \\" in script
+    assert "exec -T \\" in script
     assert "web flask ai weekly-insights" in script
+    assert "run --rm --no-deps" not in script
 
 
 def test_build_script_passes_month_to_monthly_command() -> None:


### PR DESCRIPTION
## Summary
The scheduled **weekly** (and monthly) AI insights SSM job has failed 3 weeks
running (#1249) — each run hit `AwsCliError: Timeout waiting for AI insights SSM
command` (~30 min).

**Root cause:** `scripts/aws_ai_insights_job.py` ran the CLI via
`docker compose run --rm --no-deps web flask ai <mode>-insights`. But the prod
image ENTRYPOINT (`scripts/entrypoint_prod.sh`) always ends in `exec gunicorn …`
and **ignores the passed command** — so the job booted a fresh web server that
served `/healthz` forever and never ran the CLI, until the SSM wait timed out.
(The dry-run path never reproduced it; running it via `exec` in the live
container completes instantly.)

**Fix:** use `docker compose exec -T web flask ai <mode>-insights` — runs the
CLI in the already-running container and exits cleanly. Bonus: `exec` inherits
the live container's env, so the batch targets the current **local-Postgres** DB
and `LLM_PROVIDER=openai`, whereas the old `run` path used `.env.prod`, still
pointing at the **decommissioned RDS** endpoint.

Verified via SSM on prod: dry-run lists 7 eligible Premium users and exits.

## Refs
Closes #1249