### PR TITLE
ci(semgrep): substituir SonarCloud por Semgrep SAST blocking

### DIFF
--- a/.github/workflows/aws-security-audit.yml
+++ b/.github/workflows/aws-security-audit.yml
@@ -51,9 +51,11 @@ jobs:
       - name: Run IAM audit
         if: ${{ steps.guard.outputs.configured == 'true' }}
         shell: bash
+        env:
+          FAIL_ON_INPUT: ${{ github.event.inputs.fail_on }}
         run: |
           set -euo pipefail
-          FAIL_ON="${{ github.event.inputs.fail_on }}"
+          FAIL_ON="${FAIL_ON_INPUT}"
           if [ -z "${FAIL_ON}" ]; then
             FAIL_ON="fail"
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -735,138 +735,34 @@ jobs:
         with:
           name: security-evidence
           path: reports/security/security-evidence.md
-
-  sonar:
-    name: SonarQube Cloud
+  # ── Semgrep SAST ─────────────────────────────────────────────────────────────
+  # SAST OSS cross-file/dataflow (standalone, sem conta). Bloqueia merge em finding
+  # de severidade ERROR; SARIF como artifact (Code Scanning exige GHAS pago em repo
+  # privado). Dashboard de qualidade: SonarQube Community Build local no
+  # auraxis-platform (`make sonar`). sonar-project.properties e scripts/sonar_*.sh
+  # permanecem no repo para uso local; saíram apenas do CI.
+  semgrep:
+    name: Semgrep SAST
     runs-on: ubuntu-latest
-    needs: [tests, schemathesis, mutation, trivy, osv-scanner, security-evidence]
-
     steps:
-      - name: Check Sonar capability
-        id: capability
-        env:
-          SONAR_TOKEN_VALUE: ${{ secrets.SONAR_TOKEN }}
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - name: Install Semgrep
+        run: pip install --quiet semgrep
+      - name: Run Semgrep (blocking on ERROR)
         run: |
-          if [ -n "${SONAR_TOKEN_VALUE:-}" ] && [ -n "${{ vars.SONAR_PROJECT_KEY }}" ] && [ -n "${{ vars.SONAR_ORGANIZATION }}" ]; then
-            echo "enabled=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "enabled=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::SonarQube Cloud skipped: token or repo variables not available for this run."
-          fi
-
-      - name: Checkout
-        if: steps.capability.outputs.enabled == 'true'
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Download coverage artifact
-        if: steps.capability.outputs.enabled == 'true'
-        uses: actions/download-artifact@v4
-        with:
-          name: coverage-report
-          path: .
-
-      - name: SonarQube Scan
-        if: steps.capability.outputs.enabled == 'true'
-        uses: SonarSource/sonarqube-scan-action@v6
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_HOST_URL: https://sonarcloud.io
-        with:
-          args: >
-            -Dsonar.organization=${{ vars.SONAR_ORGANIZATION }}
-            -Dsonar.projectKey=${{ vars.SONAR_PROJECT_KEY }}
-            -Dsonar.python.coverage.reportPaths=coverage.xml
-
-      - name: SonarQube Quality Gate
-        id: sonar_quality_gate
-        if: steps.capability.outputs.enabled == 'true'
-        continue-on-error: true
-        uses: SonarSource/sonarqube-quality-gate-action@v1.2.0
-        timeout-minutes: 5
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_HOST_URL: https://sonarcloud.io
-
-      - name: Enforce Sonar Policy (A ratings + no critical bugs)
-        id: sonar_policy
-        if: steps.capability.outputs.enabled == 'true'
-        continue-on-error: true
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_HOST_URL: https://sonarcloud.io
-          SONAR_PROJECT_KEY: ${{ vars.SONAR_PROJECT_KEY }}
-          SONAR_BRANCH: ${{ github.head_ref || github.ref_name }}
-          SONAR_PULL_REQUEST: ${{ github.event.pull_request.number || '' }}
-          SONAR_POLICY_REPORT_PATH: ${{ runner.temp }}/sonar-policy-report.json
-        run: |
-          bash scripts/sonar_enforce_ci.sh
-
-      - name: Upload Sonar policy report artifact
-        if: ${{ always() && steps.capability.outputs.enabled == 'true' }}
+          semgrep scan \
+            --config p/python --config p/flask \
+            --config p/security-audit --config p/owasp-top-ten --config p/secrets \
+            --severity ERROR --error --metrics=off \
+            --sarif --output semgrep.sarif
+      - name: Upload Semgrep SARIF
+        if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: sonar-policy-report
-          path: ${{ runner.temp }}/sonar-policy-report.json
+          name: semgrep-sarif
+          path: semgrep.sarif
           if-no-files-found: ignore
 
