### PR TITLE
fix(deploy): pinar FLASK_APP=run.py no docker exec das migrations

### DIFF
--- a/scripts/aws_deploy_i6.py
+++ b/scripts/aws_deploy_i6.py
@@ -1074,7 +1074,13 @@ fi
 if [ "$MODE" = "deploy" ]; then
   echo "[i6] applying pending alembic migrations (flask db upgrade) in $WEB_CID..."
   ALEMBIC_STDERR="$(mktemp)"
-  if ! docker exec "$WEB_CID" flask db upgrade 2>"$ALEMBIC_STDERR"; then
+  # Pin FLASK_APP=run.py: the running container leaves FLASK_APP empty, so a bare
+  # `flask` relies on app auto-discovery, which can resolve to a context whose
+  # migrations script_location is wrong → "Can't locate revision ..." (exit 36)
+  # even when image + DB are correct. Setting it explicitly makes app→migrations
+  # resolution deterministic (matches run.py:create_app).
+  if ! docker exec -e FLASK_APP=run.py "$WEB_CID" \\
+    flask db upgrade 2>"$ALEMBIC_STDERR"; then
     echo "[i6] alembic upgrade failed (web_cid=$WEB_CID)"
     # Dump compose diagnostics FIRST, then the alembic stderr LAST: the SSM
     # output is capped (~24KB, keeps the tail), so whatever prints last is what
@@ -1095,9 +1101,9 @@ if [ "$MODE" = "deploy" ]; then
   # this fails the deploy has applied migrations but the resulting tip
   # diverges from the code's expected head — indicates alembic config drift
   # or a manual edit to the live DB. Abort before flipping traffic.
-  CUR_REV="$(docker exec "$WEB_CID" flask db current 2>/dev/null \\
+  CUR_REV="$(docker exec -e FLASK_APP=run.py "$WEB_CID" flask db current 2>/dev/null \\
     | awk '{{print $1}}' | tail -1)"
-  HEAD_REV="$(docker exec "$WEB_CID" flask db heads 2>/dev/null \\
+  HEAD_REV="$(docker exec -e FLASK_APP=run.py "$WEB_CID" flask db heads 2>/dev/null \\
     | awk '{{print $1}}' | tail -1)"
   echo "[i6] alembic current=$CUR_REV heads=$HEAD_REV"
   if [ -z "$CUR_REV" ] || [ -z "$HEAD_REV" ] || [ "$CUR_REV" != "$HEAD_REV" ]; then

--- a/tests/test_aws_deploy_i6.py
+++ b/tests/test_aws_deploy_i6.py
@@ -219,6 +219,10 @@ def test_build_script_prints_alembic_stderr_last_for_ssm_tail_visibility() -> No
     assert "logs --tail=15 reverse-proxy" in script
     # WEB_CID resolution is defensive against a transient multi-id / zombie.
     assert "ps -q web | head -n1" in script
+    # #1431: flask db exec must pin FLASK_APP so app→migrations resolution is
+    # deterministic (a bare `flask` relies on auto-discovery → "Can't locate
+    # revision" exit-36 flakes). All three db commands must set it.
+    assert script.count("docker exec -e FLASK_APP=run.py") >= 3
 
 
 def test_build_script_asserts_alembic_current_equals_heads_after_upgrade() -> None:
@@ -249,10 +253,13 @@ def test_build_script_migration_targets_pinned_web_container() -> None:
         git_ref="origin/master",
         mode="deploy",
     )
-    # Upgrade + drift queries must use the captured container id.
-    assert 'docker exec "$WEB_CID" flask db upgrade' in script
-    assert 'docker exec "$WEB_CID" flask db current' in script
-    assert 'docker exec "$WEB_CID" flask db heads' in script
+    # Upgrade + drift queries must use the captured container id (#1431 pins
+    # FLASK_APP for deterministic app→migrations resolution).
+    assert 'docker exec -e FLASK_APP=run.py "$WEB_CID" flask db current' in script
+    assert 'docker exec -e FLASK_APP=run.py "$WEB_CID" flask db heads' in script
+    # upgrade spans two lines; assert the pinned-container prefix and the command.
+    assert 'docker exec -e FLASK_APP=run.py "$WEB_CID"' in script
+    assert "flask db upgrade" in script
     # And must NOT re-resolve the service by name for these commands.
     assert "exec -T web flask db upgrade" not in script
     assert "exec -T web flask db current" not in script


### PR DESCRIPTION
## Problema
Deploys falhavam com `Can't locate revision 'sq1_simulation_quota_usage'` (exit 36) mesmo com imagem/DB/host/compose **verificados corretos** (recreate manual + exec da mesma imagem = RC=0). O container roda com `FLASK_APP` vazio → o `docker exec $WEB_CID flask db upgrade` (bare) usa auto-descoberta da app, que resolve um contexto cujo `script_location` do alembic diverge → erro espúrio.

## Fix
`-e FLASK_APP=run.py` nos 3 `docker exec ... flask db {upgrade,current,heads}` → resolução determinística (igual ao runtime e aos meus testes manuais que passaram).

## Verificação
- `pytest tests/test_aws_deploy_i6.py` (23 ✓), ruff/mypy ✓.
- Vou validar com deploy prod real após merge.

Closes #1431 · segue #1430 (visibilidade) / #1429