### PR TITLE
fix(credit-card): deletar cartão remove as dívidas/parcelas associadas

### DIFF
--- a/app/application/services/credit_card_application_service.py
+++ b/app/application/services/credit_card_application_service.py
@@ -1,0 +1,55 @@
+"""Credit card application service (#1459).
+
+Deleting a credit card must also remove the debts/expenses charged to it —
+otherwise the installments stay visible in the transactions list pointing at a
+card that no longer exists. This service deletes a card and soft-deletes every
+transaction linked to it (all installments share the same ``credit_card_id``),
+in a single transaction.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from app.extensions.database import db
+from app.models.credit_card import CreditCard
+from app.models.transaction import Transaction
+from app.utils.datetime_utils import utc_now_naive
+
+
+def delete_card_with_transactions(*, card_id: UUID, user_id: UUID) -> bool:
+    """Delete a user's credit card and soft-delete its linked transactions.
+
+    All transactions charged to the card (every installment, since each row
+    carries the same ``credit_card_id``) are soft-deleted so they disappear from
+    the transactions list, and their ``credit_card_id`` is cleared so the card
+    hard-delete cannot trip the foreign key regardless of its ``ondelete`` rule.
+
+    Args:
+        card_id: The credit card to delete.
+        user_id: The owner; scopes both the card and the transactions.
+
+    Returns:
+        True when the card existed and was deleted; False when not found
+        (caller maps this to a 404).
+    """
+    card: CreditCard | None = CreditCard.query.filter_by(
+        id=card_id, user_id=user_id
+    ).first()
+    if card is None:
+        return False
+
+    Transaction.query.filter_by(credit_card_id=card_id, user_id=user_id).update(
+        {
+            "deleted": True,
+            "credit_card_id": None,
+            "updated_at": utc_now_naive(),
+        },
+        synchronize_session=False,
+    )
+    db.session.delete(card)
+    db.session.commit()
+    return True
+
+
+__all__ = ["delete_card_with_transactions"]

--- a/app/controllers/credit_card/resources.py
+++ b/app/controllers/credit_card/resources.py
@@ -9,6 +9,9 @@ from uuid import UUID
 
 from flask import request
 
+from app.application.services.credit_card_application_service import (
+    delete_card_with_transactions,
+)
 from app.auth import current_user_id
 from app.controllers.response_contract import compat_error_tuple, compat_success_tuple
 from app.decorators import require_email_verified
@@ -366,17 +369,14 @@ def update_credit_card(credit_card_id: UUID) -> tuple[dict[str, Any], int]:
 def delete_credit_card(credit_card_id: UUID) -> tuple[dict[str, Any], int]:
     """Delete a credit card belonging to the authenticated user."""
     user_id = current_user_id()
-    card = CreditCard.query.filter_by(id=credit_card_id, user_id=user_id).first()
-    if card is None:
+    deleted = delete_card_with_transactions(card_id=credit_card_id, user_id=user_id)
+    if not deleted:
         return compat_error_tuple(
             legacy_payload={"error": CREDIT_CARD_NOT_FOUND_MESSAGE},
             status_code=404,
             message=CREDIT_CARD_NOT_FOUND_MESSAGE,
             error_code="NOT_FOUND",
         )
-
-    db.session.delete(card)
-    db.session.commit()
 
     return compat_success_tuple(
         legacy_payload={"message": "Cartão removido com sucesso"},

--- a/app/models/transaction.py
+++ b/app/models/transaction.py
@@ -99,7 +99,9 @@ class Transaction(db.Model):
         UUID(as_uuid=True), db.ForeignKey("accounts.id"), nullable=True
     )
     credit_card_id = db.Column(
-        UUID(as_uuid=True), db.ForeignKey("credit_cards.id"), nullable=True
+        UUID(as_uuid=True),
+        db.ForeignKey("credit_cards.id", ondelete="SET NULL"),
+        nullable=True,
     )
     installment_group_id = db.Column(UUID(as_uuid=True), nullable=True)
     # Links all occurrences of one recurring series so a user can delete a

--- a/migrations/versions/cc1_credit_card_fk_set_null.py
+++ b/migrations/versions/cc1_credit_card_fk_set_null.py
@@ -1,0 +1,56 @@
+"""cc1 — transactions.credit_card_id FK ondelete=SET NULL (#1459).
+
+Deleting a credit card must not be blocked by — nor orphan — the transactions
+charged to it. The application service soft-deletes and unlinks those rows
+explicitly, but the FK is hardened to SET NULL as a data-integrity backstop for
+any path that deletes a card directly (raw SQL, future cascades).
+
+The FK was created unnamed in the initial schema, so PostgreSQL auto-named it
+``transactions_credit_card_id_fkey``. On SQLite (test runtime the schema comes
+from ``db.create_all`` and FKs are not enforced) this migration is a no-op.
+
+Revision ID: cc1_credit_card_fk_set_null
+Revises: ai7
+Create Date: 2026-06-07
+
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "cc1_credit_card_fk_set_null"
+down_revision = "ai7"
+branch_labels = None
+depends_on = None
+
+_FK = "transactions_credit_card_id_fkey"
+
+
+def upgrade() -> None:
+    bind = op.get_context().connection
+    if bind.dialect.name == "sqlite":
+        return
+    op.drop_constraint(_FK, "transactions", type_="foreignkey")
+    op.create_foreign_key(
+        _FK,
+        "transactions",
+        "credit_cards",
+        ["credit_card_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_context().connection
+    if bind.dialect.name == "sqlite":
+        return
+    op.drop_constraint(_FK, "transactions", type_="foreignkey")
+    op.create_foreign_key(
+        _FK,
+        "transactions",
+        "credit_cards",
+        ["credit_card_id"],
+        ["id"],
+    )

--- a/tests/test_credit_card_delete_cascade.py
+++ b/tests/test_credit_card_delete_cascade.py
@@ -1,0 +1,126 @@
+"""Deleting a credit card removes the debts/installments charged to it (#1459).
+
+Regression: creating a card + an installment expense, then deleting the card,
+used to leave the installments in the transactions list pointing at a card that
+no longer exists.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+from flask_jwt_extended import decode_token
+
+from app.extensions.database import db
+from app.models.transaction import Transaction, TransactionStatus, TransactionType
+
+
+def _register_and_login(client, *, prefix: str) -> str:
+    suffix = uuid4().hex[:8]
+    email = f"{prefix}-{suffix}@email.com"
+    register = client.post(
+        "/auth/register",
+        json={"name": f"user-{suffix}", "email": email, "password": "StrongPass@123"},
+    )
+    assert register.status_code == 201
+    login = client.post(
+        "/auth/login", json={"email": email, "password": "StrongPass@123"}
+    )
+    assert login.status_code == 200
+    return login.get_json()["token"]
+
+
+def _headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}", "X-API-Contract": "v2"}
+
+
+def _create_card(client, headers) -> dict:
+    resp = client.post(
+        "/credit-cards",
+        json={
+            "name": "Nubank",
+            "brand": "mastercard",
+            "limit_amount": 5000.0,
+            "closing_day": 10,
+            "due_day": 15,
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201
+    return resp.get_json()["data"]["credit_card"]
+
+
+def _user_id(app, token: str) -> str:
+    with app.app_context():
+        return str(decode_token(token)["sub"])
+
+
+def _add_installments(app, *, user_id: str, card_id: str, n: int) -> str:
+    """Insert *n* installments of one parcelled expense charged to the card."""
+    group_id = uuid4()
+    with app.app_context():
+        for i in range(n):
+            db.session.add(
+                Transaction(
+                    user_id=UUID(user_id),
+                    credit_card_id=UUID(card_id),
+                    installment_group_id=group_id,
+                    title=f"Parcela {i + 1}/{n}",
+                    amount=Decimal("100.00"),
+                    due_date=date(2026, 6, 1),
+                    status=TransactionStatus.PENDING,
+                    type=TransactionType.EXPENSE,
+                )
+            )
+        db.session.commit()
+    return str(group_id)
+
+
+class TestCreditCardDeleteCascade:
+    def test_deleting_card_soft_deletes_its_installments(self, app, client) -> None:
+        token = _register_and_login(client, prefix="cc-del")
+        headers = _headers(token)
+        card = _create_card(client, headers)
+        user_id = _user_id(app, token)
+        _add_installments(app, user_id=user_id, card_id=card["id"], n=3)
+
+        # The debt is visible before deleting the card.
+        before = client.get("/transactions", headers=headers)
+        assert before.status_code == 200
+
+        resp = client.delete(f"/credit-cards/{card['id']}", headers=headers)
+        assert resp.status_code == 200
+
+        # All installments are soft-deleted and unlinked from the card.
+        with app.app_context():
+            rows = Transaction.query.filter_by(user_id=UUID(user_id)).all()
+            assert len(rows) == 3
+            assert all(r.deleted is True for r in rows)
+            assert all(r.credit_card_id is None for r in rows)
+
+    def test_deleting_card_keeps_other_cards_transactions(self, app, client) -> None:
+        token = _register_and_login(client, prefix="cc-del-keep")
+        headers = _headers(token)
+        user_id = _user_id(app, token)
+        card_a = _create_card(client, headers)
+        card_b = _create_card(client, headers)
+        _add_installments(app, user_id=user_id, card_id=card_a["id"], n=2)
+        _add_installments(app, user_id=user_id, card_id=card_b["id"], n=2)
+
+        resp = client.delete(f"/credit-cards/{card_a['id']}", headers=headers)
+        assert resp.status_code == 200
+
+        with app.app_context():
+            active = Transaction.query.filter_by(
+                user_id=UUID(user_id), deleted=False
+            ).all()
+            # Only card B's transactions survive.
+            assert len(active) == 2
+            assert all(r.credit_card_id == UUID(card_b["id"]) for r in active)
+
+    def test_delete_missing_card_returns_404(self, app, client) -> None:
+        token = _register_and_login(client, prefix="cc-del-404")
+        resp = client.delete(f"/credit-cards/{uuid4()}", headers=_headers(token))
+        assert resp.status_code == 404


### PR DESCRIPTION
## Problema
Deletar um cartão só removia o cartão; as transações cobradas nele (todas as parcelas, mesmo `credit_card_id`) ficavam na lista apontando p/ um cartão inexistente.

## Fix
- `credit_card_application_service.delete_card_with_transactions`: soft-delete + unlink de todas as transações do cartão, depois deleta o cartão (uma transação).
- `DELETE /credit-cards/<id>` usa o service.
- FK `transactions.credit_card_id` → `ondelete=SET NULL` (model + migration cc1), backstop de integridade.

## Verificação
pytest: delete remove todas as parcelas (deleted=True, credit_card_id=None); outros cartões intactos; 404 quando inexistente. ruff/mypy verdes; migration up/down no PG.

Closes #1459
Nota: credit_card não tem mutation GraphQL hoje (só queries) — parity de mutation fica p/ follow-up.