### PR TITLE
fix(auth): grace window na reuse-detection do refresh (F5 não revoga mais a sessão)

### DIFF
--- a/app/application/services/session_service.py
+++ b/app/application/services/session_service.py
@@ -23,6 +23,15 @@ from app.utils.datetime_utils import utc_now_naive
 _REFRESH_TOKEN_TTL_DAYS = 30
 _MAX_SESSIONS = int(os.getenv("MAX_SESSIONS_PER_USER", str(_MAX_SESSIONS_PER_USER)))
 
+# Grace window for refresh-token reuse detection. A client booting/reloading can
+# fire two concurrent POST /auth/refresh with the same (still-old) cookie before
+# the rotated cookie propagates. The loser presents a token that was revoked a
+# fraction of a second ago — that is a benign concurrent refresh, NOT a stolen
+# token replayed minutes later. Within this window we reject the loser softly
+# (ConcurrentRefreshError) without nuking the whole token family; outside it we
+# treat reuse as theft and revoke the family.
+_REUSE_GRACE_SECONDS = int(os.getenv("AURAXIS_REFRESH_REUSE_GRACE_SECONDS", "15"))
+
 
 class SessionInfo(TypedDict):
     id: str
@@ -38,6 +47,18 @@ class SessionNotFoundError(Exception):
 
 class TokenReuseError(Exception):
     """Raised when a revoked refresh token is presented (possible theft)."""
+
+
+class ConcurrentRefreshError(Exception):
+    """Raised when a just-rotated refresh token is presented again within the
+    reuse grace window — a benign concurrent refresh (e.g. boot/F5 double-submit
+    or a second tab). The request is rejected softly: the token family is NOT
+    revoked, so the winning refresh and other sessions stay valid."""
+
+
+def _is_within_reuse_grace(revoked_at: datetime) -> bool:
+    """True when *revoked_at* is recent enough to be a benign concurrent refresh."""
+    return utc_now_naive() - revoked_at <= timedelta(seconds=_REUSE_GRACE_SECONDS)
 
 
 def _hash_token(raw_token: str) -> str:
