### PR TITLE
feat(onboarding): persistir conclusão server-side (flag no usuário, REST + GraphQL)

### DIFF
--- a/api-tests/postman/auraxis.postman_collection.json
+++ b/api-tests/postman/auraxis.postman_collection.json
@@ -1,7 +1,7 @@
 {
   "info": {
     "name": "Auraxis API",
-    "description": "Auto-generated from openapi.json (84 paths). Do not edit manually — regenerate with: npm run postman:build",
+    "description": "Auto-generated from openapi.json (85 paths). Do not edit manually — regenerate with: npm run postman:build",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "item": [
@@ -1106,6 +1106,50 @@
                 "exec": [
                   "pm.test('Remover avatar do usuário — expected 200 or 404', function () {",
                   "  pm.expect(pm.response.code).to.be.oneOf([200, 404]);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "POST /user/onboarding/complete",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/user/onboarding/complete",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "user",
+                "onboarding",
+                "complete"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('POST /user/onboarding/complete — status 200', function () {",
+                  "  pm.response.to.have.status(200);",
                   "});"
                 ],
                 "type": "text/javascript"

--- a/app/application/services/authenticated_user_context_service.py
+++ b/app/application/services/authenticated_user_context_service.py
@@ -33,6 +33,8 @@ class AuthenticatedUserProfile:
     taxonomy_version: str | None
     entitlements_version: int
     avatar_url: str | None
+    # Onboarding completion timestamp (ISO 8601) or None (#1471)
+    onboarding_completed_at: str | None = None
     # Email verification status (14d grace period soft-block)
     email_verified: bool = False
     email_verification_deadline_at: str | None = None
@@ -124,6 +126,9 @@ class AuthenticatedUserContextService:
             taxonomy_version=user.taxonomy_version,
             entitlements_version=int(user.entitlements_version or 0),
             avatar_url=user.avatar_url,
+            onboarding_completed_at=_datetime_isoformat_or_none(
+                user.onboarding_completed_at
+            ),
             email_verified=bool(user.email_verified),
             email_verification_deadline_at=_datetime_isoformat_or_none(
                 user.email_verification_deadline_at

--- a/app/controllers/user/onboarding_resource.py
+++ b/app/controllers/user/onboarding_resource.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from flask import Response
+from flask_apispec.views import MethodResource
+
+from app.auth import get_active_auth_context
+from app.extensions.database import db
+from app.utils.datetime_utils import utc_now_naive
+from app.utils.typed_decorators import typed_doc as doc
+from app.utils.typed_decorators import typed_jwt_required as jwt_required
+
+from .contracts import compat_success
+from .helpers import validate_user_token
+
+
+class OnboardingCompleteResource(MethodResource):
+    """Persist the onboarding-completed marker for the authenticated user.
+
+    Idempotent: the first call stamps ``onboarding_completed_at``; subsequent
+    calls return the existing timestamp without changing it. This lets the web
+    client record completion server-side so clearing browser storage on any
+    device does not re-trigger the onboarding wizard (#1471).
+    """
+
+    @doc(
+        description="Marca o onboarding do usuário como concluído (idempotente).",
+        tags=["Usuário"],
+        security=[{"BearerAuth": []}],
+        responses={
+            200: {"description": "Onboarding marcado como concluído"},
+            401: {"description": "Token inválido ou expirado"},
+        },
+    )
+    @jwt_required()
+    def post(self) -> Response:
+        auth_context = get_active_auth_context()
+        user_or_response = validate_user_token(auth_context)
+        if isinstance(user_or_response, Response):
+            return user_or_response
+
+        user = user_or_response
+        if user.onboarding_completed_at is None:
+            user.onboarding_completed_at = utc_now_naive()
+            db.session.commit()
+
+        completed_at = user.onboarding_completed_at.isoformat()
+        payload = {"onboarding_completed_at": completed_at}
+        return compat_success(
+            legacy_payload=payload,
+            status_code=200,
+            message="Onboarding concluído",
+            data=payload,
+        )

--- a/app/controllers/user/routes.py
+++ b/app/controllers/user/routes.py
@@ -21,6 +21,7 @@ from .helpers import validate_user_token
 from .me_export_resource import MeExportResource
 from .me_resource import UserMeResource
 from .notification_preferences_resource import NotificationPreferencesResource
+from .onboarding_resource import OnboardingCompleteResource
 from .profile_resource import UserProfileResource
 from .questionnaire_resource import UserQuestionnaireResource
 
@@ -112,6 +113,11 @@ def register_user_routes() -> None:
         "/me/avatar",
         view_func=AvatarResource.as_view("avatar"),
         methods=["POST", "DELETE"],
+    )
+    user_bp.add_url_rule(
+        "/onboarding/complete",
+        view_func=OnboardingCompleteResource.as_view("onboarding_complete"),
+        methods=["POST"],
     )
     _ROUTES_REGISTERED = True
 

--- a/app/graphql/docs_catalog.py
+++ b/app/graphql/docs_catalog.py
@@ -892,6 +892,18 @@ GRAPHQL_OPERATION_CATALOG: tuple[GraphQLOperationDoc, ...] = (
         ),
         source_module="app.graphql.mutations.ai_insight",
     ),
+    # Onboarding completion (#1471)
+    GraphQLOperationDoc(
+        name="completeOnboarding",
+        operation_type="mutation",
+        domain="user",
+        access="auth_required",
+        summary=(
+            "Marca o onboarding do usuário autenticado como concluído "
+            "(idempotente). Paridade com POST /user/onboarding/complete."
+        ),
+        source_module="app.graphql.mutations.user",
+    ),
 )
 
 

--- a/app/graphql/mutations/__init__.py
+++ b/app/graphql/mutations/__init__.py
@@ -71,6 +71,7 @@ from app.graphql.mutations.transaction import (
     DeleteTransactionMutation,
     UpdateTransactionMutation,
 )
+from app.graphql.mutations.user import CompleteOnboardingMutation
 from app.graphql.mutations.wallet import (
     AddWalletEntryMutation,
     DeleteWalletEntryMutation,
@@ -187,6 +188,8 @@ class Mutation(graphene.ObjectType):
     # AI Advisory — canonical GraphQL parity for POST /ai/insights/generate
     generate_ai_insight = GenerateAiInsightMutation.Field()
     submit_ai_insight_feedback = SubmitAiInsightFeedbackMutation.Field()
+    # Onboarding completion — REST parity: POST /user/onboarding/complete (#1471)
+    complete_onboarding = CompleteOnboardingMutation.Field()
 
 
 __all__ = ["Mutation"]

--- a/app/graphql/mutations/user.py
+++ b/app/graphql/mutations/user.py
@@ -1,0 +1,40 @@
+"""GraphQL mutations for user account state (#1471)."""
+
+from __future__ import annotations
+
+import graphene
+
+from app.extensions.database import db
+from app.graphql.auth import get_current_user_required
+from app.graphql.types import MutationPayload
+from app.utils.datetime_utils import utc_now_naive
+
+
+class CompleteOnboardingPayload(MutationPayload):
+    """Canonical payload for completeOnboarding mutation."""
+
+    onboarding_completed_at = graphene.String(
+        description="ISO 8601 timestamp when onboarding was completed."
+    )
+
+
+class CompleteOnboardingMutation(graphene.Mutation):
+    """Mark the authenticated user's onboarding as completed (idempotent).
+
+    REST parity: ``POST /user/onboarding/complete``.
+    """
+
+    Output = CompleteOnboardingPayload
+
+    def mutate(self, info: graphene.ResolveInfo) -> CompleteOnboardingPayload:
+        user = get_current_user_required()
+        if user.onboarding_completed_at is None:
+            user.onboarding_completed_at = utc_now_naive()
+            db.session.commit()
+
+        return CompleteOnboardingPayload(
+            ok=True,
+            message="Onboarding concluído",
+            errors=[],
+            onboarding_completed_at=user.onboarding_completed_at.isoformat(),
+        )

--- a/app/graphql/types.py
+++ b/app/graphql/types.py
@@ -27,6 +27,8 @@ class UserType(graphene.ObjectType):
     profile_quiz_score = graphene.Int()
     taxonomy_version = graphene.String()
     avatar_url = graphene.String()
+    # #1471: server-side onboarding completion marker (ISO 8601 or null)
+    onboarding_completed_at = graphene.String()
     # #1325 / #1331: 14-day email verification grace period
     email_verified = graphene.Boolean()
     email_verification_deadline_at = graphene.String()

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -63,6 +63,11 @@ class User(db.Model):
     # User avatar — URL of the uploaded image stored in S3/CDN.
     avatar_url = db.Column(db.String(500), nullable=True)
 
+    # Onboarding — server-side completion marker (#1471).
+    # Persisted so clearing browser storage on any device does NOT re-trigger
+    # the onboarding wizard. Null means the user has not finished onboarding.
+    onboarding_completed_at = db.Column(db.DateTime, nullable=True)
+
     # LGPD — soft-delete / account erasure.
     # When set, this account has been anonymised and must be treated as deleted.
     deleted_at = db.Column(db.DateTime, nullable=True)

--- a/app/services/authenticated_user_payloads.py
+++ b/app/services/authenticated_user_payloads.py
@@ -70,6 +70,7 @@ class AuthenticatedUserInvestorProfilePayload(TypedDict):
 
 class AuthenticatedUserProductContextPayload(TypedDict):
     entitlements_version: int
+    onboarding_completed_at: str | None
 
 
 class AuthenticatedUserEmailVerificationPayload(TypedDict):
@@ -133,6 +134,7 @@ def to_user_profile_payload(profile: AuthenticatedUserProfile) -> UserProfilePay
     """
     payload = asdict(profile)
     payload.pop("entitlements_version", None)
+    payload.pop("onboarding_completed_at", None)
     payload.pop("email_verified", None)
     payload.pop("email_verification_deadline_at", None)
     payload.pop("email_verification_required_now", None)
@@ -172,6 +174,7 @@ def to_authenticated_user_canonical_payload(
         },
         "product_context": {
             "entitlements_version": profile.entitlements_version,
+            "onboarding_completed_at": profile.onboarding_completed_at,
         },
         "email_verification": {
             "verified": profile.email_verified,

--- a/app/services/authenticated_user_payloads.py
+++ b/app/services/authenticated_user_payloads.py
@@ -36,6 +36,7 @@ class UserProfilePayload(TypedDict):
     profile_quiz_score: int | None
     taxonomy_version: str | None
     avatar_url: str | None
+    onboarding_completed_at: str | None
 
 
 class AuthenticatedUserIdentityPayload(TypedDict):
@@ -127,14 +128,14 @@ class WalletEntryPayload(TypedDict):
 def to_user_profile_payload(profile: AuthenticatedUserProfile) -> UserProfilePayload:
     """Build the legacy v2 flat user payload.
 
-    The v2 contract is **frozen**: it does not include the new
-    email-verification fields. Clients on v2 read verification status
-    from a separate header/endpoint; v3 surfaces it inside the canonical
-    ``email_verification`` block.
+    The v2 contract excludes the email-verification fields (clients read
+    those from a separate header/endpoint; v3 surfaces them in the canonical
+    ``email_verification`` block). ``onboarding_completed_at`` is exposed here
+    too as an additive, backward-compatible field so the v2 web client can
+    decide whether to show onboarding without migrating to v3 (#1471).
     """
     payload = asdict(profile)
     payload.pop("entitlements_version", None)
-    payload.pop("onboarding_completed_at", None)
     payload.pop("email_verified", None)
     payload.pop("email_verification_deadline_at", None)
     payload.pop("email_verification_required_now", None)

--- a/graphql.introspection.json
+++ b/graphql.introspection.json
@@ -9889,6 +9889,18 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "onboardingCompletedAt",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "emailVerified",
               "type": {
                 "kind": "SCALAR",
@@ -13668,6 +13680,18 @@
                 "name": "AIInsightFeedbackPayload",
                 "ofType": null
               }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Mark the authenticated user's onboarding as completed (idempotent).\n\nREST parity: ``POST /user/onboarding/complete``.",
+              "isDeprecated": false,
+              "name": "completeOnboarding",
+              "type": {
+                "kind": "OBJECT",
+                "name": "CompleteOnboardingPayload",
+                "ofType": null
+              }
             }
           ],
           "inputFields": null,
@@ -17042,6 +17066,86 @@
           "interfaces": [],
           "kind": "OBJECT",
           "name": "AIInsightFeedbackPayload",
+          "possibleTypes": null,
+          "specifiedByURL": null
+        },
+        {
+          "description": "Canonical payload for completeOnboarding mutation.",
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "True when the mutation completed without errors.",
+              "isDeprecated": false,
+              "name": "ok",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Human-readable status message.",
+              "isDeprecated": false,
+              "name": "message",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Field-level validation errors (empty on success).",
+              "isDeprecated": false,
+              "name": "errors",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "ValidationError",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "ISO 8601 timestamp when onboarding was completed.",
+              "isDeprecated": false,
+              "name": "onboardingCompletedAt",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "CompleteOnboardingPayload",
           "possibleTypes": null,
           "specifiedByURL": null
         },

--- a/graphql.operations.manifest.json
+++ b/graphql.operations.manifest.json
@@ -741,5 +741,13 @@
     "operation_type": "mutation",
     "source_module": "app.graphql.mutations.ai_insight",
     "summary": "Registra feedback (notas 0–5 de relevância/veracidade/profundidade/utilidade + comentário) de um insight do próprio usuário. Paridade com POST /ai/insights/<id>/feedback."
+  },
+  {
+    "access": "auth_required",
+    "domain": "user",
+    "name": "completeOnboarding",
+    "operation_type": "mutation",
+    "source_module": "app.graphql.mutations.user",
+    "summary": "Marca o onboarding do usuário autenticado como concluído (idempotente). Paridade com POST /user/onboarding/complete."
   }
 ]

--- a/migrations/versions/onb1_user_onboarding_completed_at.py
+++ b/migrations/versions/onb1_user_onboarding_completed_at.py
@@ -1,0 +1,44 @@
+"""onb1 — add users.onboarding_completed_at with backfill.
+
+Persists onboarding completion server-side so clearing browser storage on any
+device does not re-trigger the onboarding wizard. Existing users are backfilled
+as already onboarded (they are active product users) so the new server flag
+never forces them through onboarding again (#1471).
+
+Revision ID: onb1_user_onboarding
+Revises: cc2_card_privacy
+Create Date: 2026-06-08
+
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "onb1_user_onboarding"
+down_revision = "cc2_card_privacy"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("onboarding_completed_at", sa.DateTime(), nullable=True),
+    )
+    # Backfill: every pre-existing user is treated as already onboarded.
+    op.execute(
+        "UPDATE users SET onboarding_completed_at = CURRENT_TIMESTAMP "
+        "WHERE onboarding_completed_at IS NULL"
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_context().connection
+    if bind.dialect.name == "sqlite":
+        with op.batch_alter_table("users") as batch:
+            batch.drop_column("onboarding_completed_at")
+        return
+
+    op.drop_column("users", "onboarding_completed_at")

--- a/openapi.json
+++ b/openapi.json
@@ -2,6 +2,7 @@
   "components": {
     "schemas": {
       "InstallmentVsCashCalculation": {
+        "additionalProperties": false,
         "properties": {
           "cash_price": {
             "minimum": 0.01,
@@ -75,6 +76,7 @@
         "type": "object"
       },
       "InstallmentVsCashGoalBridge": {
+        "additionalProperties": false,
         "properties": {
           "category": {
             "default": "planned_purchase",
@@ -125,6 +127,7 @@
         "type": "object"
       },
       "InstallmentVsCashPlannedExpenseBridge": {
+        "additionalProperties": false,
         "properties": {
           "account_id": {
             "default": null,
@@ -211,6 +214,7 @@
         "type": "object"
       },
       "InstallmentVsCashSave": {
+        "additionalProperties": false,
         "properties": {
           "cash_price": {
             "minimum": 0.01,
@@ -284,6 +288,7 @@
         "type": "object"
       },
       "TransactionCreate": {
+        "additionalProperties": false,
         "properties": {
           "account_id": {
             "description": "ID da conta bancária associada",
@@ -484,6 +489,7 @@
         "type": "object"
       },
       "TransactionCreate_7d3b606eab": {
+        "additionalProperties": false,
         "properties": {
           "account_id": {
             "description": "ID da conta bancária associada",
@@ -678,6 +684,7 @@
         "type": "object"
       },
       "app_schemas_ai_insight_schema_AIInsightGenerateRequestSchema": {
+        "additionalProperties": false,
         "properties": {
           "anchor_date": {
             "description": "Data âncora do período no formato YYYY-MM-DD.",
@@ -716,6 +723,7 @@
         "type": "object"
       },
       "app_schemas_ai_insight_schema_AIMonthlyReportRequestSchema": {
+        "additionalProperties": false,
         "properties": {
           "anchor_date": {
             "description": "Data âncora do mês a consolidar. Quando omitida, a API usa a data atual.",
@@ -734,6 +742,7 @@
         "type": "object"
       },
       "app_schemas_auth_schema_AuthSchema": {
+        "additionalProperties": false,
         "properties": {
           "captcha_token": {
             "default": null,
@@ -761,6 +770,7 @@
         "type": "object"
       },
       "app_schemas_auth_schema_ConfirmEmailSchema": {
+        "additionalProperties": false,
         "properties": {
           "token": {
             "description": "Token de confirmacao recebido por email",
@@ -776,6 +786,7 @@
         "type": "object"
       },
       "app_schemas_auth_schema_ForgotPasswordSchema": {
+        "additionalProperties": false,
         "properties": {
           "email": {
             "description": "Email da conta que deseja recuperar acesso",
@@ -790,6 +801,7 @@
         "type": "object"
       },
       "app_schemas_auth_schema_ResetPasswordSchema": {
+        "additionalProperties": false,
         "properties": {
           "new_password": {
             "description": "Nova senha (mínimo 10 caracteres, com maiúscula, número e símbolo)",
@@ -813,6 +825,7 @@
         "type": "object"
       },
       "app_schemas_consent_schemas_ConsentRecordSchema": {
+        "additionalProperties": false,
         "properties": {
           "action": {
             "enum": [
@@ -855,6 +868,7 @@
         "type": "object"
       },
       "app_schemas_push_subscription_schema_SubscribeSchema": {
+        "additionalProperties": false,
         "properties": {
           "device_label": {
             "default": null,
@@ -889,6 +903,7 @@
         "type": "object"
       },
       "app_schemas_push_subscription_schema_UnsubscribeSchema": {
+        "additionalProperties": false,
         "properties": {
           "endpoint": {
             "type": "string"
@@ -900,6 +915,7 @@
         "type": "object"
       },
       "app_schemas_user_schemas_DeleteAccountSchema": {
+        "additionalProperties": false,
         "properties": {
           "password": {
             "description": "Senha atual do usuário para confirmar a exclusão da conta",
@@ -914,6 +930,7 @@
         "type": "object"
       },
       "app_schemas_user_schemas_QuestionnaireAnswerSchema": {
+        "additionalProperties": false,
         "properties": {
           "answers": {
             "description": "Lista de 5 respostas — pontos da opção escolhida em cada pergunta (1–3).",
@@ -933,6 +950,7 @@
         "type": "object"
       },
       "app_schemas_user_schemas_SalaryIncreaseSimulationRequestSchema": {
+        "additionalProperties": false,
         "properties": {
           "base_date": {
             "description": "Data base do salário atual",
@@ -968,6 +986,7 @@
         "type": "object"
       },
       "app_schemas_user_schemas_UserProfileSchema": {
+        "additionalProperties": false,
         "properties": {
           "birth_date": {
             "description": "Data de nascimento",
@@ -1080,6 +1099,7 @@
         "type": "object"
       },
       "app_schemas_user_schemas_UserRegistrationSchema": {
+        "additionalProperties": false,
         "properties": {
           "captcha_token": {
             "default": null,
@@ -11669,6 +11689,28 @@
           },
           "400": {
             "description": "Dados inválidos"
+          },
+          "401": {
+            "description": "Token inválido ou expirado"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Usuário"
+        ]
+      }
+    },
+    "/user/onboarding/complete": {
+      "post": {
+        "description": "Marca o onboarding do usuário como concluído (idempotente).",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Onboarding marcado como concluído"
           },
           "401": {
             "description": "Token inválido ou expirado"

--- a/schema.graphql
+++ b/schema.graphql
@@ -802,6 +802,7 @@ type UserType {
   profileQuizScore: Int
   taxonomyVersion: String
   avatarUrl: String
+  onboardingCompletedAt: String
   emailVerified: Boolean
   emailVerificationDeadlineAt: String
   emailVerificationRequiredNow: Boolean
@@ -934,6 +935,13 @@ type Mutation {
 
   """GraphQL parity for POST /ai/insights/<id>/feedback (#1387)."""
   submitAiInsightFeedback(comment: String, depth: Int!, insightId: String!, relevance: Int!, truthfulness: Int!, usefulness: Int!): AIInsightFeedbackPayload
+
+  """
+  Mark the authenticated user's onboarding as completed (idempotent).
+  
+  REST parity: ``POST /user/onboarding/complete``.
+  """
+  completeOnboarding: CompleteOnboardingPayload
 }
 
 type AuthPayloadType {
@@ -1354,4 +1362,19 @@ type AIInsightFeedbackPayload {
   depth: Int
   usefulness: Int
   comment: String
+}
+
+"""Canonical payload for completeOnboarding mutation."""
+type CompleteOnboardingPayload {
+  """True when the mutation completed without errors."""
+  ok: Boolean!
+
+  """Human-readable status message."""
+  message: String!
+
+  """Field-level validation errors (empty on success)."""
+  errors: [ValidationError!]!
+
+  """ISO 8601 timestamp when onboarding was completed."""
+  onboardingCompletedAt: String
 }

--- a/tests/test_onboarding_completion.py
+++ b/tests/test_onboarding_completion.py
@@ -1,0 +1,138 @@
+"""Tests for server-side onboarding completion (#1471).
+
+Covers:
+- POST /user/onboarding/complete stamps the marker and is idempotent.
+- GET /user/me (v3) exposes product_context.onboarding_completed_at.
+- GraphQL completeOnboarding mutation + me.onboardingCompletedAt parity.
+- New users start with a null marker (so the wizard shows once).
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from app.extensions.database import db
+from app.models.user import User
+
+
+def _register_and_login(client, *, prefix: str = "onb") -> str:
+    suffix = uuid4().hex[:8]
+    email = f"{prefix}-{suffix}@email.com"
+    password = "StrongPass@123"
+    register = client.post(
+        "/auth/register",
+        json={"name": f"user-{suffix}", "email": email, "password": password},
+    )
+    assert register.status_code == 201
+    login = client.post("/auth/login", json={"email": email, "password": password})
+    assert login.status_code == 200
+    return login.get_json()["token"]
+
+
+def _auth(token: str, contract: str | None = None) -> dict[str, str]:
+    headers = {"Authorization": f"Bearer {token}"}
+    if contract:
+        headers["X-API-Contract"] = contract
+    return headers
+
+
+def _gql(client, query, token):
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "X-API-Contract": "v2",
+        "Content-Type": "application/json",
+    }
+    return client.post("/graphql", json={"query": query}, headers=headers)
+
+
+class TestOnboardingCompleteEndpoint:
+    def test_new_user_starts_without_onboarding_marker(self, client) -> None:
+        token = _register_and_login(client)
+        resp = client.get("/user/me", headers=_auth(token, "v3"))
+        assert resp.status_code == 200
+        product_context = resp.get_json()["data"]["user"]["product_context"]
+        assert "onboarding_completed_at" in product_context
+        assert product_context["onboarding_completed_at"] is None
+
+    def test_complete_stamps_marker(self, client) -> None:
+        token = _register_and_login(client)
+        resp = client.post("/user/onboarding/complete", headers=_auth(token, "v2"))
+        assert resp.status_code == 200
+        completed_at = resp.get_json()["data"]["onboarding_completed_at"]
+        assert completed_at is not None
+
+        me = client.get("/user/me", headers=_auth(token, "v3"))
+        assert (
+            me.get_json()["data"]["user"]["product_context"]["onboarding_completed_at"]
+            == completed_at
+        )
+
+    def test_complete_is_idempotent(self, client) -> None:
+        token = _register_and_login(client)
+        first = client.post("/user/onboarding/complete", headers=_auth(token, "v2"))
+        second = client.post("/user/onboarding/complete", headers=_auth(token, "v2"))
+        assert first.status_code == second.status_code == 200
+        # The timestamp must not move on the second call.
+        assert (
+            first.get_json()["data"]["onboarding_completed_at"]
+            == second.get_json()["data"]["onboarding_completed_at"]
+        )
+
+    def test_requires_auth(self, client) -> None:
+        resp = client.post("/user/onboarding/complete")
+        assert resp.status_code == 401
+
+
+class TestOnboardingGraphQLParity:
+    def test_complete_onboarding_mutation_and_me_field(self, client) -> None:
+        token = _register_and_login(client)
+
+        mutation = """
+        mutation {
+          completeOnboarding {
+            ok
+            onboardingCompletedAt
+          }
+        }
+        """
+        resp = _gql(client, mutation, token)
+        assert resp.status_code == 200
+        data = resp.get_json()["data"]["completeOnboarding"]
+        assert data["ok"] is True
+        assert data["onboardingCompletedAt"] is not None
+
+        me_query = "query { me { onboardingCompletedAt } }"
+        me_resp = _gql(client, me_query, token)
+        assert me_resp.status_code == 200
+        assert (
+            me_resp.get_json()["data"]["me"]["onboardingCompletedAt"]
+            == data["onboardingCompletedAt"]
+        )
+
+    def test_complete_onboarding_requires_auth(self, client) -> None:
+        mutation = "mutation { completeOnboarding { ok } }"
+        resp = client.post(
+            "/graphql",
+            json={"query": mutation},
+            headers={"X-API-Contract": "v2", "Content-Type": "application/json"},
+        )
+        body = resp.get_json()
+        assert body.get("errors")
+
+
+def test_build_profile_reads_onboarding_marker(app) -> None:
+    from app.application.services.authenticated_user_context_service import (
+        AuthenticatedUserContextService,
+    )
+    from app.utils.datetime_utils import utc_now_naive
+
+    with app.app_context():
+        user = User(name="Onb", email=f"onb-{uuid4().hex[:8]}@e.com", password="x")
+        user.onboarding_completed_at = utc_now_naive()
+        db.session.add(user)
+        db.session.commit()
+
+        profile = AuthenticatedUserContextService.with_defaults().build_profile(user)
+        assert (
+            profile.onboarding_completed_at == user.onboarding_completed_at.isoformat()
+        )

--- a/tests/test_onboarding_completion.py
+++ b/tests/test_onboarding_completion.py
@@ -67,6 +67,16 @@ class TestOnboardingCompleteEndpoint:
             == completed_at
         )
 
+    def test_v2_flat_me_exposes_onboarding_marker(self, client) -> None:
+        # The v2 web client reads the flat /user/me; the field must be present
+        # there too (additive), starting as null for new users.
+        token = _register_and_login(client)
+        resp = client.get("/user/me", headers=_auth(token, "v2"))
+        assert resp.status_code == 200
+        user = resp.get_json()["data"]["user"]
+        assert "onboarding_completed_at" in user
+        assert user["onboarding_completed_at"] is None
+
     def test_complete_is_idempotent(self, client) -> None:
         token = _register_and_login(client)
         first = client.post("/user/onboarding/complete", headers=_auth(token, "v2"))

--- a/tests/test_user_contract.py
+++ b/tests/test_user_contract.py
@@ -102,7 +102,7 @@ INVESTOR_PROFILE_FIELDS = {
     "taxonomy_version",
     "financial_objectives",
 }
-PRODUCT_CONTEXT_FIELDS = {"entitlements_version"}
+PRODUCT_CONTEXT_FIELDS = {"entitlements_version", "onboarding_completed_at"}
 
 TRANSACTION_ITEM_FIELDS = {
     "id",

--- a/tests/test_user_contract.py
+++ b/tests/test_user_contract.py
@@ -67,6 +67,7 @@ USER_FIELDS = {
     "profile_quiz_score",
     "taxonomy_version",
     "avatar_url",
+    "onboarding_completed_at",
 }
 
 CANONICAL_USER_KEYS = {


### PR DESCRIPTION
## Summary

A conclusão do onboarding vivia só no `localStorage` da web — limpar dados do navegador (ou trocar de PC) forçava o usuário a refazer tudo. Agora há um marcador **server-side** atrelado à conta.

### Mudanças
- **Model + migration** `onb1`: `users.onboarding_completed_at` (DateTime nullable) com **backfill** marcando todos os usuários existentes como já onboardados (não forçam refazer).
- **/user/me v3**: expõe `product_context.onboarding_completed_at`. Contrato **v2 flat permanece congelado** (campo é removido lá).
- **REST**: `POST /user/onboarding/complete` — idempotente (carimba o timestamp na 1ª vez, mantém nas seguintes).
- **GraphQL parity**: campo `me.onboardingCompletedAt` + mutation `completeOnboarding`; entrada no docs catalog.
- Artefatos regenerados: `schema.graphql`, `openapi.json`, collection Postman.

### Companion
- Web: #1033 (consumir o flag em `useOnboarding.shouldShow`).

## Verificação
- `run_ci_quality_local.sh --local`: **2508 passed**, coverage **91.09%** (≥85%).
- Migration up/down testada em postgres efêmero (`test_migrations_local.sh`).

## Refs
Closes #1471