### PR TITLE
fix(ai): cobertura incompleta de dimensões não derruba geração de insight (#1412)

### DIFF
--- a/app/services/ai_advisory_service.py
+++ b/app/services/ai_advisory_service.py
@@ -466,8 +466,17 @@ def _ensure_financial_insight_dimension_coverage(
         if dimension not in present_dimensions
     ]
     if missing:
-        raise LLMProviderError(
-            "Missing financial insight dimensions: " + ", ".join(missing)
+        # Cobertura incompleta de dimensões NÃO é falha do provider. O modelo
+        # nem sempre emite o item de ausência esperado para domínios vazios
+        # (ex.: usuário sem cartões → dimensão credit_cards ausente), e derrubar
+        # a geração inteira com 500 deixava o recurso inutilizável em uso normal
+        # (incidente 2026-06-01, request_id 2f172716142dcc05b047a5ab76615ed1).
+        # Degradamos com um sinal de data-quality: o frontend filtra por
+        # dimensão, então a ausência apenas deixa aquela aba vazia neste run.
+        log.warning(
+            "ai_advisory.dimension_coverage_incomplete missing=%s present=%s",
+            ",".join(missing),
+            ",".join(sorted(present_dimensions)),
         )
 
 

--- a/tests/test_ai_advisory_service.py
+++ b/tests/test_ai_advisory_service.py
@@ -17,6 +17,7 @@ Coverage areas:
 
 from __future__ import annotations
 
+import logging
 import uuid
 from datetime import date, datetime, timezone
 from decimal import Decimal
@@ -448,9 +449,10 @@ class TestAIAdvisoryServiceFinancialInsights:
             future_prompt = provider.generate_with_usage.call_args_list[0].args[0]
             assert "MODO PREVISÃO" in future_prompt
 
-    def test_financial_insights_reject_missing_required_dimensions(
+    def test_financial_insights_tolerate_missing_required_dimensions(
         self,
         app,
+        caplog,
     ) -> None:
         with app.app_context():
             from app.extensions.database import db
@@ -476,17 +478,21 @@ class TestAIAdvisoryServiceFinancialInsights:
             )
 
             service = AIAdvisoryService(user_id=user_id, llm_provider=provider)
-            with pytest.raises(
-                LLMProviderError,
-                match="Missing financial insight dimensions",
-            ):
-                service.generate_financial_insights(
+            # Cobertura incompleta de dimensões NÃO deve derrubar a geração
+            # (incidente 2026-06-01): degrada com aviso e persiste o insight
+            # com as dimensões que o modelo retornou.
+            with caplog.at_level(logging.WARNING):
+                result = service.generate_financial_insights(
                     period_type="daily",
                     anchor_date=date(2026, 5, 17),
                 )
 
+            assert result["items"][0]["dimension"] == "general"
+            assert "dimension_coverage_incomplete" in caplog.text
+            assert "credit_cards" in caplog.text
+
             saved = db.session.query(AIInsight).filter_by(user_id=user_id).first()
-            assert saved is None
+            assert saved is not None
 
     def test_financial_insights_prompt_uses_structured_deltas_not_previous_text(
         self,

--- a/tests/test_ai_insight_cost_and_limits.py
+++ b/tests/test_ai_insight_cost_and_limits.py
@@ -63,24 +63,34 @@ def _reset_ai_counter() -> None:
     _InMemoryAICounter.reset()
 
 
-def _seed_llm_cost(user_id: uuid.UUID, *, cost_usd: str, endpoint: str) -> None:
+def _seed_llm_cost(
+    user_id: uuid.UUID,
+    *,
+    cost_usd: str,
+    endpoint: str,
+    created_at: datetime | None = None,
+) -> None:
     from app.extensions.database import db
     from app.models.llm_audit_log import LLMAuditLog
 
-    db.session.add(
-        LLMAuditLog(
-            user_id=user_id,
-            endpoint=endpoint,
-            model="gpt-4o-mini",
-            prompt="p",
-            response_text="r",
-            prompt_tokens=10,
-            completion_tokens=10,
-            total_tokens=20,
-            estimated_cost_usd=Decimal(cost_usd),
-            latency_ms=10,
-        )
+    # Stamp created_at explicitly when the test enforces a specific month window —
+    # sem isso a linha cai no mês corrente real e o enforcement (que consulta a
+    # janela do `now` do teste) não a enxerga, quebrando o teste fora de maio/2026.
+    entry = LLMAuditLog(
+        user_id=user_id,
+        endpoint=endpoint,
+        model="gpt-4o-mini",
+        prompt="p",
+        response_text="r",
+        prompt_tokens=10,
+        completion_tokens=10,
+        total_tokens=20,
+        estimated_cost_usd=Decimal(cost_usd),
+        latency_ms=10,
     )
+    if created_at is not None:
+        entry.created_at = created_at
+    db.session.add(entry)
     db.session.commit()
 
 
@@ -125,7 +135,10 @@ class TestUserCostEnforcement:
             now = datetime(2026, 5, 15, 12, 0, 0)
             # Budget ≈ 2.72 USD; seed 3.00 this month.
             _seed_llm_cost(
-                user_id, cost_usd="3.00", endpoint="financial_insights_daily"
+                user_id,
+                cost_usd="3.00",
+                endpoint="financial_insights_daily",
+                created_at=now,
             )
             with pytest.raises(AIInsightCostBudgetExceededError) as exc:
                 _enforce_ai_insight_user_cost_budget(user_id=user_id, now=now)
@@ -140,7 +153,10 @@ class TestUserCostEnforcement:
             user_id = uuid.uuid4()
             now = datetime(2026, 5, 15, 12, 0, 0)
             _seed_llm_cost(
-                user_id, cost_usd="0.50", endpoint="financial_insights_daily"
+                user_id,
+                cost_usd="0.50",
+                endpoint="financial_insights_daily",
+                created_at=now,
             )
             # Must not raise.
             _enforce_ai_insight_user_cost_budget(user_id=user_id, now=now)

--- a/tests/test_ai_insight_model.py
+++ b/tests/test_ai_insight_model.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import uuid
-from datetime import date
+from datetime import date, timedelta
 
 from app.models.ai_insight import AIInsight, InsightType
 
@@ -43,12 +43,15 @@ class TestAIInsightModel:
 
             user_id = uuid.uuid4()
             today = date.today()
+            # timedelta, não replace(day=today.day-1): no dia 1 do mês day-1=0 e
+            # date.replace(day=0) levanta "day is out of range for month".
+            yesterday = today - timedelta(days=1)
 
             first = AIInsight(
                 user_id=user_id,
                 content="Insight de ontem.",
                 insight_type=InsightType.daily,
-                period_label=(today.replace(day=today.day - 1)).strftime("%Y-%m-%d"),
+                period_label=yesterday.strftime("%Y-%m-%d"),
                 period_start=today,
                 period_end=today,
                 model="gpt-4o-mini",

--- a/tests/test_budget_category.py
+++ b/tests/test_budget_category.py
@@ -137,13 +137,16 @@ class TestBudgetGetSpentForCategory:
 
         with app.app_context():
             # Create transactions: one with category alimentacao, one without
+            # Data no mês corrente: o budget mensal soma o mês de date.today();
+            # uma data fixa (ex.: 2026-05-10) faz o teste quebrar fora daquele mês.
+            current_month_day = __import__("datetime").date.today().replace(day=10)
             tx_with_cat = Transaction(
                 user_id=user_id,
                 title="Mercado",
                 amount=Decimal("150.00"),
                 type=TransactionType.EXPENSE,
                 status=TransactionStatus.PAID,
-                due_date=__import__("datetime").date(2026, 5, 10),
+                due_date=current_month_day,
                 category=TransactionCategory.alimentacao,
             )
             tx_no_cat = Transaction(
@@ -152,7 +155,7 @@ class TestBudgetGetSpentForCategory:
                 amount=Decimal("80.00"),
                 type=TransactionType.EXPENSE,
                 status=TransactionStatus.PAID,
-                due_date=__import__("datetime").date(2026, 5, 10),
+                due_date=current_month_day,
                 category=None,
             )
             db.session.add_all([tx_with_cat, tx_no_cat])


### PR DESCRIPTION
## Incidente (2026-06-01)

`POST /ai/insights/generate` retornava **500** em uso normal (request_id `2f172716142dcc05b047a5ab76615ed1`).

## Causa raiz (reproduzida em prod via SSM)

```
LLMProviderError: Missing financial insight dimensions: credit_cards
  ai_advisory_service.py:469 _ensure_financial_insight_dimension_coverage
```

O LLM responde com sucesso, mas o validador exigia cobertura de **todas** as `INSIGHT_DIMENSIONS` (`required_dimensions = list(INSIGHT_DIMENSIONS)` em `financial_insight_context_builder.py:273`). Quando o modelo não emite o item de ausência esperado para um domínio vazio (ex.: usuário sem cartões), a geração inteira falha — regressão ampla do trabalho de dimensões MVP-3.

## Fix

Degrada em vez de derrubar: cobertura incompleta vira **aviso estruturado de data-quality** (`ai_advisory.dimension_coverage_incomplete`), não 500. O frontend filtra por dimensão, então a ausência só deixa aquela aba vazia no run. Teste de regressão atualizado (de "reject" para "tolerate").

## Verificação

- Reproduzido em prod (a falha) e a suite `test_ai_advisory_service.py` + `test_financial_insight_context_builder.py` passam; ruff + mypy limpos.
- **Prod precisa de deploy após merge** (auto-deploy quebrado — #1408); vou disparar o `workflow_dispatch -f env=prod`.

Closes #1412