### PR TITLE
fix(cors): allow X-CSRF-TOKEN so reload restores session (#1436)

### DIFF
--- a/app/middleware/cors.py
+++ b/app/middleware/cors.py
@@ -38,9 +38,13 @@ def _build_cors_policy_from_env() -> CorsPolicy:
         "CORS_ALLOWED_METHODS",
         "GET,POST,PUT,PATCH,DELETE,OPTIONS",
     ).strip()
+    # X-CSRF-TOKEN is required for the SEC-AUD-03 double-submit refresh flow:
+    # the browser preflights POST /auth/refresh with this header whenever
+    # AURAXIS_CSRF_ENFORCE=true, so omitting it blocks session restore on every
+    # hard reload (#1436).
     allowed_headers = os.getenv(
         "CORS_ALLOWED_HEADERS",
-        "Authorization,Content-Type,X-API-Contract,Idempotency-Key",
+        "Authorization,Content-Type,X-API-Contract,Idempotency-Key,X-CSRF-TOKEN",
     ).strip()
     return CorsPolicy(
         allowed_origins=_parse_allowed_origins(os.getenv("CORS_ALLOWED_ORIGINS")),

--- a/tests/test_cors_policy.py
+++ b/tests/test_cors_policy.py
@@ -75,12 +75,30 @@ def test_build_cors_policy_from_env_respects_defaults(
     assert policy.allowed_origins == {"https://api.auraxis.com.br"}
     assert policy.allow_credentials is True
     assert policy.allow_methods == "GET,POST,PUT,PATCH,DELETE,OPTIONS"
-    assert (
-        policy.allow_headers
-        == "Authorization,Content-Type,X-API-Contract,Idempotency-Key"
+    assert policy.allow_headers == (
+        "Authorization,Content-Type,X-API-Contract,Idempotency-Key,X-CSRF-TOKEN"
     )
     assert policy.max_age_seconds == 600
     assert policy.is_production is True
+
+
+def test_default_allowed_headers_include_csrf_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """X-CSRF-TOKEN must be in the default CORS allow-list.
+
+    The session-restore flow (SEC-GAP-01) re-mints the access token via
+    POST /auth/refresh, sending the double-submit X-CSRF-TOKEN header
+    (SEC-AUD-03) whenever AURAXIS_CSRF_ENFORCE=true. If the header is absent
+    from Access-Control-Allow-Headers the browser preflight blocks the refresh
+    on every hard reload, logging the user out. Regression guard for #1436.
+    """
+    monkeypatch.delenv("CORS_ALLOWED_HEADERS", raising=False)
+    monkeypatch.setenv("CORS_ALLOWED_ORIGINS", "https://app.auraxis.com.br")
+
+    policy = _build_cors_policy_from_env()
+
+    assert "X-CSRF-TOKEN" in policy.allow_headers.split(",")
 
 
 def test_build_cors_policy_marks_non_production_when_testing_enabled(
@@ -246,6 +264,31 @@ def test_register_cors_handles_preflight_for_allowed_origin(
         response.headers.get("Access-Control-Allow-Origin")
         == "https://frontend.auraxis.com.br"
     )
+
+
+def test_register_cors_preflight_echoes_default_csrf_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end guard for #1436: with default headers, the OPTIONS preflight
+    for an allowed origin must advertise X-CSRF-TOKEN so the browser permits the
+    credentialed POST /auth/refresh that restores the session on reload."""
+    monkeypatch.setenv("FLASK_DEBUG", "true")
+    monkeypatch.setenv("FLASK_TESTING", "true")
+    monkeypatch.setenv("CORS_ALLOWED_ORIGINS", "https://app.auraxis.com.br")
+    monkeypatch.delenv("CORS_ALLOWED_HEADERS", raising=False)
+
+    app = _build_app()
+    register_cors(app)
+    client = app.test_client()
+
+    response = client.options(
+        "/ping",
+        headers={"Origin": "https://app.auraxis.com.br"},
+    )
+
+    assert response.status_code == 204
+    allow_headers = response.headers.get("Access-Control-Allow-Headers", "")
+    assert "X-CSRF-TOKEN" in allow_headers.split(",")
 
 
 def test_register_cors_rejects_invalid_production_policy(


### PR DESCRIPTION
## Problema

Recarregar uma página autenticada na web (pull-to-refresh no celular = reload; F5 no desktop) deslogava o usuário, jogando-o pra `/login`. Confirmado **no desktop também** e **em produção** — não era mobile-specific.

## Root cause (confirmado contra prod)

O access token vive só em memória (SEC-GAP-01); no reload é re-emitido via `POST /auth/refresh` com o header `X-CSRF-TOKEN` (double-submit SEC-AUD-03, `AURAXIS_CSRF_ENFORCE=true` em prod). O preflight CORS de prod respondia:

```
access-control-allow-headers: Authorization,Content-Type,X-API-Contract,Idempotency-Key
```

**Sem `X-CSRF-TOKEN`** → o navegador bloqueia o preflight do refresh → axios lança → `catch {}` silencioso chama `signOut()` → middleware redireciona pra login. Funcionava durante a sessão viva porque as chamadas normais só mandam `Authorization`+`X-API-Contract`.

## Fix

Adiciona `X-CSRF-TOKEN` ao default de `CORS_ALLOWED_HEADERS` em `app/middleware/cors.py`. Prod usa o default (não há override), então o redeploy resolve. O preflight reusa o mesmo handler, então o header passa a constar no `OPTIONS` e nas respostas normais.

## Testes (TDD)

- `test_build_cors_policy_from_env_respects_defaults` atualizado.
- `test_default_allowed_headers_include_csrf_token` (guard dedicado).
- `test_register_cors_preflight_echoes_default_csrf_header` (preflight OPTIONS end-to-end).
- `tests/test_cors_policy.py` — 36 passando; ruff + mypy ok.

## Verificação pós-deploy

```bash
curl -sS -i -X OPTIONS https://api.auraxis.com.br/auth/refresh \
  -H 'Origin: https://app.auraxis.com.br' \
  -H 'Access-Control-Request-Method: POST' \
  -H 'Access-Control-Request-Headers: x-api-contract,x-csrf-token'
# espera: access-control-allow-headers inclui X-CSRF-TOKEN
```
Smoke: logar em app.auraxis.com.br → F5 → sessão persiste.

Closes #1436