### PR TITLE
fix(deploy): pin alembic upgrade + drift gate to the recreated web container (#1405)

### DIFF
--- a/scripts/aws_deploy_i6.py
+++ b/scripts/aws_deploy_i6.py
@@ -1042,7 +1042,7 @@ if [ "$WEB_HEALTH" != "healthy" ]; then
   exit 34
 fi
 
-# Apply pending Alembic migrations against the canonical DB (RDS in prod).
+# Apply pending Alembic migrations against the canonical DB.
 # This runs inside the freshly-started web container, after the container is
 # healthy (gunicorn up, DATABASE_URL connectable) but BEFORE the /healthz
 # smoke check validates the deploy. Rationale: /healthz does not exercise
@@ -1051,14 +1051,23 @@ fi
 # the first real request. Failing here aborts the deploy and blocks traffic.
 # See issue #1252.
 #
+# IMPORTANT (#1405): we target the pinned container id "$WEB_CID" captured and
+# health-validated right after --force-recreate, NOT "docker compose exec web".
+# Re-resolving the "web" service by name can select a STALE one-off container
+# (e.g. leftover auraxis-web-run-* from a prior `docker compose run`), whose
+# image carries an OLDER migration set. Running upgrade there is a no-op and
+# the drift gate then sees current==heads for the *old* head — so the deploy
+# reports success while the live container serves new code against an
+# un-migrated DB (the 2026-05-31 transactions outage: recurrence_* columns
+# missing at alembic head ai6). Pinning to $WEB_CID makes this deterministic.
+#
 # We intentionally do NOT run this in rollback mode: rolling back schema is
 # risky with multi-head merges and out-of-scope for the rollback path
 # (forward-only migrations is the policy).
 if [ "$MODE" = "deploy" ]; then
-  echo "[i6] applying pending alembic migrations (flask db upgrade)..."
+  echo "[i6] applying pending alembic migrations (flask db upgrade) in $WEB_CID..."
   ALEMBIC_STDERR="$(mktemp)"
-  if ! docker compose --env-file "$ENV_FILE" -f docker-compose.prod.yml \\
-       exec -T web flask db upgrade 2>"$ALEMBIC_STDERR"; then
+  if ! docker exec "$WEB_CID" flask db upgrade 2>"$ALEMBIC_STDERR"; then
     echo "[i6] alembic upgrade failed"
     echo "[i6] stderr:"
     cat "$ALEMBIC_STDERR" || true
@@ -1074,11 +1083,9 @@ if [ "$MODE" = "deploy" ]; then
   # this fails the deploy has applied migrations but the resulting tip
   # diverges from the code's expected head — indicates alembic config drift
   # or a manual edit to the live DB. Abort before flipping traffic.
-  CUR_REV="$(docker compose --env-file "$ENV_FILE" -f docker-compose.prod.yml \\
-    exec -T web flask db current 2>/dev/null \\
+  CUR_REV="$(docker exec "$WEB_CID" flask db current 2>/dev/null \\
     | awk '{{print $1}}' | tail -1)"
-  HEAD_REV="$(docker compose --env-file "$ENV_FILE" -f docker-compose.prod.yml \\
-    exec -T web flask db heads 2>/dev/null \\
+  HEAD_REV="$(docker exec "$WEB_CID" flask db heads 2>/dev/null \\
     | awk '{{print $1}}' | tail -1)"
   echo "[i6] alembic current=$CUR_REV heads=$HEAD_REV"
   if [ -z "$CUR_REV" ] || [ -z "$HEAD_REV" ] || [ "$CUR_REV" != "$HEAD_REV" ]; then

--- a/tests/test_aws_deploy_i6.py
+++ b/tests/test_aws_deploy_i6.py
@@ -204,6 +204,30 @@ def test_build_script_asserts_alembic_current_equals_heads_after_upgrade() -> No
     assert "exit 37" in script
 
 
+def test_build_script_migration_targets_pinned_web_container() -> None:
+    """#1405: migrate/drift must target the pinned $WEB_CID, not `compose exec web`.
+
+    Re-resolving the ``web`` service by name can hit a stale one-off container
+    (``auraxis-web-run-*``) with an older migration set, making the upgrade a
+    no-op and the drift gate pass against the wrong head — the deploy reports
+    success while the live container serves new code against an un-migrated DB.
+    """
+    script = aws_deploy_i6._build_script(
+        env_name="prod",
+        aws_region="us-east-1",
+        git_ref="origin/master",
+        mode="deploy",
+    )
+    # Upgrade + drift queries must use the captured container id.
+    assert 'docker exec "$WEB_CID" flask db upgrade' in script
+    assert 'docker exec "$WEB_CID" flask db current' in script
+    assert 'docker exec "$WEB_CID" flask db heads' in script
+    # And must NOT re-resolve the service by name for these commands.
+    assert "exec -T web flask db upgrade" not in script
+    assert "exec -T web flask db current" not in script
+    assert "exec -T web flask db heads" not in script
+
+
 def test_build_script_rollback_does_not_run_flask_db_upgrade() -> None:
     """Rollback must NOT run migrations — schema downgrades are out of scope."""
     script = aws_deploy_i6._build_script(


### PR DESCRIPTION
## Problem

Prod deploys **already** run `flask db upgrade` + a `current == heads` drift gate (added in #1252) — so \"add an explicit migrate step\" was a red herring: the step exists. It just didn't work.

Both the upgrade and the drift queries used `docker compose exec -T web`, which **re-resolves the `web` service by name**. That can select a stale one-off container (`auraxis-web-run-*` left over from a prior `docker compose run` — the #1249 zombie class) whose image carries an **older migration set**. Result:

1. `flask db upgrade` runs in the stale container → no-op (its head is already applied)
2. drift gate reads `current`/`heads` from the same stale container → `ai6 == ai6` → **passes**
3. deploy reports **success** while the live `auraxis-web-1` (new image) serves new code against the un-migrated DB

This is the **2026-05-31 transactions outage**: prod stuck at alembic head `ai6`, `recurrence_interval`/`recurrence_unit` columns missing, every `GET /transactions` → 500.

## Fix

Target the **pinned `$WEB_CID`** — the container id captured and health-validated right after `docker compose up -d --force-recreate web` — via `docker exec`, for the upgrade and both drift queries. Always the freshly deployed container, never an ambiguous service re-resolution.

```diff
- docker compose --env-file "$ENV_FILE" -f docker-compose.prod.yml exec -T web flask db upgrade
+ docker exec "$WEB_CID" flask db upgrade
```

(`$WEB_CID` is already validated `healthy` earlier in the deploy flow, so it is guaranteed to be the new container.)

## Verification

- New regression test `test_build_script_migration_targets_pinned_web_container` asserts the migrate/drift commands use `$WEB_CID` and never `exec -T web flask db ...`.
- Rendered deploy script passes `bash -n` syntax check; all 3 commands (`upgrade`/`current`/`heads`) render pinned.
- `bash scripts/run_ci_quality_local.sh --local` → **2431 passed, coverage 91.03%**, ruff/mypy/bandit clean.

## Notes

- Forward-only: the migrate block stays gated on `MODE=deploy` (rollback never migrates).
- Complements #1403 (which stopped new run-zombies from being created); this makes the migrate step robust even if one exists.
- Until this merges + the next deploy runs, migration-bearing deploys still need a manual `flask db upgrade` (already done for the 2026-05-31 incident; prod is at head `fb1_ai_insight_feedback`).

Closes #1405