### PR TITLE
fix(deploy): tornar erro do alembic visível no exit 36 + endurecer $WEB_CID

### DIFF
--- a/scripts/aws_deploy_i6.py
+++ b/scripts/aws_deploy_i6.py
@@ -914,20 +914,24 @@ dump_compose_diagnostics() {{
   docker compose --env-file "$ENV_FILE" -f docker-compose.prod.yml ps || true
   WEB_CID="$(
     docker compose --env-file "$ENV_FILE" -f docker-compose.prod.yml \\
-      ps -q web || true
+      ps -q web | head -n1 || true
   )"
   if [ -n "$WEB_CID" ]; then
     echo "[i6] web container id: $WEB_CID"
     docker inspect --format '{{{{json .State}}}}' "$WEB_CID" || true
   fi
+  # web logs are the most useful for a failed migration; keep them. Cap the
+  # reverse-proxy access log to a few lines — at --tail=200 it floods the SSM
+  # 24KB output window and pushes the real alembic error out of the captured
+  # tail (root cause of the unreadable exit-36 deploys, 2026-06-03).
   docker compose --env-file "$ENV_FILE" -f docker-compose.prod.yml \\
-    logs --tail=200 web || true
+    logs --tail=120 web || true
   docker compose --env-file "$ENV_FILE" -f docker-compose.prod.yml \\
-    logs --tail=200 reverse-proxy || true
+    logs --tail=15 reverse-proxy || true
   docker compose --env-file "$ENV_FILE" -f docker-compose.prod.yml \\
-    logs --tail=120 db || true
+    logs --tail=40 db || true
   docker compose --env-file "$ENV_FILE" -f docker-compose.prod.yml \\
-    logs --tail=120 redis || true
+    logs --tail=20 redis || true
 }}
 
 # Phase 1: Ensure infrastructure services are up (never force-recreate if healthy).
@@ -1004,9 +1008,12 @@ if ! docker compose --env-file "$ENV_FILE" -f docker-compose.prod.yml \\
   exit 31
 fi
 
+# head -n1: defensive against a transient multi-id (old + new during recreate,
+# or a leftover auraxis-web-run-* zombie). A multi-line $WEB_CID makes the later
+# `docker exec "$WEB_CID" ...` target an invalid id and fail opaquely (exit 36).
 WEB_CID="$(
   docker compose --env-file "$ENV_FILE" -f docker-compose.prod.yml \\
-    ps -q web || true
+    ps -q web | head -n1 || true
 )"
 if [ -z "$WEB_CID" ]; then
   echo "[i6] web container id not found after compose up"
@@ -1068,11 +1075,16 @@ if [ "$MODE" = "deploy" ]; then
   echo "[i6] applying pending alembic migrations (flask db upgrade) in $WEB_CID..."
   ALEMBIC_STDERR="$(mktemp)"
   if ! docker exec "$WEB_CID" flask db upgrade 2>"$ALEMBIC_STDERR"; then
-    echo "[i6] alembic upgrade failed"
-    echo "[i6] stderr:"
-    cat "$ALEMBIC_STDERR" || true
-    rm -f "$ALEMBIC_STDERR" || true
+    echo "[i6] alembic upgrade failed (web_cid=$WEB_CID)"
+    # Dump compose diagnostics FIRST, then the alembic stderr LAST: the SSM
+    # output is capped (~24KB, keeps the tail), so whatever prints last is what
+    # survives. Printing the real error last makes exit-36 deploys diagnosable
+    # from the CI log (2026-06-03 incident: the error was being truncated away).
     dump_compose_diagnostics
+    echo "[i6] ===== alembic upgrade stderr (real failure cause) ====="
+    cat "$ALEMBIC_STDERR" || true
+    echo "[i6] ===== end alembic upgrade stderr ====="
+    rm -f "$ALEMBIC_STDERR" || true
     exit 36
   fi
   rm -f "$ALEMBIC_STDERR" || true
@@ -1089,9 +1101,11 @@ if [ "$MODE" = "deploy" ]; then
     | awk '{{print $1}}' | tail -1)"
   echo "[i6] alembic current=$CUR_REV heads=$HEAD_REV"
   if [ -z "$CUR_REV" ] || [ -z "$HEAD_REV" ] || [ "$CUR_REV" != "$HEAD_REV" ]; then
