### PR TITLE
feat(ai): instrument insight runs, cost, rejections, truncation & purge (#1314)

### DIFF
--- a/app/extensions/prometheus_metrics.py
+++ b/app/extensions/prometheus_metrics.py
@@ -48,15 +48,31 @@ _CACHE_INVALIDATIONS_TOTAL: Any = None
 _AI_INSIGHT_GENERATED_TOTAL: Any = None
 _AI_INSIGHT_TOKENS: Any = None
 _AI_INSIGHT_SNAPSHOT_BYTES: Any = None
+_AI_INSIGHT_RUNS_TOTAL: Any = None
+_AI_INSIGHT_COST_USD_TOTAL: Any = None
+_AI_INSIGHT_REJECTIONS_TOTAL: Any = None
+_AI_INSIGHT_TRUNCATED_TOTAL: Any = None
+_AI_INSIGHT_DATA_QUALITY_DOMAINS: Any = None
+_AI_INSIGHT_RUNS_PURGED_TOTAL: Any = None
 
 _DURATION_BUCKETS = (0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5)
 _AI_TOKENS_BUCKETS = (100, 250, 500, 1000, 2500, 5000, 10000, 25000)
 _AI_SNAPSHOT_BYTES_BUCKETS = (1024, 2048, 4096, 8192, 12288, 16384, 32768)
+_AI_DATA_QUALITY_DOMAIN_BUCKETS = (0, 1, 2, 3, 4, 5, 6)
 
 
 def _init_ai_insight_metrics() -> None:
     """Lazily initialise the MVP-3 AI insight observability instruments."""
-    global _AI_INSIGHT_GENERATED_TOTAL, _AI_INSIGHT_TOKENS, _AI_INSIGHT_SNAPSHOT_BYTES
+    global \
+        _AI_INSIGHT_GENERATED_TOTAL, \
+        _AI_INSIGHT_TOKENS, \
+        _AI_INSIGHT_SNAPSHOT_BYTES, \
+        _AI_INSIGHT_RUNS_TOTAL, \
+        _AI_INSIGHT_COST_USD_TOTAL, \
+        _AI_INSIGHT_REJECTIONS_TOTAL, \
+        _AI_INSIGHT_TRUNCATED_TOTAL, \
+        _AI_INSIGHT_DATA_QUALITY_DOMAINS, \
+        _AI_INSIGHT_RUNS_PURGED_TOTAL
 
     if _AI_INSIGHT_GENERATED_TOTAL is None:
         _AI_INSIGHT_GENERATED_TOTAL = Counter(
@@ -77,6 +93,48 @@ def _init_ai_insight_metrics() -> None:
             "Snapshot size in bytes sent to the LLM (post truncation)",
             ["period_type", "truncated"],
             buckets=_AI_SNAPSHOT_BYTES_BUCKETS,
+        )
+    # #1314 — governance/quality observability for AI insight runs.
+    if _AI_INSIGHT_RUNS_TOTAL is None:
+        _AI_INSIGHT_RUNS_TOTAL = Counter(
+            "auraxis_ai_insight_runs_total",
+            (
+                "AIInsightRun lifecycle state entries by status and period_type. "
+                "A single logical run contributes once per status it enters "
+                "(e.g. previewed then generated), so rates like "
+                "rejected/previewed are derivable."
+            ),
+            ["status", "period_type"],
+        )
+    if _AI_INSIGHT_COST_USD_TOTAL is None:
+        _AI_INSIGHT_COST_USD_TOTAL = Counter(
+            "auraxis_ai_insight_cost_usd_total",
+            "Cumulative estimated LLM cost (USD) attributed to AI insight runs",
+            ["period_type"],
+        )
+    if _AI_INSIGHT_REJECTIONS_TOTAL is None:
+        _AI_INSIGHT_REJECTIONS_TOTAL = Counter(
+            "auraxis_ai_insight_rejections_total",
+            "AI insight items rejected by the evidence validator, by reason",
+            ["reason"],
+        )
+    if _AI_INSIGHT_TRUNCATED_TOTAL is None:
+        _AI_INSIGHT_TRUNCATED_TOTAL = Counter(
+            "auraxis_ai_insight_truncated_total",
+            "AI insight runs whose snapshot was truncated before the LLM call",
+            ["period_type"],
+        )
+    if _AI_INSIGHT_DATA_QUALITY_DOMAINS is None:
+        _AI_INSIGHT_DATA_QUALITY_DOMAINS = Histogram(
+            "auraxis_ai_insight_data_quality_domains",
+            "Number of financial domains present in the run snapshot (0-6)",
+            ["period_type"],
+            buckets=_AI_DATA_QUALITY_DOMAIN_BUCKETS,
+        )
+    if _AI_INSIGHT_RUNS_PURGED_TOTAL is None:
+        _AI_INSIGHT_RUNS_PURGED_TOTAL = Counter(
+            "auraxis_ai_insight_runs_purged_total",
+            "AIInsightRun snapshot payloads purged by the retention job",
         )
 
 
@@ -272,6 +330,62 @@ def record_ai_insight_generated(
         ).observe(snapshot_bytes)
 
 
+def record_ai_insight_run(*, status: str, period_type: str) -> None:
+    """Count an ``AIInsightRun`` entering *status* (#1314).
+
+    ``status`` is an ``AIInsightRunStatus`` value (previewed/generated/cached/
+    rejected/blocked/failed/purged); ``period_type`` is an ``InsightType``
+    value. Both are bounded enums — safe label cardinality, no PII.
+    """
+    _ensure_metrics_initialized()
+    if _AI_INSIGHT_RUNS_TOTAL is not None:
+        _AI_INSIGHT_RUNS_TOTAL.labels(
+            status=status or "unknown",
+            period_type=period_type or "unknown",
+        ).inc()
+
+
+def record_ai_insight_cost(*, period_type: str, cost_usd: float) -> None:
+    """Add *cost_usd* to the cumulative AI insight cost counter (#1314)."""
+    _ensure_metrics_initialized()
+    if _AI_INSIGHT_COST_USD_TOTAL is not None and cost_usd > 0:
+        _AI_INSIGHT_COST_USD_TOTAL.labels(
+            period_type=period_type or "unknown",
+        ).inc(cost_usd)
+
+
+def record_ai_insight_rejection(*, reason: str) -> None:
+    """Count one evidence-validation rejection by stable *reason* (#1314)."""
+    _ensure_metrics_initialized()
+    if _AI_INSIGHT_REJECTIONS_TOTAL is not None:
+        _AI_INSIGHT_REJECTIONS_TOTAL.labels(reason=reason or "unknown").inc()
+
+
+def record_ai_insight_truncated(*, period_type: str) -> None:
+    """Count one AI insight run whose snapshot was truncated (#1314)."""
+    _ensure_metrics_initialized()
+    if _AI_INSIGHT_TRUNCATED_TOTAL is not None:
+        _AI_INSIGHT_TRUNCATED_TOTAL.labels(
+            period_type=period_type or "unknown",
+        ).inc()
+
+
+def record_ai_insight_data_quality(*, period_type: str, domains_present: int) -> None:
+    """Observe how many financial domains were present in the run snapshot."""
+    _ensure_metrics_initialized()
+    if _AI_INSIGHT_DATA_QUALITY_DOMAINS is not None and domains_present >= 0:
+        _AI_INSIGHT_DATA_QUALITY_DOMAINS.labels(
+            period_type=period_type or "unknown",
+        ).observe(domains_present)
+
+
+def record_ai_insight_runs_purged(count: int) -> None:
+    """Increment ``auraxis_ai_insight_runs_purged_total`` by *count* (#1314)."""
+    _ensure_metrics_initialized()
+    if _AI_INSIGHT_RUNS_PURGED_TOTAL is not None and count > 0:
+        _AI_INSIGHT_RUNS_PURGED_TOTAL.inc(count)
+
+
 def generate_latest_metrics() -> tuple[bytes, str]:
     """Return ``(body_bytes, content_type)`` for the Prometheus scrape endpoint.
 
@@ -321,7 +435,13 @@ def register_prometheus_middleware(app: "Flask") -> None:
 
 __all__ = [
     "generate_latest_metrics",
+    "record_ai_insight_cost",
+    "record_ai_insight_data_quality",
     "record_ai_insight_generated",
+    "record_ai_insight_rejection",
+    "record_ai_insight_run",
+    "record_ai_insight_runs_purged",
+    "record_ai_insight_truncated",
     "record_audit_purge",
     "record_auth_login",
     "record_auth_login_cookie_only_header",

--- a/app/services/ai_advisory_service.py
+++ b/app/services/ai_advisory_service.py
@@ -37,6 +37,7 @@ from app.models.goal import Goal
 from app.models.goal_contribution import GoalContribution
 from app.models.llm_audit_log import LLMAuditLog
 from app.models.transaction import Transaction, TransactionStatus, TransactionType
+from app.services.ai_insight_runs import transition_ai_insight_run_status
 from app.services.ai_lgpd import (
     ensure_ai_consent_granted,
     minimize_prompt_data,
@@ -851,13 +852,13 @@ def _mark_preview_run_cached(
     preview_run: AIInsightRun,
     cached: AIInsight,
 ) -> None:
-    preview_run.status = AIInsightRunStatus.cached
     preview_run.ai_insight_id = cached.id
     preview_run.model = cached.model
     preview_run.tokens_in = 0
     preview_run.tokens_out = 0
     preview_run.tokens_total = 0
     preview_run.cost_usd = Decimal("0")
+    transition_ai_insight_run_status(preview_run, AIInsightRunStatus.cached)
     db.session.commit()
 
 
@@ -866,8 +867,10 @@ def _mark_preview_run_blocked(
     preview_run: AIInsightRun,
     reason: str,
 ) -> None:
-    preview_run.status = AIInsightRunStatus.blocked
     preview_run.rejection_reasons_json = [reason]
+    transition_ai_insight_run_status(
+        preview_run, AIInsightRunStatus.blocked, reason=reason
+    )
     db.session.commit()
 
 
@@ -1176,13 +1179,13 @@ class AIAdvisoryService:
         )
 
         if preview_run is not None:
-            preview_run.status = AIInsightRunStatus.generated
             preview_run.ai_insight_id = saved_insight.id
             preview_run.model = llm_resp.model
             preview_run.tokens_in = int(llm_resp.prompt_tokens or 0)
             preview_run.tokens_out = int(llm_resp.completion_tokens or 0)
             preview_run.tokens_total = int(llm_resp.total_tokens or 0)
             preview_run.cost_usd = Decimal(str(llm_resp.estimated_cost_usd))
+            transition_ai_insight_run_status(preview_run, AIInsightRunStatus.generated)
             db.session.commit()
 
         try:

--- a/app/services/ai_insight_runs.py
+++ b/app/services/ai_insight_runs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import re
 from datetime import date, datetime
 from decimal import Decimal
@@ -7,6 +8,13 @@ from typing import Any
 from uuid import UUID
 
 from app.extensions.database import db
+from app.extensions.prometheus_metrics import (
+    record_ai_insight_cost,
+    record_ai_insight_data_quality,
+    record_ai_insight_run,
+    record_ai_insight_runs_purged,
+    record_ai_insight_truncated,
+)
 from app.models.ai_insight import InsightType
 from app.models.ai_insight_run import (
     DEFAULT_AI_INSIGHT_RUN_RETENTION_DAYS,
@@ -14,6 +22,38 @@ from app.models.ai_insight_run import (
     AIInsightRunStatus,
 )
 from app.utils.datetime_utils import utc_now_naive
+
+log = logging.getLogger(__name__)
+
+
+def _count_domains_present(data_quality_json: Any) -> int:
+    """Count financial domains flagged present in ``data_quality.domain_presence``.
+
+    Defensive against shape drift: a domain counts as present when its value is
+    truthy, or (when a dict) when its ``present``/``available`` field is truthy.
+    Returns 0 when the structure is missing or unrecognised. No PII is read.
+    """
+    if not isinstance(data_quality_json, dict):
+        return 0
+    presence = data_quality_json.get("domain_presence")
+    if not isinstance(presence, dict):
+        return 0
+    count = 0
+    for value in presence.values():
+        if isinstance(value, dict):
+            if value.get("present") or value.get("available") or value.get("has_data"):
+                count += 1
+        elif value:
+            count += 1
+    return count
+
+
+def _is_truncated(truncation_flags_json: Any) -> bool:
+    return bool(
+        isinstance(truncation_flags_json, dict)
+        and truncation_flags_json.get("truncated")
+    )
+
 
 _EMAIL_RE = re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.IGNORECASE)
 _CPF_RE = re.compile(r"\b\d{3}\.\d{3}\.\d{3}-\d{2}\b")
@@ -134,7 +174,68 @@ def create_ai_insight_run(
     db.session.add(run)
     if commit:
         db.session.commit()
+
+    # #1314 — observability: emit lifecycle/quality metrics + a PII-free
+    # structured log keyed by run_id/snapshot_hash. snapshot_json itself is
+    # never logged (it carries deterministic facts but we keep logs lean).
+    period_value = period_type.value
+    record_ai_insight_run(status=status.value, period_type=period_value)
+    if _is_truncated(truncation_flags_json):
+        record_ai_insight_truncated(period_type=period_value)
+    domains_present = _count_domains_present(data_quality_json)
+    record_ai_insight_data_quality(
+        period_type=period_value,
+        domains_present=domains_present,
+    )
+    cost_value = float(run.cost_usd)
+    if cost_value > 0:
+        record_ai_insight_cost(period_type=period_value, cost_usd=cost_value)
+    log.info(
+        "ai_insight.run.created run_id=%s status=%s period_type=%s "
+        "period=%s snapshot_hash=%s tokens=%s cost_usd=%s truncated=%s "
+        "domains_present=%s",
+        run.id,
+        status.value,
+        period_value,
+        period_label,
+        snapshot_hash,
+        run.tokens_total,
+        cost_value,
+        _is_truncated(truncation_flags_json),
+        domains_present,
+    )
     return run
+
+
+def transition_ai_insight_run_status(
+    run: AIInsightRun,
+    new_status: AIInsightRunStatus,
+    *,
+    reason: str | None = None,
+) -> None:
+    """Move *run* to *new_status*, emitting the lifecycle metric + a log (#1314).
+
+    Centralises status changes so every transition is observable. Callers keep
+    setting their other side-effect fields (ai_insight_id, tokens, cost) around
+    this call. The structured log uses run_id/snapshot_hash only — no PII.
+    """
+    run.status = new_status
+    period_value = run.period_type.value
+    record_ai_insight_run(status=new_status.value, period_type=period_value)
+    cost_value = float(run.cost_usd)
+    if new_status is AIInsightRunStatus.generated and cost_value > 0:
+        record_ai_insight_cost(period_type=period_value, cost_usd=cost_value)
+    log.info(
+        "ai_insight.run.transition run_id=%s status=%s period_type=%s "
+        "snapshot_hash=%s tokens=%s cost_usd=%s reason=%s",
+        run.id,
+        new_status.value,
+        period_value,
+        run.snapshot_hash,
+        run.tokens_total,
+        cost_value,
+        reason or "",
+    )
 
 
 def purge_expired_ai_insight_runs(*, now: datetime | None = None) -> int:
@@ -155,8 +256,15 @@ def purge_expired_ai_insight_runs(*, now: datetime | None = None) -> int:
         row.evidence_manifest_json = None
         row.status = AIInsightRunStatus.purged
         row.purged_at = purge_at
+        record_ai_insight_run(
+            status=AIInsightRunStatus.purged.value,
+            period_type=row.period_type.value,
+        )
     db.session.commit()
-    return len(rows)
+    purged = len(rows)
+    record_ai_insight_runs_purged(purged)
+    log.info("ai_insight.run.purged count=%s purge_at=%s", purged, purge_at)
+    return purged
 
 
 __all__ = [
@@ -164,4 +272,5 @@ __all__ = [
     "create_ai_insight_run",
     "purge_expired_ai_insight_runs",
     "sanitize_audit_snapshot",
+    "transition_ai_insight_run_status",
 ]

--- a/app/services/insight_evidence_validator.py
+++ b/app/services/insight_evidence_validator.py
@@ -23,6 +23,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from app.extensions.prometheus_metrics import record_ai_insight_rejection
+
 log = logging.getLogger(__name__)
 
 
@@ -156,6 +158,7 @@ def filter_valid_items(
         if ok:
             accepted.append(item)
             continue
+        record_ai_insight_rejection(reason=reason or "unknown")
         log.warning(
             "ai_advisory.evidence_validation.rejected user=%s reason=%s "
             "dimension=%s type=%s evidence=%s",

--- a/docs/wiki/AI-Insights-Observability-Alerts.md
+++ b/docs/wiki/AI-Insights-Observability-Alerts.md
@@ -1,0 +1,71 @@
+# AI Insights — Observability & Alerts
+
+Reference for the run/cost/quality/governance metrics emitted by the AI insight
+pipeline and the alerts to configure on them (épico #814, issue #1314).
+
+Metrics are Prometheus instruments defined in
+`app/extensions/prometheus_metrics.py` and scraped at `/ops/metrics`. Structured
+logs are emitted by `app/services/ai_insight_runs.py` and
+`app/services/insight_evidence_validator.py`.
+
+## Metrics
+
+| Metric | Type | Labels | Emitted where |
+|---|---|---|---|
+| `auraxis_ai_insight_runs_total` | Counter | `status`, `period_type` | every `AIInsightRun` state entry — `create_ai_insight_run` (previewed) + `transition_ai_insight_run_status` (generated/cached/blocked) + purge (purged) |
+| `auraxis_ai_insight_cost_usd_total` | Counter | `period_type` | on `generated` runs, summing `estimated_cost_usd` |
+| `auraxis_ai_insight_rejections_total` | Counter | `reason` | `filter_valid_items` per rejected item |
+| `auraxis_ai_insight_truncated_total` | Counter | `period_type` | `create_ai_insight_run` when the snapshot was truncated |
+| `auraxis_ai_insight_data_quality_domains` | Histogram | `period_type` | `create_ai_insight_run`; observes domains present (0–6) |
+| `auraxis_ai_insight_runs_purged_total` | Counter | — | `purge_expired_ai_insight_runs` |
+| `auraxis_ai_insight_generated_total` | Counter | `period_type`, `dimension` | (pre-existing) per generated dimension |
+| `auraxis_ai_insight_tokens` | Histogram | `period_type` | (pre-existing) tokens per generation |
+| `auraxis_ai_insight_snapshot_bytes` | Histogram | `period_type`, `truncated` | (pre-existing) snapshot size post-truncation |
+
+> `runs_total` counts **state entries**, not distinct runs: a single run that
+> goes `previewed → generated` increments both. This lets you derive rates such
+> as rejection-rate = `blocked / previewed` and conversion = `generated /
+> previewed`.
+
+### `rejections_total` reason values
+
+Stable, bounded labels from `insight_evidence_validator`: `invalid_dimension`,
+`missing_evidence`, `empty_evidence`, `unknown_path_prefix`,
+`dimension_evidence_mismatch`.
+
+## Structured logs (no PII)
+
+Run-scoped logs carry only auditable, non-PII fields — `run_id`,
+`snapshot_hash`, `period_type`, `period`, `status`, `tokens`, `cost_usd`,
+`truncated`, `domains_present`. The raw snapshot and prompt are **never**
+logged. PII in free text is additionally scrubbed before persistence by
+`sanitize_audit_snapshot` (emails/CPF/long numbers → placeholders; id-like keys
+dropped).
+
+- `ai_insight.run.created …` — on persistence (`logging.INFO`)
+- `ai_insight.run.transition …` — on each status change
+- `ai_insight.run.purged count=… …` — on retention purge
+- `ai_advisory.evidence_validation.rejected …` — per rejected item (`WARNING`)
+
+## Alerts
+
+Configure these against the metrics above (thresholds are starting points —
+tune with production baselines).
+
+| Alert | Condition (PromQL sketch) | Why |
+|---|---|---|
+| **High cost** | `increase(auraxis_ai_insight_cost_usd_total[1h]) > 1.0` (US$/h) or daily sum approaching `AI_INSIGHTS_DAILY_BUDGET_USD` | LLM spend running hot before the org budget gate trips |
+| **High rejection rate** | `sum(rate(auraxis_ai_insight_rejections_total[15m])) / sum(rate(auraxis_ai_insight_runs_total{status="previewed"}[15m])) > 0.3` | LLM producing evidence-inconsistent items → prompt/model regression |
+| **Frequent truncation** | `sum(rate(auraxis_ai_insight_truncated_total[1h])) / sum(rate(auraxis_ai_insight_runs_total{status="previewed"}[1h])) > 0.25` | Snapshots consistently exceeding the byte cap → context loss; revisit `MAX_SNAPSHOT_BYTES` or snapshot shape |
+| **Purge failure / stall** | `increase(auraxis_ai_insight_runs_purged_total[36h]) == 0` while expired rows exist | Retention job not running → LGPD/retention risk (snapshots kept past window) |
+| **Low data quality** | `histogram_quantile(0.5, rate(auraxis_ai_insight_data_quality_domains_bucket[6h])) < 2` | Insights generated on sparse data → low-value output |
+| **Generation failures** | sustained `previewed` with no matching `generated`/`cached`/`blocked` | runs stuck mid-lifecycle (LLM errors / crashes) |
+
+The purge job is the monthly recap cron's sibling; if `runs_purged_total` is
+flat, check the retention scheduler before assuming zero expired rows.
+
+## Related
+
+- [AI-Insights-Cost-And-Recap](AI-Insights-Cost-And-Recap.md) — cost ceiling & caps
+- [AI-Insights-Rate-Limit](AI-Insights-Rate-Limit.md) — per-user daily/monthly caps
+- [AI-Insights-Structured-Output](AI-Insights-Structured-Output.md) — evidence contract

--- a/tests/test_ai_insight_observability.py
+++ b/tests/test_ai_insight_observability.py
@@ -201,3 +201,203 @@ class TestMaxBytesEnvOverride:
         # 12 KiB. Just sanity-check the unit (multiple of 1024).
         assert MAX_SNAPSHOT_BYTES > 0
         assert MAX_SNAPSHOT_BYTES % 1024 == 0
+
+
+class TestRunGovernanceMetrics:
+    """#1314 — runs/cost/rejections/truncation/data-quality/purge observability."""
+
+    @staticmethod
+    def _make_run(user_id: UUID, *, status, truncated, with_pii=False):
+        from datetime import date as _date
+
+        from app.models.ai_insight import InsightType
+        from app.services.ai_insight_runs import create_ai_insight_run
+
+        snapshot = {
+            "schema_version": "financial_insight_snapshot.v1",
+            "data_quality": {
+                "domain_presence": {
+                    "transactions": {"present": True},
+                    "goals": {"present": True},
+                    "wallet": {"present": False},
+                }
+            },
+        }
+        if with_pii:
+            snapshot["note"] = "contato fulano@email.com cpf 123.456.789-00"
+        return create_ai_insight_run(
+            user_id=user_id,
+            status=status,
+            period_type=InsightType.daily,
+            period_label="2026-05-18",
+            period_start=_date(2026, 5, 18),
+            period_end=_date(2026, 5, 18),
+            snapshot_schema_version="financial_insight_snapshot.v1",
+            snapshot_hash="hash-abc123",
+            prompt_template_version="v1",
+            snapshot_json=snapshot,
+            data_quality_json=snapshot["data_quality"],
+            truncation_flags_json={"truncated": truncated},
+        )
+
+    def test_create_emits_run_truncation_and_data_quality(self, app, client) -> None:
+        from app.models.ai_insight_run import AIInsightRunStatus
+
+        _, user_id_str = _register_and_login(client)
+        user_id = UUID(user_id_str)
+        with app.app_context():
+            with (
+                patch("app.services.ai_insight_runs.record_ai_insight_run") as run_m,
+                patch(
+                    "app.services.ai_insight_runs.record_ai_insight_truncated"
+                ) as trunc_m,
+                patch(
+                    "app.services.ai_insight_runs.record_ai_insight_data_quality"
+                ) as dq_m,
+            ):
+                self._make_run(
+                    user_id,
+                    status=AIInsightRunStatus.previewed,
+                    truncated=True,
+                )
+
+            assert run_m.call_args.kwargs == {
+                "status": "previewed",
+                "period_type": "daily",
+            }
+            assert trunc_m.call_args.kwargs == {"period_type": "daily"}
+            # 2 of 3 domains present (wallet flagged absent).
+            assert dq_m.call_args.kwargs == {
+                "period_type": "daily",
+                "domains_present": 2,
+            }
+
+    def test_create_does_not_emit_truncation_when_not_truncated(
+        self, app, client
+    ) -> None:
+        from app.models.ai_insight_run import AIInsightRunStatus
+
+        _, user_id_str = _register_and_login(client)
+        user_id = UUID(user_id_str)
+        with app.app_context():
+            with patch(
+                "app.services.ai_insight_runs.record_ai_insight_truncated"
+            ) as trunc_m:
+                self._make_run(
+                    user_id,
+                    status=AIInsightRunStatus.previewed,
+                    truncated=False,
+                )
+            assert not trunc_m.called
+
+    def test_create_structured_log_carries_run_fields_without_pii(
+        self, app, client, caplog
+    ) -> None:
+        import logging
+
+        from app.models.ai_insight_run import AIInsightRunStatus
+
+        _, user_id_str = _register_and_login(client)
+        user_id = UUID(user_id_str)
+        with app.app_context():
+            with caplog.at_level(logging.INFO, logger="app.services.ai_insight_runs"):
+                self._make_run(
+                    user_id,
+                    status=AIInsightRunStatus.previewed,
+                    truncated=False,
+                    with_pii=True,
+                )
+
+        created = [r for r in caplog.records if "ai_insight.run.created" in r.message]
+        assert created, "expected an ai_insight.run.created structured log"
+        msg = created[0].getMessage()
+        # Carries the auditable, non-PII fields.
+        assert "snapshot_hash=hash-abc123" in msg
+        assert "status=previewed" in msg
+        assert "period_type=daily" in msg
+        # Never leaks PII from the snapshot.
+        assert "fulano@email.com" not in msg
+        assert "123.456.789-00" not in msg
+
+    def test_transition_emits_run_and_cost_on_generated(self, app, client) -> None:
+        from decimal import Decimal
+
+        from app.extensions.database import db
+        from app.models.ai_insight_run import AIInsightRunStatus
+        from app.services.ai_insight_runs import transition_ai_insight_run_status
+
+        _, user_id_str = _register_and_login(client)
+        user_id = UUID(user_id_str)
+        with app.app_context():
+            run = self._make_run(
+                user_id,
+                status=AIInsightRunStatus.previewed,
+                truncated=False,
+            )
+            run.cost_usd = Decimal("0.0123")
+            db.session.commit()
+            with (
+                patch("app.services.ai_insight_runs.record_ai_insight_run") as run_m,
+                patch("app.services.ai_insight_runs.record_ai_insight_cost") as cost_m,
+            ):
+                transition_ai_insight_run_status(run, AIInsightRunStatus.generated)
+
+            assert run_m.call_args.kwargs == {
+                "status": "generated",
+                "period_type": "daily",
+            }
+            assert cost_m.call_args.kwargs["period_type"] == "daily"
+            assert cost_m.call_args.kwargs["cost_usd"] > 0
+
+    def test_purge_emits_purged_metric(self, app, client) -> None:
+        from datetime import timedelta
+
+        from app.extensions.database import db
+        from app.models.ai_insight_run import AIInsightRunStatus
+        from app.services.ai_insight_runs import purge_expired_ai_insight_runs
+        from app.utils.datetime_utils import utc_now_naive
+
+        _, user_id_str = _register_and_login(client)
+        user_id = UUID(user_id_str)
+        with app.app_context():
+            run = self._make_run(
+                user_id,
+                status=AIInsightRunStatus.previewed,
+                truncated=False,
+            )
+            run.expires_at = utc_now_naive() - timedelta(days=1)
+            db.session.commit()
+
+            with (
+                patch(
+                    "app.services.ai_insight_runs.record_ai_insight_runs_purged"
+                ) as purged_m,
+                patch("app.services.ai_insight_runs.record_ai_insight_run") as run_m,
+            ):
+                count = purge_expired_ai_insight_runs()
+
+            assert count >= 1
+            assert purged_m.call_args.args[0] >= 1
+            statuses = {c.kwargs["status"] for c in run_m.call_args_list}
+            assert "purged" in statuses
+
+    def test_filter_valid_items_emits_rejection_per_reason(self) -> None:
+        from app.services.insight_evidence_validator import filter_valid_items
+
+        items = [
+            {"dimension": "nope", "type": "x", "evidence": ["transactions"]},
+            {"dimension": "transactions", "type": "x", "evidence": []},
+            {
+                "dimension": "general",
+                "type": "x",
+                "evidence": ["current_period.paid.balance"],
+            },
+        ]
+        with patch(
+            "app.services.insight_evidence_validator.record_ai_insight_rejection"
+        ) as rej_m:
+            accepted = filter_valid_items(items, user_id=None)
+
+        assert len(accepted) == 1
+        reasons = {c.kwargs["reason"] for c in rej_m.call_args_list}
+        assert reasons == {"invalid_dimension", "missing_evidence"}


### PR DESCRIPTION
## What

Implements **#1314** — governance/quality observability for the AI insight pipeline (épico #814, Frente C). Adds metrics + structured logs + alert docs that measure *quality, cost and governance*, not just raw tokens.

## Acceptance criteria

- [x] Métricas para runs por status, custo, rejeições, truncamento, data-quality e expurgo
- [x] Logs estruturados com `run_id`/`snapshot_hash`/período/status/tokens/custo
- [x] Logs sem PII nem prompt bruto
- [x] Alertas documentados (custo alto, rejeição alta, truncamento, falha de expurgo, data-quality)
- [x] Testes de emissão de métricas/logs sem PII

## Changes

- **`prometheus_metrics.py`** — 6 new instruments: `auraxis_ai_insight_runs_total{status,period_type}`, `cost_usd_total{period_type}`, `rejections_total{reason}`, `truncated_total{period_type}`, `data_quality_domains` histogram, `runs_purged_total`. All labels are bounded enums (no PII, safe cardinality).
- **`ai_insight_runs.py`** — new `transition_ai_insight_run_status()` centralises status changes (metric + PII-free log); `create_ai_insight_run` emits run/truncation/data-quality/cost; `purge_expired_ai_insight_runs` emits purged metrics.
- **`ai_advisory_service.py`** — the 3 status-change sites (generated/cached/blocked) route through the transition helper.
- **`insight_evidence_validator.py`** — `filter_valid_items` emits `rejections_total{reason}` per rejected item.
- **`docs/wiki/AI-Insights-Observability-Alerts.md`** — metric catalog + alert thresholds.

## Notes

`runs_total` counts **state entries** (a run goes `previewed`→`generated` and increments both) so rejection-rate / conversion are derivable in PromQL. Documented in the metric help text + runbook.

## Verification

- `bash scripts/run_ci_quality_local.sh --local` → **2436 passed, 1 skipped, coverage 91.04%**, ruff/mypy/bandit clean.
- 6 new tests in `tests/test_ai_insight_observability.py` (emission per metric + no-PII log assertion).

Closes #1314