### PR TITLE
feat(simulation): contador de quota freemium + REST + GraphQL (#1409)

### DIFF
--- a/api-tests/postman/auraxis.postman_collection.json
+++ b/api-tests/postman/auraxis.postman_collection.json
@@ -1,7 +1,7 @@
 {
   "info": {
     "name": "Auraxis API",
-    "description": "Auto-generated from openapi.json (80 paths). Do not edit manually — regenerate with: npm run postman:build",
+    "description": "Auto-generated from openapi.json (82 paths). Do not edit manually — regenerate with: npm run postman:build",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "item": [
@@ -3973,6 +3973,89 @@
               "script": {
                 "exec": [
                   "pm.test('DELETE /simulations/{simulation_id} — status 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "GET /simulations/quota",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/simulations/quota",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "simulations",
+                "quota"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('GET /simulations/quota — status 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "POST /simulations/quota/consume",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/simulations/quota/consume",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "simulations",
+                "quota",
+                "consume"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('POST /simulations/quota/consume — status 200', function () {",
                   "  pm.response.to.have.status(200);",
                   "});"
                 ],

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -100,6 +100,9 @@ from app.models.refresh_token import RefreshToken  # noqa: F401
 from app.models.shared_entry import Invitation, SharedEntry  # noqa: F401
 from app.models.sharing_audit import SharingAuditEvent  # noqa: F401
 from app.models.simulation import Simulation  # noqa: F401
+from app.models.simulation_quota_usage import (  # noqa: F401
+    SimulationQuotaUsage,
+)
 from app.models.subscription import Subscription  # noqa: F401
 from app.models.tag import Tag  # noqa: F401
 from app.models.webhook_event import WebhookEvent  # noqa: F401

--- a/app/application/services/simulation_quota_service.py
+++ b/app/application/services/simulation_quota_service.py
@@ -1,0 +1,129 @@
+"""Service de quota do simulador de metas (freemium) — #1409.
+
+Free tier: ``FREE_MONTHLY_LIMIT`` simulações completas por mês (UTC). Premium
+(entitlement ``advanced_simulations``) é ilimitado. O consumo nunca lança erro
+por esgotamento — retorna ``allowed=False`` para o cliente decidir a UX (paywall).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TypedDict, cast
+from uuid import UUID
+
+from app.extensions.database import db
+from app.models.simulation_quota_usage import SimulationQuotaUsage
+from app.services.entitlement_service import has_entitlement
+from app.utils.datetime_utils import utc_now_naive
+
+FREE_MONTHLY_LIMIT = 1
+PREMIUM_FEATURE_KEY = "advanced_simulations"
+
+
+class SimulationQuota(TypedDict):
+    """Snapshot da quota retornado por get_quota/consume."""
+
+    limit: int
+    used: int
+    remaining: int | None  # None quando unlimited
+    unlimited: bool
+    allowed: bool
+    reset_at: str  # ISO UTC do próximo reset (1º dia do próximo mês 00:00)
+
+
+def _current_period(now: datetime | None = None) -> str:
+    return (now or utc_now_naive()).strftime("%Y-%m")
+
+
+def _next_reset_at(now: datetime | None = None) -> str:
+    ref = now or utc_now_naive()
+    year = ref.year + (1 if ref.month == 12 else 0)
+    month = 1 if ref.month == 12 else ref.month + 1
+    return datetime(year, month, 1).isoformat() + "Z"
+
+
+def _is_premium(user_id: str | UUID) -> bool:
+    return has_entitlement(user_id, PREMIUM_FEATURE_KEY)
+
+
+def _get_or_create_row(user_id: UUID, period: str) -> SimulationQuotaUsage:
+    row = cast(
+        "SimulationQuotaUsage | None",
+        SimulationQuotaUsage.query.filter_by(
+            user_id=user_id, period=period
+        ).one_or_none(),
+    )
+    if row is None:
+        row = SimulationQuotaUsage(user_id=user_id, period=period, count=0)
+        db.session.add(row)
+        db.session.flush()
+    return row
+
+
+def _unlimited_snapshot() -> SimulationQuota:
+    return SimulationQuota(
+        limit=FREE_MONTHLY_LIMIT,
+        used=0,
+        remaining=None,
+        unlimited=True,
+        allowed=True,
+        reset_at=_next_reset_at(),
+    )
+
+
+def get_quota(user_id: str | UUID) -> SimulationQuota:
+    """Snapshot da quota do usuário (sem consumir)."""
+    normalized = UUID(str(user_id))
+    if _is_premium(normalized):
+        return _unlimited_snapshot()
+
+    period = _current_period()
+    row = SimulationQuotaUsage.query.filter_by(
+        user_id=normalized, period=period
+    ).one_or_none()
+    used = row.count if row is not None else 0
+    remaining = max(FREE_MONTHLY_LIMIT - used, 0)
+    return SimulationQuota(
+        limit=FREE_MONTHLY_LIMIT,
+        used=used,
+        remaining=remaining,
+        unlimited=False,
+        allowed=remaining > 0,
+        reset_at=_next_reset_at(),
+    )
+
+
+def consume(user_id: str | UUID) -> SimulationQuota:
+    """Consome 1 simulação se permitido. Não lança em esgotamento.
+
+    - premium → no-op, retorna unlimited/allowed.
+    - free com saldo → incrementa e retorna allowed=True.
+    - free esgotado → retorna allowed=False sem incrementar.
+    """
+    normalized = UUID(str(user_id))
+    if _is_premium(normalized):
+        return _unlimited_snapshot()
+
+    period = _current_period()
+    row = _get_or_create_row(normalized, period)
+    if row.count >= FREE_MONTHLY_LIMIT:
+        db.session.commit()
+        return SimulationQuota(
+            limit=FREE_MONTHLY_LIMIT,
+            used=row.count,
+            remaining=0,
+            unlimited=False,
+            allowed=False,
+            reset_at=_next_reset_at(),
+        )
+
+    row.count += 1
+    db.session.commit()
+    return SimulationQuota(
+        limit=FREE_MONTHLY_LIMIT,
+        used=row.count,
+        remaining=max(FREE_MONTHLY_LIMIT - row.count, 0),
+        unlimited=False,
+        allowed=True,
+        reset_at=_next_reset_at(),
+    )

--- a/app/controllers/simulation/quota_resources.py
+++ b/app/controllers/simulation/quota_resources.py
@@ -1,0 +1,68 @@
+"""REST resources da quota de simulação (freemium) — #1409.
+
+- ``GET  /simulations/quota``         → snapshot da quota (não consome)
+- ``POST /simulations/quota/consume`` → consome 1 simulação (allowed=False se esgotado)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from flask_apispec.views import MethodResource
+
+from app.application.services import simulation_quota_service
+from app.auth import current_user_id
+from app.decorators import require_email_verified
+from app.utils.typed_decorators import typed_doc as doc
+from app.utils.typed_decorators import typed_jwt_required as jwt_required
+
+from .contracts import compat_success
+
+_TAGS = ["Simulações"]
+
+
+class SimulationQuotaResource(MethodResource):
+    @doc(
+        description="Retorna a quota de simulações do usuário autenticado.",
+        tags=_TAGS,
+        security=[{"BearerAuth": []}],
+        responses={
+            200: {"description": "Snapshot da quota"},
+            401: {"description": "Token inválido"},
+        },
+    )
+    @jwt_required()
+    @require_email_verified
+    def get(self) -> Any:
+        quota = simulation_quota_service.get_quota(current_user_id())
+        return compat_success(
+            legacy_payload=dict(quota),
+            status_code=200,
+            message="Quota de simulação recuperada com sucesso.",
+            data=dict(quota),
+        )
+
+
+class SimulationQuotaConsumeResource(MethodResource):
+    @doc(
+        description=(
+            "Consome uma simulação completa. Premium é ilimitado; free esgotado "
+            "retorna allowed=false (sem erro) para o cliente exibir o paywall."
+        ),
+        tags=_TAGS,
+        security=[{"BearerAuth": []}],
+        responses={
+            200: {"description": "Quota atualizada (ver campo allowed)"},
+            401: {"description": "Token inválido"},
+        },
+    )
+    @jwt_required()
+    @require_email_verified
+    def post(self) -> Any:
+        quota = simulation_quota_service.consume(current_user_id())
+        return compat_success(
+            legacy_payload=dict(quota),
+            status_code=200,
+            message="Quota de simulação atualizada.",
+            data=dict(quota),
+        )

--- a/app/controllers/simulation/routes.py
+++ b/app/controllers/simulation/routes.py
@@ -8,6 +8,10 @@ from .installment_vs_cash_resources import (
     SimulationGoalBridgeResource,
     SimulationPlannedExpenseBridgeResource,
 )
+from .quota_resources import (
+    SimulationQuotaConsumeResource,
+    SimulationQuotaResource,
+)
 from .resources import SimulationCollectionResource, SimulationResource
 
 _ROUTES_REGISTERED = False
@@ -57,6 +61,16 @@ def register_simulation_routes() -> None:
         view_func=SimulationPlannedExpenseBridgeResource.as_view(
             "simulation_planned_expense_bridge"
         ),
+        methods=["POST"],
+    )
+    simulation_bp.add_url_rule(
+        "/quota",
+        view_func=SimulationQuotaResource.as_view("simulation_quota"),
+        methods=["GET"],
+    )
+    simulation_bp.add_url_rule(
+        "/quota/consume",
+        view_func=SimulationQuotaConsumeResource.as_view("simulation_quota_consume"),
         methods=["POST"],
     )
 

--- a/app/graphql/docs_catalog.py
+++ b/app/graphql/docs_catalog.py
@@ -203,6 +203,14 @@ GRAPHQL_OPERATION_CATALOG: tuple[GraphQLOperationDoc, ...] = (
         source_module=QUERY_SIMULATION_MODULE,
     ),
     GraphQLOperationDoc(
+        name="simulationQuota",
+        operation_type="query",
+        domain="simulations",
+        access="auth_required",
+        summary="Snapshot da quota freemium de simulações do usuário (#1409).",
+        source_module=QUERY_SIMULATION_MODULE,
+    ),
+    GraphQLOperationDoc(
         name="walletEntries",
         operation_type="query",
         domain="wallet",
@@ -427,6 +435,14 @@ GRAPHQL_OPERATION_CATALOG: tuple[GraphQLOperationDoc, ...] = (
         summary="Converte uma simulação em despesa planejada.",
         source_module=MUTATION_SIMULATION_MODULE,
         entitlements=(ADVANCED_SIMULATIONS,),
+    ),
+    GraphQLOperationDoc(
+        name="consumeSimulationQuota",
+        operation_type="mutation",
+        domain="simulations",
+        access="auth_required",
+        summary="Consome 1 simulação da quota freemium do usuário (#1409).",
+        source_module=MUTATION_SIMULATION_MODULE,
     ),
     GraphQLOperationDoc(
         name="addWalletEntry",

--- a/app/graphql/mutations/__init__.py
+++ b/app/graphql/mutations/__init__.py
@@ -51,6 +51,7 @@ from app.graphql.mutations.investment_operation import (
 )
 from app.graphql.mutations.notification import UpdateNotificationPreferencesMutation
 from app.graphql.mutations.simulation import (
+    ConsumeSimulationQuotaMutation,
     CreateGoalFromInstallmentVsCashSimulationMutation,
     CreatePlannedExpenseFromInstallmentVsCashSimulationMutation,
     SaveInstallmentVsCashSimulationMutation,
@@ -116,6 +117,7 @@ class Mutation(graphene.ObjectType):
     create_planned_expense_from_installment_vs_cash_simulation = (
         CreatePlannedExpenseFromInstallmentVsCashSimulationMutation.Field()
     )
+    consume_simulation_quota = ConsumeSimulationQuotaMutation.Field()
     # ADR-0002: CRUD mutations deprecated — use REST endpoints.
     add_wallet_entry = AddWalletEntryMutation.Field(
         deprecation_reason="ADR-0002: use POST /wallet"

--- a/app/graphql/mutations/simulation.py
+++ b/app/graphql/mutations/simulation.py
@@ -161,3 +161,23 @@ class CreatePlannedExpenseFromInstallmentVsCashSimulationMutation(graphene.Mutat
             ],
             simulation=to_installment_vs_cash_simulation_type(result["simulation"]),
         )
+
+
+class ConsumeSimulationQuotaMutation(graphene.Mutation):
+    """Consome 1 simulação da quota freemium (#1409).
+
+    Parity de ``POST /simulations/quota/consume``. Não falha em esgotamento:
+    retorna ``quota.allowed=False`` para o cliente exibir o paywall.
+    """
+
+    quota = graphene.Field(
+        "app.graphql.queries.simulation.SimulationQuotaType", required=True
+    )
+
+    def mutate(self, _info: graphene.ResolveInfo) -> "ConsumeSimulationQuotaMutation":
+        from app.application.services import simulation_quota_service
+        from app.graphql.queries.simulation import _to_quota_type
+
+        user = get_current_user_required()
+        quota = simulation_quota_service.consume(UUID(str(user.id)))
+        return ConsumeSimulationQuotaMutation(quota=_to_quota_type(dict(quota)))

--- a/app/graphql/queries/simulation.py
+++ b/app/graphql/queries/simulation.py
@@ -71,6 +71,28 @@ def _raise_simulation_graphql_error(exc: SimulationApplicationError) -> None:
     raise build_public_graphql_error(exc.message, code=code)
 
 
+class SimulationQuotaType(graphene.ObjectType):
+    """Snapshot da quota freemium do simulador (#1409)."""
+
+    limit = graphene.Int(required=True)
+    used = graphene.Int(required=True)
+    remaining = graphene.Int()  # nulo quando unlimited (premium)
+    unlimited = graphene.Boolean(required=True)
+    allowed = graphene.Boolean(required=True)
+    reset_at = graphene.String(required=True)
+
+
+def _to_quota_type(data: dict[str, Any]) -> "SimulationQuotaType":
+    return SimulationQuotaType(
+        limit=data["limit"],
+        used=data["used"],
+        remaining=data["remaining"],
+        unlimited=data["unlimited"],
+        allowed=data["allowed"],
+        reset_at=data["reset_at"],
+    )
+
+
 class SimulationQueryMixin:
     installment_vs_cash_calculate = graphene.Field(
         InstallmentVsCashCalculationPayloadType,
@@ -99,6 +121,17 @@ class SimulationQueryMixin:
         SimulationType,
         id=graphene.UUID(required=True),
     )
+
+    simulation_quota = graphene.Field(SimulationQuotaType, required=True)
+
+    def resolve_simulation_quota(
+        self, _info: graphene.ResolveInfo
+    ) -> SimulationQuotaType:
+        from app.application.services import simulation_quota_service
+
+        user = get_current_user_required()
+        quota = simulation_quota_service.get_quota(UUID(str(user.id)))
+        return _to_quota_type(dict(quota))
 
     def resolve_installment_vs_cash_calculate(
         self,

--- a/app/lgpd/registry.py
+++ b/app/lgpd/registry.py
@@ -118,6 +118,7 @@ def _build_registry() -> list[EntityRule]:
     from app.models.shared_entry import Invitation, SharedEntry
     from app.models.sharing_audit import SharingAuditEvent
     from app.models.simulation import Simulation
+    from app.models.simulation_quota_usage import SimulationQuotaUsage
     from app.models.subscription import Subscription
     from app.models.tag import Tag
     from app.models.transaction import Transaction
@@ -247,6 +248,16 @@ def _build_registry() -> list[EntityRule]:
             retention_reason=RetentionReason.NONE,
             retention_days=None,
             description="Saved financial simulations",
+        ),
+        EntityRule(
+            model=SimulationQuotaUsage,
+            user_id_field="user_id",
+            table_name="simulation_quota_usage",
+            deletion_strategy=DeletionStrategy.DELETE,
+            export_included=False,
+            retention_reason=RetentionReason.NONE,
+            retention_days=None,
+            description="Monthly freemium simulation quota counter (#1409)",
         ),
         EntityRule(
             model=Alert,

--- a/app/models/simulation_quota_usage.py
+++ b/app/models/simulation_quota_usage.py
@@ -1,0 +1,49 @@
+# mypy: disable-error-code="name-defined"
+"""SimulationQuotaUsage model — freemium quota do simulador de metas (#1409).
+
+Conta quantas simulações completas um usuário free executou no mês corrente.
+O reset mensal é implícito: cada período (``YYYY-MM`` em UTC) tem sua própria
+linha, então virar o mês cria um novo contador zerado. Premium (entitlement
+``advanced_simulations``) ignora a tabela e é tratado como ilimitado no service.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy.dialects.postgresql import UUID
+
+from app.extensions.database import db
+from app.utils.datetime_utils import utc_now_naive
+
+
+class SimulationQuotaUsage(db.Model):
+    """Contador mensal de simulações completas por usuário (free tier)."""
+
+    __tablename__ = "simulation_quota_usage"
+
+    id = db.Column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, nullable=False
+    )
+    user_id = db.Column(
+        UUID(as_uuid=True), db.ForeignKey("users.id"), nullable=False, index=True
+    )
+    # Período de cobrança no formato ``YYYY-MM`` calculado em UTC.
+    period = db.Column(db.String(7), nullable=False)
+    count = db.Column(db.Integer, nullable=False, default=0)
+    created_at = db.Column(db.DateTime, nullable=False, default=utc_now_naive)
+    updated_at = db.Column(
+        db.DateTime, nullable=False, default=utc_now_naive, onupdate=utc_now_naive
+    )
+
+    __table_args__ = (
+        db.UniqueConstraint(
+            "user_id", "period", name="uq_simulation_quota_user_period"
+        ),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<SimulationQuotaUsage user={self.user_id} period={self.period}"
+            f" count={self.count}>"
+        )

--- a/graphql.introspection.json
+++ b/graphql.introspection.json
@@ -1089,6 +1089,22 @@
               }
             },
             {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "simulationQuota",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "SimulationQuotaType",
+                  "ofType": null
+                }
+              }
+            },
+            {
               "args": [
                 {
                   "defaultValue": "1",
@@ -7474,6 +7490,110 @@
           "specifiedByURL": null
         },
         {
+          "description": "Snapshot da quota freemium do simulador (#1409).",
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "limit",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "used",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "remaining",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "unlimited",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "allowed",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "resetAt",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "SimulationQuotaType",
+          "possibleTypes": null,
+          "specifiedByURL": null
+        },
+        {
           "description": null,
           "enumValues": null,
           "fields": [
@@ -11551,6 +11671,18 @@
               }
             },
             {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Consome 1 simulação da quota freemium (#1409).\n\nParity de ``POST /simulations/quota/consume``. Não falha em esgotamento:\nretorna ``quota.allowed=False`` para o cliente exibir o paywall.",
+              "isDeprecated": false,
+              "name": "consumeSimulationQuota",
+              "type": {
+                "kind": "OBJECT",
+                "name": "ConsumeSimulationQuotaMutation",
+                "ofType": null
+              }
+            },
+            {
               "args": [
                 {
                   "defaultValue": null,
@@ -14309,6 +14441,34 @@
           "interfaces": [],
           "kind": "OBJECT",
           "name": "CreatePlannedExpenseFromInstallmentVsCashSimulationMutation",
+          "possibleTypes": null,
+          "specifiedByURL": null
+        },
+        {
+          "description": "Consome 1 simulação da quota freemium (#1409).\n\nParity de ``POST /simulations/quota/consume``. Não falha em esgotamento:\nretorna ``quota.allowed=False`` para o cliente exibir o paywall.",
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "quota",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "SimulationQuotaType",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "ConsumeSimulationQuotaMutation",
           "possibleTypes": null,
           "specifiedByURL": null
         },

--- a/graphql.operations.manifest.json
+++ b/graphql.operations.manifest.json
@@ -114,6 +114,14 @@
   },
   {
     "access": "auth_required",
+    "domain": "simulations",
+    "name": "simulationQuota",
+    "operation_type": "query",
+    "source_module": "app.graphql.queries.simulation",
+    "summary": "Snapshot da quota freemium de simulações do usuário (#1409)."
+  },
+  {
+    "access": "auth_required",
     "domain": "wallet",
     "name": "walletEntries",
     "operation_type": "query",
@@ -341,6 +349,14 @@
     "operation_type": "mutation",
     "source_module": "app.graphql.mutations.simulation",
     "summary": "Converte uma simulação em despesa planejada."
+  },
+  {
+    "access": "auth_required",
+    "domain": "simulations",
+    "name": "consumeSimulationQuota",
+    "operation_type": "mutation",
+    "source_module": "app.graphql.mutations.simulation",
+    "summary": "Consome 1 simulação da quota freemium do usuário (#1409)."
   },
   {
     "access": "auth_required",

--- a/migrations/versions/sq1_simulation_quota_usage.py
+++ b/migrations/versions/sq1_simulation_quota_usage.py
@@ -1,0 +1,48 @@
+"""add simulation_quota_usage table (freemium simulador) — #1409
+
+Revision ID: sq1_simulation_quota_usage
+Revises: fb1_ai_insight_feedback
+Create Date: 2026-05-31
+
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = "sq1_simulation_quota_usage"
+down_revision = "fb1_ai_insight_feedback"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "simulation_quota_usage",
+        sa.Column("id", UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("period", sa.String(length=7), nullable=False),
+        sa.Column("count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "user_id", "period", name="uq_simulation_quota_user_period"
+        ),
+    )
+    op.create_index(
+        "ix_simulation_quota_usage_user_id",
+        "simulation_quota_usage",
+        ["user_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_simulation_quota_usage_user_id", table_name="simulation_quota_usage"
+    )
+    op.drop_table("simulation_quota_usage")

--- a/openapi.json
+++ b/openapi.json
@@ -6640,6 +6640,50 @@
         ]
       }
     },
+    "/simulations/quota": {
+      "get": {
+        "description": "Retorna a quota de simulações do usuário autenticado.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Snapshot da quota"
+          },
+          "401": {
+            "description": "Token inválido"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Simulações"
+        ]
+      }
+    },
+    "/simulations/quota/consume": {
+      "post": {
+        "description": "Consome uma simulação completa. Premium é ilimitado; free esgotado retorna allowed=false (sem erro) para o cliente exibir o paywall.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Quota atualizada (ver campo allowed)"
+          },
+          "401": {
+            "description": "Token inválido"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Simulações"
+        ]
+      }
+    },
     "/simulations/{simulation_id}": {
       "delete": {
         "description": "Remove uma simulação específica do usuário autenticado.",

--- a/schema.graphql
+++ b/schema.graphql
@@ -37,6 +37,7 @@ type Query {
   installmentVsCashCalculate(cashPrice: String!, installmentCount: Int!, installmentAmount: String, installmentTotal: String, firstPaymentDelayDays: Int = 30, opportunityRateType: String = "manual", opportunityRateAnnual: String, inflationRateAnnual: String!, feesEnabled: Boolean = false, feesUpfront: String = "0.00", scenarioLabel: String): InstallmentVsCashCalculationPayloadType
   simulations(page: Int = 1, perPage: Int = 20, toolId: String): SimulationListPayloadType!
   simulation(id: UUID!): SimulationType
+  simulationQuota: SimulationQuotaType!
   goals(page: Int = 1, perPage: Int = 10, status: String): GoalListPayloadType
   goal(goalId: UUID!): GoalTypeObject
   goalPlan(goalId: UUID!): GoalPlanType
@@ -584,6 +585,16 @@ value as specified by
 """
 scalar DateTime
 
+"""Snapshot da quota freemium do simulador (#1409)."""
+type SimulationQuotaType {
+  limit: Int!
+  used: Int!
+  remaining: Int
+  unlimited: Boolean!
+  allowed: Boolean!
+  resetAt: String!
+}
+
 type GoalListPayloadType {
   items: [GoalTypeObject]!
   pagination: PaginationType!
@@ -800,6 +811,14 @@ type Mutation {
   saveInstallmentVsCashSimulation(cashPrice: String!, feesEnabled: Boolean = false, feesUpfront: String = "0.00", firstPaymentDelayDays: Int = 30, inflationRateAnnual: String!, installmentAmount: String, installmentCount: Int!, installmentTotal: String, opportunityRateAnnual: String, opportunityRateType: String = "manual", scenarioLabel: String): SaveInstallmentVsCashSimulationMutation
   createGoalFromInstallmentVsCashSimulation(category: String = "planned_purchase", currentAmount: String = "0.00", description: String, priority: Int = 3, selectedOption: String!, simulationId: UUID!, targetDate: String, title: String!): CreateGoalFromInstallmentVsCashSimulationMutation
   createPlannedExpenseFromInstallmentVsCashSimulation(accountId: UUID, creditCardId: UUID, currency: String = "BRL", description: String, dueDate: String, firstDueDate: String, observation: String, selectedOption: String!, simulationId: UUID!, status: String = "pending", tagId: UUID, title: String!, upfrontDueDate: String): CreatePlannedExpenseFromInstallmentVsCashSimulationMutation
+
+  """
+  Consome 1 simulação da quota freemium (#1409).
+  
+  Parity de ``POST /simulations/quota/consume``. Não falha em esgotamento:
+  retorna ``quota.allowed=False`` para o cliente exibir o paywall.
+  """
+  consumeSimulationQuota: ConsumeSimulationQuotaMutation
   addWalletEntry(annualRate: DecimalScalar, assetClass: WalletAssetClass, name: String!, quantity: Int, registerDate: String, shouldBeOnWallet: Boolean!, targetWithdrawDate: String, ticker: String, value: DecimalScalar): AddWalletEntryMutation @deprecated(reason: "ADR-0002: use POST /wallet")
   updateWalletEntry(annualRate: DecimalScalar, assetClass: WalletAssetClass, investmentId: UUID!, name: String, quantity: Int, registerDate: String, shouldBeOnWallet: Boolean, targetWithdrawDate: String, ticker: String, value: DecimalScalar): UpdateWalletEntryMutation @deprecated(reason: "ADR-0002: use PATCH /wallet/{id}")
   deleteWalletEntry(investmentId: UUID!): DeleteWalletEntryMutation @deprecated(reason: "ADR-0002: use DELETE /wallet/{id}")
@@ -1002,6 +1021,16 @@ type CreatePlannedExpenseFromInstallmentVsCashSimulationMutation {
   message: String!
   transactions: [TransactionTypeObject]!
   simulation: InstallmentVsCashSimulationType!
+}
+
+"""
+Consome 1 simulação da quota freemium (#1409).
+
+Parity de ``POST /simulations/quota/consume``. Não falha em esgotamento:
+retorna ``quota.allowed=False`` para o cliente exibir o paywall.
+"""
+type ConsumeSimulationQuotaMutation {
+  quota: SimulationQuotaType!
 }
 
 type AddWalletEntryMutation {

--- a/tests/test_simulation_quota_api.py
+++ b/tests/test_simulation_quota_api.py
@@ -1,0 +1,81 @@
+"""Integração REST da quota de simulação (freemium) — #1409."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from app.application.services import simulation_quota_service as svc
+
+
+def _register_and_login(client, *, prefix: str) -> str:
+    suffix = uuid.uuid4().hex[:8]
+    email = f"{prefix}-{suffix}@email.com"
+    password = "StrongPass@123"
+    reg = client.post(
+        "/auth/register",
+        json={"name": f"user-{suffix}", "email": email, "password": password},
+    )
+    assert reg.status_code == 201
+    login = client.post("/auth/login", json={"email": email, "password": password})
+    assert login.status_code == 200
+    return login.get_json()["token"]
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _data(resp) -> dict:
+    """Lê o snapshot de quota tanto no contrato legacy (flat) quanto standard (data)."""
+    body = resp.get_json()
+    return body.get("data", body)
+
+
+def test_get_quota_free(client, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(svc, "has_entitlement", lambda *_a, **_k: False)
+    token = _register_and_login(client, prefix="quota-get")
+    resp = client.get("/simulations/quota", headers=_auth(token))
+    assert resp.status_code == 200
+    data = _data(resp)
+    assert data["limit"] == 1
+    assert data["remaining"] == 1
+    assert data["unlimited"] is False
+    assert data["allowed"] is True
+
+
+def test_consume_free_then_paywall(client, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(svc, "has_entitlement", lambda *_a, **_k: False)
+    token = _register_and_login(client, prefix="quota-consume")
+
+    first = client.post("/simulations/quota/consume", headers=_auth(token))
+    assert first.status_code == 200
+    assert _data(first)["allowed"] is True
+
+    second = client.post("/simulations/quota/consume", headers=_auth(token))
+    assert second.status_code == 200  # sem erro HTTP — paywall é decisão do client
+    body = _data(second)
+    assert body["allowed"] is False
+    assert body["remaining"] == 0
+
+
+def test_premium_unlimited(client, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(svc, "has_entitlement", lambda *_a, **_k: True)
+    token = _register_and_login(client, prefix="quota-premium")
+
+    snapshot = _data(client.get("/simulations/quota", headers=_auth(token)))
+    assert snapshot["unlimited"] is True
+    assert snapshot["remaining"] is None
+
+    for _ in range(3):
+        consumed = _data(
+            client.post("/simulations/quota/consume", headers=_auth(token))
+        )
+        assert consumed["allowed"] is True
+        assert consumed["unlimited"] is True
+
+
+def test_quota_requires_auth(client) -> None:
+    assert client.get("/simulations/quota").status_code == 401
+    assert client.post("/simulations/quota/consume").status_code == 401

--- a/tests/test_simulation_quota_graphql.py
+++ b/tests/test_simulation_quota_graphql.py
@@ -1,0 +1,77 @@
+"""Parity GraphQL da quota de simulação (freemium) — #1409."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from app.application.services import simulation_quota_service as svc
+
+
+def _register_and_login(client, *, prefix: str) -> str:
+    suffix = uuid.uuid4().hex[:8]
+    email = f"{prefix}-{suffix}@email.com"
+    password = "StrongPass@123"
+    reg = client.post(
+        "/auth/register",
+        json={"name": f"user-{suffix}", "email": email, "password": password},
+    )
+    assert reg.status_code == 201
+    login = client.post("/auth/login", json={"email": email, "password": password})
+    assert login.status_code == 200
+    return login.get_json()["token"]
+
+
+def _gql(client, token: str, query: str):
+    return client.post(
+        "/graphql",
+        json={"query": query},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+
+def test_simulation_quota_query(client, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(svc, "has_entitlement", lambda *_a, **_k: False)
+    token = _register_and_login(client, prefix="gql-quota")
+    resp = _gql(
+        client,
+        token,
+        "query { simulationQuota { limit used remaining unlimited allowed resetAt } }",
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert "errors" not in body, body
+    quota = body["data"]["simulationQuota"]
+    assert quota["limit"] == 1
+    assert quota["remaining"] == 1
+    assert quota["unlimited"] is False
+    assert quota["allowed"] is True
+
+
+def test_consume_simulation_quota_mutation_then_paywall(
+    client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(svc, "has_entitlement", lambda *_a, **_k: False)
+    token = _register_and_login(client, prefix="gql-consume")
+    mutation = (
+        "mutation { consumeSimulationQuota { quota { allowed remaining unlimited } } }"
+    )
+
+    first = _gql(client, token, mutation).get_json()
+    assert "errors" not in first, first
+    assert first["data"]["consumeSimulationQuota"]["quota"]["allowed"] is True
+
+    second = _gql(client, token, mutation).get_json()
+    quota = second["data"]["consumeSimulationQuota"]["quota"]
+    assert quota["allowed"] is False
+    assert quota["remaining"] == 0
+
+
+def test_simulation_quota_requires_auth(client) -> None:
+    out = client.post(
+        "/graphql",
+        json={"query": "query { simulationQuota { limit } }"},
+    )
+    body = out.get_json()
+    assert body.get("errors"), body

--- a/tests/test_simulation_quota_service.py
+++ b/tests/test_simulation_quota_service.py
@@ -1,0 +1,114 @@
+"""Testes do simulation_quota_service (freemium simulador) — #1409."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.application.services import simulation_quota_service as svc
+from app.extensions.database import db
+from app.models.simulation_quota_usage import SimulationQuotaUsage
+from app.models.user import User
+
+
+def _make_user(email: str) -> User:
+    user = User(name="quota-user", email=email, password="hash")
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+@pytest.fixture
+def _free(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(svc, "has_entitlement", lambda *_a, **_k: False)
+
+
+@pytest.fixture
+def _premium(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(svc, "has_entitlement", lambda *_a, **_k: True)
+
+
+def test_get_quota_free_initial(app: Any, _free: None) -> None:
+    with app.app_context():
+        user = _make_user("q1@email.com")
+        quota = svc.get_quota(user.id)
+        assert quota["limit"] == 1
+        assert quota["used"] == 0
+        assert quota["remaining"] == 1
+        assert quota["unlimited"] is False
+        assert quota["allowed"] is True
+        assert quota["reset_at"].endswith("Z")
+
+
+def test_consume_free_first_then_exhausted(app: Any, _free: None) -> None:
+    with app.app_context():
+        user = _make_user("q2@email.com")
+
+        first = svc.consume(user.id)
+        assert first["allowed"] is True
+        assert first["used"] == 1
+        assert first["remaining"] == 0
+
+        second = svc.consume(user.id)
+        assert second["allowed"] is False
+        assert second["used"] == 1  # não incrementa além do limite
+        assert second["remaining"] == 0
+
+        rows = SimulationQuotaUsage.query.filter_by(user_id=user.id).all()
+        assert len(rows) == 1
+        assert rows[0].count == 1
+
+
+def test_premium_is_unlimited_and_creates_no_row(app: Any, _premium: None) -> None:
+    with app.app_context():
+        user = _make_user("q3@email.com")
+
+        quota = svc.get_quota(user.id)
+        assert quota["unlimited"] is True
+        assert quota["remaining"] is None
+        assert quota["allowed"] is True
+
+        for _ in range(3):
+            consumed = svc.consume(user.id)
+            assert consumed["unlimited"] is True
+            assert consumed["allowed"] is True
+
+        assert SimulationQuotaUsage.query.filter_by(user_id=user.id).count() == 0
+
+
+def test_get_quota_reflects_existing_usage(app: Any, _free: None) -> None:
+    with app.app_context():
+        user = _make_user("q4@email.com")
+        period = svc._current_period()
+        db.session.add(SimulationQuotaUsage(user_id=user.id, period=period, count=1))
+        db.session.commit()
+
+        quota = svc.get_quota(user.id)
+        assert quota["used"] == 1
+        assert quota["remaining"] == 0
+        assert quota["allowed"] is False
+
+
+def test_period_isolation_resets_next_month(
+    app: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(svc, "has_entitlement", lambda *_a, **_k: False)
+    with app.app_context():
+        user = _make_user("q5@email.com")
+
+        monkeypatch.setattr(svc, "_current_period", lambda *_a, **_k: "2026-05")
+        assert svc.consume(user.id)["allowed"] is True
+        assert svc.consume(user.id)["allowed"] is False
+
+        # Vira o mês → novo período → quota zerada de novo.
+        monkeypatch.setattr(svc, "_current_period", lambda *_a, **_k: "2026-06")
+        assert svc.get_quota(user.id)["remaining"] == 1
+        assert svc.consume(user.id)["allowed"] is True
+
+
+def test_next_reset_handles_december_rollover() -> None:
+    from datetime import datetime
+
+    reset = svc._next_reset_at(datetime(2026, 12, 15))
+    assert reset.startswith("2027-01-01")


### PR DESCRIPTION
## O que

Backend do gate freemium do simulador de metas (web #566, umbrella #536). Free tier: **1 simulação completa/mês** (reset implícito por período `YYYY-MM` UTC); premium (entitlement `advanced_simulations`) ilimitado.

## Entrega

- **Model** `SimulationQuotaUsage(user_id, period, count)` + migration (up/down testada em postgres efêmero, head único).
- **Service** `simulation_quota_service`: `get_quota`/`consume` (premium via `has_entitlement`). Consumo **não falha** em esgotamento — retorna `allowed=false` para o cliente exibir o paywall (UX sobre erro HTTP).
- **REST**: `GET /simulations/quota` + `POST /simulations/quota/consume`.
- **GraphQL parity**: query `simulationQuota` + mutation `consumeSimulationQuota`.
- **Testes**: service (6) + REST (4) + GraphQL (3); regression `test_graphql_auth_everywhere` ok. ruff/mypy limpos.

## Contrato (allowed-based, sem erro de esgotamento)

```json
{ "limit": 1, "used": 1, "remaining": 0, "unlimited": false, "allowed": false, "reset_at": "2026-06-01T00:00:00Z" }
```

Spec: `auraxis-platform docs/superpowers/specs/2026-05-31-freemium-simulator-design.md`.

Closes #1409