### PR TITLE
feat(notifications): web push (VAPID) send + alert dispatch (#1446)

### DIFF
--- a/app/services/alert_service.py
+++ b/app/services/alert_service.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 from uuid import UUID
 
 from app.extensions.database import db
 from app.models.alert import Alert, AlertPreference, AlertStatus
 from app.utils.datetime_utils import utc_now_naive
+
+log = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Trigger matrix
@@ -22,6 +25,55 @@ TRIGGER_MATRIX: dict[str, dict[str, str]] = {
     "due_soon_7_days": {"severity": "info", "category": "due_soon"},
     "due_soon_1_day": {"severity": "warning", "category": "due_soon"},
 }
+
+# Browser-push copy per alert type: (title, body, click-through path).
+_PUSH_COPY: dict[str, tuple[str, str, str]] = {
+    "balance_low": (
+        "Saldo baixo",
+        "Seu saldo está baixo. Confira sua carteira.",
+        "/dashboard",
+    ),
+    "goal_deadline": ("Meta chegando", "Uma meta está perto do prazo.", "/goals"),
+    "suspicious_transaction": (
+        "Transação suspeita",
+        "Detectamos uma transação fora do padrão.",
+        "/transactions",
+    ),
+    "subscription_expiring": (
+        "Assinatura expirando",
+        "Sua assinatura está perto de expirar.",
+        "/subscription",
+    ),
+    "due_soon_7_days": (
+        "Vencimento em 7 dias",
+        "Você tem uma conta vencendo em breve.",
+        "/transactions",
+    ),
+    "due_soon_1_day": (
+        "Vence amanhã",
+        "Você tem uma conta vencendo amanhã.",
+        "/transactions",
+    ),
+}
+
+
+def _dispatch_web_push(user_id: UUID, alert_type: str) -> None:
+    """Best-effort browser push for a dispatched alert. Never raises."""
+    copy = _PUSH_COPY.get(alert_type)
+    if copy is None:
+        return
+    title, body, url = copy
+    try:
+        from app.services.web_push_service import send_web_push
+
+        send_web_push(user_id, title=title, body=body, url=url, tag=alert_type)
+    except Exception as exc:  # noqa: BLE001 — push must never break alert creation
+        log.warning(
+            "alert.web_push_failed user_id=%s type=%s error=%s",
+            user_id,
+            alert_type,
+            exc,
+        )
 
 
 class AlertServiceError(Exception):
@@ -104,6 +156,7 @@ def dispatch_alert(
     )
     db.session.add(alert)
     db.session.commit()
+    _dispatch_web_push(user_id, alert_type)
     return alert
 
 

--- a/app/services/web_push_service.py
+++ b/app/services/web_push_service.py
@@ -1,0 +1,123 @@
+"""Web Push (VAPID) dispatch service (#1446).
+
+Sends browser push notifications to a user's registered ``web_push``
+subscriptions using the VAPID protocol (pywebpush). It is a no-op when VAPID
+keys are not configured, so the application runs normally without push enabled.
+
+Companion to ``analysis_ready_notification_service`` (Expo/mobile push); this
+module owns the browser/PWA channel.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import cast
+from uuid import UUID
+
+from flask import current_app
+from pywebpush import WebPushException, webpush
+
+from app.extensions.database import db
+from app.models.push_subscription import PushSubscription, PushTransport
+
+log = logging.getLogger(__name__)
+
+# Push endpoints answer 404/410 once the browser subscription is gone — prune
+# those so a dead device never blocks future sends.
+_GONE_STATUSES = frozenset({404, 410})
+_MAX_BODY_CHARS = 240
+
+
+def _status_of(exc: WebPushException) -> int | None:
+    response = getattr(exc, "response", None)
+    return getattr(response, "status_code", None)
+
+
+def send_web_push(
+    user_id: UUID,
+    *,
+    title: str,
+    body: str,
+    url: str = "/dashboard",
+    tag: str = "auraxis",
+) -> int:
+    """Send a Web Push notification to every web_push subscription of *user_id*.
+
+    No-op (returns 0) when VAPID is not configured. Individual delivery
+    failures are swallowed so one dead endpoint never blocks the rest; gone
+    subscriptions (404/410) are deleted.
+
+    Args:
+        user_id: Recipient user.
+        title: Notification title.
+        body: Notification body (truncated to a safe length).
+        url: Relative path opened when the user clicks the notification.
+        tag: Notification tag used to coalesce duplicates.
+
+    Returns:
+        Number of subscriptions the push was accepted by.
+    """
+    private_key = str(current_app.config.get("VAPID_PRIVATE_KEY") or "")
+    public_key = str(current_app.config.get("VAPID_PUBLIC_KEY") or "")
+    if not private_key or not public_key:
+        log.debug("web_push.skipped reason=vapid_not_configured user_id=%s", user_id)
+        return 0
+
+    subject = str(
+        current_app.config.get("VAPID_SUBJECT") or "mailto:suporte@auraxis.com.br"
+    )
+    subscriptions = cast(
+        "list[PushSubscription]",
+        PushSubscription.query.filter_by(
+            user_id=user_id,
+            transport=PushTransport.web_push,
+        ).all(),
+    )
+    if not subscriptions:
+        return 0
+
+    payload = json.dumps(
+        {"title": title, "body": body[:_MAX_BODY_CHARS], "url": url, "tag": tag}
+    )
+    sent = 0
+    stale: list[PushSubscription] = []
+    for sub in subscriptions:
+        try:
+            webpush(
+                subscription_info={
+                    "endpoint": str(sub.endpoint),
+                    "keys": dict(sub.keys or {}),
+                },
+                data=payload,
+                vapid_private_key=private_key,
+                vapid_claims={"sub": subject},
+                timeout=10,
+            )
+            sent += 1
+        except WebPushException as exc:
+            status = _status_of(exc)
+            if status in _GONE_STATUSES:
+                stale.append(sub)
+                log.info(
+                    "web_push.subscription_gone user_id=%s status=%s", user_id, status
+                )
+            else:
+                log.warning(
+                    "web_push.failed user_id=%s status=%s error=%s",
+                    user_id,
+                    status,
+                    str(exc)[:120],
+                )
+        except Exception as exc:  # noqa: BLE001 — never let push break the caller
+            log.warning("web_push.error user_id=%s error=%s", user_id, exc)
+
+    if stale:
+        for sub in stale:
+            db.session.delete(sub)
+        db.session.commit()
+
+    return sent
+
+
+__all__ = ["send_web_push"]

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -146,6 +146,14 @@ class Config:
     # Brapi config
     BRAPI_KEY = os.getenv("BRAPI_KEY")
 
+    # Web Push (VAPID). Both keys are base64url-encoded (raw EC point for the
+    # public/applicationServerKey, raw 32-byte private value for the private
+    # key). When unset, web-push dispatch is a no-op so the app runs normally.
+    # Generate with: py_vapid / `npx web-push generate-vapid-keys`.
+    VAPID_PUBLIC_KEY = os.getenv("VAPID_PUBLIC_KEY", "")
+    VAPID_PRIVATE_KEY = os.getenv("VAPID_PRIVATE_KEY", "")
+    VAPID_SUBJECT = os.getenv("VAPID_SUBJECT", "mailto:suporte@auraxis.com.br")
+
     # Cloudflare Turnstile CAPTCHA
     # Set CLOUDFLARE_TURNSTILE_SECRET_KEY in the environment to enable verification.
     # When the key is empty the service falls back to allow-all (dev/test mode).

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,3 +50,7 @@ types-python-dateutil==2.9.0.20260508
 types-requests==2.33.0.20260518
 reportlab==4.5.1
 boto3==1.43.19
+pywebpush==2.0.3
+py-vapid==1.9.4
+http-ece==1.2.1
+cryptography==48.0.0

--- a/tests/test_web_push_service.py
+++ b/tests/test_web_push_service.py
@@ -1,0 +1,126 @@
+"""Tests for the Web Push (VAPID) dispatch service (#1446)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+from pywebpush import WebPushException
+
+from app.extensions.database import db
+from app.models.push_subscription import PushSubscription, PushTransport
+from app.services import web_push_service
+
+
+def _web_sub(
+    user_id, endpoint: str = "https://fcm.googleapis.com/x"
+) -> PushSubscription:
+    return PushSubscription(
+        user_id=user_id,
+        transport=PushTransport.web_push,
+        endpoint=endpoint,
+        keys={"p256dh": "p", "auth": "a"},
+    )
+
+
+def _configure_vapid(app: object) -> None:
+    app.config["VAPID_PUBLIC_KEY"] = "pub"  # type: ignore[attr-defined]
+    app.config["VAPID_PRIVATE_KEY"] = "priv"  # type: ignore[attr-defined]
+    app.config["VAPID_SUBJECT"] = "mailto:suporte@auraxis.com.br"  # type: ignore[attr-defined]
+
+
+def test_noop_when_vapid_not_configured(
+    app: object, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with app.app_context():  # type: ignore[attr-defined]
+        app.config["VAPID_PUBLIC_KEY"] = ""  # type: ignore[attr-defined]
+        app.config["VAPID_PRIVATE_KEY"] = ""  # type: ignore[attr-defined]
+        user_id = uuid4()
+        db.session.add(_web_sub(user_id))
+        db.session.commit()
+
+        called = {"n": 0}
+        monkeypatch.setattr(
+            web_push_service,
+            "webpush",
+            lambda **_: called.__setitem__("n", called["n"] + 1),
+        )
+
+        assert web_push_service.send_web_push(user_id, title="t", body="b") == 0
+        assert called["n"] == 0
+
+
+def test_sends_to_each_web_push_subscription(
+    app: object, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with app.app_context():  # type: ignore[attr-defined]
+        _configure_vapid(app)
+        user_id = uuid4()
+        db.session.add_all(
+            [_web_sub(user_id, "https://a"), _web_sub(user_id, "https://b")]
+        )
+        # An Expo subscription must be ignored by the web-push channel.
+        db.session.add(
+            PushSubscription(
+                user_id=user_id,
+                transport=PushTransport.expo,
+                endpoint="ExponentPushToken[x]",
+            )
+        )
+        db.session.commit()
+
+        seen: list[str] = []
+        monkeypatch.setattr(
+            web_push_service,
+            "webpush",
+            lambda **kwargs: seen.append(kwargs["subscription_info"]["endpoint"]),
+        )
+
+        sent = web_push_service.send_web_push(
+            user_id, title="Vence amanhã", body="conta", url="/transactions"
+        )
+
+        assert sent == 2
+        assert sorted(seen) == ["https://a", "https://b"]
+
+
+def test_prunes_gone_subscriptions(
+    app: object, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with app.app_context():  # type: ignore[attr-defined]
+        _configure_vapid(app)
+        user_id = uuid4()
+        db.session.add(_web_sub(user_id, "https://gone"))
+        db.session.commit()
+
+        def _raise_gone(**_: object) -> None:
+            raise WebPushException("gone", response=SimpleNamespace(status_code=410))
+
+        monkeypatch.setattr(web_push_service, "webpush", _raise_gone)
+
+        sent = web_push_service.send_web_push(user_id, title="t", body="b")
+
+        assert sent == 0
+        remaining = PushSubscription.query.filter_by(user_id=user_id).count()
+        assert remaining == 0  # the 410 endpoint was pruned
+
+
+def test_dispatch_alert_triggers_web_push(
+    app: object, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.services import alert_service
+
+    with app.app_context():  # type: ignore[attr-defined]
+        user_id = uuid4()
+        calls: list[tuple] = []
+        monkeypatch.setattr(
+            "app.services.web_push_service.send_web_push",
+            lambda uid, **kw: calls.append((uid, kw.get("title"), kw.get("url"))) or 1,
+        )
+
+        alert_service.dispatch_alert(user_id, "due_soon_1_day")
+
+        assert len(calls) == 1
+        assert calls[0][0] == user_id
+        assert calls[0][2] == "/transactions"


### PR DESCRIPTION
Backend do push web (#1446). web_push_service.send_web_push assina via pywebpush/VAPID, envia pra cada subscription web_push, remove endpoints mortos (404/410), e é no-op sem VAPID configurado. Config VAPID_PUBLIC/PRIVATE_KEY/SUBJECT. alert_service.dispatch_alert dispara push best-effort (copy por tipo) após persistir o alerta. pywebpush pinado. 4 testes. Ativação: VAPID env em prod + handlers no SW (web PR). Refs #1446