### PR TITLE
fix(deploy): reset para origin/<branch> (causa-raiz do exit 36)

### DIFF
--- a/scripts/aws_deploy_i6.py
+++ b/scripts/aws_deploy_i6.py
@@ -573,6 +573,25 @@ if ! sudo -u "$OP_USER" bash -lc \\
   exit 15
 fi
 SYNC_REF="${{GIT_REF:-origin/master}}"
+# Normalize a bare branch name (e.g. "master") to its remote-tracking ref
+# ("origin/master"). `git fetch` advances origin/<branch> but NOT the local
+# <branch>, so `git reset --hard <local-branch>` can land on a stale commit.
+# Root cause of the exit-36 deploys (2026-06-03): the host's local `master` was
+# 481 commits behind, so the reset restored an ancient docker-compose.prod.yml
+# pinning `image: auraxis-web` (a local build without recent migrations) instead
+# of `${{WEB_IMAGE:-ghcr...}}` — the migration step then hit "Can't locate
+# revision". A sha or tag is used as-is.
+case "$SYNC_REF" in
+  origin/* | refs/* | HEAD) : ;;
+  *)
+    if sudo -u "$OP_USER" bash -lc \\
+      "cd '$REPO' && git show-ref --verify -q 'refs/remotes/origin/$SYNC_REF'"
+    then
+      echo "[i6] normalizing branch ref '$SYNC_REF' -> 'origin/$SYNC_REF'"
+      SYNC_REF="origin/$SYNC_REF"
+    fi
+    ;;
+esac
 sudo -u "$OP_USER" bash -lc \\
   "cd '$REPO' \\
     && git -c core.sshCommand='$GIT_SSH_COMMAND_AURAXIS' fetch --all --prune \\
@@ -1073,13 +1092,7 @@ fi
 # (forward-only migrations is the policy).
 if [ "$MODE" = "deploy" ]; then
   echo "[i6] applying pending alembic migrations (flask db upgrade) in $WEB_CID..."
-  # Temporary diagnostics (#1429/#1431): the recreated container vs. its image
-  # vs. the alembic state, to root-cause the intermittent "Can't locate
-  # revision" exit-36 that resists isolation. Cheap; prints one block.
-  echo "[i6][diag] WEB_CID=$WEB_CID image=$(docker inspect --format '{{{{.Config.Image}}}}' "$WEB_CID" 2>&1)"
-  echo "[i6][diag] migrations_head_files=$(docker exec "$WEB_CID" sh -c 'ls /app/migrations/versions/ 2>&1 | grep -cE "sq1|fb1|rec1"' 2>&1)"
-  echo "[i6][diag] script_heads=$(docker exec -e FLASK_APP=run.py "$WEB_CID" flask db heads 2>&1 | tr '\\n' ' ')"
-  echo "[i6][diag] db_current=$(docker exec -e FLASK_APP=run.py "$WEB_CID" flask db current 2>&1 | tr '\\n' ' ')"
+  echo "[i6] migrate target image=$(docker inspect --format '{{{{.Config.Image}}}}' "$WEB_CID" 2>&1)"
   ALEMBIC_STDERR="$(mktemp)"
   # Pin FLASK_APP=run.py: the running container leaves FLASK_APP empty, so a bare
   # `flask` relies on app auto-discovery, which can resolve to a context whose

--- a/tests/test_aws_deploy_i6.py
+++ b/tests/test_aws_deploy_i6.py
@@ -225,6 +225,26 @@ def test_build_script_prints_alembic_stderr_last_for_ssm_tail_visibility() -> No
     assert script.count("docker exec -e FLASK_APP=run.py") >= 3
 
 
+def test_build_script_normalizes_bare_branch_ref_to_origin() -> None:
+    """#1434: a bare branch ref must be reset to its remote-tracking ref.
+
+    `git fetch` advances origin/<branch> but not the local <branch>, so resetting
+    to a local branch can land on a stale commit (root cause of the exit-36
+    deploys: stale compose pinned an old local image without recent migrations).
+    """
+    script = aws_deploy_i6._build_script(
+        env_name="prod",
+        aws_region="us-east-1",
+        git_ref="master",
+        mode="deploy",
+    )
+    # The normalization branch must exist and map bare names to origin/<name>.
+    assert "refs/remotes/origin/$SYNC_REF" in script
+    assert 'SYNC_REF="origin/$SYNC_REF"' in script
+    # And the reset must target the (normalized) SYNC_REF, not a hardcoded local.
+    assert "git reset --hard '$SYNC_REF'" in script
+
+
 def test_build_script_asserts_alembic_current_equals_heads_after_upgrade() -> None:
     """AC: post-deploy assertion that flask db current == flask db heads."""
     script = aws_deploy_i6._build_script(


### PR DESCRIPTION
## Causa-raiz (provada via SSM)
O deploy fazia `git reset --hard $SYNC_REF` com `SYNC_REF` = input `git_ref` (ex.: `master` = branch **local**). `git fetch` avança `origin/master` mas **não** a branch local — que no host estava **481 commits atrás** (d0cb02d). O reset restaurava um `docker-compose.prod.yml` antigo com `image: auraxis-web` (build local sem migrations recentes) em vez de `${WEB_IMAGE:-ghcr...}` → `compose up` recriava o web com imagem velha sem `sq1` → `Can't locate revision sq1` (exit 36).

## Fix
- Normalizar branch nu para o ref remoto `origin/<branch>`; sha/tag/origin-prefixados ficam como estão.
- Trocar o diagnóstico temporário do #1433 por uma linha `migrate target image=` (que teria pego isso na hora).

## Prova (SSM)
reset para `master` local → image=auraxis-web, sq1 ausente; reset para `origin/master` → imagem ghcr, sq1 presente, current=sq1 (head), healthz ok.

## Testes
`pytest tests/test_aws_deploy_i6.py` 24 ✓ (novo teste da normalização). ruff/mypy ✓.

Closes #1434 (causa-raiz definitiva) · #1429 #1430 #1431 #1432 #1433