### PR TITLE
fix(recurrence): comando flask reconcile + agendamento diário (recorrentes somem em meses futuros)

### DIFF
--- a/.github/workflows/daily-recurrence.yml
+++ b/.github/workflows/daily-recurrence.yml
@@ -1,12 +1,18 @@
-name: Recurrence Job
+name: Daily Recurrence Reconcile
 
 on:
-  # Schedule disabled: superseded by the Flask-command-based recurrence implementation.
-  # Kept as workflow_dispatch for emergency manual runs only.
+  schedule:
+    # Every day at 04:00 UTC = 01:00 BRT (after the nightly maintenance window).
+    - cron: "0 4 * * *"
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry-run only (count recurring templates, create nothing)"
+        type: boolean
+        default: false
 
 concurrency:
-  group: recurrence-job-${{ github.ref }}
+  group: daily-recurrence
   cancel-in-progress: false
 
 permissions:
@@ -15,8 +21,8 @@ permissions:
   issues: write
 
 jobs:
-  generate-recurring-transactions:
-    name: Generate Recurring Transactions
+  reconcile:
+    name: Reconcile recurring transactions (materialise future months)
     runs-on: ubuntu-latest
     environment: prod
 
@@ -24,7 +30,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Validate required recurrence variables
+      - name: Validate required variables
         run: |
           [ -n "${AWS_REGION:-}" ] || { echo "Missing var AWS_REGION"; exit 1; }
           [ -n "${AWS_ROLE_ARN_PROD:-}" ] || { echo "Missing var AWS_ROLE_ARN_PROD"; exit 1; }
@@ -52,25 +58,25 @@ jobs:
           role-to-assume: ${{ vars.AWS_ROLE_ARN_PROD }}
           aws-region: ${{ vars.AWS_REGION }}
 
-      - name: Run recurrence generation script via SSM
+      - name: Run recurrence reconcile via SSM
         env:
           AWS_REGION: ${{ vars.AWS_REGION }}
           PROD_INSTANCE_ID: ${{ vars.AURAXIS_PROD_INSTANCE_ID }}
-          RECURRENCE_DIAGNOSTICS_PATH: ${{ runner.temp }}/recurrence-ssm-diagnostics.json
+          DIAGNOSTICS_PATH: ${{ runner.temp }}/daily-recurrence-diagnostics.json
         run: |
           python scripts/aws_recurrence_job.py \
             --profile "" \
             --region "${AWS_REGION}" \
             --env prod \
             --instance-id "${PROD_INSTANCE_ID}" \
-            --diagnostics-json-path "${RECURRENCE_DIAGNOSTICS_PATH}"
+            --diagnostics-json-path "${DIAGNOSTICS_PATH}"
 
-      - name: Upload recurrence diagnostics artifact
-        if: ${{ always() }}
+      - name: Upload diagnostics artifact
+        if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: recurrence-ssm-diagnostics
-          path: ${{ runner.temp }}/recurrence-ssm-diagnostics.json
+          name: daily-recurrence-diagnostics
+          path: ${{ runner.temp }}/daily-recurrence-diagnostics.json
           if-no-files-found: ignore
 
       - name: Notify failure via GitHub Issue
@@ -81,26 +87,24 @@ jobs:
           script: |
             const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const now = new Date().toISOString();