@@ -138,6 +159,11 @@ def rotate_session(
         raise SessionNotFoundError("Refresh token not found.")
 
     if existing.revoked_at is not None:
+        if _is_within_reuse_grace(existing.revoked_at):
+            # Benign concurrent refresh — reject softly, keep the family alive.
+            raise ConcurrentRefreshError(
+                "Concurrent refresh — token rotated moments ago."
+            )
         # Token reuse detected — revoke the entire family.
         _revoke_family(existing.family_id)
         raise TokenReuseError(
@@ -191,6 +217,12 @@ def rotate_session_by_jti(
     # Revocation check is already done by @jwt_required(refresh=True), but
     # handle the edge case defensively.
     if existing.revoked_at is not None:
+        if _is_within_reuse_grace(existing.revoked_at):
+            # Benign concurrent refresh (boot/F5 double-submit) — reject softly
+            # without revoking the family so the winning session stays valid.
+            raise ConcurrentRefreshError(
+                "Concurrent refresh — token rotated moments ago."
+            )
         _revoke_family(existing.family_id)
         raise TokenReuseError("Refresh token already used — possible theft detected.")
 
@@ -337,6 +369,7 @@ def _fmt(dt: datetime) -> str:
 
 __all__ = [
     "SessionInfo",
+    "ConcurrentRefreshError",
     "SessionNotFoundError",
     "TokenReuseError",
     "check_refresh_jti_revoked",

--- a/app/controllers/auth/refresh_token_resource.py
+++ b/app/controllers/auth/refresh_token_resource.py
@@ -8,6 +8,7 @@ from flask_apispec.views import MethodResource
 from flask_jwt_extended import get_jwt, get_jwt_identity, set_refresh_cookies
 
 from app.application.services.session_service import (
+    ConcurrentRefreshError,
     SessionNotFoundError,
     TokenReuseError,
     rotate_session_by_jti,
@@ -113,6 +114,18 @@ class RefreshTokenResource(MethodResource):
                     remote_addr=request_context.client_ip,
                 )
             except TokenReuseError:
+                return compat_error(
+                    legacy_payload={"message": _TOKEN_INVALID_OR_USED_MESSAGE},
+                    status_code=401,
+                    message=_TOKEN_INVALID_OR_USED_MESSAGE,
+                    error_code="TOKEN_REUSED",
+                )
+            except ConcurrentRefreshError:
+                # Benign concurrent refresh (boot/F5 double-submit): the other
+                # request already rotated the token. Reject this one softly with
+                # a plain 401 — do NOT revoke the family and do NOT touch user
+                # state, so the winning session and other devices stay valid.
+                db.session.rollback()
                 return compat_error(
                     legacy_payload={"message": _TOKEN_INVALID_OR_USED_MESSAGE},
                     status_code=401,

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -195,7 +195,14 @@ class TestSessionServiceRotate:
             assert old is not None and old.revoked_at is not None
 
     def test_rotate_revoked_jti_raises_token_reuse_error(self, app) -> None:
+        """Reuse OUTSIDE the grace window is treated as theft → family revoked."""
         with app.app_context():
+            from datetime import timedelta
+
+            from app.application.services import session_service
+            from app.extensions.database import db
+            from app.utils.datetime_utils import utc_now_naive
+
             user_id = uuid.uuid4()
             rt = create_session(
                 user_id=user_id,
@@ -203,9 +210,11 @@ class TestSessionServiceRotate:
                 refresh_jti="reuse-jti",
                 access_jti="reuse-acc",
             )
-            rt.revoke()
-            from app.extensions.database import db
-
+            # Revoked well outside the grace window → genuine replay, not a
+            # concurrent boot refresh.
+            rt.revoked_at = utc_now_naive() - timedelta(
+                seconds=session_service._REUSE_GRACE_SECONDS + 60
+            )
             db.session.commit()
             with pytest.raises(TokenReuseError):
                 rotate_session_by_jti(
@@ -214,6 +223,53 @@ class TestSessionServiceRotate:
                     new_refresh_jti="any-new",
                     new_access_jti="any-acc",
                 )
+
+    def test_rotate_within_grace_raises_concurrent_and_keeps_family(self, app) -> None:
+        """A just-rotated token re-presented within the grace window is a benign
+        concurrent refresh: ConcurrentRefreshError, family NOT revoked."""
+        with app.app_context():
+            from app.application.services.session_service import (
+                ConcurrentRefreshError,
+            )
+            from app.extensions.database import db
+
+            user_id = uuid.uuid4()
+            create_session(
+                user_id=user_id,
+                raw_refresh_token="raw-grace",
+                refresh_jti="grace-jti",
+                access_jti="grace-acc",
+            )
+            # Winner rotates the token (revokes it ~now) and creates a successor.
+            winner = rotate_session_by_jti(
+                old_jti="grace-jti",
+                new_raw_refresh_token="winner-raw",
+                new_refresh_jti="winner-jti",
+                new_access_jti="winner-acc",
+            )
+            db.session.commit()
+            assert winner is not None
+            family_id = winner.family_id
+
+            # Loser presents the same (now just-revoked) jti within the grace window.
+            with pytest.raises(ConcurrentRefreshError):
+                rotate_session_by_jti(
+                    old_jti="grace-jti",
+                    new_raw_refresh_token="loser-raw",
+                    new_refresh_jti="loser-jti",
+                    new_access_jti="loser-acc",
+                )
+
+            # The winning successor must still be active — family NOT nuked.
+            successor = RefreshToken.query.filter_by(jti="winner-jti").first()
+            assert successor is not None
+            assert successor.revoked_at is None
+            active = (
+                RefreshToken.query.filter_by(family_id=family_id)
+                .filter(RefreshToken.revoked_at.is_(None))
+                .count()
+            )
+            assert active == 1
 
     def test_rotate_unknown_jti_returns_none(self, app) -> None:
         with app.app_context():


### PR DESCRIPTION
## Problema
F5/boot dispara 2 `POST /auth/refresh` concorrentes com o mesmo cookie. O vencedor rotaciona (revoga o jti antigo); o perdedor apresenta o jti recém-revogado → reuse-detection chamava `_revoke_family` → **revogava a família inteira** → logout de todas as sessões.

## Fix
Token revogado dentro de uma janela de graça (`_REUSE_GRACE_SECONDS=15`) = refresh concorrente benigno → `ConcurrentRefreshError` (401 simples, **sem** revogar a família, sem alterar estado). Reuso real (token antigo muito depois) ainda revoga.

## Verificação
pytest: dentro da graça → ConcurrentRefreshError + família preservada; fora da graça → TokenReuseError. 41 testes de refresh + 24 de session verdes; ruff/mypy ok.

Closes #1458
Par do fix frontend (web #1023, single-flight).