### PR TITLE
feat(ai): gateway proxy /ai/insights/spending-patterns → v2 (PROD-04, #567)

### DIFF
--- a/api-tests/postman/auraxis.postman_collection.json
+++ b/api-tests/postman/auraxis.postman_collection.json
@@ -1,7 +1,7 @@
 {
   "info": {
     "name": "Auraxis API",
-    "description": "Auto-generated from openapi.json (82 paths). Do not edit manually — regenerate with: npm run postman:build",
+    "description": "Auto-generated from openapi.json (83 paths). Do not edit manually — regenerate with: npm run postman:build",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "item": [
@@ -4891,6 +4891,51 @@
                 "exec": [
                   "pm.test('AI goal projection — expected 200 or 400 or 403 or 404', function () {",
                   "  pm.expect(pm.response.code).to.be.oneOf([200, 400, 403, 404]);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "POST — Radar de gastos compulsivos (Premium)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/ai/insights/spending-patterns",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "ai",
+                "insights",
+                "spending-patterns"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "// Premium gateway proxy to auraxis-api-v2. 503 when v2 unconfigured/down.",
+                  "pm.test('AI spending patterns — expected 200, 403, 429 or 503', function () {",
+                  "  pm.expect(pm.response.code).to.be.oneOf([200, 403, 429, 503]);",
                   "});"
                 ],
                 "type": "text/javascript"

--- a/app/controllers/ai/routes.py
+++ b/app/controllers/ai/routes.py
@@ -12,6 +12,7 @@ from .resources import (
     AISpendingInsightsResource,
     AIWeeklySummaryResource,
 )
+from .spending_patterns_proxy import AISpendingPatternsProxyResource
 
 _ROUTES_REGISTERED = False
 
@@ -30,6 +31,11 @@ def register_ai_routes() -> None:
         "/insights/spending",
         view_func=AISpendingInsightsResource.as_view("ai_spending_insights"),
         methods=["GET"],
+    )
+    ai_bp.add_url_rule(
+        "/insights/spending-patterns",
+        view_func=AISpendingPatternsProxyResource.as_view("ai_spending_patterns"),
+        methods=["POST"],
     )
     ai_bp.add_url_rule(
         "/goals/<goal_id>/projection",

--- a/app/controllers/ai/spending_patterns_proxy.py
+++ b/app/controllers/ai/spending_patterns_proxy.py
@@ -1,0 +1,122 @@
+"""Gateway proxy: POST /ai/insights/spending-patterns → auraxis-api-v2 (PROD-04, #567).
+
+New LLM logic lives in auraxis-api-v2 (FastAPI); v1 is being decommissioned and
+acts only as an authenticated gateway. This resource enforces the premium
+entitlement (the v2 access token carries no tier claim) and forwards the request
+— body + Authorization header — to the v2 spending-patterns endpoint.
+
+The v2 base URL comes from the ``AURAXIS_API_V2_BASE_URL`` env var. When it is
+unset (e.g. v2 not yet deployed) the endpoint returns 503 rather than failing
+obscurely, so clients can degrade gracefully.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import httpx
+from flask import Response, request
+from flask_apispec.views import MethodResource
+
+from app.auth import current_user_id
+from app.controllers.response_contract import (
+    compat_error_response,
+    compat_success_response,
+)
+from app.controllers.transaction.utils import _guard_revoked_token
+from app.middleware.ai_rate_limit import ai_daily_limit
+from app.services.entitlement_service import has_entitlement
+from app.utils.typed_decorators import typed_doc as doc
+from app.utils.typed_decorators import typed_jwt_required as jwt_required
+
+log = logging.getLogger(__name__)
+
+_ENTITLEMENT_KEY = "advanced_simulations"
+_V2_PATH = "/v2/insights/spending-patterns"
+_TIMEOUT_SECONDS = 30.0
+
+
+def _v2_base_url() -> str:
+    """Return the configured v2 base URL without a trailing slash (or empty)."""
+    return os.getenv("AURAXIS_API_V2_BASE_URL", "").rstrip("/")
+
+
+class AISpendingPatternsProxyResource(MethodResource):
+    """POST /ai/insights/spending-patterns — premium gateway to v2."""
+
+    @doc(
+        summary="Radar de gastos compulsivos (Premium)",
+        description=(
+            "Recebe as transações dos últimos ~90 dias e encaminha para o "
+            "auraxis-api-v2, que roda a detecção de padrões via LLM. Requer "
+            "entitlement 'advanced_simulations'. Retorna 503 quando a v2 está "
+            "indisponível."
+        ),
+        tags=["AI Advisory"],
+        security=[{"BearerAuth": []}],
+    )
+    @jwt_required()
+    @ai_daily_limit()
+    def post(self) -> Response:
+        token_error = _guard_revoked_token()
+        if token_error is not None:
+            return token_error
+
+        user_id = current_user_id()
+        if not has_entitlement(user_id, _ENTITLEMENT_KEY):
+            return compat_error_response(
+                legacy_payload={"error": "Recurso exclusivo para assinantes Premium."},
+                status_code=403,
+                message="Recurso exclusivo para assinantes Premium.",
+                error_code="ENTITLEMENT_REQUIRED",
+            )
+
+        base_url = _v2_base_url()
+        if not base_url:
+            log.warning("spending_patterns_proxy.v2_unconfigured")
+            return compat_error_response(
+                legacy_payload={"error": "Serviço de insights indisponível."},
+                status_code=503,
+                message="Serviço de insights temporariamente indisponível.",
+                error_code="SERVICE_UNAVAILABLE",
+            )
+
+        body = request.get_json(silent=True) or {}
+        auth_header = request.headers.get("Authorization", "")
+
+        try:
+            upstream = httpx.post(
+                f"{base_url}{_V2_PATH}",
+                json=body,
+                headers={"Authorization": auth_header},
+                timeout=_TIMEOUT_SECONDS,
+            )
+        except httpx.HTTPError:
+            log.warning("spending_patterns_proxy.v2_unreachable", exc_info=True)
+            return compat_error_response(
+                legacy_payload={"error": "Serviço de insights indisponível."},
+                status_code=503,
+                message="Serviço de insights temporariamente indisponível.",
+                error_code="SERVICE_UNAVAILABLE",
+            )
+
+        try:
+            payload = upstream.json()
+        except ValueError:
+            payload = {}
+
+        if upstream.status_code >= 400:
+            return compat_error_response(
+                legacy_payload=payload or {"error": "Falha no serviço de insights."},
+                status_code=upstream.status_code,
+                message="Falha ao gerar o radar de gastos.",
+                error_code="UPSTREAM_ERROR",
+            )
+
+        return compat_success_response(
+            legacy_payload=payload,
+            status_code=200,
+            message="Radar de gastos gerado com sucesso",
+            data=payload,
+        )

--- a/app/controllers/ai/spending_patterns_proxy.py
+++ b/app/controllers/ai/spending_patterns_proxy.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import logging
 import os
 
-import httpx
+import requests
 from flask import Response, request
 from flask_apispec.views import MethodResource
 
@@ -86,13 +86,13 @@ class AISpendingPatternsProxyResource(MethodResource):
         auth_header = request.headers.get("Authorization", "")
 
         try:
-            upstream = httpx.post(
+            upstream = requests.post(
                 f"{base_url}{_V2_PATH}",
                 json=body,
                 headers={"Authorization": auth_header},
                 timeout=_TIMEOUT_SECONDS,
             )
-        except httpx.HTTPError:
+        except requests.exceptions.RequestException:
             log.warning("spending_patterns_proxy.v2_unreachable", exc_info=True)
             return compat_error_response(
                 legacy_payload={"error": "Serviço de insights indisponível."},

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,6 @@
   "components": {
     "schemas": {
       "InstallmentVsCashCalculation": {
-        "additionalProperties": false,
         "properties": {
           "cash_price": {
             "minimum": 0.01,
@@ -76,7 +75,6 @@
         "type": "object"
       },
       "InstallmentVsCashGoalBridge": {
-        "additionalProperties": false,
         "properties": {
           "category": {
             "default": "planned_purchase",
@@ -127,7 +125,6 @@
         "type": "object"
       },
       "InstallmentVsCashPlannedExpenseBridge": {
-        "additionalProperties": false,
         "properties": {
           "account_id": {
             "default": null,
@@ -214,7 +211,6 @@
         "type": "object"
       },
       "InstallmentVsCashSave": {
-        "additionalProperties": false,
         "properties": {
           "cash_price": {
             "minimum": 0.01,
@@ -288,7 +284,6 @@
         "type": "object"
       },
       "TransactionCreate": {
-        "additionalProperties": false,
         "properties": {
           "account_id": {
             "description": "ID da conta bancária associada",
@@ -489,7 +484,6 @@
         "type": "object"
       },
       "TransactionCreate_7d3b606eab": {
-        "additionalProperties": false,
         "properties": {
           "account_id": {
             "description": "ID da conta bancária associada",
@@ -684,7 +678,6 @@
         "type": "object"
       },
       "app_schemas_ai_insight_schema_AIInsightGenerateRequestSchema": {
-        "additionalProperties": false,
         "properties": {
           "anchor_date": {
             "description": "Data âncora do período no formato YYYY-MM-DD.",
@@ -723,7 +716,6 @@
         "type": "object"
       },
       "app_schemas_ai_insight_schema_AIMonthlyReportRequestSchema": {
-        "additionalProperties": false,
         "properties": {
           "anchor_date": {
             "description": "Data âncora do mês a consolidar. Quando omitida, a API usa a data atual.",
@@ -742,7 +734,6 @@
         "type": "object"
       },
       "app_schemas_auth_schema_AuthSchema": {
-        "additionalProperties": false,
         "properties": {
           "captcha_token": {
             "default": null,
@@ -770,7 +761,6 @@
         "type": "object"
       },
       "app_schemas_auth_schema_ConfirmEmailSchema": {
-        "additionalProperties": false,
         "properties": {
           "token": {
             "description": "Token de confirmacao recebido por email",
@@ -786,7 +776,6 @@
         "type": "object"
       },
       "app_schemas_auth_schema_ForgotPasswordSchema": {
-        "additionalProperties": false,
         "properties": {
           "email": {
             "description": "Email da conta que deseja recuperar acesso",
@@ -801,7 +790,6 @@
         "type": "object"
       },
       "app_schemas_auth_schema_ResetPasswordSchema": {
-        "additionalProperties": false,
         "properties": {
           "new_password": {
             "description": "Nova senha (mínimo 10 caracteres, com maiúscula, número e símbolo)",
@@ -825,7 +813,6 @@
         "type": "object"
       },
       "app_schemas_consent_schemas_ConsentRecordSchema": {
-        "additionalProperties": false,
         "properties": {
           "action": {
             "enum": [
@@ -868,7 +855,6 @@
         "type": "object"
       },
       "app_schemas_push_subscription_schema_SubscribeSchema": {
-        "additionalProperties": false,
         "properties": {
           "device_label": {
             "default": null,
@@ -903,7 +889,6 @@
         "type": "object"
       },
       "app_schemas_push_subscription_schema_UnsubscribeSchema": {
-        "additionalProperties": false,
         "properties": {
           "endpoint": {
             "type": "string"
@@ -915,7 +900,6 @@
         "type": "object"
       },
       "app_schemas_user_schemas_DeleteAccountSchema": {
-        "additionalProperties": false,
         "properties": {
           "password": {
             "description": "Senha atual do usuário para confirmar a exclusão da conta",
@@ -930,7 +914,6 @@
         "type": "object"
       },
       "app_schemas_user_schemas_QuestionnaireAnswerSchema": {
-        "additionalProperties": false,
         "properties": {
           "answers": {
             "description": "Lista de 5 respostas — pontos da opção escolhida em cada pergunta (1–3).",
@@ -950,7 +933,6 @@
         "type": "object"
       },
       "app_schemas_user_schemas_SalaryIncreaseSimulationRequestSchema": {
-        "additionalProperties": false,
         "properties": {
           "base_date": {
             "description": "Data base do salário atual",
@@ -986,7 +968,6 @@
         "type": "object"
       },
       "app_schemas_user_schemas_UserProfileSchema": {
-        "additionalProperties": false,
         "properties": {
           "birth_date": {
             "description": "Data de nascimento",
@@ -1099,7 +1080,6 @@
         "type": "object"
       },
       "app_schemas_user_schemas_UserRegistrationSchema": {
-        "additionalProperties": false,
         "properties": {
           "captcha_token": {
             "default": null,
@@ -2292,6 +2272,22 @@
           }
         ],
         "summary": "Insights de gastos com IA (Premium)",
+        "tags": [
+          "AI Advisory"
+        ]
+      }
+    },
+    "/ai/insights/spending-patterns": {
+      "post": {
+        "description": "Recebe as transações dos últimos ~90 dias e encaminha para o auraxis-api-v2, que roda a detecção de padrões via LLM. Requer entitlement 'advanced_simulations'. Retorna 503 quando a v2 está indisponível.",
+        "parameters": [],
+        "responses": {},
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Radar de gastos compulsivos (Premium)",
         "tags": [
           "AI Advisory"
         ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ packaging==25.0
 pluggy==1.6.0
 psycopg2-binary==2.9.12
 Pygments==2.20.0
-PyJWT==2.12.1
+PyJWT==2.13.0
 pytest==9.0.3
 pytest-cov==6.3.0
 pytest-flask==1.3.0

--- a/scripts/openapi_to_postman.py
+++ b/scripts/openapi_to_postman.py
@@ -885,6 +885,14 @@ ENRICHMENT: dict[str, dict[str, Any]] = {
             "});",
         ],
     },
+    "POST /ai/insights/spending-patterns": {
+        "test_lines": [
+            "// Premium gateway proxy to auraxis-api-v2. 503 when v2 unconfigured/down.",
+            "pm.test('AI spending patterns — expected 200, 403, 429 or 503', function () {",
+            "  pm.expect(pm.response.code).to.be.oneOf([200, 403, 429, 503]);",
+            "});",
+        ],
+    },
     "GET /ai/insights/weekly-summary": {
         "test_lines": [
             "pm.test('AI weekly summary — expected 200 or 403 or 429', function () {",

--- a/tests/test_ai_spending_patterns_proxy.py
+++ b/tests/test_ai_spending_patterns_proxy.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import uuid as _uuid
 
+import requests
+
 from app.controllers.ai import spending_patterns_proxy
 
 _PAYLOAD = {
@@ -63,7 +65,7 @@ class _FakeResponse:
 
 
 def test_returns_403_without_entitlement(app, client, monkeypatch) -> None:
-    monkeypatch.setenv("AURAXIS_API_V2_BASE_URL", "http://v2.test")
+    monkeypatch.setenv("AURAXIS_API_V2_BASE_URL", "https://v2.test")
     token, _ = _register_and_login(client)
     # Fresh users get a trial entitlement; revoke it to exercise the gate.
     from flask_jwt_extended import decode_token
@@ -97,10 +99,10 @@ def test_returns_503_when_v2_unconfigured(app, client, monkeypatch) -> None:
 
 
 def test_forwards_to_v2_and_returns_patterns(app, client, monkeypatch) -> None:
-    monkeypatch.setenv("AURAXIS_API_V2_BASE_URL", "http://v2.test")
+    monkeypatch.setenv("AURAXIS_API_V2_BASE_URL", "https://v2.test")
     captured: dict = {}
 
-    def _fake_post(url, json, headers, timeout):  # noqa: A002 — mirror httpx kwarg
+    def _fake_post(url, json, headers, timeout):  # noqa: A002 — mirror requests kwarg
         captured["url"] = url
         captured["json"] = json
         captured["auth"] = headers.get("Authorization")
@@ -113,7 +115,7 @@ def test_forwards_to_v2_and_returns_patterns(app, client, monkeypatch) -> None:
             },
         )
 
-    monkeypatch.setattr(spending_patterns_proxy.httpx, "post", _fake_post)
+    monkeypatch.setattr(spending_patterns_proxy.requests, "post", _fake_post)
     token, _ = _register_and_login(client)
     _grant_premium(app, token)
 
@@ -123,7 +125,7 @@ def test_forwards_to_v2_and_returns_patterns(app, client, monkeypatch) -> None:
         headers={"Authorization": f"Bearer {token}", "X-API-Contract": "v2"},
     )
     assert resp.status_code == 200, resp.get_json()
-    assert captured["url"] == "http://v2.test/v2/insights/spending-patterns"
+    assert captured["url"] == "https://v2.test/v2/insights/spending-patterns"
     assert captured["auth"] == f"Bearer {token}"
     body = resp.get_json() or {}
     data = body.get("data") or body
@@ -131,14 +133,12 @@ def test_forwards_to_v2_and_returns_patterns(app, client, monkeypatch) -> None:
 
 
 def test_returns_503_when_v2_unreachable(app, client, monkeypatch) -> None:
-    import httpx
-
-    monkeypatch.setenv("AURAXIS_API_V2_BASE_URL", "http://v2.test")
+    monkeypatch.setenv("AURAXIS_API_V2_BASE_URL", "https://v2.test")
 
     def _boom(*_args, **_kwargs):
-        raise httpx.ConnectError("refused")
+        raise requests.exceptions.ConnectionError("refused")
 
-    monkeypatch.setattr(spending_patterns_proxy.httpx, "post", _boom)
+    monkeypatch.setattr(spending_patterns_proxy.requests, "post", _boom)
     token, _ = _register_and_login(client)
     _grant_premium(app, token)
 

--- a/tests/test_ai_spending_patterns_proxy.py
+++ b/tests/test_ai_spending_patterns_proxy.py
@@ -1,0 +1,150 @@
+"""Tests for the spending-patterns gateway proxy (PROD-04, #567).
+
+The proxy forwards POST /ai/insights/spending-patterns to auraxis-api-v2 after
+enforcing the premium entitlement. v2 itself is mocked here — these tests cover
+the gateway behaviour (entitlement gate, v2-unconfigured, forwarding, upstream
+failure), not the LLM.
+"""
+
+from __future__ import annotations
+
+import uuid as _uuid
+
+from app.controllers.ai import spending_patterns_proxy
+
+_PAYLOAD = {
+    "transactions": [
+        {"amount": 12.5, "occurred_on": "2026-05-01", "category": "food"},
+    ],
+    "period_days": 90,
+}
+
+
+def _register_and_login(client) -> tuple[str, str]:
+    suffix = _uuid.uuid4().hex[:8]
+    email = f"sp-proxy-{suffix}@test.com"
+    password = "StrongPass@123"
+    reg = client.post(
+        "/auth/register",
+        json={"name": f"sp-{suffix}", "email": email, "password": password},
+    )
+    assert reg.status_code == 201, reg.get_json()
+    login = client.post("/auth/login", json={"email": email, "password": password})
+    assert login.status_code == 200, login.get_json()
+    return login.get_json()["token"], email
+
+
+def _grant_premium(app, token: str) -> None:
+    from flask_jwt_extended import decode_token
+
+    from app.extensions.database import db
+    from app.models.entitlement import Entitlement, EntitlementSource
+
+    with app.app_context():
+        user_id = _uuid.UUID(decode_token(token)["sub"])
+        db.session.add(
+            Entitlement(
+                user_id=user_id,
+                feature_key="advanced_simulations",
+                source=EntitlementSource.MANUAL,
+                expires_at=None,
+            )
+        )
+        db.session.commit()
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: dict) -> None:
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self) -> dict:
+        return self._payload
+
+
+def test_returns_403_without_entitlement(app, client, monkeypatch) -> None:
+    monkeypatch.setenv("AURAXIS_API_V2_BASE_URL", "http://v2.test")
+    token, _ = _register_and_login(client)
+    # Fresh users get a trial entitlement; revoke it to exercise the gate.
+    from flask_jwt_extended import decode_token
+
+    from app.services.entitlement_service import deactivate_premium
+
+    with app.app_context():
+        deactivate_premium(_uuid.UUID(decode_token(token)["sub"]))
+    resp = client.post(
+        "/ai/insights/spending-patterns",
+        json=_PAYLOAD,
+        headers={"Authorization": f"Bearer {token}", "X-API-Contract": "v2"},
+    )
+    assert resp.status_code == 403
+    error = (resp.get_json() or {}).get("error", {})
+    assert error.get("code") == "ENTITLEMENT_REQUIRED"
+
+
+def test_returns_503_when_v2_unconfigured(app, client, monkeypatch) -> None:
+    monkeypatch.delenv("AURAXIS_API_V2_BASE_URL", raising=False)
+    token, _ = _register_and_login(client)
+    _grant_premium(app, token)
+    resp = client.post(
+        "/ai/insights/spending-patterns",
+        json=_PAYLOAD,
+        headers={"Authorization": f"Bearer {token}", "X-API-Contract": "v2"},
+    )
+    assert resp.status_code == 503
+    error = (resp.get_json() or {}).get("error", {})
+    assert error.get("code") == "SERVICE_UNAVAILABLE"
+
+
+def test_forwards_to_v2_and_returns_patterns(app, client, monkeypatch) -> None:
+    monkeypatch.setenv("AURAXIS_API_V2_BASE_URL", "http://v2.test")
+    captured: dict = {}
+
+    def _fake_post(url, json, headers, timeout):  # noqa: A002 — mirror httpx kwarg
+        captured["url"] = url
+        captured["json"] = json
+        captured["auth"] = headers.get("Authorization")
+        return _FakeResponse(
+            200,
+            {
+                "patterns": [{"description": "Cafés", "severity": "high"}],
+                "model": "stub",
+                "generated_count": 1,
+            },
+        )
+
+    monkeypatch.setattr(spending_patterns_proxy.httpx, "post", _fake_post)
+    token, _ = _register_and_login(client)
+    _grant_premium(app, token)
+
+    resp = client.post(
+        "/ai/insights/spending-patterns",
+        json=_PAYLOAD,
+        headers={"Authorization": f"Bearer {token}", "X-API-Contract": "v2"},
+    )
+    assert resp.status_code == 200, resp.get_json()
+    assert captured["url"] == "http://v2.test/v2/insights/spending-patterns"
+    assert captured["auth"] == f"Bearer {token}"
+    body = resp.get_json() or {}
+    data = body.get("data") or body
+    assert data["generated_count"] == 1
+
+
+def test_returns_503_when_v2_unreachable(app, client, monkeypatch) -> None:
+    import httpx
+
+    monkeypatch.setenv("AURAXIS_API_V2_BASE_URL", "http://v2.test")
+
+    def _boom(*_args, **_kwargs):
+        raise httpx.ConnectError("refused")
+
+    monkeypatch.setattr(spending_patterns_proxy.httpx, "post", _boom)
+    token, _ = _register_and_login(client)
+    _grant_premium(app, token)
+
+    resp = client.post(
+        "/ai/insights/spending-patterns",
+        json=_PAYLOAD,
+        headers={"Authorization": f"Bearer {token}", "X-API-Contract": "v2"},
+    )
+    assert resp.status_code == 503


### PR DESCRIPTION
## Contexto
PROD-04 (#537). O backend de detecção vive na **auraxis-api-v2** (PR auraxis-api-v2#50). A v1 está em descontinuação e atua só como **gateway autenticado** — este é o mecanismo de redirect v1→v2.

## O que entra
`POST /ai/insights/spending-patterns`:
- Enforce entitlement **premium** (`advanced_simulations`) — o token v2 não carrega claim de tier, então o gate fica aqui.
- Encaminha body (transações ~90d) + header Authorization para `{AURAXIS_API_V2_BASE_URL}/v2/insights/spending-patterns`.
- v2 ausente/inacessível → **503 gracioso** (sem env configurado = v2 ainda não deployada).
- Sucesso → repassa o envelope da v2.

## Quality
- Testes: entitlement gate (403), v2 unconfigured (503), forward (200), v2 unreachable (503).
- `@doc` adicionado → `openapi.json` (83 paths) + coleção Postman (109 reqs) regenerados; contract tests verdes; mypy/ruff ok.

## Infra (follow-up)
- `AURAXIS_API_V2_BASE_URL` precisa ser configurada via SSM **e a v2 deployada atrás do nginx** para o fluxo e2e. Até lá, o proxy responde 503 e o web degrada (estado vazio). Gargalo do #537 já sinalizado no plano.

Refs #567
Refs #537