### PR TITLE
fix(migrations): rec1 idempotente — destrava deploy prod (exit 36)

### DIFF
--- a/migrations/versions/rec1_recurrence_cadence.py
+++ b/migrations/versions/rec1_recurrence_cadence.py
@@ -31,25 +31,40 @@ branch_labels = None
 depends_on = None
 
 
+def _transactions_columns() -> set[str]:
+    """Return the existing column names on the ``transactions`` table."""
+    inspector = sa.inspect(op.get_context().connection)
+    return {col["name"] for col in inspector.get_columns("transactions")}
+
+
 def upgrade() -> None:
-    op.add_column(
-        "transactions",
-        sa.Column(
-            "recurrence_interval",
-            sa.Integer(),
-            nullable=False,
-            server_default="1",
-        ),
-    )
-    op.add_column(
-        "transactions",
-        sa.Column(
-            "recurrence_unit",
-            sa.String(length=10),
-            nullable=False,
-            server_default="month",
-        ),
-    )
+    # Idempotent: during the 2026-05-31 prod incident these columns were added
+    # manually as a hotfix without stamping this revision, so a later
+    # `flask db upgrade` failed with "column already exists" (deploy exit 36).
+    # Guard each add so the migration reconciles that drift safely while still
+    # creating the columns on a fresh database.
+    existing = _transactions_columns()
+
+    if "recurrence_interval" not in existing:
+        op.add_column(
+            "transactions",
+            sa.Column(
+                "recurrence_interval",
+                sa.Integer(),
+                nullable=False,
+                server_default="1",
+            ),
+        )
+    if "recurrence_unit" not in existing:
+        op.add_column(
+            "transactions",
+            sa.Column(
+                "recurrence_unit",
+                sa.String(length=10),
+                nullable=False,
+                server_default="month",
+            ),
+        )
 
 
 def downgrade() -> None:


### PR DESCRIPTION
## Problema
Deploy prod falha em `flask db upgrade` (exit 36, rollback). `rec1_recurrence_cadence` adicionava `recurrence_interval`/`recurrence_unit` sem guarda; no incidente de 2026-05-31 essas colunas foram criadas manualmente (hotfix) sem stampar a revisão → upgrade quebra com 'column already exists'. (PRs #1421/#1423 não têm migration — bloqueio pré-existente.)

## Fix
`rec1` agora só adiciona cada coluna se não existir (inspector via `op.get_context().connection`). Reconcilia o drift de prod e continua criando as colunas em DB novo.

## Verificação
- `scripts/test_migrations_local.sh`: upgrade ✓ / downgrade ✓ / single-head ✓
- `scripts/check_migration_patterns.py` ✓ · ruff ✓ · mypy ✓ (pre-commit completo passou)

## Pós-merge
Re-rodar deploy prod (workflow_dispatch env=prod); depois o backfill de recorrência (#1422): `flask recurrence reconcile` no container.

Closes #1425