### PR TITLE
chore(deps): coordinated OpenTelemetry bump 1.42.1 / 0.63b1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 alembic==1.16.2
 apispec==6.10.0
-opentelemetry-api==1.41.1
-opentelemetry-sdk==1.41.1
-opentelemetry-exporter-otlp-proto-http==1.41.1
-opentelemetry-instrumentation-flask==0.62b1
-opentelemetry-instrumentation-sqlalchemy==0.62b1
+opentelemetry-api==1.42.1
+opentelemetry-sdk==1.42.1
+opentelemetry-exporter-otlp-proto-http==1.42.1
+opentelemetry-instrumentation-flask==0.63b1
+opentelemetry-instrumentation-sqlalchemy==0.63b1
 prometheus-client==0.25.0
 blinker==1.9.0
 click==8.4.1


### PR DESCRIPTION
Consolida os 3 PRs Dependabot que conflitavam por bump isolado. Bump casado: api/sdk/exporter `1.42.1` + instrumentation-flask/sqlalchemy `0.63b1`.

Verificado local: install sem conflitos; `import app.extensions.otel` OK; 79 testes de observability/otel verdes.

Closes #1452
Supersedes #1360, #1361, #1362