-      - name: Summarize Sonar outcome
-        if: ${{ always() && steps.capability.outputs.enabled == 'true' }}
-        env:
-          SONAR_QUALITY_GATE_OUTCOME: ${{ steps.sonar_quality_gate.outcome }}
-          SONAR_POLICY_OUTCOME: ${{ steps.sonar_policy.outcome }}
-          SONAR_POLICY_REPORT_PATH: ${{ runner.temp }}/sonar-policy-report.json
-        run: |
-          python - <<'PY'
-          import json
-          import os
-          from pathlib import Path
-
-          summary_path = os.environ["GITHUB_STEP_SUMMARY"]
-          report_path = Path(os.environ["SONAR_POLICY_REPORT_PATH"])
-          quality_gate_outcome = os.environ.get("SONAR_QUALITY_GATE_OUTCOME", "unknown")
-          policy_outcome = os.environ.get("SONAR_POLICY_OUTCOME", "unknown")
-
-          lines = [
-              "## Sonar Outcome",
-              "",
-              f"- Quality Gate step outcome: `{quality_gate_outcome}`",
-              f"- Custom policy step outcome: `{policy_outcome}`",
-          ]
-
-          if report_path.exists():
-              payload = json.loads(report_path.read_text(encoding="utf-8"))
-              errors = payload.get("errors", [])
-              lines.append("- Policy artifact: `sonar-policy-report`")
-              if quality_gate_outcome == "success" and policy_outcome == "failure":
-                  lines.extend([
-                      "",
-                      "### Why the job is red",
-                      "",
-                      "The Sonar scan and quality gate completed, but the **custom Auraxis Sonar policy** rejected the run.",
-                  ])
-              if errors:
-                  lines.extend(["", "### Policy rejection details", ""])
-                  lines.extend(f"- {error}" for error in errors)
-          else:
-              lines.extend([
-                  "",
-                  "### Policy report unavailable",
-                  "",
-                  "- The custom policy report file was not generated.",
-              ])
-
-          with open(summary_path, "a", encoding="utf-8") as handle:
-              handle.write("\n".join(lines) + "\n")
-          PY
-
-      - name: Fail on Sonar gate or policy rejection
-        if: >-
-          ${{
-            steps.capability.outputs.enabled == 'true' &&
-            (steps.sonar_quality_gate.outcome == 'failure' || steps.sonar_policy.outcome == 'failure')
-          }}
-        run: |
-          echo "Sonar pipeline failed. Review the Sonar Outcome section in the job summary." >&2
-          exit 1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -120,8 +120,9 @@ jobs:
           DEPLOY_DIAGNOSTICS_PATH: ${{ runner.temp }}/deploy-prod-ssm-diagnostics.json
           IMAGE_TAG: ${{ needs.build-and-push.outputs.image }}
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_GIT_REF: ${{ inputs.git_ref }}
         run: |
-          INPUT_REF="${{ inputs.git_ref }}"
+          INPUT_REF="${INPUT_GIT_REF}"
           REF="${INPUT_REF}"
           if [ -z "${REF}" ]; then
             # Use absolute SHA — avoids stale origin/master on EC2 if git fetch
@@ -247,18 +248,25 @@ jobs:
 
       - name: Deploy summary (PROD)
         if: ${{ always() }}