-    echo "[i6] alembic drift detected after upgrade: current='$CUR_REV' \
-heads='$HEAD_REV' — aborting deploy before traffic flips."
     dump_compose_diagnostics
+    # Print the drift verdict LAST so it survives the SSM output tail cap.
+    echo "[i6] ===== alembic drift detected after upgrade ====="
+    echo "[i6] current='$CUR_REV' heads='$HEAD_REV' — aborting before traffic flips."
+    echo "[i6] ===== end alembic drift ====="
     exit 37
   fi
 fi

--- a/tests/test_aws_deploy_i6.py
+++ b/tests/test_aws_deploy_i6.py
@@ -190,6 +190,37 @@ def test_build_script_aborts_when_alembic_upgrade_fails() -> None:
     assert "alembic upgrade failed" in script
 
 
+def test_build_script_prints_alembic_stderr_last_for_ssm_tail_visibility() -> None:
+    """#1429: the real alembic error must print AFTER dump_compose_diagnostics.
+
+    SSM caps command output (~24KB, keeps the tail). With diagnostics (incl.
+    reverse-proxy access logs) printed last, the actual alembic stderr was
+    truncated away — exit-36 deploys were undiagnosable (2026-06-03). The fix
+    prints the stderr last and caps the reverse-proxy flood.
+    """
+    script = aws_deploy_i6._build_script(
+        env_name="prod",
+        aws_region="us-east-1",
+        git_ref="origin/master",
+        mode="deploy",
+    )
+    start = script.find("alembic upgrade failed")
+    end = script.find("end alembic upgrade stderr")
+    fail_block = script[start:end]
+    diag_idx = fail_block.find("dump_compose_diagnostics")
+    stderr_idx = fail_block.find('cat "$ALEMBIC_STDERR"')
+    assert start != -1 and end != -1
+    assert diag_idx != -1 and stderr_idx != -1
+    assert diag_idx < stderr_idx, (
+        "alembic stderr must be printed AFTER dump_compose_diagnostics so it "
+        "survives the SSM output tail cap"
+    )
+    # reverse-proxy access logs capped low so they don't flood the tail window.
+    assert "logs --tail=15 reverse-proxy" in script
+    # WEB_CID resolution is defensive against a transient multi-id / zombie.
+    assert "ps -q web | head -n1" in script
+
+
 def test_build_script_asserts_alembic_current_equals_heads_after_upgrade() -> None:
     """AC: post-deploy assertion that flask db current == flask db heads."""
     script = aws_deploy_i6._build_script(


### PR DESCRIPTION
## Problema
Deploys prod falhavam em `docker exec $WEB_CID flask db upgrade` (exit 36) com o **erro real do alembic truncado**: o SSM corta o output (~24KB, mantém o tail) e o `dump_compose_diagnostics` despejava 200 linhas de access log do reverse-proxy **depois** do erro, empurrando-o pra fora da janela. Resultado: 3 deploys ilegíveis em 2026-06-03 (prod foi deployado manualmente via SSM, sha 061811d).

## Fix
- Imprimir `$ALEMBIC_STDERR` **por último** (após `dump_compose_diagnostics`), com marcadores, nos caminhos de falha do upgrade (36) e do drift gate (37) → o erro sobrevive ao tail do SSM.
- `dump_compose_diagnostics`: reduzir reverse-proxy `--tail` 200→15 (access logs são ruído) + trim db/redis; web mantém 120.
- Endurecer `$WEB_CID` com `head -n1` (captura + diagnostics) — multi-id transitório (overlap do recreate / zumbi `auraxis-web-run-*`) fazia o `docker exec` mirar id inválido e falhar opaco.

## Verificação
- `pytest tests/test_aws_deploy_i6.py` (23 ✓), incl. novo teste de ordem stderr/diagnostics + tail + head -n1.
- ruff ✓ · mypy ✓ (pre-commit completo passou).

## Aceite
Próximo deploy prod: verde, ou — se falhar — erro do alembic **legível** no log do CI.

Closes #1429