### PR TITLE
fix(wallet): expose cost_basis/current_value/change_percent (#1442)

### DIFF
--- a/app/application/services/wallet_application_service.py
+++ b/app/application/services/wallet_application_service.py
@@ -309,5 +309,56 @@ class WalletApplicationService:
             item.pop("value", None)
         return item
 
+    def _safe_market_price(self, ticker: str | None) -> float | None:
+        """Fetches the current market price, swallowing provider failures.
+
+        BRAPI lookups are cached and circuit-broken upstream; here we treat any
+        failure (timeout, circuit open, invalid payload) as "no live quote" so
+        serialization never raises and the position still renders its cost basis.
+
+        @param ticker Asset ticker, or None for non-market assets.
+        @return Current unit price, or None when unavailable.
+        """
+        if not ticker:
+            return None
+        try:
+            price = self._get_market_price(ticker)
+        except Exception:  # noqa: BLE001 — provider errors must not break serialization
+            return None
+        return float(price) if isinstance(price, (int, float, Decimal)) else None
+
+    def _enrich_market_fields(
+        self, item: dict[str, Any], wallet: Wallet
+    ) -> dict[str, Any]:
+        """Adds cost_basis / current_value / change_percent the web table reads.
+
+        For ticker assets cost_basis is the estimated value at registration and
+        current_value is quantity × live quote (falling back to cost_basis when
+        BRAPI has no quote, so a held position never shows R$ 0,00). Non-ticker
+        assets use the stored manual value for both.
+
+        @param item Already-serialized wallet dict.
+        @param wallet Source ORM entity.
+        @return The same dict with market fields populated.
+        """
+        quantity = wallet.quantity or 0
+        if wallet.ticker and quantity:
+            cost_basis = float(wallet.estimated_value_on_create_date or 0)
+            price = self._safe_market_price(wallet.ticker)
+            current_value = price * quantity if price is not None else cost_basis
+        else:
+            cost_basis = float(wallet.value or 0)
+            current_value = cost_basis
+
+        item["cost_basis"] = cost_basis
+        item["current_value"] = current_value
+        item["change_percent"] = (
+            round((current_value - cost_basis) / cost_basis * 100, 2)
+            if cost_basis > 0
+            else None
+        )
+        return item
+
     def _serialize_wallet_item(self, wallet: Wallet) -> dict[str, Any]:
-        return self._strip_contract_fields(self._schema.dump(wallet))
+        item = self._strip_contract_fields(self._schema.dump(wallet))
+        return self._enrich_market_fields(item, wallet)

--- a/tests/test_wallet_market_enrichment.py
+++ b/tests/test_wallet_market_enrichment.py
@@ -1,0 +1,88 @@
+"""Unit tests for wallet serialization market enrichment (#1442).
+
+GET /wallet must expose cost_basis / current_value / change_percent so the
+portfolio table can render Preço médio and Cotação atual instead of R$ 0,00.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from uuid import uuid4
+
+from app.application.services.wallet_application_service import (
+    WalletApplicationService,
+)
+from app.models.wallet import Wallet
+
+
+def _service(price: float | None = None) -> WalletApplicationService:
+    return WalletApplicationService(
+        user_id=uuid4(),
+        calculate_estimated_value=lambda _data: None,
+        get_market_price=lambda _ticker: price,
+    )
+
+
+def _ticker_wallet() -> Wallet:
+    return Wallet(
+        user_id=uuid4(),
+        name="PETROLEO BRASILEIRO S.A. PETROBRAS",
+        ticker="PETR4",
+        quantity=1000,
+        estimated_value_on_create_date=Decimal("44480.00"),
+        asset_class="stock",
+        register_date=date(2016, 3, 30),
+        should_be_on_wallet=True,
+    )
+
+
+def test_ticker_position_uses_live_quote_for_current_value() -> None:
+    item = _service(price=50.0)._serialize_wallet_item(_ticker_wallet())
+
+    assert item["cost_basis"] == 44480.0  # avg = 44.48 (web: cost_basis/quantity)
+    assert item["current_value"] == 50000.0  # 1000 × 50.00
+    assert item["change_percent"] == round((50000.0 - 44480.0) / 44480.0 * 100, 2)
+
+
+def test_ticker_position_falls_back_to_cost_basis_without_quote() -> None:
+    item = _service(price=None)._serialize_wallet_item(_ticker_wallet())
+
+    # No live quote → current_value mirrors cost basis so the row never shows 0.
+    assert item["cost_basis"] == 44480.0
+    assert item["current_value"] == 44480.0
+    assert item["change_percent"] == 0.0
+
+
+def test_provider_failure_is_swallowed() -> None:
+    def _boom(_ticker: str | None) -> float:
+        raise RuntimeError("brapi down")
+
+    service = WalletApplicationService(
+        user_id=uuid4(),
+        calculate_estimated_value=lambda _data: None,
+        get_market_price=_boom,
+    )
+
+    item = service._serialize_wallet_item(_ticker_wallet())
+
+    assert item["current_value"] == 44480.0  # graceful fallback, no exception
+
+
+def test_non_ticker_asset_uses_stored_value() -> None:
+    wallet = Wallet(
+        user_id=uuid4(),
+        name="Tesouro Selic",
+        value=Decimal("1000.00"),
+        ticker=None,
+        asset_class="tesouro",
+        annual_rate=Decimal("0.1100"),
+        register_date=date(2024, 1, 1),
+        should_be_on_wallet=True,
+    )
+
+    item = _service(price=999.0)._serialize_wallet_item(wallet)
+
+    assert item["cost_basis"] == 1000.0
+    assert item["current_value"] == 1000.0  # ignores quote for non-market assets
+    assert item["change_percent"] == 0.0


### PR DESCRIPTION
## Problema
Carteira mostrava Preço médio e Cotação atual = R$ 0,00 para ativos com ticker.

## Causa
GET /wallet só serializava os campos do schema; o web lê `cost_basis`/`current_value` (que não existiam).

## Fix
`_serialize_wallet_item` enriquece com:
- `cost_basis` = `estimated_value_on_create_date` (ticker) ou `value` (não-ticker)
- `current_value` = `quantity × cotação Brapi` (injetada/cacheada), fallback p/ cost_basis sem cotação
- `change_percent`
Falhas do provider são engolidas (nunca quebram a serialização). +4 testes unitários; 22 testes de carteira existentes verdes; ruff/mypy ok.

Closes #1442