-            const title = '🚨 [recurrence-job] Falha na geração de transações recorrentes';
+            const title = '🚨 [daily-recurrence] Falha na reconciliação de recorrências';
             const issueBody = [
-              '## Recurrence Job falhou',
+              '## Daily Recurrence Reconcile falhou',
               '',
               `**Última falha:** ${now}`,
               `**Run:** ${runUrl}`,
               '',
-              'O job agendado de geração de transações recorrentes falhou via SSM.',
-              'Verifique os logs do workflow, o diagnóstico do comando SSM e o estado da stack de produção.',
+              'O job diário de materialização de ocorrências recorrentes falhou via SSM.',
               '',
               '### Ações sugeridas',
               '- Revisar logs da execução no link acima',
-              '- Revisar o artifact `recurrence-ssm-diagnostics`',
-              '- Verificar o estado de `docker compose` e do container `web` na instância PROD',
-              '- Executar o helper `scripts/aws_recurrence_job.py` manualmente se necessário',
+              '- Verificar o artifact `daily-recurrence-diagnostics`',
+              '- Executar `flask recurrence reconcile --dry-run` no container para validar',
               '',
               '_Issue criada automaticamente pelo GitHub Actions._',
             ].join('\n');
             const commentBody = [
-              'Nova falha detectada no recurrence job.',
+              'Nova falha detectada no daily recurrence reconcile job.',
               '',
               `- Data: ${now}`,
               `- Run: ${runUrl}`,
@@ -118,7 +122,6 @@ jobs:
             const matchingIssue = search.data.items.find(
               (item) => item.title === title,
             );
-
             if (matchingIssue) {
               if (matchingIssue.state === 'closed') {
                 await github.rest.issues.update({
@@ -136,7 +139,6 @@ jobs:
               });
               return;
             }
-
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -15,6 +15,7 @@ from sqlalchemy.pool import NullPool
 from app.cli.ai_insights_cli import register_ai_insights_commands
 from app.cli.features import features as features_cli_group
 from app.cli.openapi_export import openapi_export_command
+from app.cli.recurrence_cli import register_recurrence_commands
 from app.cli.worker_cli import worker_cli_group
 from app.controllers.account import account_bp
 from app.controllers.admin.ai_insights import admin_ai_insights_bp
@@ -303,6 +304,7 @@ def create_app(*, enable_http_runtime: bool = True) -> Flask:
     register_billing_webhooks_commands(app)
     register_reminders_commands(app)
     register_ai_insights_commands(app)
+    register_recurrence_commands(app)
     register_email_dlq_commands(app)
     app.cli.add_command(features_cli_group, "features")
     app.cli.add_command(openapi_export_command)

--- a/app/cli/recurrence_cli.py
+++ b/app/cli/recurrence_cli.py
@@ -1,0 +1,69 @@
+"""Flask CLI command for the scheduled recurrence reconciliation job (#1422).
+
+Command:
+  flask recurrence reconcile  — materialise missing future occurrences for every
+                                recurring transaction template.
+
+This is the periodic counterpart to the inline materialisation that runs on
+transaction create (``RecurrenceService.materialize_for_template``). It exists
+to:
+  * back-fill templates created before inline materialisation shipped (#1388),
+  * extend the rolling 2-year horizon as time passes, and
+  * recover occurrences whose best-effort inline materialisation failed.
+
+Intended to run daily (see ``.github/workflows/daily-recurrence.yml``). The
+underlying service is idempotent: occurrences that already exist are skipped.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import date
+
+import click
+from flask import Flask
+from flask.cli import AppGroup
+
+from app.services.recurrence_service import RecurrenceService
+
+recurrence_cli = AppGroup("recurrence", help="Recurring-transaction batch commands.")
+
+
+@recurrence_cli.command("reconcile")
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Report how many recurring templates exist without creating occurrences.",
+)
+def reconcile(dry_run: bool) -> None:
+    """Materialise missing future occurrences for all recurring templates.
+
+    Idempotent and safe to run repeatedly. Exits non-zero only on an
+    unhandled error so the scheduler can surface failures.
+    """
+    if dry_run:
+        from app.models.transaction import Transaction
+
+        count = Transaction.query.filter_by(is_recurring=True, deleted=False).count()
+        click.echo(f"recurrence reconcile dry-run: {count} recurring template(s).")
+        sys.exit(0)
+
+    try:
+        created = RecurrenceService.generate_missing_occurrences(
+            reference_date=date.today()
+        )
+    except Exception as exc:  # noqa: BLE001
+        click.echo(f"recurrence reconcile ERROR: {exc}", err=True)
+        sys.exit(1)
+
+    click.echo(f"recurrence reconcile: created={created}")
+    sys.exit(0)
+
+
+def register_recurrence_commands(app: Flask) -> None:
+    """Register the ``recurrence`` CLI group on *app*."""
+    app.cli.add_command(recurrence_cli)
+
+
+__all__ = ["recurrence_cli", "register_recurrence_commands"]

--- a/scripts/aws_recurrence_job.py
+++ b/scripts/aws_recurrence_job.py
@@ -282,13 +282,15 @@ for SERVICE in db redis; do
   fi
 done
 
-docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" run --rm --no-deps \\
-  --entrypoint sh web -lc \\
-  'cd /app \\
-   && HOME=/tmp python -m pip install --user --no-cache-dir \\
-        --disable-pip-version-check --quiet -r requirements.txt \\
-   && PYTHONPATH=/tmp/.local/lib/python3.13/site-packages:/app \\
-        python scripts/generate_recurring_transactions.py'
+# Exec the CLI inside the *running* web container (same fix as #1249 for the AI
+# insights job). `docker compose run web ...` is broken here: the prod ENTRYPOINT
+# always `exec gunicorn` and ignores the command, so the one-off container never
+# exits and the SSM wait times out; worse, the `run` path loaded .env.prod which
+# still pointed at the decommissioned RDS. `exec` reuses the live container with
+# the correct DATABASE_URL and exits cleanly when reconciliation finishes.
+docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" exec -T \\
+  -e FLASK_APP=run.py \\
+  web flask recurrence reconcile
 """
 
 

--- a/tests/test_aws_recurrence_job.py
+++ b/tests/test_aws_recurrence_job.py
@@ -10,7 +10,7 @@ import pytest
 from scripts import aws_recurrence_job
 
 
-def test_build_script_runs_recurrence_inside_web_service() -> None:
+def test_build_script_execs_reconcile_inside_running_web_container() -> None:
     script = aws_recurrence_job._build_script(env_name="prod")
     expected_up = (
         'docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d db redis'
@@ -19,11 +19,12 @@ def test_build_script_runs_recurrence_inside_web_service() -> None:
     assert 'ENV_FILE=".env.prod"' in script
     assert 'COMPOSE_FILE="docker-compose.prod.yml"' in script
     assert expected_up in script
-    assert "HOME=/tmp python -m pip install --user --no-cache-dir" in script
-    assert "PYTHONPATH=/tmp/.local/lib/python3.13/site-packages:/app" in script
-    assert "python scripts/generate_recurring_transactions.py" in script
-    assert "run --rm --no-deps \\" in script
-    assert "--entrypoint sh web -lc \\" in script
+    # Issue #1422: exec the flask command in the running container (mirrors the
+    # #1249 fix for AI insights) — no one-off `run` container, no runtime pip.
+    assert "exec -T \\" in script
+    assert "web flask recurrence reconcile" in script
+    assert "run --rm --no-deps" not in script
+    assert "pip install" not in script
 
 
 def test_wait_raises_ssm_command_failed_with_report(

--- a/tests/test_recurrence_cli.py
+++ b/tests/test_recurrence_cli.py
@@ -1,0 +1,118 @@
+"""Tests for the 'flask recurrence reconcile' CLI command (#1422)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+
+def _invoke(app, *args: str) -> object:
+    from app.cli.recurrence_cli import recurrence_cli
+
+    runner = CliRunner()
+    with app.app_context():
+        return runner.invoke(recurrence_cli, ["reconcile", *args])
+
+
+def _create_recurring_template(app) -> uuid.UUID:
+    """Persist a monthly recurring template with a future end date."""
+    with app.app_context():
+        from app.extensions.database import db
+        from app.models.account import Account
+        from app.models.transaction import (
+            RecurrenceUnit,
+            Transaction,
+            TransactionType,
+        )
+        from app.models.user import User
+
+        uid = uuid.uuid4()
+        db.session.add(
+            User(
+                id=uid,
+                name="Rec User",
+                email=f"rec-{uid.hex[:8]}@test.com",
+                password="x",
+            )
+        )
+        db.session.add(Account(user_id=uid, name="Main", account_type="checking"))
+        today = date.today()
+        db.session.add(
+            Transaction(
+                user_id=uid,
+                title="Financiamento carro",
+                amount=1200,
+                type=TransactionType.EXPENSE,
+                due_date=today,
+                start_date=today,
+                end_date=date(today.year + 2, today.month, 1),
+                is_recurring=True,
+                is_installment=False,
+                recurrence_interval=1,
+                recurrence_unit=RecurrenceUnit.month,
+            )
+        )
+        db.session.commit()
+        return uid
+
+
+class TestRecurrenceReconcileCLI:
+    def test_reconcile_reports_created_count(self, app) -> None:
+        with patch(
+            "app.cli.recurrence_cli.RecurrenceService.generate_missing_occurrences",
+            return_value=7,
+        ) as mock_gen:
+            result = _invoke(app)
+
+        assert result.exit_code == 0
+        assert "created=7" in result.output
+        assert mock_gen.call_count == 1
+
+    def test_reconcile_materialises_future_occurrences(self, app) -> None:
+        """End-to-end: a recurring template gains future-month occurrences."""
+        user_id = _create_recurring_template(app)
+
+        result = _invoke(app)
+        assert result.exit_code == 0
+
+        with app.app_context():
+            from app.models.transaction import Transaction
+
+            rows = Transaction.query.filter_by(
+                user_id=user_id, is_recurring=True, deleted=False
+            ).all()
+            # Template + materialised future occurrences (rolling horizon).
+            assert len(rows) > 1
+            months = {(r.due_date.year, r.due_date.month) for r in rows}
+            today = date.today()
+            next_month = (
+                (today.year + 1, 1)
+                if today.month == 12
+                else (today.year, today.month + 1)
+            )
+            assert next_month in months
+
+    def test_dry_run_counts_without_creating(self, app) -> None:
+        _create_recurring_template(app)
+        with patch(
+            "app.cli.recurrence_cli.RecurrenceService.generate_missing_occurrences"
+        ) as mock_gen:
+            result = _invoke(app, "--dry-run")
+
+        assert result.exit_code == 0
+        assert "dry-run" in result.output
+        assert "1 recurring template" in result.output
+        mock_gen.assert_not_called()
+
+    def test_reconcile_exits_nonzero_on_error(self, app) -> None:
+        with patch(
+            "app.cli.recurrence_cli.RecurrenceService.generate_missing_occurrences",
+            side_effect=RuntimeError("db down"),
+        ):
+            result = _invoke(app)
+
+        assert result.exit_code == 1
+        assert "ERROR" in result.output


### PR DESCRIPTION
## Problema
Transações recorrentes não aparecem em meses futuros (ex.: financiamento 50x). 

## Causa-raiz
A materialização de ocorrências (#1388) só roda **inline no create**. A reconciliação periódica (`generate_missing_occurrences`) que faz backfill de templates antigos + estende o horizonte rolante **não rodava**: o `recurrence-job.yml` teve o `schedule` desabilitado ("superseded by the Flask-command-based implementation") mas esse comando nunca existiu, e o job usava o padrão quebrado `compose run` contra `.env.prod` (RDS descomissionado) → execuções falhando.

## Solução
- **Novo `flask recurrence reconcile`** (espelha `flask ai ...`) chamando `RecurrenceService.generate_missing_occurrences`; registrado no app factory; idempotente; `--dry-run`.
- `aws_recurrence_job.py` agora faz `docker compose exec -T web flask recurrence reconcile` no container **rodando** (mesma correção #1249 do job de IA: DATABASE_URL correto, sai limpo) em vez de `run` + pip em runtime.
- **Novo `daily-recurrence.yml`** (cron `0 4 * * *`) substitui o `recurrence-job.yml` desabilitado/falhando.
- Testes: CLI reconcile/dry-run/erro + e2e materializando o próximo mês; assertions do build-script atualizadas.

## Pós-deploy (runbook)
Rodar uma vez em prod para backfill das recorrentes existentes:
```
python scripts/aws_recurrence_job.py --profile "" --region us-east-1 --env prod --instance-id <PROD_INSTANCE_ID>
# ou, no container: flask recurrence reconcile
```

Closes #1422