### PR TITLE
feat(goals): registrar aporte/retirada + histórico de contribuições (REST + GraphQL)

### DIFF
--- a/api-tests/postman/auraxis.postman_collection.json
+++ b/api-tests/postman/auraxis.postman_collection.json
@@ -2798,8 +2798,8 @@
               "listen": "test",
               "script": {
                 "exec": [
-                  "pm.test('GET /goals/{goal_id}/contributions — status 200', function () {",
-                  "  pm.response.to.have.status(200);",
+                  "pm.test('Historico de contribuicoes — expected 200 or 404', function () {",
+                  "  pm.expect(pm.response.code).to.be.oneOf([200, 404]);",
                   "});"
                 ],
                 "type": "text/javascript"
@@ -2841,6 +2841,10 @@
                   "value": "{{goalId}}"
                 }
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"amount\": \"100.00\",\n  \"note\": \"smoke {{runSeed}}\"\n}"
             }
           },
           "event": [
@@ -2848,8 +2852,8 @@
               "listen": "test",
               "script": {
                 "exec": [
-                  "pm.test('POST /goals/{goal_id}/contributions — status 201', function () {",
-                  "  pm.response.to.have.status(201);",
+                  "pm.test('Registrar contribuicao — expected 201 or 400 or 404', function () {",
+                  "  pm.expect(pm.response.code).to.be.oneOf([201, 400, 404]);",
                   "});"
                 ],
                 "type": "text/javascript"

--- a/api-tests/postman/auraxis.postman_collection.json
+++ b/api-tests/postman/auraxis.postman_collection.json
@@ -1,7 +1,7 @@
 {
   "info": {
     "name": "Auraxis API",
-    "description": "Auto-generated from openapi.json (85 paths). Do not edit manually — regenerate with: npm run postman:build",
+    "description": "Auto-generated from openapi.json (86 paths). Do not edit manually — regenerate with: npm run postman:build",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "item": [

--- a/api-tests/postman/auraxis.postman_collection.json
+++ b/api-tests/postman/auraxis.postman_collection.json
@@ -1,7 +1,7 @@
 {
   "info": {
     "name": "Auraxis API",
-    "description": "Auto-generated from openapi.json (84 paths). Do not edit manually — regenerate with: npm run postman:build",
+    "description": "Auto-generated from openapi.json (85 paths). Do not edit manually — regenerate with: npm run postman:build",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "item": [
@@ -2710,6 +2710,102 @@
                 "exec": [
                   "pm.test('DELETE /goals/{goal_id} — status 200', function () {",
                   "  pm.response.to.have.status(200);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "GET /goals/{goal_id}/contributions",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/goals/:goal_id/contributions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "goals",
+                ":goal_id",
+                "contributions"
+              ],
+              "variable": [
+                {
+                  "key": "goal_id",
+                  "value": "{{goalId}}"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('GET /goals/{goal_id}/contributions — status 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "POST /goals/{goal_id}/contributions",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/goals/:goal_id/contributions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "goals",
+                ":goal_id",
+                "contributions"
+              ],
+              "variable": [
+                {
+                  "key": "goal_id",
+                  "value": "{{goalId}}"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('POST /goals/{goal_id}/contributions — status 201', function () {",
+                  "  pm.response.to.have.status(201);",
                   "});"
                 ],
                 "type": "text/javascript"

--- a/app/application/services/goal_application_service.py
+++ b/app/application/services/goal_application_service.py
@@ -12,9 +12,14 @@ from app.extensions.database import db
 from app.models.goal_contribution import GoalContribution
 from app.models.user import User
 from app.schemas.goal_planning_schema import GoalSimulationSchema
+from app.schemas.goal_schema import (
+    GoalContributionInputSchema,
+    GoalContributionSchema,
+)
 from app.services.goal_planning_service import GoalPlanningInput, GoalPlanningService
 from app.services.goal_projection_service import GoalProjectionService
 from app.services.goal_service import GoalService, GoalServiceError
+from app.utils.datetime_utils import utc_now_naive
 
 log = logging.getLogger(__name__)
 
@@ -41,6 +46,8 @@ class GoalApplicationService:
         self._goal_planning_service_factory = goal_planning_service_factory
         self._get_user_by_id = get_user_by_id
         self._simulation_schema = GoalSimulationSchema()
+        self._contribution_input_schema = GoalContributionInputSchema()
+        self._contribution_output_schema = GoalContributionSchema()
 
     @classmethod
     def with_defaults(cls, user_id: UUID) -> GoalApplicationService:
@@ -110,6 +117,91 @@ class GoalApplicationService:
                 )
 
         return self._goal_service.serialize(goal)
+
+    def add_contribution(
+        self, goal_id: UUID, payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Register a deposit (+) or withdrawal (-) against a goal.
+
+        Applies the signed delta to ``current_amount``, records a
+        ``GoalContribution`` history row and auto-completes the goal when the
+        target is reached. Rejects withdrawals that would drive the balance
+        negative.
+        """
+        try:
+            validated = self._contribution_input_schema.load(payload)
+        except ValidationError as exc:
+            raise GoalApplicationError(
+                message="Dados inválidos para a contribuição.",
+                code="VALIDATION_ERROR",
+                status_code=400,
+                details={"messages": exc.messages},
+            ) from exc
+
+        try:
+            goal = self._goal_service.get_goal(goal_id)
+        except GoalServiceError as exc:
+            raise _to_goal_application_error(exc) from exc
+
+        amount = Decimal(str(validated["amount"]))
+        current = Decimal(str(goal.current_amount or 0))
+        new_amount = current + amount
+        if new_amount < 0:
+            raise GoalApplicationError(
+                message="A retirada excede o saldo acumulado da meta.",
+                code="INSUFFICIENT_BALANCE",
+                status_code=400,
+            )
+
+        goal.current_amount = new_amount
+        target = Decimal(str(goal.target_amount or 0))
+        if target > 0 and new_amount >= target and goal.status == "active":
+            goal.status = "completed"
+
+        occurred_at = validated.get("occurred_at") or utc_now_naive().date()
+        contribution = GoalContribution(
+            goal_id=goal.id,
+            user_id=self._user_id,
+            amount=amount,
+            note=validated.get("note"),
+            occurred_at=occurred_at,
+        )
+        db.session.add(contribution)
+        db.session.commit()
+
+        return {
+            "goal": self._goal_service.serialize(goal),
+            "contribution": self._contribution_output_schema.dump(contribution),
+        }
+
+    def list_contributions(
+        self, goal_id: UUID, *, page: int, per_page: int
+    ) -> dict[str, Any]:
+        """Return the paginated contribution history for a goal (newest first)."""
+        try:
+            self._goal_service.get_goal(goal_id)
+        except GoalServiceError as exc:
+            raise _to_goal_application_error(exc) from exc
+
+        pagination = (
+            GoalContribution.query.filter_by(goal_id=goal_id)
+            .order_by(
+                GoalContribution.occurred_at.desc(),
+                GoalContribution.created_at.desc(),
+            )
+            .paginate(page=page, per_page=per_page, error_out=False)
+        )
+        return {
+            "items": [
+                self._contribution_output_schema.dump(item) for item in pagination.items
+            ],
+            "pagination": {
+                "total": int(pagination.total),
+                "page": int(pagination.page),
+                "per_page": int(pagination.per_page),
+                "pages": int(pagination.pages),
+            },
+        }
 
     def delete_goal(self, goal_id: UUID) -> None:
         try:

--- a/app/controllers/goal/resources.py
+++ b/app/controllers/goal/resources.py
@@ -351,6 +351,91 @@ class GoalProjectionResource(MethodResource):
         )
 
 
+class GoalContributionsResource(MethodResource):
+    @doc(
+        description=(
+            "Registra um aporte (valor positivo) ou retirada (valor negativo) "
+            "na meta, atualizando o valor acumulado e o histórico."
+        ),
+        tags=["Metas"],
+        security=[{"BearerAuth": []}],
+        params={"goal_id": {"in": "path", "type": "string", "required": True}},
+        responses={
+            201: {"description": "Contribuição registrada com sucesso"},
+            400: {"description": "Dados inválidos ou saldo insuficiente"},
+            401: {"description": "Token inválido"},
+            403: {"description": "Sem permissão"},
+            404: {"description": "Meta não encontrada"},
+        },
+    )
+    @jwt_required()
+    @require_email_verified
+    def post(self, goal_id: UUID) -> Any:
+        user_id = current_user_id()
+        payload = request.get_json() or {}
+        dependencies = get_goal_dependencies()
+        service = dependencies.goal_application_service_factory(user_id)
+        try:
+            result = service.add_contribution(goal_id, payload)
+        except GoalApplicationError as exc:
+            return goal_application_error_response(exc)
+
+        return compat_success(
+            legacy_payload={
+                "message": "Contribuição registrada com sucesso",
+                "goal": result["goal"],
+                "contribution": result["contribution"],
+            },
+            status_code=201,
+            message="Contribuição registrada com sucesso",
+            data={
+                "goal": result["goal"],
+                "contribution": result["contribution"],
+            },
+        )
+
+    @doc(
+        description="Lista o histórico de contribuições de uma meta (paginado).",
+        tags=["Metas"],
+        security=[{"BearerAuth": []}],
+        params={
+            "goal_id": {"in": "path", "type": "string", "required": True},
+        },
+        responses={
+            200: {"description": "Histórico paginado de contribuições"},
+            401: {"description": "Token inválido"},
+            403: {"description": "Sem permissão"},
+            404: {"description": "Meta não encontrada"},
+        },
+    )
+    @use_kwargs(
+        {
+            "page": fields.Int(load_default=1, validate=lambda x: x > 0),
+            "per_page": fields.Int(load_default=10, validate=lambda x: 0 < x <= 100),
+        },
+        location="query",
+    )
+    @jwt_required()
+    def get(self, goal_id: UUID, page: int, per_page: int) -> Any:
+        user_id = current_user_id()
+        dependencies = get_goal_dependencies()
+        service = dependencies.goal_application_service_factory(user_id)
+        try:
+            result = service.list_contributions(goal_id, page=page, per_page=per_page)
+        except GoalApplicationError as exc:
+            return goal_application_error_response(exc)
+
+        items = result["items"]
+        pagination = result["pagination"]
+        return compat_success(
+            legacy_payload={"items": items, **pagination},
+            status_code=200,
+            message="Histórico de contribuições retornado com sucesso",
+            data={"items": items},
+            meta={"pagination": pagination},
+        )
+
+
 class GoalSimulationResource(MethodResource):
     @doc(
         description=(

--- a/app/controllers/goal/routes.py
+++ b/app/controllers/goal/routes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from .blueprint import goal_bp
 from .resources import (
     GoalCollectionResource,
+    GoalContributionsResource,
     GoalPlanResource,
     GoalProjectionResource,
     GoalResource,
@@ -41,6 +42,11 @@ def register_goal_routes() -> None:
         "/<uuid:goal_id>/projection",
         view_func=GoalProjectionResource.as_view("goal_projection"),
         methods=["GET"],
+    )
+    goal_bp.add_url_rule(
+        "/<uuid:goal_id>/contributions",
+        view_func=GoalContributionsResource.as_view("goal_contributions"),
+        methods=["GET", "POST"],
     )
 
     _ROUTES_REGISTERED = True

--- a/app/graphql/docs_catalog.py
+++ b/app/graphql/docs_catalog.py
@@ -176,6 +176,17 @@ GRAPHQL_OPERATION_CATALOG: tuple[GraphQLOperationDoc, ...] = (
         source_module=QUERY_GOAL_MODULE,
     ),
     GraphQLOperationDoc(
+        name="goalContributions",
+        operation_type="query",
+        domain="goals",
+        access="auth_required",
+        summary=(
+            "Lista o histórico paginado de contribuições (aportes/retiradas) "
+            "de uma meta. Paridade com GET /goals/{id}/contributions."
+        ),
+        source_module=QUERY_GOAL_MODULE,
+    ),
+    GraphQLOperationDoc(
         name="installmentVsCashCalculate",
         operation_type="query",
         domain="simulations",
@@ -408,6 +419,17 @@ GRAPHQL_OPERATION_CATALOG: tuple[GraphQLOperationDoc, ...] = (
         domain="goals",
         access="auth_required",
         summary="Simula o plano de aporte de uma meta sem persistir dados.",
+        source_module=MUTATION_GOAL_MODULE,
+    ),
+    GraphQLOperationDoc(
+        name="recordGoalContribution",
+        operation_type="mutation",
+        domain="goals",
+        access="auth_required",
+        summary=(
+            "Registra um aporte (+) ou retirada (-) em uma meta, atualizando o "
+            "valor acumulado. Paridade com POST /goals/{id}/contributions."
+        ),
         source_module=MUTATION_GOAL_MODULE,
     ),
     GraphQLOperationDoc(

--- a/app/graphql/goal_presenters.py
+++ b/app/graphql/goal_presenters.py
@@ -9,7 +9,12 @@ from app.graphql.errors import (
     GRAPHQL_ERROR_CODE_VALIDATION,
     build_public_graphql_error,
 )
-from app.graphql.types import GoalPlanType, GoalRecommendationType, GoalTypeObject
+from app.graphql.types import (
+    GoalContributionType,
+    GoalPlanType,
+    GoalRecommendationType,
+    GoalTypeObject,
+)
 
 _GOAL_GRAPHQL_FIELDS = {
     "id",
@@ -24,10 +29,19 @@ _GOAL_GRAPHQL_FIELDS = {
     "created_at",
     "updated_at",
 }
+_GOAL_CONTRIBUTION_GRAPHQL_FIELDS = {
+    "id",
+    "goal_id",
+    "amount",
+    "note",
+    "occurred_at",
+    "created_at",
+}
 _GOAL_ERROR_CODE_MAP = {
     "VALIDATION_ERROR": GRAPHQL_ERROR_CODE_VALIDATION,
     "NOT_FOUND": GRAPHQL_ERROR_CODE_NOT_FOUND,
     "FORBIDDEN": GRAPHQL_ERROR_CODE_FORBIDDEN,
+    "INSUFFICIENT_BALANCE": GRAPHQL_ERROR_CODE_VALIDATION,
 }
 
 
@@ -41,6 +55,17 @@ def to_goal_type_object(goal_data: Mapping[str, object]) -> GoalTypeObject:
         key: value for key, value in goal_data.items() if key in _GOAL_GRAPHQL_FIELDS
     }
     return GoalTypeObject(**filtered)
+
+
+def to_goal_contribution_type(
+    contribution_data: Mapping[str, object],
+) -> GoalContributionType:
+    filtered = {
+        key: value
+        for key, value in contribution_data.items()
+        if key in _GOAL_CONTRIBUTION_GRAPHQL_FIELDS
+    }
+    return GoalContributionType(**filtered)
 
 
 def to_goal_plan_type(plan_data: Mapping[str, object]) -> GoalPlanType:

--- a/app/graphql/mutations/__init__.py
+++ b/app/graphql/mutations/__init__.py
@@ -41,6 +41,7 @@ from app.graphql.mutations.fiscal import (
 from app.graphql.mutations.goal import (
     CreateGoalMutation,
     DeleteGoalMutation,
+    RecordGoalContributionMutation,
     SimulateGoalPlanMutation,
     UpdateGoalMutation,
 )
@@ -108,6 +109,9 @@ class Mutation(graphene.ObjectType):
         deprecation_reason="ADR-0002: use DELETE /goals/{id}"
     )
     simulate_goal_plan = SimulateGoalPlanMutation.Field()
+    # Goal contributions — canonical GraphQL parity for
+    # POST /goals/{id}/contributions (#1470)
+    record_goal_contribution = RecordGoalContributionMutation.Field()
     save_installment_vs_cash_simulation = (
         SaveInstallmentVsCashSimulationMutation.Field()
     )

--- a/app/graphql/mutations/goal.py
+++ b/app/graphql/mutations/goal.py
@@ -14,11 +14,12 @@ from app.graphql.decorators import graphql_error_adapter, resolver_with_user_con
 from app.graphql.enums import GoalStatusEnum, coerce_enum_kwargs
 from app.graphql.goal_presenters import (
     raise_goal_graphql_error,
+    to_goal_contribution_type,
     to_goal_plan_type,
     to_goal_type_object,
 )
 from app.graphql.observability import log_graphql_resolver
-from app.graphql.types import GoalPlanType, GoalTypeObject
+from app.graphql.types import GoalContributionType, GoalPlanType, GoalTypeObject
 
 
 class CreateGoalMutation(graphene.Mutation):
@@ -100,6 +101,39 @@ class DeleteGoalMutation(graphene.Mutation):
         return DeleteGoalMutation(
             ok=True,
             message="Meta removida com sucesso",
+        )
+
+
+class RecordGoalContributionMutation(graphene.Mutation):
+    """Register a deposit (+) or withdrawal (-) against a goal.
+
+    REST parity: ``POST /goals/{goal_id}/contributions``.
+    """
+
+    class Arguments:
+        goal_id = graphene.UUID(required=True)
+        amount = graphene.String(required=True)
+        occurred_at = graphene.String()
+        note = graphene.String()
+
+    message = graphene.String(required=True)
+    goal = graphene.Field(GoalTypeObject, required=True)
+    contribution = graphene.Field(GoalContributionType, required=True)
+
+    def mutate(
+        self, info: graphene.ResolveInfo, goal_id: UUID, **kwargs: Any
+    ) -> "RecordGoalContributionMutation":
+        user = get_current_user_required()
+        service = GoalApplicationService.with_defaults(UUID(str(user.id)))
+        payload = {k: v for k, v in kwargs.items() if v is not None}
+        try:
+            result = service.add_contribution(goal_id, payload)
+        except GoalApplicationError as exc:
+            raise_goal_graphql_error(exc)
+        return RecordGoalContributionMutation(
+            message="Contribuição registrada com sucesso",
+            goal=to_goal_type_object(result["goal"]),
+            contribution=to_goal_contribution_type(result["contribution"]),
         )
 
 

--- a/app/graphql/queries/goal.py
+++ b/app/graphql/queries/goal.py
@@ -12,11 +12,17 @@ from app.application.services.goal_application_service import (
 from app.graphql.auth import get_current_user_required
 from app.graphql.goal_presenters import (
     raise_goal_graphql_error,
+    to_goal_contribution_type,
     to_goal_plan_type,
     to_goal_type_object,
 )
 from app.graphql.queries.common import paginate
-from app.graphql.types import GoalListPayloadType, GoalPlanType, GoalTypeObject
+from app.graphql.types import (
+    GoalContributionListPayloadType,
+    GoalListPayloadType,
+    GoalPlanType,
+    GoalTypeObject,
+)
 
 
 class GoalQueryMixin:
@@ -33,6 +39,12 @@ class GoalQueryMixin:
     goal_plan = graphene.Field(
         GoalPlanType,
         goal_id=graphene.UUID(required=True),
+    )
+    goal_contributions = graphene.Field(
+        GoalContributionListPayloadType,
+        goal_id=graphene.UUID(required=True),
+        page=graphene.Int(default_value=1),
+        per_page=graphene.Int(default_value=10),
     )
 
     def resolve_goals(
@@ -89,3 +101,28 @@ class GoalQueryMixin:
         except GoalApplicationError as exc:
             raise_goal_graphql_error(exc)
         return to_goal_plan_type(cast(dict[str, Any], result["goal_plan"]))
+
+    def resolve_goal_contributions(
+        self,
+        _info: graphene.ResolveInfo,
+        goal_id: UUID,
+        page: int,
+        per_page: int,
+    ) -> GoalContributionListPayloadType:
+        user = get_current_user_required()
+        service = GoalApplicationService.with_defaults(UUID(str(user.id)))
+        try:
+            result = service.list_contributions(goal_id, page=page, per_page=per_page)
+        except GoalApplicationError as exc:
+            raise_goal_graphql_error(exc)
+
+        items = [to_goal_contribution_type(item) for item in result["items"]]
+        pagination_meta = result["pagination"]
+        return GoalContributionListPayloadType(
+            items=items,
+            pagination=paginate(
+                total=pagination_meta["total"],
+                page=pagination_meta["page"],
+                per_page=pagination_meta["per_page"],
+            ),
+        )

--- a/app/graphql/types.py
+++ b/app/graphql/types.py
@@ -214,6 +214,20 @@ class GoalListPayloadType(graphene.ObjectType):
     pagination = graphene.Field(PaginationType, required=True)
 
 
+class GoalContributionType(graphene.ObjectType):
+    id = graphene.ID(required=True)
+    goal_id = graphene.ID(required=True)
+    amount = graphene.String(required=True)
+    note = graphene.String()
+    occurred_at = graphene.String(required=True)
+    created_at = graphene.String()
+
+
+class GoalContributionListPayloadType(graphene.ObjectType):
+    items = graphene.List(GoalContributionType, required=True)
+    pagination = graphene.Field(PaginationType, required=True)
+
+
 class GoalRecommendationType(graphene.ObjectType):
     priority = graphene.String(required=True)
     title = graphene.String(required=True)

--- a/app/models/goal_contribution.py
+++ b/app/models/goal_contribution.py
@@ -35,6 +35,11 @@ class GoalContribution(db.Model):
     )
     amount = db.Column(db.Numeric(12, 2), nullable=False)
     note = db.Column(db.String(200), nullable=True)
+    # User-facing contribution date (may be back-dated by the client). Defaults
+    # to the creation date. created_at stays as the immutable audit timestamp.
+    occurred_at = db.Column(
+        db.Date, default=lambda: utc_now_naive().date(), nullable=False
+    )
     created_at = db.Column(db.DateTime, default=utc_now_naive, nullable=False)
 
     __table_args__ = (

--- a/app/schemas/goal_schema.py
+++ b/app/schemas/goal_schema.py
@@ -1,6 +1,16 @@
 from __future__ import annotations
 
-from marshmallow import Schema, fields, pre_load, validate
+from datetime import date
+from typing import Any
+
+from marshmallow import (
+    Schema,
+    ValidationError,
+    fields,
+    pre_load,
+    validate,
+    validates,
+)
 
 from app.schemas.sanitization import sanitize_string_fields
 
@@ -44,3 +54,47 @@ class GoalSchema(Schema):
         if isinstance(sanitized, dict) and isinstance(sanitized.get("status"), str):
             sanitized["status"] = str(sanitized["status"]).lower()
         return sanitized
+
+
+class GoalContributionInputSchema(Schema):
+    """Payload for registering a goal contribution (deposit or withdrawal).
+
+    ``amount`` is a signed delta: positive deposits add to the goal, negative
+    withdrawals subtract. Zero is rejected. ``occurred_at`` defaults to today
+    and may be back-dated but never set in the future.
+    """
+
+    class Meta:
+        name = "GoalContributionInput"
+
+    amount = fields.Decimal(as_string=True, required=True)
+    occurred_at = fields.Date(load_default=None, allow_none=True)
+    note = fields.Str(allow_none=True, validate=validate.Length(max=200))
+
+    @validates("amount")
+    def _validate_amount(self, value: Any, **kwargs: Any) -> None:
+        if value == 0:
+            raise ValidationError("O valor do aporte/retirada não pode ser zero.")
+
+    @validates("occurred_at")
+    def _validate_occurred_at(self, value: date | None, **kwargs: Any) -> None:
+        if value is not None and value > date.today():
+            raise ValidationError("A data não pode ser futura.")
+
+    @pre_load
+    def sanitize_input(self, data: object, **kwargs: object) -> object:
+        return sanitize_string_fields(data, {"note"})
+
+
+class GoalContributionSchema(Schema):
+    """Serialized goal contribution (audit history entry)."""
+
+    class Meta:
+        name = "GoalContribution"
+
+    id = fields.UUID(dump_only=True)
+    goal_id = fields.UUID(dump_only=True)
+    amount = fields.Decimal(as_string=True, dump_only=True)
+    note = fields.Str(dump_only=True, allow_none=True)
+    occurred_at = fields.Date(dump_only=True)
+    created_at = fields.DateTime(dump_only=True)

--- a/graphql.introspection.json
+++ b/graphql.introspection.json
@@ -1229,6 +1229,59 @@
             {
               "args": [
                 {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "goalId",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "UUID",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "defaultValue": "1",
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "page",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": "10",
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "perPage",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "goalContributions",
+              "type": {
+                "kind": "OBJECT",
+                "name": "GoalContributionListPayloadType",
+                "ofType": null
+              }
+            },
+            {
+              "args": [
+                {
                   "defaultValue": "1",
                   "deprecationReason": null,
                   "description": null,
@@ -8166,6 +8219,154 @@
                   "name": null,
                   "ofType": {
                     "kind": "OBJECT",
+                    "name": "GoalContributionType",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "pagination",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PaginationType",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "GoalContributionListPayloadType",
+          "possibleTypes": null,
+          "specifiedByURL": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "id",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "goalId",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "amount",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "note",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "occurredAt",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "createdAt",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "GoalContributionType",
+          "possibleTypes": null,
+          "specifiedByURL": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "items",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
                     "name": "TransactionTypeObject",
                     "ofType": null
                   }
@@ -11321,6 +11522,75 @@
                   "deprecationReason": null,
                   "description": null,
                   "isDeprecated": false,
+                  "name": "amount",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "goalId",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "UUID",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "note",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "occurredAt",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "Register a deposit (+) or withdrawal (-) against a goal.\n\nREST parity: ``POST /goals/{goal_id}/contributions``.",
+              "isDeprecated": false,
+              "name": "recordGoalContribution",
+              "type": {
+                "kind": "OBJECT",
+                "name": "RecordGoalContributionMutation",
+                "ofType": null
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
                   "name": "cashPrice",
                   "type": {
                     "kind": "NON_NULL",
@@ -14212,6 +14482,66 @@
           "interfaces": [],
           "kind": "OBJECT",
           "name": "SimulateGoalPlanMutation",
+          "possibleTypes": null,
+          "specifiedByURL": null
+        },
+        {
+          "description": "Register a deposit (+) or withdrawal (-) against a goal.\n\nREST parity: ``POST /goals/{goal_id}/contributions``.",
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "message",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "goal",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "GoalTypeObject",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "contribution",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "GoalContributionType",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "RecordGoalContributionMutation",
           "possibleTypes": null,
           "specifiedByURL": null
         },

--- a/graphql.operations.manifest.json
+++ b/graphql.operations.manifest.json
@@ -89,6 +89,14 @@
     "summary": "Retorna o plano projetado de uma meta existente."
   },
   {
+    "access": "auth_required",
+    "domain": "goals",
+    "name": "goalContributions",
+    "operation_type": "query",
+    "source_module": "app.graphql.queries.goal",
+    "summary": "Lista o histórico paginado de contribuições (aportes/retiradas) de uma meta. Paridade com GET /goals/{id}/contributions."
+  },
+  {
     "access": "public",
     "domain": "simulations",
     "name": "installmentVsCashCalculate",
@@ -319,6 +327,14 @@
     "operation_type": "mutation",
     "source_module": "app.graphql.mutations.goal",
     "summary": "Simula o plano de aporte de uma meta sem persistir dados."
+  },
+  {
+    "access": "auth_required",
+    "domain": "goals",
+    "name": "recordGoalContribution",
+    "operation_type": "mutation",
+    "source_module": "app.graphql.mutations.goal",
+    "summary": "Registra um aporte (+) ou retirada (-) em uma meta, atualizando o valor acumulado. Paridade com POST /goals/{id}/contributions."
   },
   {
     "access": "auth_required",

--- a/migrations/versions/gc1_goal_contribution_occurred_at.py
+++ b/migrations/versions/gc1_goal_contribution_occurred_at.py
@@ -1,0 +1,52 @@
+"""gc1 — add goal_contributions.occurred_at.
+
+Adds a user-facing contribution date (may be back-dated by the client) to the
+goal contribution history. Backfills existing rows from created_at so the
+column can be NOT NULL. created_at stays as the immutable audit timestamp
+(#1470).
+
+Revision ID: gc1_goal_contrib_date
+Revises: cc2_card_privacy
+Create Date: 2026-06-08
+
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "gc1_goal_contrib_date"
+down_revision = "cc2_card_privacy"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Add as nullable first so existing rows can be backfilled, then enforce
+    # NOT NULL (works on both PostgreSQL and SQLite via batch).
+    op.add_column(
+        "goal_contributions",
+        sa.Column("occurred_at", sa.Date(), nullable=True),
+    )
+    op.execute(
+        "UPDATE goal_contributions "
+        "SET occurred_at = CAST(created_at AS DATE) "
+        "WHERE occurred_at IS NULL"
+    )
+    bind = op.get_context().connection
+    if bind.dialect.name == "sqlite":
+        with op.batch_alter_table("goal_contributions") as batch:
+            batch.alter_column("occurred_at", existing_type=sa.Date(), nullable=False)
+    else:
+        op.alter_column("goal_contributions", "occurred_at", nullable=False)
+
+
+def downgrade() -> None:
+    bind = op.get_context().connection
+    if bind.dialect.name == "sqlite":
+        with op.batch_alter_table("goal_contributions") as batch:
+            batch.drop_column("occurred_at")
+        return
+
+    op.drop_column("goal_contributions", "occurred_at")

--- a/migrations/versions/gc1_goal_contribution_occurred_at.py
+++ b/migrations/versions/gc1_goal_contribution_occurred_at.py
@@ -6,7 +6,7 @@ column can be NOT NULL. created_at stays as the immutable audit timestamp
 (#1470).
 
 Revision ID: gc1_goal_contrib_date
-Revises: cc2_card_privacy
+Revises: onb1_user_onboarding
 Create Date: 2026-06-08
 
 """
@@ -17,7 +17,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision = "gc1_goal_contrib_date"
-down_revision = "cc2_card_privacy"
+down_revision = "onb1_user_onboarding"
 branch_labels = None
 depends_on = None
 

--- a/openapi.json
+++ b/openapi.json
@@ -2,6 +2,7 @@
   "components": {
     "schemas": {
       "InstallmentVsCashCalculation": {
+        "additionalProperties": false,
         "properties": {
           "cash_price": {
             "minimum": 0.01,
@@ -75,6 +76,7 @@
         "type": "object"
       },
       "InstallmentVsCashGoalBridge": {
+        "additionalProperties": false,
         "properties": {
           "category": {
             "default": "planned_purchase",
@@ -125,6 +127,7 @@
         "type": "object"
       },
       "InstallmentVsCashPlannedExpenseBridge": {
+        "additionalProperties": false,
         "properties": {
           "account_id": {
             "default": null,
@@ -211,6 +214,7 @@
         "type": "object"
       },
       "InstallmentVsCashSave": {
+        "additionalProperties": false,
         "properties": {
           "cash_price": {
             "minimum": 0.01,
@@ -284,6 +288,7 @@
         "type": "object"
       },
       "TransactionCreate": {
+        "additionalProperties": false,
         "properties": {
           "account_id": {
             "description": "ID da conta bancária associada",
@@ -484,6 +489,7 @@
         "type": "object"
       },
       "TransactionCreate_7d3b606eab": {
+        "additionalProperties": false,
         "properties": {
           "account_id": {
             "description": "ID da conta bancária associada",
@@ -678,6 +684,7 @@
         "type": "object"
       },
       "app_schemas_ai_insight_schema_AIInsightGenerateRequestSchema": {
+        "additionalProperties": false,
         "properties": {
           "anchor_date": {
             "description": "Data âncora do período no formato YYYY-MM-DD.",
@@ -716,6 +723,7 @@
         "type": "object"
       },
       "app_schemas_ai_insight_schema_AIMonthlyReportRequestSchema": {
+        "additionalProperties": false,
         "properties": {
           "anchor_date": {
             "description": "Data âncora do mês a consolidar. Quando omitida, a API usa a data atual.",
@@ -734,6 +742,7 @@
         "type": "object"
       },
       "app_schemas_auth_schema_AuthSchema": {
+        "additionalProperties": false,
         "properties": {
           "captcha_token": {
             "default": null,
@@ -761,6 +770,7 @@
         "type": "object"
       },
       "app_schemas_auth_schema_ConfirmEmailSchema": {
+        "additionalProperties": false,
         "properties": {
           "token": {
             "description": "Token de confirmacao recebido por email",
@@ -776,6 +786,7 @@
         "type": "object"
       },
       "app_schemas_auth_schema_ForgotPasswordSchema": {
+        "additionalProperties": false,
         "properties": {
           "email": {
             "description": "Email da conta que deseja recuperar acesso",
@@ -790,6 +801,7 @@
         "type": "object"
       },
       "app_schemas_auth_schema_ResetPasswordSchema": {
+        "additionalProperties": false,
         "properties": {
           "new_password": {
             "description": "Nova senha (mínimo 10 caracteres, com maiúscula, número e símbolo)",
@@ -813,6 +825,7 @@
         "type": "object"
       },
       "app_schemas_consent_schemas_ConsentRecordSchema": {
+        "additionalProperties": false,
         "properties": {
           "action": {
             "enum": [
@@ -855,6 +868,7 @@
         "type": "object"
       },
       "app_schemas_push_subscription_schema_SubscribeSchema": {
+        "additionalProperties": false,
         "properties": {
           "device_label": {
             "default": null,
@@ -889,6 +903,7 @@
         "type": "object"
       },
       "app_schemas_push_subscription_schema_UnsubscribeSchema": {
+        "additionalProperties": false,
         "properties": {
           "endpoint": {
             "type": "string"
@@ -900,6 +915,7 @@
         "type": "object"
       },
       "app_schemas_user_schemas_DeleteAccountSchema": {
+        "additionalProperties": false,
         "properties": {
           "password": {
             "description": "Senha atual do usuário para confirmar a exclusão da conta",
@@ -914,6 +930,7 @@
         "type": "object"
       },
       "app_schemas_user_schemas_QuestionnaireAnswerSchema": {
+        "additionalProperties": false,
         "properties": {
           "answers": {
             "description": "Lista de 5 respostas — pontos da opção escolhida em cada pergunta (1–3).",
@@ -933,6 +950,7 @@
         "type": "object"
       },
       "app_schemas_user_schemas_SalaryIncreaseSimulationRequestSchema": {
+        "additionalProperties": false,
         "properties": {
           "base_date": {
             "description": "Data base do salário atual",
@@ -968,6 +986,7 @@
         "type": "object"
       },
       "app_schemas_user_schemas_UserProfileSchema": {
+        "additionalProperties": false,
         "properties": {
           "birth_date": {
             "description": "Data de nascimento",
@@ -1080,6 +1099,7 @@
         "type": "object"
       },
       "app_schemas_user_schemas_UserRegistrationSchema": {
+        "additionalProperties": false,
         "properties": {
           "captcha_token": {
             "default": null,
@@ -5704,6 +5724,95 @@
           },
           "400": {
             "description": "Dados inválidos"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "403": {
+            "description": "Sem permissão"
+          },
+          "404": {
+            "description": "Meta não encontrada"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Metas"
+        ]
+      }
+    },
+    "/goals/{goal_id}/contributions": {
+      "get": {
+        "description": "Lista o histórico de contribuições de uma meta (paginado).",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "goal_id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "per_page",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Histórico paginado de contribuições"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "403": {
+            "description": "Sem permissão"
+          },
+          "404": {
+            "description": "Meta não encontrada"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": [
+          "Metas"
+        ]
+      },
+      "post": {
+        "description": "Registra um aporte (valor positivo) ou retirada (valor negativo) na meta, atualizando o valor acumulado e o histórico.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "goal_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Contribuição registrada com sucesso"
+          },
+          "400": {
+            "description": "Dados inválidos ou saldo insuficiente"
           },
           "401": {
             "description": "Token inválido"

--- a/schema.graphql
+++ b/schema.graphql
@@ -42,6 +42,7 @@ type Query {
   goals(page: Int = 1, perPage: Int = 10, status: String): GoalListPayloadType
   goal(goalId: UUID!): GoalTypeObject
   goalPlan(goalId: UUID!): GoalPlanType
+  goalContributions(goalId: UUID!, page: Int = 1, perPage: Int = 10): GoalContributionListPayloadType
   transactions(page: Int = 1, perPage: Int = 10, type: String, status: String, startDate: String, endDate: String, tagId: UUID, accountId: UUID, creditCardId: UUID): TransactionListPayloadType
   transactionSummary(month: String!, page: Int = 1, perPage: Int = 10, pageSize: Int @deprecated(reason: "Use perPage.")): TransactionSummaryPayloadType
   transactionDashboard(month: String!): TransactionDashboardPayloadType @deprecated(reason: "Use dashboardOverview.")
@@ -651,6 +652,20 @@ type GoalRecommendationType {
   estimatedDate: String
 }
 
+type GoalContributionListPayloadType {
+  items: [GoalContributionType]!
+  pagination: PaginationType!
+}
+
+type GoalContributionType {
+  id: ID!
+  goalId: ID!
+  amount: String!
+  note: String
+  occurredAt: String!
+  createdAt: String
+}
+
 type TransactionListPayloadType {
   items: [TransactionTypeObject]!
   pagination: PaginationType!
@@ -824,6 +839,13 @@ type Mutation {
   updateGoal(category: String, currentAmount: String, description: String, goalId: UUID!, priority: Int, status: GoalStatus, targetAmount: String, targetDate: String, title: String): UpdateGoalMutation @deprecated(reason: "ADR-0002: use PATCH /goals/{id}")
   deleteGoal(goalId: UUID!): DeleteGoalMutation @deprecated(reason: "ADR-0002: use DELETE /goals/{id}")
   simulateGoalPlan(currentAmount: String, monthlyContribution: String, monthlyExpenses: String, monthlyIncome: String, targetAmount: String!, targetDate: String): SimulateGoalPlanMutation
+
+  """
+  Register a deposit (+) or withdrawal (-) against a goal.
+  
+  REST parity: ``POST /goals/{goal_id}/contributions``.
+  """
+  recordGoalContribution(amount: String!, goalId: UUID!, note: String, occurredAt: String): RecordGoalContributionMutation
   saveInstallmentVsCashSimulation(cashPrice: String!, feesEnabled: Boolean = false, feesUpfront: String = "0.00", firstPaymentDelayDays: Int = 30, inflationRateAnnual: String!, installmentAmount: String, installmentCount: Int!, installmentTotal: String, opportunityRateAnnual: String, opportunityRateType: String = "manual", scenarioLabel: String): SaveInstallmentVsCashSimulationMutation
   createGoalFromInstallmentVsCashSimulation(category: String = "planned_purchase", currentAmount: String = "0.00", description: String, priority: Int = 3, selectedOption: String!, simulationId: UUID!, targetDate: String, title: String!): CreateGoalFromInstallmentVsCashSimulationMutation
   createPlannedExpenseFromInstallmentVsCashSimulation(accountId: UUID, creditCardId: UUID, currency: String = "BRL", description: String, dueDate: String, firstDueDate: String, observation: String, selectedOption: String!, simulationId: UUID!, status: String = "pending", tagId: UUID, title: String!, upfrontDueDate: String): CreatePlannedExpenseFromInstallmentVsCashSimulationMutation
@@ -1007,6 +1029,17 @@ type DeleteGoalMutation {
 type SimulateGoalPlanMutation {
   message: String!
   goalPlan: GoalPlanType!
+}
+
+"""
+Register a deposit (+) or withdrawal (-) against a goal.
+
+REST parity: ``POST /goals/{goal_id}/contributions``.
+"""
+type RecordGoalContributionMutation {
+  message: String!
+  goal: GoalTypeObject!
+  contribution: GoalContributionType!
 }
 
 type SaveInstallmentVsCashSimulationMutation {

--- a/scripts/openapi_to_postman.py
+++ b/scripts/openapi_to_postman.py
@@ -218,6 +218,9 @@ CUSTOM_VALIDATION_ENDPOINTS: set[str] = {
     "POST /wallet",
     "PATCH /wallet/{investment_id}",
     "PUT /wallet/{investment_id}",
+    # goal_schema.py GoalContributionInputSchema — @validates amount (non-zero)
+    # and occurred_at (no future dates); auto-body fails these.
+    "POST /goals/{goal_id}/contributions",
 }
 
 # ---------------------------------------------------------------------------
@@ -560,6 +563,28 @@ ENRICHMENT: dict[str, dict[str, Any]] = {
             },
             indent=2,
         ),
+    },
+    "POST /goals/{goal_id}/contributions": {
+        "body_override": json.dumps(
+            {"amount": "100.00", "note": "smoke {{runSeed}}"},
+            indent=2,
+        ),
+        # Custom @validates (amount non-zero, no future date) + ownership:
+        # with a real {{goalId}} and valid body this is 201; tolerate 400/404
+        # when the goal var is unset in a partial run.
+        "test_lines": [
+            "pm.test('Registrar contribuicao — expected 201 or 400 or 404', "
+            "function () {",
+            "  pm.expect(pm.response.code).to.be.oneOf([201, 400, 404]);",
+            "});",
+        ],
+    },
+    "GET /goals/{goal_id}/contributions": {
+        "test_lines": [
+            "pm.test('Historico de contribuicoes — expected 200 or 404', function () {",
+            "  pm.expect(pm.response.code).to.be.oneOf([200, 404]);",
+            "});",
+        ],
     },
     # ── Wallet ────────────────────────────────────────────────────────
     "PATCH /wallet/{investment_id}": {

--- a/tests/test_goal_contributions.py
+++ b/tests/test_goal_contributions.py
@@ -1,0 +1,233 @@
+"""Tests for goal contributions — deposits/withdrawals + history (#1470).
+
+Covers REST POST/GET /goals/{id}/contributions and GraphQL parity
+(recordGoalContribution mutation + goalContributions query):
+- deposits add, withdrawals subtract, below-zero rejected
+- zero amount and future date rejected
+- reaching target auto-completes the goal
+- history is paginated, newest first
+- ownership enforced
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from uuid import uuid4
+
+from app.extensions.database import db
+from app.models.goal_contribution import GoalContribution
+
+
+def _register_and_login(client, *, prefix: str = "gc") -> str:
+    suffix = uuid4().hex[:8]
+    email = f"{prefix}-{suffix}@email.com"
+    password = "StrongPass@123"
+    register = client.post(
+        "/auth/register",
+        json={"name": f"user-{suffix}", "email": email, "password": password},
+    )
+    assert register.status_code == 201
+    login = client.post("/auth/login", json={"email": email, "password": password})
+    assert login.status_code == 200
+    return login.get_json()["token"]
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}", "X-API-Contract": "v2"}
+
+
+def _create_goal(client, token, *, target="1000.00", current="0.00") -> str:
+    resp = client.post(
+        "/goals",
+        json={"title": "Reserva", "target_amount": target, "current_amount": current},
+        headers=_auth(token),
+    )
+    assert resp.status_code == 201, resp.get_json()
+    return resp.get_json()["data"]["goal"]["id"]
+
+
+def _gql(client, query, token, variables=None):
+    return client.post(
+        "/graphql",
+        json={"query": query, "variables": variables or {}},
+        headers={**_auth(token), "Content-Type": "application/json"},
+    )
+
+
+class TestRecordContributionRest:
+    def test_deposit_adds_to_current_amount(self, client) -> None:
+        token = _register_and_login(client)
+        goal_id = _create_goal(client, token, target="1000.00", current="100.00")
+
+        resp = client.post(
+            f"/goals/{goal_id}/contributions",
+            json={"amount": "250.00", "note": "salário"},
+            headers=_auth(token),
+        )
+        assert resp.status_code == 201
+        data = resp.get_json()["data"]
+        assert data["goal"]["current_amount"] == "350.00"
+        assert data["contribution"]["amount"] == "250.00"
+        assert data["contribution"]["note"] == "salário"
+        assert data["contribution"]["occurred_at"] == date.today().isoformat()
+
+    def test_withdrawal_subtracts(self, client) -> None:
+        token = _register_and_login(client)
+        goal_id = _create_goal(client, token, current="500.00")
+
+        resp = client.post(
+            f"/goals/{goal_id}/contributions",
+            json={"amount": "-200.00"},
+            headers=_auth(token),
+        )
+        assert resp.status_code == 201
+        assert resp.get_json()["data"]["goal"]["current_amount"] == "300.00"
+
+    def test_withdrawal_below_zero_is_rejected(self, client) -> None:
+        token = _register_and_login(client)
+        goal_id = _create_goal(client, token, current="100.00")
+
+        resp = client.post(
+            f"/goals/{goal_id}/contributions",
+            json={"amount": "-150.00"},
+            headers=_auth(token),
+        )
+        assert resp.status_code == 400
+        assert resp.get_json()["error"]["code"] == "INSUFFICIENT_BALANCE"
+
+    def test_zero_amount_is_rejected(self, client) -> None:
+        token = _register_and_login(client)
+        goal_id = _create_goal(client, token)
+        resp = client.post(
+            f"/goals/{goal_id}/contributions",
+            json={"amount": "0"},
+            headers=_auth(token),
+        )
+        assert resp.status_code == 400
+
+    def test_future_date_is_rejected(self, client) -> None:
+        token = _register_and_login(client)
+        goal_id = _create_goal(client, token)
+        future = (date.today() + timedelta(days=2)).isoformat()
+        resp = client.post(
+            f"/goals/{goal_id}/contributions",
+            json={"amount": "10.00", "occurred_at": future},
+            headers=_auth(token),
+        )
+        assert resp.status_code == 400
+
+    def test_reaching_target_completes_goal(self, client) -> None:
+        token = _register_and_login(client)
+        goal_id = _create_goal(client, token, target="1000.00", current="900.00")
+
+        resp = client.post(
+            f"/goals/{goal_id}/contributions",
+            json={"amount": "100.00"},
+            headers=_auth(token),
+        )
+        assert resp.status_code == 201
+        assert resp.get_json()["data"]["goal"]["status"] == "completed"
+
+    def test_backdated_contribution_is_accepted(self, client) -> None:
+        token = _register_and_login(client)
+        goal_id = _create_goal(client, token)
+        past = (date.today() - timedelta(days=10)).isoformat()
+        resp = client.post(
+            f"/goals/{goal_id}/contributions",
+            json={"amount": "50.00", "occurred_at": past},
+            headers=_auth(token),
+        )
+        assert resp.status_code == 201
+        assert resp.get_json()["data"]["contribution"]["occurred_at"] == past
+
+
+class TestListContributionsRest:
+    def test_history_is_paginated_newest_first(self, client) -> None:
+        token = _register_and_login(client)
+        goal_id = _create_goal(client, token, current="0.00")
+        for i in range(3):
+            day = (date.today() - timedelta(days=i)).isoformat()
+            client.post(
+                f"/goals/{goal_id}/contributions",
+                json={"amount": "10.00", "occurred_at": day, "note": f"n{i}"},
+                headers=_auth(token),
+            )
+
+        resp = client.get(
+            f"/goals/{goal_id}/contributions?page=1&per_page=2", headers=_auth(token)
+        )
+        assert resp.status_code == 200
+        body = resp.get_json()
+        items = body["data"]["items"]
+        assert len(items) == 2
+        # newest first → today's entry (n0) leads.
+        assert items[0]["occurred_at"] == date.today().isoformat()
+        assert body["meta"]["pagination"]["total"] == 3
+
+    def test_other_user_cannot_list(self, client) -> None:
+        owner = _register_and_login(client, prefix="gc-owner")
+        goal_id = _create_goal(client, owner)
+        stranger = _register_and_login(client, prefix="gc-stranger")
+        resp = client.get(f"/goals/{goal_id}/contributions", headers=_auth(stranger))
+        assert resp.status_code == 403
+
+
+class TestContributionGraphQLParity:
+    def test_record_and_list_via_graphql(self, client) -> None:
+        token = _register_and_login(client)
+        goal_id = _create_goal(client, token, target="1000.00", current="0.00")
+
+        mutation = """
+        mutation Record($id: UUID!, $amount: String!) {
+          recordGoalContribution(goalId: $id, amount: $amount) {
+            message
+            goal { currentAmount }
+            contribution { amount occurredAt }
+          }
+        }
+        """
+        resp = _gql(client, mutation, token, {"id": str(goal_id), "amount": "120.00"})
+        assert resp.status_code == 200, resp.get_json()
+        payload = resp.get_json()["data"]["recordGoalContribution"]
+        assert payload["goal"]["currentAmount"] == "120.00"
+        assert payload["contribution"]["amount"] == "120.00"
+
+        query = """
+        query History($id: UUID!) {
+          goalContributions(goalId: $id) {
+            items { amount occurredAt }
+            pagination { total }
+          }
+        }
+        """
+        list_resp = _gql(client, query, token, {"id": str(goal_id)})
+        assert list_resp.status_code == 200
+        data = list_resp.get_json()["data"]["goalContributions"]
+        assert data["pagination"]["total"] == 1
+        assert data["items"][0]["amount"] == "120.00"
+
+    def test_record_requires_auth(self, client) -> None:
+        mutation = """
+        mutation { recordGoalContribution(goalId: "%s", amount: "10") { message } }
+        """ % str(uuid4())
+        resp = client.post(
+            "/graphql",
+            json={"query": mutation},
+            headers={"X-API-Contract": "v2", "Content-Type": "application/json"},
+        )
+        assert resp.get_json().get("errors")
+
+
+def test_contribution_persists_occurred_at(app) -> None:
+    with app.app_context():
+        contribution = GoalContribution(
+            goal_id=uuid4(),
+            user_id=uuid4(),
+            amount="10.00",
+            occurred_at=date(2026, 1, 15),
+        )
+        db.session.add(contribution)
+        db.session.commit()
+        stored = db.session.get(GoalContribution, contribution.id)
+        assert stored is not None
+        assert stored.occurred_at == date(2026, 1, 15)


### PR DESCRIPTION
## Summary

Retrabalho de Metas no backend: agora o usuário registra **aportes (+) e retiradas (−)** numa meta, com histórico. A tabela `goal_contributions` já existia (auto-registrava deltas); este PR expõe endpoints dedicados e adiciona a data da contribuição.

### Mudanças
- **Migration `gc1`**: `goal_contributions.occurred_at` (Date, backfill de `created_at`), para a data informada pelo usuário (back-date permitido). `created_at` segue como timestamp de auditoria.
- **REST**:
  - `POST /goals/{id}/contributions` — aplica delta assinado a `current_amount`; rejeita retirada abaixo de zero (`INSUFFICIENT_BALANCE`), valor zero e data futura; **auto-conclui** a meta ao atingir o alvo.
  - `GET /goals/{id}/contributions` — histórico paginado (mais recente primeiro).
- **GraphQL parity**: mutation `recordGoalContribution` + query `goalContributions` (+ tipos, presenter, docs catalog).
- Artefatos regenerados: `schema.graphql`, `openapi.json`, collection Postman.

### Companion
- Web: #1032 (modal "Registrar entrada", timeline, rework visual).

## ⚠️ Ordem de merge
Esta PR adiciona a migration `gc1` encadeada em `cc2_card_privacy`. A PR de onboarding (#1473) adiciona `onb1` no mesmo ponto. **Mergear #1473 primeiro**; esta branch será rebaseada para encadear `gc1` sobre `onb1` antes do merge (evita múltiplos heads). Auto-merge **não** armado até a reconciliação.

## Verificação
- `run_ci_quality_local.sh --local`: **2514 passed**, coverage **91.10%** (≥85%).
- Migration up/down testada em postgres efêmero.

## Refs
Closes #1470