### PR TITLE
feat(ai): cache spending-patterns via cron + read-only endpoint (sem cota)

### DIFF
--- a/.github/workflows/spending-patterns-job.yml
+++ b/.github/workflows/spending-patterns-job.yml
@@ -1,0 +1,151 @@
+name: Spending Patterns Job
+
+on:
+  schedule:
+    # Every day at 06:00 UTC = 03:00 BRT
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry-run only (print eligible users, no v2 calls)"
+        type: boolean
+        default: false
+
+concurrency:
+  group: spending-patterns-job
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+  issues: write
+
+jobs:
+  spending-patterns:
+    name: Generate cached Radar de Gastos (Premium users)
+    runs-on: ubuntu-latest
+    environment: prod
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate required variables
+        run: |
+          [ -n "${AWS_REGION:-}" ] || { echo "Missing var AWS_REGION"; exit 1; }
+          [ -n "${AWS_ROLE_ARN_PROD:-}" ] || { echo "Missing var AWS_ROLE_ARN_PROD"; exit 1; }
+          [ -n "${AURAXIS_PROD_INSTANCE_ID:-}" ] || { echo "Missing var AURAXIS_PROD_INSTANCE_ID"; exit 1; }
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+          AWS_ROLE_ARN_PROD: ${{ vars.AWS_ROLE_ARN_PROD }}
+          AURAXIS_PROD_INSTANCE_ID: ${{ vars.AURAXIS_PROD_INSTANCE_ID }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN_PROD }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Run spending-patterns job via SSM
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+          PROD_INSTANCE_ID: ${{ vars.AURAXIS_PROD_INSTANCE_ID }}
+          DIAGNOSTICS_PATH: ${{ runner.temp }}/spending-patterns-diagnostics.json
+        run: |
+          python scripts/aws_ai_insights_job.py \
+            --mode spending-patterns \
+            --profile "" \
+            --region "${AWS_REGION}" \
+            --env prod \
+            --instance-id "${PROD_INSTANCE_ID}" \
+            --diagnostics-json-path "${DIAGNOSTICS_PATH}"
+
+      - name: Upload diagnostics artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: spending-patterns-diagnostics
+          path: ${{ runner.temp }}/spending-patterns-diagnostics.json
+          if-no-files-found: ignore
+
+      - name: Notify failure via GitHub Issue
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const now = new Date().toISOString();
+            const title = '🚨 [spending-patterns] Falha na geração do radar de gastos';
+            const issueBody = [
+              '## Spending Patterns Job falhou',
+              '',
+              `**Última falha:** ${now}`,
+              `**Run:** ${runUrl}`,
+              '',
+              'O job diário de geração do radar de gastos (cache) falhou via SSM.',
+              'Verifique os logs do workflow e o artifact de diagnóstico.',
+              '',
+              '### Ações sugeridas',
+              '- Revisar logs da execução no link acima',
+              '- Verificar o artifact `spending-patterns-diagnostics`',
+              '- Confirmar que `AURAXIS_API_V2_BASE_URL` está no SSM Parameter Store (`/auraxis/prod/`) e que a v2 está no ar',
+              '- Executar `flask ai spending-patterns --dry-run` no container para validar a listagem de usuários',
+              '',
+              '_Issue criada automaticamente pelo GitHub Actions._',
+            ].join('\n');
+            const commentBody = [
+              'Nova falha detectada no spending-patterns job.',
+              '',
+              `- Data: ${now}`,
+              `- Run: ${runUrl}`,
+            ].join('\n');
+            const query = [
+              `repo:${context.repo.owner}/${context.repo.repo}`,
+              'is:issue',
+              'in:title',
+              `"${title}"`,
+            ].join(' ');
+            const search = await github.rest.search.issuesAndPullRequests({
+              q: query,
+              per_page: 10,
+            });
+            const matchingIssue = search.data.items.find(
+              (item) => item.title === title,
+            );
+            if (matchingIssue) {
+              if (matchingIssue.state === 'closed') {
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: matchingIssue.number,
+                  state: 'open',
+                });
+              }
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: matchingIssue.number,
+                body: commentBody,
+              });
+              return;
+            }
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body: issueBody,
+              labels: ['bug', 'ops'],
+            });

