### PR TITLE
fix(migrations): cons1/cc1/cc2/fb1/sq1 idempotentes — destrava deploy prod

### DIFF
--- a/migrations/versions/cc1_credit_card_extension.py
+++ b/migrations/versions/cc1_credit_card_extension.py
@@ -25,41 +25,51 @@ branch_labels = None
 depends_on = None
 
 
+def _credit_cards_columns() -> set[str]:
+    """Return existing column names on the ``credit_cards`` table."""
+    inspector = sa.inspect(op.get_context().connection)
+    return {col["name"] for col in inspector.get_columns("credit_cards")}
+
+
 def upgrade() -> None:
-    op.add_column(
-        "credit_cards",
-        sa.Column("bank", sa.String(80), nullable=True),
-    )
-    op.add_column(
-        "credit_cards",
-        sa.Column("description", sa.String(300), nullable=True),
-    )
-    op.add_column(
-        "credit_cards",
-        sa.Column("benefits", sa.Text(), nullable=True),
-    )
-    op.add_column(
-        "credit_cards",
-        sa.Column("validity_date", sa.Date(), nullable=True),
-    )
-    op.add_column(
-        "credit_cards",
-        sa.Column(
-            "created_at",
-            sa.DateTime(),
-            nullable=False,
-            server_default=sa.func.now(),
-        ),
-    )
-    op.add_column(
-        "credit_cards",
-        sa.Column(
-            "updated_at",
-            sa.DateTime(),
-            nullable=False,
-            server_default=sa.func.now(),
-        ),
-    )
+    # Idempotent: prod carries drift from partial/hotfix runs, so guard each
+    # add so a re-run of `flask db upgrade` reconciles instead of failing with
+    # "column already exists". All columns are nullable or have a server_default,
+    # so adding them on a fresh DB stays downtime-safe.
+    existing = _credit_cards_columns()
+
+    if "bank" not in existing:
+        op.add_column("credit_cards", sa.Column("bank", sa.String(80), nullable=True))
+    if "description" not in existing:
+        op.add_column(
+            "credit_cards", sa.Column("description", sa.String(300), nullable=True)
+        )
+    if "benefits" not in existing:
+        op.add_column("credit_cards", sa.Column("benefits", sa.Text(), nullable=True))
+    if "validity_date" not in existing:
+        op.add_column(
+            "credit_cards", sa.Column("validity_date", sa.Date(), nullable=True)
+        )
+    if "created_at" not in existing:
+        op.add_column(
+            "credit_cards",
+            sa.Column(
+                "created_at",
+                sa.DateTime(),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+        )
+    if "updated_at" not in existing:
+        op.add_column(
+            "credit_cards",
+            sa.Column(
+                "updated_at",
+                sa.DateTime(),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+        )
 
 
 def downgrade() -> None:

--- a/migrations/versions/cc2_ai_insight_metadata.py
+++ b/migrations/versions/cc2_ai_insight_metadata.py
@@ -29,11 +29,19 @@ branch_labels = None
 depends_on = None
 
 
+def _ai_insights_columns() -> set[str]:
+    """Return existing column names on the ``ai_insights`` table."""
+    inspector = sa.inspect(op.get_context().connection)
+    return {col["name"] for col in inspector.get_columns("ai_insights")}
+
+
 def upgrade() -> None:
-    op.add_column(
-        "ai_insights",
-        sa.Column("metadata_json", sa.Text(), nullable=True),
-    )
+    # Idempotent: skip if the column already exists (prod drift reconciliation).
+    if "metadata_json" not in _ai_insights_columns():
+        op.add_column(
+            "ai_insights",
+            sa.Column("metadata_json", sa.Text(), nullable=True),
+        )
 
 
 def downgrade() -> None:

--- a/migrations/versions/cons1_add_consents.py
+++ b/migrations/versions/cons1_add_consents.py
@@ -32,7 +32,19 @@ def _quoted_in_clause(values: tuple[str, ...]) -> str:
     return "(" + ", ".join(f"'{v}'" for v in values) + ")"
 
 
+def _has_table(name: str) -> bool:
+    """Return True when *name* already exists in the database."""
+    inspector = sa.inspect(op.get_context().connection)
+    return name in inspector.get_table_names()
+
+
 def upgrade() -> None:
+    # Idempotent: prod drift may already carry this table from a partial run;
+    # skip so `flask db upgrade` reconciles instead of failing with
+    # "relation already exists". On a fresh DB the table+indexes are created.
+    if _has_table("consents"):
+        return
+
     op.create_table(
         "consents",
         sa.Column(

--- a/migrations/versions/fb1_ai_insight_feedback.py
+++ b/migrations/versions/fb1_ai_insight_feedback.py
@@ -23,7 +23,17 @@ branch_labels = None
 depends_on = None
 
 
+def _has_table(name: str) -> bool:
+    """Return True when *name* already exists in the database."""
+    inspector = sa.inspect(op.get_context().connection)
+    return name in inspector.get_table_names()
+
+
 def upgrade() -> None:
+    # Idempotent: skip if prod drift already created this table (reconciliation).
+    if _has_table("ai_insight_feedback"):
+        return
+
     op.create_table(
         "ai_insight_feedback",
         sa.Column("id", UUID(as_uuid=True), primary_key=True),

--- a/migrations/versions/sq1_simulation_quota_usage.py
+++ b/migrations/versions/sq1_simulation_quota_usage.py
@@ -18,7 +18,17 @@ branch_labels = None
 depends_on = None
 
 
+def _has_table(name: str) -> bool:
+    """Return True when *name* already exists in the database."""
+    inspector = sa.inspect(op.get_context().connection)
+    return name in inspector.get_table_names()
+
+
 def upgrade() -> None:
+    # Idempotent: skip if prod drift already created this table (reconciliation).
+    if _has_table("simulation_quota_usage"):
+        return
+
     op.create_table(
         "simulation_quota_usage",
         sa.Column("id", UUID(as_uuid=True), nullable=False),


### PR DESCRIPTION
## Problema
Após #1426 (rec1 idempotente) o deploy prod **ainda** falha em `flask db upgrade` (exit 36) — o drift de prod abrange mais migrations. Objetos (colunas/tabelas) já existem em prod por runs parciais/hotfix sem stamp → `add_column`/`create_table` quebram com 'already exists'.

## Fix
Guardas idempotentes via inspector (`op.get_context().connection`):
- `cc1`: adiciona colunas de `credit_cards` só se faltarem
- `cc2`: adiciona `ai_insights.metadata_json` só se faltar
- `cons1`/`fb1`/`sq1`: pula `create_table` (+índices) se a tabela já existir

## Verificação
- `scripts/test_migrations_local.sh`: upgrade ✓ / downgrade ✓ / single-head ✓
- `check_migration_patterns.py` ✓ · ruff ✓ · mypy ✓ (pre-commit completo passou)

## Pós-merge
Re-rodar deploy prod; depois backfill de recorrência (#1422).

Closes #1427