### PR TITLE
fix(ai): weekly-summary read-only; email só no batch agendado

### DIFF
--- a/app/cli/ai_insights_cli.py
+++ b/app/cli/ai_insights_cli.py
@@ -32,6 +32,9 @@ from app.models.entitlement import Entitlement
 from app.models.user import User
 from app.services.ai_advisory_service import AIAdvisoryService
 from app.services.ai_insight_audit import get_ai_insight_run_dossier
+from app.services.analysis_ready_notification_service import (
+    dispatch_analysis_ready_notification,
+)
 
 ai_insights_cli = AppGroup("ai", help="Scheduled AI insights batch commands.")
 
@@ -164,6 +167,20 @@ def _write_dossier_files(
     return written
 
 
+def _notification_preview(result: dict[str, Any]) -> str:
+    """Build a short email preview from a generated insight result.
+
+    Uses the insight summary truncated to ~280 chars on a word boundary; falls
+    back to the service default when no summary is present.
+    """
+    summary = str(result.get("summary") or "").strip()
+    if not summary:
+        return "Sua análise financeira está disponível."
+    if len(summary) <= 280:
+        return summary
+    return summary[:280].rsplit(" ", 1)[0]
+
+
 def _run_batch(
     *,
     user_ids: list[uuid.UUID],
@@ -214,6 +231,20 @@ def _run_batch(
             else:
                 total_cost += float(result.get("cost_usd", 0))
                 processed += 1
+                # Notify the user that a fresh analysis is ready. This is the
+                # ONLY place the "analysis ready" email is sent — reads of
+                # /ai/insights/weekly-summary are side-effect free. Best-effort:
+                # a notification failure must not abort the batch.
+                try:
+                    dispatch_analysis_ready_notification(
+                        user_id=user_id,
+                        summary_preview=_notification_preview(result),
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    click.echo(
+                        f"{label} NOTIFY-WARN user={user_id} error={exc}",
+                        err=True,
+                    )
         except Exception as exc:  # noqa: BLE001
             click.echo(
                 f"{label} ERROR user={user_id} error={exc}",

--- a/app/controllers/ai/resources.py
+++ b/app/controllers/ai/resources.py
@@ -55,9 +55,6 @@ from app.services.ai_monthly_report_service import (
     get_monthly_report_run_status,
     process_monthly_report_run,
 )
-from app.services.analysis_ready_notification_service import (
-    dispatch_analysis_ready_notification,
-)
 from app.services.entitlement_service import has_entitlement
 from app.services.llm_provider import LLMProviderError
 from app.utils import timezone_utils
@@ -637,23 +634,27 @@ class AIWeeklySummaryResource(MethodResource):
     """GET /ai/insights/weekly-summary — AI narrative for weekly summary."""
 
     @doc(
-        summary="Briefing semanal com IA (Premium)",
+        summary="Briefing semanal com IA (Premium, somente leitura)",
         description=(
-            "Gera um briefing narrativo do resumo financeiro da semana atual. "
-            "Requer entitlement 'advanced_simulations' (plano Premium)."
+            "Retorna o resumo financeiro da semana atual (agregação de "
+            "transações) e a narrativa do último insight semanal já gerado pelo "
+            "batch agendado. NÃO chama o LLM nem envia email — a geração ocorre "
+            "exclusivamente no cron semanal. Quando ainda não há insight, "
+            "'narrative' vem vazio. Requer entitlement 'advanced_simulations'."
         ),
         tags=["AI Advisory"],
         security=[{"BearerAuth": []}],
         responses={
             200: json_success_response(
-                description="Briefing gerado com sucesso",
-                message="Briefing semanal gerado com sucesso",
+                description="Resumo semanal retornado com sucesso",
+                message="Resumo semanal retornado com sucesso",
                 data_example={
                     "narrative": "Esta semana você gastou R$ 1.200...",
                     "tokens_used": 280,
                     "cost_usd": 0.000042,
                     "summary": {"current_week": {}, "previous_week": {}},
                     "model": "gpt-4o-mini",
+                    "generated_at": "2026-06-01T03:00:00",
                 },
             ),
             401: json_error_response(
@@ -669,15 +670,14 @@ class AIWeeklySummaryResource(MethodResource):
                 status_code=403,
             ),
             500: json_error_response(
-                description="Falha do provider LLM",
-                message="Erro ao gerar briefing semanal",
+                description="Erro interno",
+                message="Erro ao ler resumo semanal",
                 error_code="INTERNAL_ERROR",
                 status_code=500,
             ),
         },
     )
     @jwt_required()
-    @ai_daily_limit()
     def get(self) -> Response:
         token_error = _guard_revoked_token()
         if token_error is not None:
@@ -691,34 +691,19 @@ class AIWeeklySummaryResource(MethodResource):
 
         service = AIAdvisoryService(user_id=user_id)
         try:
-            result = service.generate_weekly_summary_narrative()
-        except AIConsentRequiredError as exc:
-            return _ai_consent_required_response(exc)
-        except LLMProviderError as exc:
-            return compat_error_response(
-                legacy_payload={"error": str(exc)},
-                status_code=500,
-                message="Erro ao gerar briefing semanal",
-                error_code="INTERNAL_ERROR",
-            )
+            result = service.read_weekly_summary_narrative()
         except Exception:
             return compat_error_response(
                 legacy_payload={"error": "Erro interno"},
                 status_code=500,
-                message="Erro interno ao gerar briefing semanal",
+                message="Erro ao ler resumo semanal",
                 error_code="INTERNAL_ERROR",
             )
-
-        # Notify the user that a new analysis is ready (fire-and-forget).
-        # Truncate narrative to 280 chars for the email preview.
-        _notify_analysis_ready(
-            user_id=user_id, narrative=str(result.get("narrative", ""))
-        )
 
         return compat_success_response(
             legacy_payload=result,
             status_code=200,
-            message="Briefing semanal gerado com sucesso",
+            message="Resumo semanal retornado com sucesso",
             data=result,
         )
 
@@ -971,28 +956,6 @@ class AIInsightDetailResource(MethodResource):
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
-
-
-def _notify_analysis_ready(*, user_id: UUID, narrative: str) -> None:
-    """Fire-and-forget: send 'analysis ready' notification to the user.
-
-    Swallows all exceptions so notification failures never break the response.
-    The notification service itself handles entitlement gating — free users
-    are silently skipped without reaching this point in practice because the
-    endpoint already requires 'advanced_simulations', but the service enforces
-    'email_reminders' independently.
-    """
-    try:
-        preview = (
-            narrative[:280].rsplit(" ", 1)[0] if len(narrative) > 280 else narrative
-        )
-        dispatch_analysis_ready_notification(
-            user_id=user_id,
-            summary_preview=preview
-            or "Sua análise financeira semanal está disponível.",  # noqa: E501
-        )
-    except Exception as exc:
-        log.warning("ai.weekly_summary.notify_failed user_id=%s error=%s", user_id, exc)
 
 
 def _strip_history_json_code_fence(content: str) -> str:

--- a/app/services/ai_advisory_service.py
+++ b/app/services/ai_advisory_service.py
@@ -260,6 +260,48 @@ def _get_latest_insight_for_period_context(
     return insight
 
 
+def _get_latest_insight_by_type(
+    *,
+    user_id: UUID,
+    insight_type: InsightType,
+) -> AIInsight | None:
+    """Return the most recently created AIInsight of a given type, or None."""
+    insight: AIInsight | None = (
+        db.session.query(AIInsight)
+        .filter_by(user_id=user_id, insight_type=insight_type)
+        .order_by(AIInsight.created_at.desc())
+        .first()
+    )
+    return insight
+
+
+def _extract_insight_narrative(content: str) -> str:
+    """Extract a human-readable narrative from a persisted insight's content.
+
+    Insight content is stored as JSON (``{"summary": ..., "items": [...]}``) for
+    period-aware insights, but legacy rows may hold raw prose. This helper
+    tolerates both: it returns the ``summary`` field when present, otherwise the
+    raw content stripped of any markdown code fence.
+    """
+    text = content.strip()
+    if text.startswith("```"):
+        first_newline = text.find("\n")
+        if first_newline != -1:
+            text = text[first_newline + 1 :]
+        if text.rstrip().endswith("```"):
+            text = text.rstrip()[:-3]
+        text = text.strip()
+    try:
+        parsed = json.loads(text)
+    except (ValueError, TypeError):
+        return text
+    if isinstance(parsed, dict):
+        summary = parsed.get("summary")
+        if isinstance(summary, str) and summary.strip():
+            return summary.strip()
+    return text
+
+
 def _period_label_for_anchor(
     *,
     insight_type: InsightType,
@@ -1660,6 +1702,45 @@ class AIAdvisoryService:
             "cost_usd": llm_resp.estimated_cost_usd,
             "summary": summary,
             "model": llm_resp.model,
+        }
+
+    def read_weekly_summary_narrative(self) -> dict[str, Any]:
+        """Read-only weekly briefing for the dashboard.
+
+        Returns the current week's numeric summary (a pure DB aggregation) plus
+        the narrative from the latest persisted weekly insight, if any. This
+        method NEVER calls the LLM and NEVER sends email — generation and
+        notification happen exclusively in the scheduled batch
+        (``flask ai weekly-insights``). When no weekly insight has been
+        generated yet, ``narrative`` is an empty string and ``generated_at`` is
+        ``None`` so the UI can show a "will be generated" state.
+
+        Returns:
+            {"narrative": str, "tokens_used": int, "cost_usd": float,
+             "summary": dict, "model": str, "generated_at": str | None}
+        """
+        summary = compute_weekly_summary(user_id=self._user_id)
+        latest = _get_latest_insight_by_type(
+            user_id=self._user_id, insight_type=InsightType.weekly
+        )
+
+        if latest is None:
+            return {
+                "narrative": "",
+                "tokens_used": 0,
+                "cost_usd": 0.0,
+                "summary": summary,
+                "model": "",
+                "generated_at": None,
+            }
+
+        return {
+            "narrative": _extract_insight_narrative(latest.content),
+            "tokens_used": latest.tokens_used,
+            "cost_usd": float(latest.cost_usd),
+            "summary": summary,
+            "model": latest.model,
+            "generated_at": latest.created_at.isoformat(),
         }
 
 

--- a/tests/test_ai_advisory_service.py
+++ b/tests/test_ai_advisory_service.py
@@ -1006,6 +1006,56 @@ class TestAIAdvisoryServiceWeeklySummary:
             with pytest.raises(LLMProviderError):
                 service.generate_weekly_summary_narrative()
 
+    def test_read_weekly_summary_without_insight_returns_empty_narrative(
+        self, app
+    ) -> None:
+        with app.app_context():
+            user_id = uuid.uuid4()
+            # A broken provider proves the read path never touches the LLM.
+            broken = MagicMock()
+            broken.generate_with_usage.side_effect = LLMProviderError("must not call")
+
+            from app.services.ai_advisory_service import AIAdvisoryService
+
+            service = AIAdvisoryService(user_id=user_id, llm_provider=broken)
+            result = service.read_weekly_summary_narrative()
+
+            assert result["narrative"] == ""
+            assert result["generated_at"] is None
+            assert "current_week" in result["summary"]
+            broken.generate_with_usage.assert_not_called()
+
+    def test_read_weekly_summary_returns_latest_persisted_narrative(self, app) -> None:
+        with app.app_context():
+            from app.extensions.database import db
+            from app.models.ai_insight import AIInsight, InsightType
+            from app.services.ai_advisory_service import AIAdvisoryService
+
+            user_id = uuid.uuid4()
+            iso = date.today().isocalendar()
+            db.session.add(
+                AIInsight(
+                    user_id=user_id,
+                    content='{"summary":"Resumo da semana.","items":[]}',
+                    insight_type=InsightType.weekly,
+                    period_label=f"{iso.year}-W{iso.week:02d}",
+                    period_start=date.today(),
+                    period_end=date.today(),
+                    model="gpt-4o-mini",
+                    tokens_used=99,
+                    cost_usd=0,
+                )
+            )
+            db.session.commit()
+
+            service = AIAdvisoryService(user_id=user_id, llm_provider=MagicMock())
+            result = service.read_weekly_summary_narrative()
+
+            assert result["narrative"] == "Resumo da semana."
+            assert result["model"] == "gpt-4o-mini"
+            assert result["tokens_used"] == 99
+            assert result["generated_at"] is not None
+
 
 # ---------------------------------------------------------------------------
 # HTTP endpoint tests
@@ -1514,14 +1564,75 @@ class TestAIWeeklySummaryEndpoint:
         for key in ("narrative", "tokens_used", "cost_usd", "summary", "model"):
             assert key in data, f"Missing key: {key}"
 
-    def test_llm_error_returns_500(self, app, client) -> None:
+    def test_read_is_side_effect_free_no_llm_no_email(self, app, client) -> None:
+        """The GET must never generate an insight nor send an email."""
+        token = _register_and_login(client, prefix="ai-wnoside")
+        user_id = _get_current_user_id(app, token)
+        _grant_entitlement(app, user_id, "advanced_simulations")
+
+        with (
+            patch(
+                "app.services.ai_advisory_service.AIAdvisoryService."
+                "generate_weekly_summary_narrative"
+            ) as gen,
+            patch(
+                "app.services.analysis_ready_notification_service."
+                "dispatch_analysis_ready_notification"
+            ) as notify,
+        ):
+            resp = client.get("/ai/insights/weekly-summary", headers=_auth(token))
+
+        assert resp.status_code == 200
+        gen.assert_not_called()
+        notify.assert_not_called()
+        body = resp.get_json()
+        data = body.get("data") or body
+        # No insight generated yet → empty narrative, no generation timestamp.
+        assert data["narrative"] == ""
+        assert data["generated_at"] is None
+
+    def test_read_returns_persisted_weekly_narrative(self, app, client) -> None:
+        token = _register_and_login(client, prefix="ai-wpersist")
+        user_id = _get_current_user_id(app, token)
+        _grant_entitlement(app, user_id, "advanced_simulations")
+
+        with app.app_context():
+            from app.extensions.database import db
+            from app.models.ai_insight import AIInsight, InsightType
+
+            iso = date.today().isocalendar()
+            db.session.add(
+                AIInsight(
+                    user_id=user_id,
+                    content='{"summary":"Sua semana foi positiva.","items":[]}',
+                    insight_type=InsightType.weekly,
+                    period_label=f"{iso.year}-W{iso.week:02d}",
+                    period_start=date.today(),
+                    period_end=date.today(),
+                    model="gpt-4o-mini",
+                    tokens_used=120,
+                    cost_usd=0,
+                )
+            )
+            db.session.commit()
+
+        resp = client.get("/ai/insights/weekly-summary", headers=_auth(token))
+        assert resp.status_code == 200
+        body = resp.get_json()
+        data = body.get("data") or body
+        assert data["narrative"] == "Sua semana foi positiva."
+        assert data["model"] == "gpt-4o-mini"
+        assert data["generated_at"] is not None
+
+    def test_read_error_returns_500(self, app, client) -> None:
         token = _register_and_login(client, prefix="ai-werr")
         user_id = _get_current_user_id(app, token)
         _grant_entitlement(app, user_id, "advanced_simulations")
 
         with patch(
-            "app.services.ai_advisory_service.AIAdvisoryService.generate_weekly_summary_narrative",
-            side_effect=LLMProviderError("provider down"),
+            "app.services.ai_advisory_service.AIAdvisoryService."
+            "read_weekly_summary_narrative",
+            side_effect=RuntimeError("db down"),
         ):
             resp = client.get("/ai/insights/weekly-summary", headers=_auth(token))
             assert resp.status_code == 500

--- a/tests/test_ai_daily_rate_limit.py
+++ b/tests/test_ai_daily_rate_limit.py
@@ -371,56 +371,35 @@ class TestAIDailyRateLimitHTTP:
             or "amanhã" in str(data.get("error", {})).lower()
         )
 
-    def test_weekly_summary_also_rate_limited(self, app, client) -> None:
+    def test_weekly_summary_read_is_not_rate_limited(self, app, client) -> None:
+        """The weekly-summary GET is read-only and must NOT consume the AI daily
+        quota — generation (and its rate limit) lives in the scheduled batch."""
         token = _register_and_login(client, "ai-rl-weekly")
         _grant_premium(app, token)
 
-        with patch(
-            "app.services.ai_advisory_service.AIAdvisoryService.generate_weekly_summary_narrative",
-            return_value={
-                "narrative": "ok",
-                "tokens_used": 10,
-                "cost_usd": 0.0,
-                "summary": {},
-                "model": "stub",
-            },
-        ):
-            client.get("/ai/insights/weekly-summary", headers=_auth(token))
-            client.get("/ai/insights/weekly-summary", headers=_auth(token))
-            resp = client.get(
-                "/ai/insights/weekly-summary", headers=_auth(token, v2=True)
-            )
+        # Many reads in a row must keep returning 200, never 429.
+        client.get("/ai/insights/weekly-summary", headers=_auth(token))
+        client.get("/ai/insights/weekly-summary", headers=_auth(token))
+        resp = client.get("/ai/insights/weekly-summary", headers=_auth(token, v2=True))
 
-        assert resp.status_code == 429
-        assert resp.get_json()["error"]["code"] == "AI_DAILY_LIMIT_EXCEEDED"
+        assert resp.status_code == 200
 
-    def test_spending_and_weekly_share_same_daily_counter(self, app, client) -> None:
-        """Spending and weekly share one daily counter — at 1/day the second
-        call (weekly) is already blocked."""
+    def test_weekly_read_does_not_consume_spending_counter(self, app, client) -> None:
+        """The weekly-summary read is free; only spending consumes the daily
+        counter, so a weekly read between two spending calls does not shift the
+        limit."""
         token = _register_and_login(client, "ai-rl-shared")
         _grant_premium(app, token)
 
-        with (
-            patch(
-                "app.services.ai_advisory_service.AIAdvisoryService.generate_spending_insights",
-                return_value={
-                    "insights": "ok",
-                    "tokens_used": 10,
-                    "cost_usd": 0.0,
-                    "month": "2026-05",
-                    "model": "stub",
-                },
-            ),
-            patch(
-                "app.services.ai_advisory_service.AIAdvisoryService.generate_weekly_summary_narrative",
-                return_value={
-                    "narrative": "ok",
-                    "tokens_used": 10,
-                    "cost_usd": 0.0,
-                    "summary": {},
-                    "model": "stub",
-                },
-            ),
+        with patch(
+            "app.services.ai_advisory_service.AIAdvisoryService.generate_spending_insights",
+            return_value={
+                "insights": "ok",
+                "tokens_used": 10,
+                "cost_usd": 0.0,
+                "month": "2026-05",
+                "model": "stub",
+            },
         ):
             r1 = client.get("/ai/insights/spending", headers=_auth(token))
             r2 = client.get(
@@ -429,8 +408,8 @@ class TestAIDailyRateLimitHTTP:
             r3 = client.get("/ai/insights/spending", headers=_auth(token, v2=True))
 
         assert r1.status_code == 200
-        assert r2.status_code == 429
-        assert r3.status_code == 429
+        assert r2.status_code == 200  # read-only, not rate limited
+        assert r3.status_code == 429  # second spending call hits the daily cap
 
     def test_free_user_gets_403_not_429(self, app, client) -> None:
         """Free users are blocked by entitlement gate before reaching rate limit."""

--- a/tests/test_ai_weekly_insights_cli.py
+++ b/tests/test_ai_weekly_insights_cli.py
@@ -141,6 +141,58 @@ class TestWeeklyInsightsCLI:
         assert "processed=1" in result.output
         assert "failures=0" in result.output
 
+    def test_successful_generation_dispatches_notification(self, app) -> None:
+        """The batch is the single place the 'analysis ready' email is sent."""
+        user_id = _create_user(app)
+        _grant_advanced_simulations(app, user_id)
+
+        with (
+            patch(
+                "app.services.ai_advisory_service.AIAdvisoryService"
+                ".generate_financial_insights",
+                return_value={
+                    "summary": "Sua semana foi positiva.",
+                    "items": [],
+                    "period_type": "weekly",
+                    "tokens_used": 150,
+                    "cost_usd": 0.00002,
+                    "model": "stub",
+                    "cached": False,
+                },
+            ),
+            patch(
+                "app.cli.ai_insights_cli.dispatch_analysis_ready_notification"
+            ) as mock_notify,
+        ):
+            result = self._invoke(app)
+
+        assert result.exit_code == 0
+        assert mock_notify.call_count == 1
+        assert mock_notify.call_args.kwargs["user_id"] == user_id
+        assert (
+            mock_notify.call_args.kwargs["summary_preview"]
+            == "Sua semana foi positiva."
+        )
+
+    def test_cached_generation_does_not_dispatch_notification(self, app) -> None:
+        user_id = _create_user(app)
+        _grant_advanced_simulations(app, user_id)
+
+        with (
+            patch(
+                "app.services.ai_advisory_service.AIAdvisoryService"
+                ".generate_financial_insights",
+                return_value={"summary": "x", "items": [], "cached": True},
+            ),
+            patch(
+                "app.cli.ai_insights_cli.dispatch_analysis_ready_notification"
+            ) as mock_notify,
+        ):
+            result = self._invoke(app)
+
+        assert result.exit_code == 0
+        mock_notify.assert_not_called()
+
     def test_multiple_premium_users_each_called_once(self, app) -> None:
         user_ids = [_create_user(app) for _ in range(3)]
         for uid in user_ids:


### PR DESCRIPTION
## Problema

`GET /ai/insights/weekly-summary` gerava narrativa LLM nova **e** enviava o email "análise pronta" a **cada** chamada (com `@ai_daily_limit`). Resultado: email a cada login + ~9 chamadas no dashboard estourando 429 / cota AI zerada.

## Solução

- Endpoint agora é **read-only**: retorna o último `AIInsight` semanal persistido + o resumo numérico da semana (`compute_weekly_summary`, agregação pura). Sem LLM, sem email, sem rate limit no read.
- Novo `AIAdvisoryService.read_weekly_summary_narrative()` + helpers `_get_latest_insight_by_type` / `_extract_insight_narrative`.
- O email "análise pronta" agora dispara **apenas** no batch agendado (`flask ai weekly-insights`/`monthly-insights`) após geração bem-sucedida não-cacheada.

## Testes

- read sem LLM/email (side-effect free); read retorna narrativa persistida; read não é rate-limited; batch dispara notificação (e não dispara em cache).
- ruff + mypy limpos; suítes AI relacionadas verdes.

Closes #1420