+        env:
+          GH_REF: ${{ github.ref }}
+          GH_REF_NAME: ${{ github.ref_name }}
+          GH_EVENT_NAME: ${{ github.event_name }}
+          INPUT_GIT_REF: ${{ inputs.git_ref }}
+          DEPLOY_OUTCOME: ${{ steps.deploy_prod.outcome }}
+          DIAG_PATH: ${{ runner.temp }}/deploy-prod-ssm-diagnostics.json
         run: |
           {
             echo "## Deploy PROD"
             echo ""
-            echo "- branch/ref: \`${{ github.ref }}\`"
-            echo "- input git_ref: \`${{ inputs.git_ref }}\`"
-            echo "- event: \`${{ github.event_name }}\`"
+            echo "- branch/ref: \`${GH_REF}\`"
+            echo "- input git_ref: \`${INPUT_GIT_REF}\`"
+            echo "- event: \`${GH_EVENT_NAME}\`"
             echo "- target env: \`prod\`"
-            echo "- deploy step outcome: \`${{ steps.deploy_prod.outcome }}\`"
+            echo "- deploy step outcome: \`${DEPLOY_OUTCOME}\`"
             echo "- smoke checks: \`enabled (REST + GraphQL)\`"
             echo "- rollback on failure: \`enabled\`"
-            _diag="${{ runner.temp }}/deploy-prod-ssm-diagnostics.json"
+            _diag="${DIAG_PATH}"
             if [ -f "${_diag}" ]; then
               echo "- diagnostics artifact: \`deploy-prod-ssm-diagnostics\`"
               echo "- SSM command id: \`$(jq -r '.command_id // ""' "${_diag}")\`"
@@ -267,8 +275,8 @@ jobs:
               echo "- SSM response code: \`$(jq -r '.response_code // ""' "${_diag}")\`"
             fi
             echo "- ref resolution:"
-            echo "  - event: \`${{ github.event_name }}\`"
-            echo "  - github ref: \`${{ github.ref }}\`"
-            echo "  - github ref name: \`${{ github.ref_name }}\`"
-            echo "  - input git_ref: \`${{ inputs.git_ref }}\`"
+            echo "  - event: \`${GH_EVENT_NAME}\`"
+            echo "  - github ref: \`${GH_REF}\`"
+            echo "  - github ref name: \`${GH_REF_NAME}\`"
+            echo "  - input git_ref: \`${INPUT_GIT_REF}\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/postman-privileged.yml
+++ b/.github/workflows/postman-privileged.yml
@@ -45,9 +45,11 @@ jobs:
         run: npm run postman:build
 
       - name: Run privileged Newman suite
+        env:
+          ENVIRONMENT: ${{ inputs.environment }}
         run: |
-          ENV_FILE="api-tests/postman/environments/${{ inputs.environment }}.postman_environment.json"
-          POSTMAN_REPORT_FILE="reports/newman-privileged-${{ inputs.environment }}-report.xml" \
+          ENV_FILE="api-tests/postman/environments/${ENVIRONMENT}.postman_environment.json"
+          POSTMAN_REPORT_FILE="reports/newman-privileged-${ENVIRONMENT}-report.xml" \
           bash scripts/run_postman_suite.sh "$ENV_FILE" --profile privileged
 
       - name: Upload Newman privileged report

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,10 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 
 COPY . .
 
+# Drop root: create and switch to a non-root user (port 3333 > 1024).
+RUN adduser -D -u 10001 appuser && chown -R appuser:appuser /app
+USER appuser
+
 EXPOSE 3333
 
 CMD ["flask", "run", "--host=0.0.0.0"]

--- a/app/services/bank_statement_parsers.py
+++ b/app/services/bank_statement_parsers.py
@@ -8,7 +8,13 @@ from dataclasses import dataclass
 from datetime import date, datetime
 from decimal import Decimal, InvalidOperation
 from typing import Sequence
-from xml.etree import ElementTree
+
+# Element (type) and ParseError (malformed-XML exception) are not parsers — the
+# XXE vector is XML *parsing*, which uses defusedxml above. Type/exception-only
+# import, so the use-defused-xml rule is suppressed on this line.
+from xml.etree.ElementTree import Element, ParseError  # nosemgrep
+
+import defusedxml.ElementTree as DefusedET
 
 from app.services.csv_ingestion_service import _parse_amount, _parse_date
 
@@ -82,8 +88,8 @@ def parse_nubank_csv(content: str) -> list[ParsedEntry]:
 
 def _parse_ofx_xml(content: str, bank_name: str) -> list[ParsedEntry]:
     try:
-        root = ElementTree.fromstring(content)
-    except ElementTree.ParseError as exc:
+        root = DefusedET.fromstring(content)
+    except ParseError as exc:
         raise ValueError("Invalid OFX XML content") from exc
 
     statement_nodes = list(root.iterfind(".//STMTTRN"))
@@ -113,7 +119,7 @@ def _parse_ofx_sgml(content: str, bank_name: str) -> list[ParsedEntry]:
 
 
 def _build_ofx_entries(
-    statement_nodes: Sequence[ElementTree.Element | dict[str, str]],
+    statement_nodes: Sequence[Element | dict[str, str]],
     *,
     bank_name: str,
 ) -> list[ParsedEntry]:
@@ -149,7 +155,7 @@ def _build_ofx_entries(
 
 
 def _extract_ofx_value(
-    node: ElementTree.Element | dict[str, str],
+    node: Element | dict[str, str],
     field_name: str,
 ) -> str | None:
     if isinstance(node, dict):

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ prometheus-client==0.25.0
 blinker==1.9.0
 click==8.4.1
 coverage==7.14.1
+defusedxml==0.7.1
 Flask==3.1.3
 flask-apispec==0.11.4
 Flask-JWT-Extended==4.7.4

--- a/scripts/ci_failure_summary.py
+++ b/scripts/ci_failure_summary.py
@@ -6,10 +6,11 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import xml.etree.ElementTree as ET
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
+
+import defusedxml.ElementTree as ET
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## O quê
Substitui o job sonar (SonarCloud scan + quality-gate + custom policy enforce) por um job **Semgrep** (OSS standalone, bloqueante em finding ERROR). SARIF como artifact.

## Por quê
Migração de SAST para tornar o repo privado sem perder análise estática, custo US$0, OSS. Dashboard de qualidade passa a SonarQube Community Build local (auraxis-platform `make sonar`). Plataforma: italofelipe/auraxis-platform#829.

## Notas
- `sonar-project.properties` e `scripts/sonar_*.sh` mantidos no repo (uso local); saíram só do CI.
- Code Scanning UI não é usada (exige GHAS pago em repo privado); o gate é o exit code.

Closes #1476