--- a/api-tests/postman/auraxis.postman_collection.json
+++ b/api-tests/postman/auraxis.postman_collection.json
@@ -1,7 +1,7 @@
 {
   "info": {
     "name": "Auraxis API",
-    "description": "Auto-generated from openapi.json (83 paths). Do not edit manually — regenerate with: npm run postman:build",
+    "description": "Auto-generated from openapi.json (84 paths). Do not edit manually — regenerate with: npm run postman:build",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "item": [
@@ -4536,7 +4536,7 @@
       "name": "11 - AI Advisory",
       "item": [
         {
-          "name": "GET — Briefing semanal com IA (Premium)",
+          "name": "GET — Briefing semanal com IA (Premium, somente leitura)",
           "request": {
             "method": "GET",
             "header": [
@@ -4741,6 +4741,47 @@
                 "exec": [
                   "pm.test('AI spending insights — expected 200 or 403 or 429', function () {",
                   "  pm.expect(pm.response.code).to.be.oneOf([200, 403, 429]);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "GET — Radar de gastos em cache (Premium, somente leitura)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/ai/insights/spending-patterns/latest",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "ai",
+                "insights",
+                "spending-patterns",
+                "latest"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Radar de gastos em cache (Premium, somente leitura) — status 200', function () {",
+                  "  pm.response.to.have.status(200);",
                   "});"
                 ],
                 "type": "text/javascript"

--- a/app/cli/ai_insights_cli.py
+++ b/app/cli/ai_insights_cli.py
@@ -262,6 +262,76 @@ def _run_batch(
     return 0
 
 
+def _run_spending_patterns_batch(
+    *,
+    user_ids: list[uuid.UUID],
+    anchor_date: date,
+    dry_run: bool,
+) -> int:
+    """Generate + cache spending-patterns for Premium users (no email).
+
+    Unlike :func:`_run_batch`, this calls the v2 detector server-to-server with no
+    AI quota and never sends a notification — the cached radar is read on demand by
+    the dashboard. Idempotent per day via the ``spending_patterns`` insight_type.
+
+    Returns:
+        Exit code: 0 if at least one user succeeded/skipped (or no users);
+        1 if every processed user failed.
+    """
+    label = "spending_patterns"
+    if not user_ids:
+        click.echo(f"{label}: processed=0 failures=0 skipped=0 cost_usd=0.000000")
+        return 0
+
+    if dry_run:
+        click.echo(
+            f"{label} dry-run: {len(user_ids)} eligible Premium users — no calls made."
+        )
+        return 0
+
+    from app.services.ai_spending_patterns_service import (
+        generate_and_persist_spending_patterns,
+    )
+
+    period_label = anchor_date.isoformat()
+    processed = 0
+    failures = 0
+    skipped = 0
+    total_cost = 0.0
+
+    for user_id in user_ids:
+        if _already_has_insight(
+            user_id=user_id,
+            insight_type=InsightType.spending_patterns,
+            period_label=period_label,
+        ):
+            skipped += 1
+            continue
+
+        try:
+            result = generate_and_persist_spending_patterns(
+                user_id, anchor_date=anchor_date
+            )
+            if result.get("persisted"):
+                total_cost += float(result.get("cost_usd", 0))
+                processed += 1
+            else:
+                # v2 returned no actionable patterns; nothing cached.
+                skipped += 1
+        except Exception as exc:  # noqa: BLE001
+            click.echo(f"{label} ERROR user={user_id} error={exc}", err=True)
+            failures += 1
+
+    click.echo(
+        f"{label}: processed={processed} failures={failures} "
+        f"skipped={skipped} cost_usd={total_cost:.6f} period={period_label}"
+    )
+
+    if failures > 0 and processed == 0 and skipped == 0:
+        return 1
+    return 0
+
+
 # ---------------------------------------------------------------------------
 # weekly-insights command
 # ---------------------------------------------------------------------------
@@ -329,6 +399,30 @@ def monthly_insights(month: str | None, dry_run: bool) -> None:
     )
     if not dry_run:
         click.echo(f"monthly_insights month={month_label}")
+    sys.exit(exit_code)
+
+
+@ai_insights_cli.command("spending-patterns")
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Print eligible user count without calling v2.",
+)
+def spending_patterns(dry_run: bool) -> None:
+    """Generate + cache the Radar de Gastos for all Premium users.
+
+    Intended to run daily (06:00 UTC). Calls auraxis-api-v2 server-to-server with
+    no AI quota and persists the result so the dashboard can read it quota-free.
+    Idempotent: skips users who already have a cached radar for today. Sends NO
+    email — the radar is read on demand, not pushed.
+    """
+    user_ids = _premium_user_ids()
+    exit_code = _run_spending_patterns_batch(
+        user_ids=user_ids,
+        anchor_date=_brt_today(),
+        dry_run=dry_run,
+    )
     sys.exit(exit_code)
 
 

--- a/app/controllers/ai/routes.py
+++ b/app/controllers/ai/routes.py
@@ -12,6 +12,7 @@ from .resources import (
     AISpendingInsightsResource,
     AIWeeklySummaryResource,
 )
+from .spending_patterns_latest import AISpendingPatternsLatestResource
 from .spending_patterns_proxy import AISpendingPatternsProxyResource
 
 _ROUTES_REGISTERED = False
@@ -36,6 +37,13 @@ def register_ai_routes() -> None:
         "/insights/spending-patterns",
         view_func=AISpendingPatternsProxyResource.as_view("ai_spending_patterns"),
         methods=["POST"],
+    )
+    ai_bp.add_url_rule(
+        "/insights/spending-patterns/latest",
+        view_func=AISpendingPatternsLatestResource.as_view(
+            "ai_spending_patterns_latest"
+        ),
+        methods=["GET"],
     )
     ai_bp.add_url_rule(
         "/goals/<goal_id>/projection",

--- a/app/controllers/ai/spending_patterns_latest.py
+++ b/app/controllers/ai/spending_patterns_latest.py
@@ -1,0 +1,115 @@
+"""Read-only cached Radar de Gastos: GET /ai/insights/spending-patterns/latest (#1455).
+
+Returns the latest cron-generated spending-patterns analysis WITHOUT calling the
+LLM and WITHOUT consuming the per-user AI daily quota. Generation happens only in
+the scheduled batch (``flask ai spending-patterns``). When no analysis has been
+generated yet, ``patterns`` is empty and ``generated_at`` is ``null`` so the UI can
+render a "will be generated" state.
+
+Mirrors :class:`AIWeeklySummaryResource` (jwt only, no ``@ai_daily_limit``).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from flask import Response
+from flask_apispec.views import MethodResource
+
+from app.auth import current_user_id
+from app.controllers.response_contract import (
+    compat_error_response,
+    compat_success_response,
+)
+from app.controllers.transaction.utils import _guard_revoked_token
+from app.docs.openapi_helpers import json_error_response, json_success_response
+from app.services.ai_spending_patterns_service import read_latest_spending_patterns
+from app.services.entitlement_service import has_entitlement
+from app.utils.typed_decorators import typed_doc as doc
+from app.utils.typed_decorators import typed_jwt_required as jwt_required
+
+log = logging.getLogger(__name__)
+
+_ENTITLEMENT_KEY = "advanced_simulations"
+
+
+class AISpendingPatternsLatestResource(MethodResource):
+    """GET /ai/insights/spending-patterns/latest — cached radar (read-only)."""
+
+    @doc(
+        summary="Radar de gastos em cache (Premium, somente leitura)",
+        description=(
+            "Retorna o último radar de gastos compulsivos já gerado pelo cron "
+            "diário. NÃO chama o LLM nem consome a cota diária de IA — a geração "
+            "ocorre exclusivamente no batch agendado. Quando ainda não há análise, "
+            "'patterns' vem vazio e 'generated_at' é null. Requer entitlement "
+            "'advanced_simulations'."
+        ),
+        tags=["AI Advisory"],
+        security=[{"BearerAuth": []}],
+        responses={
+            200: json_success_response(
+                description="Radar de gastos em cache retornado com sucesso",
+                message="Radar de gastos retornado com sucesso",
+                data_example={
+                    "patterns": [{"description": "Cafés", "severity": "high"}],
+                    "generated_at": "2026-06-05T06:00:00",
+                    "period_label": "2026-06-05",
+                    "model": "v2-spending-patterns",
+                    "cost_usd": 0.000042,
+                    "tokens_used": 280,
+                },
+            ),
+            401: json_error_response(
+                description="Não autenticado",
+                message="Token inválido",
+                error_code="UNAUTHORIZED",
+                status_code=401,
+            ),
+            403: json_error_response(
+                description="Entitlement insuficiente",
+                message="Recurso exclusivo para assinantes Premium.",
+                error_code="ENTITLEMENT_REQUIRED",
+                status_code=403,
+            ),
+            500: json_error_response(
+                description="Erro interno",
+                message="Erro ao ler o radar de gastos",
+                error_code="INTERNAL_ERROR",
+                status_code=500,
+            ),
+        },
+    )
+    @jwt_required()
+    def get(self) -> Response:
+        token_error = _guard_revoked_token()
+        if token_error is not None:
+            return token_error
+
+        user_id = current_user_id()
+
+        if not has_entitlement(user_id, _ENTITLEMENT_KEY):
+            return compat_error_response(
+                legacy_payload={"error": "Recurso exclusivo para assinantes Premium."},
+                status_code=403,
+                message="Recurso exclusivo para assinantes Premium.",
+                error_code="ENTITLEMENT_REQUIRED",
+            )
+
+        try:
+            result = read_latest_spending_patterns(user_id)
+        except Exception:
+            log.exception("spending_patterns_latest.read_failed")
+            return compat_error_response(
+                legacy_payload={"error": "Erro interno"},
+                status_code=500,
+                message="Erro ao ler o radar de gastos",
+                error_code="INTERNAL_ERROR",
+            )
+
+        return compat_success_response(
+            legacy_payload=result,
+            status_code=200,
+            message="Radar de gastos retornado com sucesso",
+            data=result,
+        )

--- a/app/controllers/ai/spending_patterns_proxy.py
+++ b/app/controllers/ai/spending_patterns_proxy.py
@@ -13,9 +13,8 @@ obscurely, so clients can degrade gracefully.
 from __future__ import annotations
 
 import logging
-import os
 
-import requests
+import requests  # re-exported for test monkeypatching of the underlying client
 from flask import Response, request
 from flask_apispec.views import MethodResource
 
@@ -26,6 +25,10 @@ from app.controllers.response_contract import (
 )
 from app.controllers.transaction.utils import _guard_revoked_token
 from app.middleware.ai_rate_limit import ai_daily_limit
+from app.services.ai_spending_patterns_service import (
+    SpendingPatternsUpstreamError,
+    call_v2_spending_patterns,
+)
 from app.services.entitlement_service import has_entitlement
 from app.utils.typed_decorators import typed_doc as doc
 from app.utils.typed_decorators import typed_jwt_required as jwt_required
@@ -33,13 +36,11 @@ from app.utils.typed_decorators import typed_jwt_required as jwt_required
 log = logging.getLogger(__name__)
 
 _ENTITLEMENT_KEY = "advanced_simulations"
-_V2_PATH = "/v2/insights/spending-patterns"
-_TIMEOUT_SECONDS = 30.0
 
-
-def _v2_base_url() -> str:
-    """Return the configured v2 base URL without a trailing slash (or empty)."""
-    return os.getenv("AURAXIS_API_V2_BASE_URL", "").rstrip("/")
+# Keep ``requests`` referenced so existing tests that monkeypatch
+# ``spending_patterns_proxy.requests.post`` continue to patch the same client
+# object used by the service layer.
+assert requests is not None
 
 
 class AISpendingPatternsProxyResource(MethodResource):
@@ -72,44 +73,27 @@ class AISpendingPatternsProxyResource(MethodResource):
                 error_code="ENTITLEMENT_REQUIRED",
             )
 
-        base_url = _v2_base_url()
-        if not base_url:
-            log.warning("spending_patterns_proxy.v2_unconfigured")
-            return compat_error_response(
-                legacy_payload={"error": "Serviço de insights indisponível."},
-                status_code=503,
-                message="Serviço de insights temporariamente indisponível.",
-                error_code="SERVICE_UNAVAILABLE",
-            )
-
         body = request.get_json(silent=True) or {}
         auth_header = request.headers.get("Authorization", "")
 
         try:
-            upstream = requests.post(
-                f"{base_url}{_V2_PATH}",
-                json=body,
-                headers={"Authorization": auth_header},
-                timeout=_TIMEOUT_SECONDS,
+            status_code, payload = call_v2_spending_patterns(
+                transactions=body.get("transactions") or [],
+                period_days=int(body.get("period_days") or 90),
+                auth_header=auth_header,
             )
-        except requests.exceptions.RequestException:
-            log.warning("spending_patterns_proxy.v2_unreachable", exc_info=True)
+        except SpendingPatternsUpstreamError as exc:
             return compat_error_response(
                 legacy_payload={"error": "Serviço de insights indisponível."},
-                status_code=503,
-                message="Serviço de insights temporariamente indisponível.",
+                status_code=exc.status_code,
+                message=str(exc),
                 error_code="SERVICE_UNAVAILABLE",
             )
 
-        try:
-            payload = upstream.json()
-        except ValueError:
-            payload = {}
-
-        if upstream.status_code >= 400:
+        if status_code >= 400:
             return compat_error_response(
                 legacy_payload=payload or {"error": "Falha no serviço de insights."},
-                status_code=upstream.status_code,
+                status_code=status_code,
                 message="Falha ao gerar o radar de gastos.",
                 error_code="UPSTREAM_ERROR",
             )

--- a/app/graphql/docs_catalog.py
+++ b/app/graphql/docs_catalog.py
@@ -852,6 +852,20 @@ GRAPHQL_OPERATION_CATALOG: tuple[GraphQLOperationDoc, ...] = (
         ),
         source_module=QUERY_AI_INSIGHT_MODULE,
     ),
+    # AI Advisory — cached Radar de Gastos (#1455)
+    GraphQLOperationDoc(
+        name="spendingPatternsLatest",
+        operation_type="query",
+        domain="ai_advisory",
+        access="auth_required",
+        summary=(
+            "Retorna o último radar de gastos compulsivos já gerado pelo cron "
+            "diário (somente leitura, sem consumir cota de IA). 'patternsJson' "
+            "traz os padrões serializados; 'generatedAt' é null quando ainda não "
+            "há análise. Paridade com GET /ai/insights/spending-patterns/latest."
+        ),
+        source_module=QUERY_AI_INSIGHT_MODULE,
+    ),
     # AI Advisory — generate (MVP-3 / #1287 #1288)
     GraphQLOperationDoc(
         name="generateAiInsight",

--- a/app/graphql/queries/ai_insight.py
+++ b/app/graphql/queries/ai_insight.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import json
+
 import graphene
 
 from app.extensions.database import db
 from app.graphql.auth import get_current_user_required
 from app.models.ai_insight import AIInsight
+from app.services.ai_spending_patterns_service import read_latest_spending_patterns
 
 
 class AIInsightType(graphene.ObjectType):
@@ -42,12 +45,45 @@ def _to_ai_insight_type(row: AIInsight) -> AIInsightType:
     )
 
 
+class SpendingPatternsLatestType(graphene.ObjectType):
+    """Read-only cached Radar de Gastos (cron-generated, no quota).
+
+    The individual ``patterns`` are forwarded from auraxis-api-v2 and their shape
+    is intentionally not pinned here; they are exposed as a JSON string
+    (``patterns_json``) so the schema stays stable as v2 evolves. ``generated_at``
+    is null when no analysis has been cached yet.
+    """
+
+    patterns_json = graphene.String(required=True)
+    generated_at = graphene.String()
+    period_label = graphene.String()
+    model = graphene.String(required=True)
+    cost_usd = graphene.Float(required=True)
+    tokens_used = graphene.Int(required=True)
+
+
 class AIInsightQueryMixin:
     ai_insight_history = graphene.Field(
         AIInsightHistoryResultType,
         page=graphene.Int(default_value=1),
         per_page=graphene.Int(default_value=20),
     )
+    spending_patterns_latest = graphene.Field(SpendingPatternsLatestType)
+
+    def resolve_spending_patterns_latest(
+        self,
+        _info: graphene.ResolveInfo,
+    ) -> SpendingPatternsLatestType:
+        user = get_current_user_required()
+        result = read_latest_spending_patterns(user.id)
+        return SpendingPatternsLatestType(
+            patterns_json=json.dumps(result.get("patterns") or [], ensure_ascii=False),
+            generated_at=result.get("generated_at"),
+            period_label=result.get("period_label"),
+            model=result.get("model") or "",
+            cost_usd=float(result.get("cost_usd") or 0.0),
+            tokens_used=int(result.get("tokens_used") or 0),
+        )
 
     def resolve_ai_insight_history(
         self,

--- a/app/models/ai_insight.py
+++ b/app/models/ai_insight.py
@@ -22,6 +22,7 @@ class InsightType(enum.Enum):
     weekly = "weekly"
     monthly = "monthly"
     recap = "recap"  # end-of-month comprehensive analysis
+    spending_patterns = "spending_patterns"  # cached "Radar de Gastos" (cron-generated)
 
 
 class AIInsight(db.Model):
@@ -55,10 +56,11 @@ class AIInsight(db.Model):
         nullable=False,
     )
     # Human-readable period key for deduplication and display.
-    # daily   → "YYYY-MM-DD"
-    # weekly  → "YYYY-WNN"  (ISO week, e.g. "2026-W20")
-    # monthly → "YYYY-MM"
-    # recap   → "YYYY-MM-recap"
+    # daily             → "YYYY-MM-DD"
+    # weekly            → "YYYY-WNN"  (ISO week, e.g. "2026-W20")
+    # monthly           → "YYYY-MM"
+    # recap             → "YYYY-MM-recap"
+    # spending_patterns → "YYYY-MM-DD"
     period_label = db.Column(db.String(30), nullable=False)
     period_start = db.Column(db.Date, nullable=False)
     period_end = db.Column(db.Date, nullable=False)

--- a/app/services/ai_spending_patterns_service.py
+++ b/app/services/ai_spending_patterns_service.py
@@ -1,0 +1,306 @@
+"""Cached "Radar de Gastos" (spending-patterns) service (#1455).
+
+Historically the Radar de Gastos endpoint (``POST /ai/insights/spending-patterns``)
+forwarded every request to auraxis-api-v2, which ran the LLM detection on demand —
+and each call consumed the user's 1/day AI quota. Since the dashboard auto-fires on
+login, that single daily quota was burned before the user did anything deliberate.
+
+This service moves generation to a scheduled cron (``flask ai spending-patterns``)
+that calls v2 server-to-server (no quota) and persists the result as an
+``AIInsight`` of type ``spending_patterns``. The app then reads the cached analysis
+via a quota-free read-only endpoint — mirroring the weekly-summary pattern.
+
+Public surface:
+  * :func:`call_v2_spending_patterns` — thin v2 HTTP client (also reused by the
+    legacy on-demand proxy for DRY).
+  * :func:`read_latest_spending_patterns` — read-only cache lookup.
+  * :func:`generate_and_persist_spending_patterns` — cron-side generation.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import date, timedelta
+from decimal import Decimal
+from typing import Any
+from uuid import UUID
+
+import requests
+from flask_jwt_extended import create_access_token
+
+from app.application.services.transaction_query_service import TransactionQueryService
+from app.extensions.database import db
+from app.models.ai_insight import AIInsight, InsightType
+
+log = logging.getLogger(__name__)
+
+_V2_PATH = "/v2/insights/spending-patterns"
+_TIMEOUT_SECONDS = 30.0
+_PERIOD_DAYS = 90
+_DEFAULT_MODEL = "v2-spending-patterns"
+_EXPENSE_PAGE_SIZE = 500
+
+
+class SpendingPatternsUpstreamError(RuntimeError):
+    """Raised when the v2 spending-patterns service is unavailable or errored."""
+
+    def __init__(self, message: str, *, status_code: int) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def _v2_base_url() -> str:
+    """Return the configured v2 base URL without a trailing slash (or empty)."""
+    return os.getenv("AURAXIS_API_V2_BASE_URL", "").rstrip("/")
+
+
+def call_v2_spending_patterns(
+    *,
+    transactions: list[dict[str, Any]],
+    period_days: int,
+    auth_header: str,
+) -> tuple[int, dict[str, Any]]:
+    """POST the LGPD-safe payload to auraxis-api-v2 and return ``(status, body)``.
+
+    Raises:
+        SpendingPatternsUpstreamError: when v2 is unconfigured or unreachable.
+    """
+    base_url = _v2_base_url()
+    if not base_url:
+        log.warning("spending_patterns.v2_unconfigured")
+        raise SpendingPatternsUpstreamError(
+            "Serviço de insights temporariamente indisponível.",
+            status_code=503,
+        )
+
+    try:
+        upstream = requests.post(
+            f"{base_url}{_V2_PATH}",
+            json={"transactions": transactions, "period_days": period_days},
+            headers={"Authorization": auth_header},
+            timeout=_TIMEOUT_SECONDS,
+        )
+    except requests.exceptions.RequestException as exc:
+        log.warning("spending_patterns.v2_unreachable", exc_info=True)
+        raise SpendingPatternsUpstreamError(
+            "Serviço de insights temporariamente indisponível.",
+            status_code=503,
+        ) from exc
+
+    try:
+        body: dict[str, Any] = upstream.json()
+    except ValueError:
+        body = {}
+
+    return upstream.status_code, body
+
+
+def read_latest_spending_patterns(user_id: UUID) -> dict[str, Any]:
+    """Read the latest cached spending-patterns insight for *user_id*.
+
+    NEVER calls the LLM and NEVER consumes quota — generation happens only in the
+    scheduled cron. When no cached analysis exists yet, returns an empty patterns
+    list with ``generated_at=None`` so the UI can render a "will be generated"
+    state.
+    """
+    latest: AIInsight | None = (
+        db.session.query(AIInsight)
+        .filter_by(user_id=user_id, insight_type=InsightType.spending_patterns)
+        .order_by(AIInsight.created_at.desc())
+        .first()
+    )
+
+    if latest is None:
+        return {
+            "patterns": [],
+            "generated_at": None,
+            "period_label": None,
+            "model": "",
+            "cost_usd": 0.0,
+            "tokens_used": 0,
+        }
+
+    return {
+        "patterns": _decode_patterns(latest.content),
+        "generated_at": latest.created_at.isoformat() if latest.created_at else None,
+        "period_label": latest.period_label,
+        "model": latest.model,
+        "cost_usd": float(latest.cost_usd),
+        "tokens_used": latest.tokens_used,
+    }
+
+
+def generate_and_persist_spending_patterns(
+    user_id: UUID,
+    *,
+    anchor_date: date,
+) -> dict[str, Any]:
+    """Generate (via v2) and persist the spending-patterns insight for a user.
+
+    Pulls the last ~90 days of expenses, builds the LGPD-safe payload, mints a
+    server-to-server access token (so v2's premium gate passes) and calls v2
+    WITHOUT consuming the per-user AI quota. On success the patterns are cached
+    as an ``AIInsight`` of type ``spending_patterns``. When v2 returns no patterns
+    (empty/error) nothing is persisted and ``persisted=False`` is returned.
+
+    Returns:
+        ``{"patterns": [...], "cost_usd": float, "tokens_used": int,
+           "cached": False, "persisted": bool}``
+    """
+    end = anchor_date
+    start = anchor_date - timedelta(days=_PERIOD_DAYS)
+    transactions = _build_expense_payload(user_id=user_id, start=start, end=end)
+
+    auth_header = f"Bearer {create_access_token(str(user_id))}"
+    status_code, body = call_v2_spending_patterns(
+        transactions=transactions,
+        period_days=_PERIOD_DAYS,
+        auth_header=auth_header,
+    )
+
+    if status_code >= 400:
+        raise SpendingPatternsUpstreamError(
+            "Falha ao gerar o radar de gastos.",
+            status_code=status_code,
+        )
+
+    patterns = body.get("patterns")
+    if not isinstance(patterns, list) or not patterns:
+        # Nothing actionable returned — do not persist an empty analysis.
+        return {
+            "patterns": [],
+            "cost_usd": 0.0,
+            "tokens_used": 0,
+            "cached": False,
+            "persisted": False,
+        }
+
+    cost_usd = _safe_float(body.get("cost_usd"))
+    tokens_used = _safe_int(body.get("tokens_used") or body.get("tokens_total"))
+    model = str(body.get("model") or _DEFAULT_MODEL)
+
+    _persist(
+        user_id=user_id,
+        patterns=patterns,
+        period_start=start,
+        period_end=end,
+        period_label=anchor_date.isoformat(),
+        model=model,
+        tokens_used=tokens_used,
+        cost_usd=cost_usd,
+    )
+
+    return {
+        "patterns": patterns,
+        "cost_usd": cost_usd,
+        "tokens_used": tokens_used,
+        "cached": False,
+        "persisted": True,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_expense_payload(
+    *,
+    user_id: UUID,
+    start: date,
+    end: date,
+) -> list[dict[str, Any]]:
+    """Return an LGPD-safe list of expense rows for the v2 detector.
+
+    Only the fields v2 needs are forwarded: amount, occurred_on, category. No
+    titles, descriptions or free-text are sent.
+    """
+    from sqlalchemy import desc
+
+    from app.models.transaction import Transaction
+
+    query_service = TransactionQueryService.with_defaults(user_id)
+    result = query_service.get_expense_period(
+        start_date=start,
+        end_date=end,
+        page=1,
+        per_page=_EXPENSE_PAGE_SIZE,
+        ordering_clause=desc(Transaction.due_date),
+    )
+
+    payload: list[dict[str, Any]] = []
+    for expense in result["expenses"]:
+        payload.append(
+            {
+                "amount": expense["amount"],
+                "occurred_on": expense["due_date"],
+                "category": expense.get("category"),
+                "kind": "expense",
+            }
+        )
+    return payload
+
+
+def _persist(
+    *,
+    user_id: UUID,
+    patterns: list[Any],
+    period_start: date,
+    period_end: date,
+    period_label: str,
+    model: str,
+    tokens_used: int,
+    cost_usd: float,
+) -> AIInsight:
+    insight = AIInsight(
+        user_id=user_id,
+        content=json.dumps({"patterns": patterns}, ensure_ascii=False),
+        insight_type=InsightType.spending_patterns,
+        period_label=period_label,
+        period_start=period_start,
+        period_end=period_end,
+        model=model,
+        tokens_used=tokens_used,
+        cost_usd=Decimal(str(cost_usd)),
+        previous_insight_id=None,
+    )
+    db.session.add(insight)
+    db.session.commit()
+    return insight
+
+
+def _decode_patterns(content: str) -> list[Any]:
+    try:
+        parsed = json.loads(content)
+    except (ValueError, TypeError):
+        return []
+    if isinstance(parsed, dict):
+        patterns = parsed.get("patterns")
+        return patterns if isinstance(patterns, list) else []
+    return parsed if isinstance(parsed, list) else []
+
+
+def _safe_float(value: object) -> float:
+    try:
+        return float(value or 0)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _safe_int(value: object) -> int:
+    if value is None:
+        return 0
+    try:
+        return int(float(value))  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return 0
+
+
+__all__ = [
+    "SpendingPatternsUpstreamError",
+    "call_v2_spending_patterns",
+    "generate_and_persist_spending_patterns",
+    "read_latest_spending_patterns",
+]

--- a/graphql.introspection.json
+++ b/graphql.introspection.json
@@ -325,6 +325,18 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "spendingPatternsLatest",
+              "type": {
+                "kind": "OBJECT",
+                "name": "SpendingPatternsLatestType",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "accounts",
               "type": {
                 "kind": "OBJECT",
@@ -3024,6 +3036,106 @@
           "interfaces": [],
           "kind": "OBJECT",
           "name": "AIInsightType",
+          "possibleTypes": null,
+          "specifiedByURL": null
+        },
+        {
+          "description": "Read-only cached Radar de Gastos (cron-generated, no quota).\n\nThe individual ``patterns`` are forwarded from auraxis-api-v2 and their shape\nis intentionally not pinned here; they are exposed as a JSON string\n(``patterns_json``) so the schema stays stable as v2 evolves. ``generated_at``\nis null when no analysis has been cached yet.",
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "patternsJson",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "generatedAt",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "periodLabel",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "model",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "costUsd",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "tokensUsed",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "SpendingPatternsLatestType",
           "possibleTypes": null,
           "specifiedByURL": null
         },

--- a/graphql.operations.manifest.json
+++ b/graphql.operations.manifest.json
@@ -721,6 +721,14 @@
   {
     "access": "auth_required",
     "domain": "ai_advisory",
+    "name": "spendingPatternsLatest",
+    "operation_type": "query",
+    "source_module": "app.graphql.queries.ai_insight",
+    "summary": "Retorna o último radar de gastos compulsivos já gerado pelo cron diário (somente leitura, sem consumir cota de IA). 'patternsJson' traz os padrões serializados; 'generatedAt' é null quando ainda não há análise. Paridade com GET /ai/insights/spending-patterns/latest."
+  },
+  {
+    "access": "auth_required",
+    "domain": "ai_advisory",
     "name": "generateAiInsight",
     "operation_type": "mutation",
     "source_module": "app.graphql.mutations.ai_insight",

--- a/migrations/versions/ai7_add_spending_patterns_insight_type.py
+++ b/migrations/versions/ai7_add_spending_patterns_insight_type.py
@@ -1,0 +1,49 @@
+"""ai7 — allow 'spending_patterns' in ai_insights.insight_type CHECK (#1455).
+
+The Radar de Gastos (spending-patterns) moves from on-demand LLM calls to a
+cron-generated, cached insight. Caching reuses the ``ai_insights`` table, so the
+``ck_ai_insights_type`` CHECK constraint must accept the new ``spending_patterns``
+value alongside the existing daily/weekly/monthly/recap values.
+
+The column is a plain VARCHAR(20) + named CHECK (``native_enum=False``), so no
+PostgreSQL ``CREATE TYPE`` is involved. On PostgreSQL the constraint is dropped
+and recreated in place; on SQLite (test runtime) the table is rebuilt via
+``batch_alter_table`` so the CHECK is regenerated from scratch.
+
+Revision ID: ai7
+Revises: rs1_recurrence_series_id
+Create Date: 2026-06-05
+
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "ai7"
+down_revision = "rs1_recurrence_series_id"
+branch_labels = None
+depends_on = None
+
+_CONSTRAINT = "ck_ai_insights_type"
+_WITH_PATTERNS = "insight_type IN ('daily','weekly','monthly','recap','spending_patterns')"
+_WITHOUT_PATTERNS = "insight_type IN ('daily','weekly','monthly','recap')"
+
+
+def _swap_check(*, condition: str) -> None:
+    bind = op.get_context().connection
+    if bind.dialect.name == "sqlite":
+        # SQLite cannot ALTER a CHECK constraint in place; rebuild the table.
+        with op.batch_alter_table("ai_insights", recreate="always") as batch:
+            batch.create_check_constraint(_CONSTRAINT, condition)
+        return
+    op.drop_constraint(_CONSTRAINT, "ai_insights", type_="check")
+    op.create_check_constraint(_CONSTRAINT, "ai_insights", condition)
+
+
+def upgrade() -> None:
+    _swap_check(condition=_WITH_PATTERNS)
+
+
+def downgrade() -> None:
+    _swap_check(condition=_WITHOUT_PATTERNS)

--- a/openapi.json
+++ b/openapi.json
@@ -2,6 +2,7 @@
   "components": {
     "schemas": {
       "InstallmentVsCashCalculation": {
+        "additionalProperties": false,
         "properties": {
           "cash_price": {
             "minimum": 0.01,
@@ -75,6 +76,7 @@
         "type": "object"
       },
       "InstallmentVsCashGoalBridge": {
+        "additionalProperties": false,
         "properties": {
           "category": {
             "default": "planned_purchase",
@@ -125,6 +127,7 @@
         "type": "object"
       },
       "InstallmentVsCashPlannedExpenseBridge": {
+        "additionalProperties": false,
         "properties": {
           "account_id": {
             "default": null,
@@ -211,6 +214,7 @@
         "type": "object"
       },
       "InstallmentVsCashSave": {
+        "additionalProperties": false,
         "properties": {
           "cash_price": {
             "minimum": 0.01,
@@ -284,6 +288,7 @@
         "type": "object"
       },
       "TransactionCreate": {
+        "additionalProperties": false,
         "properties": {
           "account_id": {
             "description": "ID da conta bancária associada",
@@ -484,6 +489,7 @@
         "type": "object"
       },
       "TransactionCreate_7d3b606eab": {
+        "additionalProperties": false,
         "properties": {
           "account_id": {
             "description": "ID da conta bancária associada",
@@ -678,6 +684,7 @@
         "type": "object"
       },
       "app_schemas_ai_insight_schema_AIInsightGenerateRequestSchema": {
+        "additionalProperties": false,
         "properties": {
           "anchor_date": {
             "description": "Data âncora do período no formato YYYY-MM-DD.",
@@ -716,6 +723,7 @@
         "type": "object"
       },
       "app_schemas_ai_insight_schema_AIMonthlyReportRequestSchema": {
+        "additionalProperties": false,
         "properties": {
           "anchor_date": {
             "description": "Data âncora do mês a consolidar. Quando omitida, a API usa a data atual.",
@@ -734,6 +742,7 @@
         "type": "object"
       },
       "app_schemas_auth_schema_AuthSchema": {
+        "additionalProperties": false,
         "properties": {
           "captcha_token": {
             "default": null,
@@ -761,6 +770,7 @@
         "type": "object"
       },
       "app_schemas_auth_schema_ConfirmEmailSchema": {
+        "additionalProperties": false,
         "properties": {
           "token": {
             "description": "Token de confirmacao recebido por email",
@@ -776,6 +786,7 @@
         "type": "object"
       },
       "app_schemas_auth_schema_ForgotPasswordSchema": {
+        "additionalProperties": false,
         "properties": {
           "email": {
             "description": "Email da conta que deseja recuperar acesso",
@@ -790,6 +801,7 @@
         "type": "object"
       },
       "app_schemas_auth_schema_ResetPasswordSchema": {
+        "additionalProperties": false,
         "properties": {
           "new_password": {
             "description": "Nova senha (mínimo 10 caracteres, com maiúscula, número e símbolo)",
@@ -813,6 +825,7 @@
         "type": "object"
       },
       "app_schemas_consent_schemas_ConsentRecordSchema": {
+        "additionalProperties": false,
         "properties": {
           "action": {
             "enum": [
@@ -855,6 +868,7 @@
         "type": "object"
       },
       "app_schemas_push_subscription_schema_SubscribeSchema": {
+        "additionalProperties": false,
         "properties": {
           "device_label": {
             "default": null,
@@ -889,6 +903,7 @@
         "type": "object"
       },
       "app_schemas_push_subscription_schema_UnsubscribeSchema": {
+        "additionalProperties": false,
         "properties": {
           "endpoint": {
             "type": "string"
@@ -900,6 +915,7 @@
         "type": "object"
       },
       "app_schemas_user_schemas_DeleteAccountSchema": {
+        "additionalProperties": false,
         "properties": {
           "password": {
             "description": "Senha atual do usuário para confirmar a exclusão da conta",
@@ -914,6 +930,7 @@
         "type": "object"
       },
       "app_schemas_user_schemas_QuestionnaireAnswerSchema": {
+        "additionalProperties": false,
         "properties": {
           "answers": {
             "description": "Lista de 5 respostas — pontos da opção escolhida em cada pergunta (1–3).",
@@ -933,6 +950,7 @@
         "type": "object"
       },
       "app_schemas_user_schemas_SalaryIncreaseSimulationRequestSchema": {
+        "additionalProperties": false,
         "properties": {
           "base_date": {
             "description": "Data base do salário atual",
@@ -968,6 +986,7 @@
         "type": "object"
       },
       "app_schemas_user_schemas_UserProfileSchema": {
+        "additionalProperties": false,
         "properties": {
           "birth_date": {
             "description": "Data de nascimento",
@@ -1080,6 +1099,7 @@
         "type": "object"
       },
       "app_schemas_user_schemas_UserRegistrationSchema": {
+        "additionalProperties": false,
         "properties": {
           "captcha_token": {
             "default": null,
@@ -2293,9 +2313,9 @@
         ]
       }
     },
-    "/ai/insights/weekly-summary": {
+    "/ai/insights/spending-patterns/latest": {
       "get": {
-        "description": "Gera um briefing narrativo do resumo financeiro da semana atual. Requer entitlement 'advanced_simulations' (plano Premium).",
+        "description": "Retorna o último radar de gastos compulsivos já gerado pelo cron diário. NÃO chama o LLM nem consome a cota diária de IA — a geração ocorre exclusivamente no batch agendado. Quando ainda não há análise, 'patterns' vem vazio e 'generated_at' é null. Requer entitlement 'advanced_simulations'.",
         "parameters": [],
         "responses": {
           "200": {
@@ -2304,15 +2324,18 @@
                 "example": {
                   "data": {
                     "cost_usd": 4.2e-05,
-                    "model": "gpt-4o-mini",
-                    "narrative": "Esta semana você gastou R$ 1.200...",
-                    "summary": {
-                      "current_week": {},
-                      "previous_week": {}
-                    },
+                    "generated_at": "2026-06-05T06:00:00",
+                    "model": "v2-spending-patterns",
+                    "patterns": [
+                      {
+                        "description": "Cafés",
+                        "severity": "high"
+                      }
+                    ],
+                    "period_label": "2026-06-05",
                     "tokens_used": 280
                   },
-                  "message": "Briefing semanal gerado com sucesso"
+                  "message": "Radar de gastos retornado com sucesso"
                 },
                 "schema": {
                   "properties": {
@@ -2334,7 +2357,7 @@
                 }
               }
             },
-            "description": "Briefing gerado com sucesso",
+            "description": "Radar de gastos em cache retornado com sucesso",
             "headers": {
               "X-Request-ID": {
                 "description": "Identificador único da requisição gerado pela API.",
@@ -2434,7 +2457,7 @@
               "application/json": {
                 "example": {
                   "code": "INTERNAL_ERROR",
-                  "message": "Erro ao gerar briefing semanal",
+                  "message": "Erro ao ler o radar de gastos",
                   "status_code": 500
                 },
                 "schema": {
@@ -2460,7 +2483,7 @@
                 }
               }
             },
-            "description": "Falha do provider LLM",
+            "description": "Erro interno",
             "headers": {
               "X-Request-ID": {
                 "description": "Identificador único da requisição gerado pela API.",
@@ -2477,7 +2500,198 @@
             "BearerAuth": []
           }
         ],
-        "summary": "Briefing semanal com IA (Premium)",
+        "summary": "Radar de gastos em cache (Premium, somente leitura)",
+        "tags": [
+          "AI Advisory"
+        ]
+      }
+    },
+    "/ai/insights/weekly-summary": {
+      "get": {
+        "description": "Retorna o resumo financeiro da semana atual (agregação de transações) e a narrativa do último insight semanal já gerado pelo batch agendado. NÃO chama o LLM nem envia email — a geração ocorre exclusivamente no cron semanal. Quando ainda não há insight, 'narrative' vem vazio. Requer entitlement 'advanced_simulations'.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "cost_usd": 4.2e-05,
+                    "generated_at": "2026-06-01T03:00:00",
+                    "model": "gpt-4o-mini",
+                    "narrative": "Esta semana você gastou R$ 1.200...",
+                    "summary": {
+                      "current_week": {},
+                      "previous_week": {}
+                    },
+                    "tokens_used": 280
+                  },
+                  "message": "Resumo semanal retornado com sucesso"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Resumo semanal retornado com sucesso",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token inválido",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Não autenticado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "ENTITLEMENT_REQUIRED",
+                  "message": "Recurso exclusivo para assinantes Premium.",
+                  "status_code": 403
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Entitlement insuficiente",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Erro ao ler resumo semanal",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Briefing semanal com IA (Premium, somente leitura)",
         "tags": [
           "AI Advisory"
         ]

--- a/schema.graphql
+++ b/schema.graphql
@@ -14,6 +14,7 @@ type Query {
   creditCardBill(cardId: UUID!, month: String!): CreditCardBillType
   creditCardUtilization(cardId: UUID!): CreditCardUtilizationType
   aiInsightHistory(page: Int = 1, perPage: Int = 20): AIInsightHistoryResultType
+  spendingPatternsLatest: SpendingPatternsLatestType
   accounts: AccountListType
   account(accountId: UUID!): AccountType
   tags: TagListType
@@ -187,6 +188,23 @@ type AIInsightType {
   tokensUsed: Int!
   costUsd: Float!
   createdAt: String!
+}
+
+"""
+Read-only cached Radar de Gastos (cron-generated, no quota).
+
+The individual ``patterns`` are forwarded from auraxis-api-v2 and their shape
+is intentionally not pinned here; they are exposed as a JSON string
+(``patterns_json``) so the schema stays stable as v2 evolves. ``generated_at``
+is null when no analysis has been cached yet.
+"""
+type SpendingPatternsLatestType {
+  patternsJson: String!
+  generatedAt: String
+  periodLabel: String
+  model: String!
+  costUsd: Float!
+  tokensUsed: Int!
 }
 
 type AccountListType {

--- a/scripts/aws_ai_insights_job.py
+++ b/scripts/aws_ai_insights_job.py
@@ -2,8 +2,9 @@
 """
 Auraxis — AI Insights batch job runner via SSM (#1215, #1216).
 
-Runs ``flask ai weekly-insights`` or ``flask ai monthly-insights`` inside
-the production Docker Compose network via AWS SSM Send-Command.
+Runs ``flask ai weekly-insights``, ``flask ai monthly-insights`` or
+``flask ai spending-patterns`` inside the production Docker Compose network via
+AWS SSM Send-Command.
 
 Usage:
     python scripts/aws_ai_insights_job.py \\
@@ -222,7 +223,10 @@ def _build_script(*, env_name: str, mode: str, month: str | None = None) -> str:
         "docker-compose.prod.yml" if env_name == "prod" else "docker-compose.dev.yml"
     )
 
-    flask_cmd = f"flask ai {mode}-insights"
+    if mode == "spending-patterns":
+        flask_cmd = "flask ai spending-patterns"
+    else:
+        flask_cmd = f"flask ai {mode}-insights"
     if mode == "monthly" and month:
         flask_cmd += f" --month {month}"
 
@@ -380,9 +384,9 @@ def main() -> int:
     )
     parser.add_argument(
         "--mode",
-        choices=["weekly", "monthly"],
+        choices=["weekly", "monthly", "spending-patterns"],
         required=True,
-        help="Which batch job to run: 'weekly' or 'monthly'.",
+        help="Which batch job to run: 'weekly', 'monthly' or 'spending-patterns'.",
     )
     parser.add_argument(
         "--month",

--- a/tests/test_ai_spending_patterns_latest.py
+++ b/tests/test_ai_spending_patterns_latest.py
@@ -1,0 +1,346 @@
+"""Tests for the cached Radar de Gastos (spending-patterns) feature (#1455).
+
+Covers:
+  * GET /ai/insights/spending-patterns/latest is read-only and does NOT consume
+    the AI daily quota (two consecutive calls never 429).
+  * read_latest_spending_patterns with and without cached data.
+  * generate_and_persist_spending_patterns with v2 mocked (persists an AIInsight).
+  * flask ai spending-patterns CLI: dry-run + a real run with v2 mocked.
+"""
+
+from __future__ import annotations
+
+import uuid as _uuid
+from datetime import date, timedelta
+
+from click.testing import CliRunner
+
+from app.services import ai_spending_patterns_service as sps_service
+
+# The v2 contract envelope ({"data": ...} / {"error": {"code": ...}}) is opted
+# into via this header; without it the legacy flat payload is returned.
+_V2 = {"X-API-Contract": "v2"}
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}", **_V2}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _register_and_login(client) -> str:
+    suffix = _uuid.uuid4().hex[:8]
+    email = f"sp-latest-{suffix}@test.com"
+    password = "StrongPass@123"
+    reg = client.post(
+        "/auth/register",
+        json={"name": f"sp-{suffix}", "email": email, "password": password},
+    )
+    assert reg.status_code == 201, reg.get_json()
+    login = client.post("/auth/login", json={"email": email, "password": password})
+    assert login.status_code == 200, login.get_json()
+    return login.get_json()["token"]
+
+
+def _grant_premium(app, token: str) -> _uuid.UUID:
+    from flask_jwt_extended import decode_token
+
+    from app.extensions.database import db
+    from app.models.entitlement import Entitlement, EntitlementSource
+
+    with app.app_context():
+        user_id = _uuid.UUID(decode_token(token)["sub"])
+        db.session.add(
+            Entitlement(
+                user_id=user_id,
+                feature_key="advanced_simulations",
+                source=EntitlementSource.MANUAL,
+                expires_at=None,
+            )
+        )
+        db.session.commit()
+    return user_id
+
+
+def _seed_cached_radar(app, user_id: _uuid.UUID, *, period_label: str) -> None:
+    from app.extensions.database import db
+    from app.models.ai_insight import AIInsight, InsightType
+
+    with app.app_context():
+        anchor = date.fromisoformat(period_label)
+        db.session.add(
+            AIInsight(
+                user_id=user_id,
+                content='{"patterns":[{"description":"Cafés","severity":"high"}]}',
+                insight_type=InsightType.spending_patterns,
+                period_label=period_label,
+                period_start=anchor - timedelta(days=90),
+                period_end=anchor,
+                model="v2-spending-patterns",
+                tokens_used=280,
+                cost_usd=0.000042,
+            )
+        )
+        db.session.commit()
+
+
+# ---------------------------------------------------------------------------
+# Endpoint — read-only / no quota
+# ---------------------------------------------------------------------------
+
+
+def test_latest_requires_premium(app, client) -> None:
+    token = _register_and_login(client)
+    from flask_jwt_extended import decode_token
+
+    from app.services.entitlement_service import deactivate_premium
+
+    with app.app_context():
+        deactivate_premium(_uuid.UUID(decode_token(token)["sub"]))
+
+    resp = client.get(
+        "/ai/insights/spending-patterns/latest",
+        headers=_auth(token),
+    )
+    assert resp.status_code == 403
+    assert (resp.get_json() or {}).get("error", {}).get(
+        "code"
+    ) == "ENTITLEMENT_REQUIRED"
+
+
+def test_latest_empty_when_no_cache(app, client) -> None:
+    token = _register_and_login(client)
+    _grant_premium(app, token)
+
+    resp = client.get(
+        "/ai/insights/spending-patterns/latest",
+        headers=_auth(token),
+    )
+    assert resp.status_code == 200, resp.get_json()
+    body = resp.get_json() or {}
+    data = body.get("data") or body
+    assert data["patterns"] == []
+    assert data["generated_at"] is None
+
+
+def test_latest_returns_cached_radar(app, client) -> None:
+    token = _register_and_login(client)
+    user_id = _grant_premium(app, token)
+    _seed_cached_radar(app, user_id, period_label="2026-06-05")
+
+    resp = client.get(
+        "/ai/insights/spending-patterns/latest",
+        headers=_auth(token),
+    )
+    assert resp.status_code == 200, resp.get_json()
+    data = (resp.get_json() or {}).get("data") or {}
+    assert data["patterns"] == [{"description": "Cafés", "severity": "high"}]
+    assert data["period_label"] == "2026-06-05"
+    assert data["generated_at"] is not None
+
+
+def test_latest_does_not_consume_daily_quota(app, client) -> None:
+    """Two consecutive reads must both succeed — the endpoint has no @ai_daily_limit."""
+    token = _register_and_login(client)
+    _grant_premium(app, token)
+
+    headers = _auth(token)
+    first = client.get("/ai/insights/spending-patterns/latest", headers=headers)
+    second = client.get("/ai/insights/spending-patterns/latest", headers=headers)
+
+    assert first.status_code == 200, first.get_json()
+    assert second.status_code == 200, second.get_json()
+    assert second.status_code != 429
+
+
+# ---------------------------------------------------------------------------
+# Service — read_latest_spending_patterns
+# ---------------------------------------------------------------------------
+
+
+def test_read_latest_returns_empty_without_data(app, client) -> None:
+    token = _register_and_login(client)
+    user_id = _grant_premium(app, token)
+
+    with app.app_context():
+        result = sps_service.read_latest_spending_patterns(user_id)
+
+    assert result == {
+        "patterns": [],
+        "generated_at": None,
+        "period_label": None,
+        "model": "",
+        "cost_usd": 0.0,
+        "tokens_used": 0,
+    }
+
+
+def test_read_latest_returns_cached(app, client) -> None:
+    token = _register_and_login(client)
+    user_id = _grant_premium(app, token)
+    _seed_cached_radar(app, user_id, period_label="2026-06-04")
+
+    with app.app_context():
+        result = sps_service.read_latest_spending_patterns(user_id)
+
+    assert result["patterns"] == [{"description": "Cafés", "severity": "high"}]
+    assert result["period_label"] == "2026-06-04"
+    assert result["tokens_used"] == 280
+
+
+# ---------------------------------------------------------------------------
+# Service — generate_and_persist_spending_patterns (v2 mocked)
+# ---------------------------------------------------------------------------
+
+
+def _patch_v2(monkeypatch, *, status: int, body: dict) -> None:
+    def _fake_call(*, transactions, period_days, auth_header):  # noqa: ANN001
+        assert period_days == 90
+        assert auth_header.startswith("Bearer ")
+        return status, body
+
+    monkeypatch.setattr(sps_service, "call_v2_spending_patterns", _fake_call)
+
+
+def test_generate_persists_insight(app, client, monkeypatch) -> None:
+    token = _register_and_login(client)
+    user_id = _grant_premium(app, token)
+
+    _patch_v2(
+        monkeypatch,
+        status=200,
+        body={
+            "patterns": [{"description": "Delivery", "severity": "medium"}],
+            "model": "stub",
+            "cost_usd": 0.0001,
+            "tokens_used": 120,
+        },
+    )
+
+    with app.app_context():
+        result = sps_service.generate_and_persist_spending_patterns(
+            user_id, anchor_date=date(2026, 6, 5)
+        )
+        assert result["persisted"] is True
+        assert result["patterns"] == [{"description": "Delivery", "severity": "medium"}]
+
+        latest = sps_service.read_latest_spending_patterns(user_id)
+        assert latest["patterns"] == [{"description": "Delivery", "severity": "medium"}]
+        assert latest["period_label"] == "2026-06-05"
+        assert latest["model"] == "stub"
+        assert latest["tokens_used"] == 120
+
+
+def test_generate_does_not_persist_when_empty(app, client, monkeypatch) -> None:
+    token = _register_and_login(client)
+    user_id = _grant_premium(app, token)
+
+    _patch_v2(monkeypatch, status=200, body={"patterns": []})
+
+    with app.app_context():
+        result = sps_service.generate_and_persist_spending_patterns(
+            user_id, anchor_date=date(2026, 6, 5)
+        )
+        assert result["persisted"] is False
+        assert result["patterns"] == []
+        assert sps_service.read_latest_spending_patterns(user_id)["patterns"] == []
+
+
+def test_generate_raises_on_upstream_error(app, client, monkeypatch) -> None:
+    token = _register_and_login(client)
+    user_id = _grant_premium(app, token)
+
+    _patch_v2(monkeypatch, status=502, body={"error": "boom"})
+
+    with app.app_context():
+        try:
+            sps_service.generate_and_persist_spending_patterns(
+                user_id, anchor_date=date(2026, 6, 5)
+            )
+        except sps_service.SpendingPatternsUpstreamError as exc:
+            assert exc.status_code == 502
+        else:  # pragma: no cover - guard
+            raise AssertionError("expected SpendingPatternsUpstreamError")
+
+
+# ---------------------------------------------------------------------------
+# CLI — flask ai spending-patterns
+# ---------------------------------------------------------------------------
+
+
+def _invoke_cli(app, *args: str) -> object:
+    from app.cli.ai_insights_cli import ai_insights_cli
+
+    runner = CliRunner()
+    with app.app_context():
+        return runner.invoke(ai_insights_cli, ["spending-patterns", *args])
+
+
+def test_cli_dry_run_does_not_call_v2(app, client, monkeypatch) -> None:
+    token = _register_and_login(client)
+    _grant_premium(app, token)
+
+    called = {"n": 0}
+
+    def _boom(**_kwargs):  # noqa: ANN003
+        called["n"] += 1
+        raise AssertionError("v2 must not be called on dry-run")
+
+    monkeypatch.setattr(sps_service, "call_v2_spending_patterns", _boom)
+
+    result = _invoke_cli(app, "--dry-run")
+    assert result.exit_code == 0
+    assert "dry-run" in result.output.lower()
+    assert called["n"] == 0
+
+
+def test_cli_generates_for_premium_user(app, client, monkeypatch) -> None:
+    token = _register_and_login(client)
+    user_id = _grant_premium(app, token)
+
+    _patch_v2(
+        monkeypatch,
+        status=200,
+        body={
+            "patterns": [{"description": "Apps", "severity": "high"}],
+            "model": "stub",
+            "cost_usd": 0.0002,
+            "tokens_used": 90,
+        },
+    )
+
+    result = _invoke_cli(app)
+    assert result.exit_code == 0, result.output
+    assert "processed=1" in result.output
+    assert "failures=0" in result.output
+
+    with app.app_context():
+        latest = sps_service.read_latest_spending_patterns(user_id)
+        assert latest["patterns"] == [{"description": "Apps", "severity": "high"}]
+
+
+def test_cli_idempotent_skips_when_cached_today(app, client, monkeypatch) -> None:
+    from datetime import datetime, timedelta, timezone
+
+    token = _register_and_login(client)
+    user_id = _grant_premium(app, token)
+    today = datetime.now(timezone(timedelta(hours=-3))).date()
+    _seed_cached_radar(app, user_id, period_label=today.isoformat())
+
+    def _boom(**_kwargs):  # noqa: ANN003
+        raise AssertionError("v2 must not be called when already cached today")
+
+    monkeypatch.setattr(sps_service, "call_v2_spending_patterns", _boom)
+
+    result = _invoke_cli(app)
+    assert result.exit_code == 0
+    assert "skipped=1" in result.output
+
+
+def test_cli_no_premium_users_exits_zero(app) -> None:
+    result = _invoke_cli(app)
+    assert result.exit_code == 0
+    assert "processed=0" in result.output


### PR DESCRIPTION
## Problema
O Radar de Gastos (`/ai/insights/spending-patterns`) gerava IA a cada load do dashboard e **consumia a cota de 1/dia** — o login queimava a cota antes de qualquer ação deliberada do usuário.

## Solução (espelha o padrão weekly-summary)
- **Modelo+migration (ai7)**: novo `InsightType.spending_patterns` (VARCHAR + CHECK, sem CREATE TYPE).
- **Service**: `read_latest_spending_patterns` (read-only, sem LLM/cota) + `generate_and_persist_spending_patterns` (cron chama v2 server-to-server com token mintado, sem cota).
- **GET `/ai/insights/spending-patterns/latest`** — `@jwt_required` + entitlement, **SEM** `@ai_daily_limit()`. Paridade GraphQL: `spendingPatternsLatest`.
- **Cron** `flask ai spending-patterns` + workflow diário (idempotente, sem email).
- Proxy refatorado p/ reusar o client v2 (DRY).

## Verificação
- `run_ci_quality_local.sh --local` verde (cov 91%, 2495 testes); migration up/down no PG.
- 17 testes novos: endpoint não consome cota, read com/sem dado, generate com v2 mockado, CLI dry-run+real+idempotência.

Closes #1455
Desbloqueia auraxis-web #1016 (A3: dashboard lê do read-only).