### PR TITLE
fix(graphql): pin graphql-core + regen introspection bundle; fix TruffleHog base on push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,11 @@ jobs:
         uses: trufflesecurity/trufflehog@main
         with:
           path: ./
-          base: ${{ github.event.repository.default_branch }}
+          # On pull_request, diff against the PR base; on push (incl. to the
+          # default branch) diff against the previous tip. Using the default
+          # branch as base on a push to master makes BASE == HEAD, which the
+          # action rejects with "BASE and HEAD are the same" (exit 1).
+          base: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
           head: HEAD
           extra_args: --only-verified
 

--- a/graphql.introspection.json
+++ b/graphql.introspection.json
@@ -80,7 +80,8 @@
             "FIELD_DEFINITION",
             "ARGUMENT_DEFINITION",
             "INPUT_FIELD_DEFINITION",
-            "ENUM_VALUE"
+            "ENUM_VALUE",
+            "DIRECTIVE_DEFINITION"
           ],
           "name": "deprecated"
         },
@@ -121,9 +122,11 @@
         }
       ],
       "mutationType": {
+        "kind": "OBJECT",
         "name": "Mutation"
       },
       "queryType": {
+        "kind": "OBJECT",
         "name": "Query"
       },
       "subscriptionType": null,
@@ -17035,7 +17038,24 @@
               }
             },
             {
-              "args": [],
+              "args": [
+                {
+                  "defaultValue": "false",
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "includeDeprecated",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Boolean",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
               "deprecationReason": null,
               "description": "A list of all directives supported by this server.",
               "isDeprecated": false,
@@ -17746,6 +17766,34 @@
                   }
                 }
               }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "isDeprecated",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "deprecationReason",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             }
           ],
           "inputFields": null,
@@ -17871,6 +17919,12 @@
               "description": "Location adjacent to an input object field definition.",
               "isDeprecated": false,
               "name": "INPUT_FIELD_DEFINITION"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to a directive definition.",
+              "isDeprecated": false,
+              "name": "DIRECTIVE_DEFINITION"
             }
           ],
           "fields": null,

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ flask-marshmallow==1.4.0
 Flask-Migrate==4.1.0
 Flask-SQLAlchemy==3.1.1
 graphene==3.4.3
+graphql-core==3.2.11
 greenlet==3.5.1
 iniconfig==2.3.0
 itsdangerous==2.2.0


### PR DESCRIPTION
## Problema
`master` está vermelho. Duas causas independentes:

1. **`test_committed_graphql_docs_match_runtime_bundle` falha** — `graphql-core` é transitivo (via graphene `<3.3,>=3.1`) e **não estava pinado**. O CI instala a última versão (3.2.11), que emite introspection mais rica (`DIRECTIVE_DEFINITION`, args `includeDeprecated`) do que a versão que gerou o bundle committado → drift.
2. **Secret Scan (TruffleHog) falha em push p/ master** — `base=default_branch` + `head=HEAD` resulta em BASE==HEAD, que a action rejeita (exit 1).

## Fix
- Pin `graphql-core==3.2.11` em `requirements.txt` + regenerar `graphql.introspection.json` (`scripts/export_graphql_docs.py --source runtime`).
- TruffleHog: `base` = PR base sha em pull_request, `github.event.before` em push.

Verificado local: `pytest tests/test_graphql_docs_export.py` verde; `export_graphql_docs.py --check` exit 0.

Closes #1450