### PR TITLE
fix(credit-card): aceitar dia de vencimento/fechamento 1–31 com clamp em meses curtos

### DIFF
--- a/app/controllers/credit_card/resources.py
+++ b/app/controllers/credit_card/resources.py
@@ -28,7 +28,7 @@ INVALID_BRAND_MESSAGE = (
     "Field 'brand' must be one of: visa, mastercard, elo, hipercard, amex, other"
 )
 INVALID_DAY_MESSAGE = (
-    "Fields 'closing_day' and 'due_day' must be integers between 1 and 28"
+    "Fields 'closing_day' and 'due_day' must be integers between 1 and 31"
 )
 INVALID_BENEFITS_MESSAGE = (
     "Field 'benefits' must be a list of strings (max 12 items × 120 chars each)"
@@ -99,7 +99,7 @@ def _validate_days(payload: dict[str, Any]) -> tuple[dict[str, Any], int] | None
             continue
         try:
             v = int(val)
-            if not (1 <= v <= 28):
+            if not (1 <= v <= 31):
                 raise ValueError
         except (ValueError, TypeError):
             return _err_400(INVALID_DAY_MESSAGE, "INVALID_DAY")

--- a/app/schemas/credit_card_schema.py
+++ b/app/schemas/credit_card_schema.py
@@ -46,18 +46,18 @@ class CreditCardSchema(Schema):
     closing_day = fields.Int(
         required=False,
         allow_none=True,
-        validate=validate.Range(min=1, max=28),
+        validate=validate.Range(min=1, max=31),
         metadata={
-            "description": "Dia de fechamento da fatura (1-28)",
+            "description": "Dia de fechamento da fatura (1-31)",
             "example": 20,
         },
     )
     due_day = fields.Int(
         required=False,
         allow_none=True,
-        validate=validate.Range(min=1, max=28),
+        validate=validate.Range(min=1, max=31),
         metadata={
-            "description": "Dia de vencimento da fatura (1-28)",
+            "description": "Dia de vencimento da fatura (1-31)",
             "example": 5,
         },
     )

--- a/app/services/credit_card_bill_service.py
+++ b/app/services/credit_card_bill_service.py
@@ -14,6 +14,7 @@ Utilization aggregates expense transactions in the open cycle window, including
 
 from __future__ import annotations
 
+import calendar
 from dataclasses import dataclass
 from datetime import date, timedelta
 from decimal import Decimal
@@ -68,11 +69,20 @@ class Utilization:
 
 
 def _validate_day(label: str, value: int) -> None:
-    if not 1 <= value <= 28:
-        raise ValueError(
-            f"{label} must be between 1 and 28 (got {value}); "
-            "values 29-31 are blocked to avoid month-overflow ambiguity"
-        )
+    if not 1 <= value <= 31:
+        raise ValueError(f"{label} must be between 1 and 31 (got {value})")
+
+
+def _safe_date(year: int, month: int, day: int) -> date:
+    """Build a date clamping `day` to the month's last valid day.
+
+    A card configured to close/due on day 30 or 31 still has a well-defined
+    cycle boundary in short months: e.g. day 30 in February resolves to the
+    28th (or 29th in a leap year). This avoids `date()` raising for days that
+    do not exist in the target month.
+    """
+    last_day = calendar.monthrange(year, month)[1]
+    return date(year, month, min(day, last_day))
 
 
 def _shift_month(year: int, month: int, offset: int) -> tuple[int, int]:
@@ -107,17 +117,17 @@ def compute_bill_cycle(*, closing_day: int, due_day: int, anchor: date) -> BillC
     else:
         end_year, end_month = _shift_month(anchor.year, anchor.month, 1)
 
-    end_date = date(end_year, end_month, closing_day)
+    end_date = _safe_date(end_year, end_month, closing_day)
 
     prev_year, prev_month = _shift_month(end_year, end_month, -1)
-    prev_close = date(prev_year, prev_month, closing_day)
+    prev_close = _safe_date(prev_year, prev_month, closing_day)
     start_date = prev_close + timedelta(days=1)
 
     if due_day > closing_day:
         due_year, due_month = end_year, end_month
     else:
         due_year, due_month = _shift_month(end_year, end_month, 1)
-    due_date = date(due_year, due_month, due_day)
+    due_date = _safe_date(due_year, due_month, due_day)
 
     if anchor <= end_date:
         status: BillCycleStatus = "open"
@@ -223,7 +233,7 @@ def compute_bill(card: CreditCard, *, month: str, today: date) -> BillSummary:
     except (ValueError, AttributeError) as exc:
         raise ValueError(f"month must be in YYYY-MM format (got {month!r})") from exc
 
-    anchor_for_cycle = date(year, m, card.closing_day)
+    anchor_for_cycle = _safe_date(year, m, card.closing_day)
     cycle = compute_bill_cycle(
         closing_day=card.closing_day,
         due_day=card.due_day,

--- a/tests/test_bloco2_models.py
+++ b/tests/test_bloco2_models.py
@@ -189,13 +189,25 @@ def test_create_credit_card_invalid_brand_returns_400(client) -> None:
     assert resp.status_code == 400
 
 
+def test_create_credit_card_accepts_closing_day_30(client) -> None:
+    # #1469: day 30 used to be rejected; it is now valid (clamped per month).
+    token, _ = _register_and_login(client, "cc-day-30")
+
+    resp = client.post(
+        "/credit-cards",
+        headers=_auth(token),
+        json={"name": "Cartão", "closing_day": 30, "due_day": 5},
+    )
+    assert resp.status_code == 201
+
+
 def test_create_credit_card_invalid_closing_day_returns_400(client) -> None:
     token, _ = _register_and_login(client, "cc-invalid-day")
 
     resp = client.post(
         "/credit-cards",
         headers=_auth(token),
-        json={"name": "Cartão", "closing_day": 30},
+        json={"name": "Cartão", "closing_day": 32},
     )
     assert resp.status_code == 400
 

--- a/tests/test_credit_card_bill_cycle.py
+++ b/tests/test_credit_card_bill_cycle.py
@@ -142,16 +142,62 @@ class TestBillCycleEquality:
 class TestComputeBillCycleValidation:
     """Invalid inputs raise ValueError."""
 
-    @pytest.mark.parametrize("invalid_day", [0, -1, 29, 32, 100])
-    def test_closing_day_outside_1_28_raises(self, invalid_day: int) -> None:
+    @pytest.mark.parametrize("invalid_day", [0, -1, 32, 100])
+    def test_closing_day_outside_1_31_raises(self, invalid_day: int) -> None:
         with pytest.raises(ValueError, match="closing_day"):
             compute_bill_cycle(
                 closing_day=invalid_day, due_day=15, anchor=date(2026, 5, 5)
             )
 
-    @pytest.mark.parametrize("invalid_day", [0, -1, 29, 32])
-    def test_due_day_outside_1_28_raises(self, invalid_day: int) -> None:
+    @pytest.mark.parametrize("invalid_day", [0, -1, 32])
+    def test_due_day_outside_1_31_raises(self, invalid_day: int) -> None:
         with pytest.raises(ValueError, match="due_day"):
             compute_bill_cycle(
                 closing_day=10, due_day=invalid_day, anchor=date(2026, 5, 5)
             )
+
+    @pytest.mark.parametrize("valid_day", [29, 30, 31])
+    def test_days_29_to_31_are_accepted(self, valid_day: int) -> None:
+        # Days 29-31 used to be blocked; they are now valid and clamped per
+        # month in short months. Issue #1469.
+        cycle = compute_bill_cycle(
+            closing_day=valid_day, due_day=valid_day, anchor=date(2026, 5, 5)
+        )
+        assert isinstance(cycle, BillCycle)
+
+
+class TestComputeBillCycleMonthEndClamp:
+    """closing_day/due_day 29-31 clamp to the last valid day in short months."""
+
+    def test_closing_day_30_clamps_in_february_non_leap(self) -> None:
+        # Card closes on the 30th; February 2026 has 28 days → closes Feb 28.
+        cycle = compute_bill_cycle(closing_day=30, due_day=5, anchor=date(2026, 2, 15))
+        assert cycle.end_date == date(2026, 2, 28)
+        # Previous close (Jan 30) + 1 day → cycle start.
+        assert cycle.start_date == date(2026, 1, 31)
+        # due_day 5 < closing_day → rolls to the month after closing.
+        assert cycle.due_date == date(2026, 3, 5)
+        assert cycle.status == "open"
+
+    def test_closing_day_31_clamps_in_february_leap_year(self) -> None:
+        # February 2024 has 29 days (leap) → closes Feb 29.
+        cycle = compute_bill_cycle(closing_day=31, due_day=10, anchor=date(2024, 2, 20))
+        assert cycle.end_date == date(2024, 2, 29)
+        assert cycle.start_date == date(2024, 2, 1)
+        assert cycle.due_date == date(2024, 3, 10)
+
+    def test_closing_day_31_clamps_in_30_day_month(self) -> None:
+        # April has 30 days → a day-31 card closes April 30.
+        cycle = compute_bill_cycle(closing_day=31, due_day=31, anchor=date(2026, 4, 10))
+        assert cycle.end_date == date(2026, 4, 30)
+        assert cycle.start_date == date(2026, 4, 1)
+        # due_day == closing_day → not strictly greater → rolls to next month,
+        # clamped to May 31 (May has 31 days).
+        assert cycle.due_date == date(2026, 5, 31)
+
+    def test_due_day_30_clamps_in_february(self) -> None:
+        # closing in January, due on the 30th of February → clamps to Feb 28.
+        cycle = compute_bill_cycle(closing_day=20, due_day=30, anchor=date(2026, 1, 25))
+        assert cycle.end_date == date(2026, 2, 20)
+        # due_day 30 > closing_day 20 → same month as closing (Feb), clamp 28.
+        assert cycle.due_date == date(2026, 2, 28)

--- a/tests/test_credit_card_bill_endpoints.py
+++ b/tests/test_credit_card_bill_endpoints.py
@@ -187,6 +187,22 @@ class TestBillEndpoint:
         )
         assert response.status_code == 400
 
+    def test_accepts_day_30_and_bills_february_without_error(self, client) -> None:
+        # Regression for #1469: a card closing on the 30th used to be rejected
+        # with 400 INVALID_DAY. It must now be created and its February bill
+        # must compute a clamped cycle (Feb 28) without raising.
+        token = _register_and_login(client, prefix="bill-day-30")
+        headers = _auth_headers(token)
+        card = _create_card(client, headers, closing_day=30, due_day=5)
+
+        response = client.get(
+            f"/credit-cards/{card['id']}/bill?month=2026-02", headers=headers
+        )
+        assert response.status_code == 200
+        cycle = response.get_json()["data"]["cycle"]
+        assert cycle["end_date"] == "2026-02-28"
+        assert cycle["due_date"] == "2026-03-05"
+
 
 class TestUtilizationEndpoint:
     def test_empty_card_returns_zero(self, client) -> None:


### PR DESCRIPTION
## Summary

`closing_day`/`due_day` eram limitados a 1–28, rejeitando dias legítimos (ex.: dia 30) com `400 INVALID_DAY`. Agora aceitamos 1–31 e **clampamos** dias inexistentes para o último dia válido do mês ao calcular o ciclo de fatura — um cartão com vencimento dia 30 fatura em 28/29 de fevereiro, sem `ValueError`.

### Mudanças
- `credit_card_bill_service.py`: `_validate_day` agora 1–31; novo helper `_safe_date` (clamp via `calendar.monthrange`) aplicado em `compute_bill_cycle` e no anchor de `compute_bill`.
- `controllers/credit_card/resources.py`: `_validate_days` 1–31 + mensagem atualizada.
- `schemas/credit_card_schema.py`: `Range(max=31)` + metadata "(1-31)".
- Testes: clamp em fev (normal e bissexto), meses de 30 dias, endpoint de fatura com dia 30, e atualização das assertions que usavam o limite antigo.

Frontend (auraxis-web) já enviava `:max="31"` no form — nenhuma mudança web necessária.

## Verificação
- `run_ci_quality_local.sh --local`: **2507 passed**, coverage **91.07%** (≥85%).

## Refs
Closes #1469