### PR TITLE
feat(ai-insights): relatórios profundos por período (3min/15min) + max_tokens (#1481)

### DIFF
--- a/app/extensions/prometheus_metrics.py
+++ b/app/extensions/prometheus_metrics.py
@@ -52,6 +52,7 @@ _AI_INSIGHT_RUNS_TOTAL: Any = None
 _AI_INSIGHT_COST_USD_TOTAL: Any = None
 _AI_INSIGHT_REJECTIONS_TOTAL: Any = None
 _AI_INSIGHT_TRUNCATED_TOTAL: Any = None
+_AI_INSIGHT_DEPTH_BELOW_TARGET_TOTAL: Any = None
 _AI_INSIGHT_DATA_QUALITY_DOMAINS: Any = None
 _AI_INSIGHT_RUNS_PURGED_TOTAL: Any = None
 
@@ -61,7 +62,7 @@ _AI_SNAPSHOT_BYTES_BUCKETS = (1024, 2048, 4096, 8192, 12288, 16384, 32768)
 _AI_DATA_QUALITY_DOMAIN_BUCKETS = (0, 1, 2, 3, 4, 5, 6)
 
 
-def _init_ai_insight_metrics() -> None:
+def _init_ai_insight_metrics() -> None:  # noqa: C901 — flat list of counter inits
     """Lazily initialise the MVP-3 AI insight observability instruments."""
     global \
         _AI_INSIGHT_GENERATED_TOTAL, \
@@ -71,6 +72,7 @@ def _init_ai_insight_metrics() -> None:
         _AI_INSIGHT_COST_USD_TOTAL, \
         _AI_INSIGHT_REJECTIONS_TOTAL, \
         _AI_INSIGHT_TRUNCATED_TOTAL, \
+        _AI_INSIGHT_DEPTH_BELOW_TARGET_TOTAL, \
         _AI_INSIGHT_DATA_QUALITY_DOMAINS, \
         _AI_INSIGHT_RUNS_PURGED_TOTAL
 
@@ -122,6 +124,12 @@ def _init_ai_insight_metrics() -> None:
         _AI_INSIGHT_TRUNCATED_TOTAL = Counter(
             "auraxis_ai_insight_truncated_total",
             "AI insight runs whose snapshot was truncated before the LLM call",
+            ["period_type"],
+        )
+    if _AI_INSIGHT_DEPTH_BELOW_TARGET_TOTAL is None:
+        _AI_INSIGHT_DEPTH_BELOW_TARGET_TOTAL = Counter(
+            "auraxis_ai_insight_depth_below_target_total",
+            "AI insight generations whose text fell below the reading-time target",
             ["period_type"],
         )
     if _AI_INSIGHT_DATA_QUALITY_DOMAINS is None:
@@ -366,6 +374,20 @@ def record_ai_insight_truncated(*, period_type: str) -> None:
     _ensure_metrics_initialized()
     if _AI_INSIGHT_TRUNCATED_TOTAL is not None:
         _AI_INSIGHT_TRUNCATED_TOTAL.labels(
+            period_type=period_type or "unknown",
+        ).inc()
+
+
+def record_ai_insight_depth_below_target(*, period_type: str) -> None:
+    """Count one AI insight whose text fell short of the reading-time target.
+
+    The depth gate is *advisory* (#1481): it never re-calls the LLM (that would
+    double the cost) — it only surfaces shallow generations for monitoring so we
+    can tune prompts/`max_tokens` over time.
+    """
+    _ensure_metrics_initialized()
+    if _AI_INSIGHT_DEPTH_BELOW_TARGET_TOTAL is not None:
+        _AI_INSIGHT_DEPTH_BELOW_TARGET_TOTAL.labels(
             period_type=period_type or "unknown",
         ).inc()
 

--- a/app/services/ai_advisory_service.py
+++ b/app/services/ai_advisory_service.py
@@ -29,7 +29,10 @@ from dateutil.relativedelta import relativedelta
 from sqlalchemy import case, func, or_
 
 from app.extensions.database import db
-from app.extensions.prometheus_metrics import record_ai_insight_generated
+from app.extensions.prometheus_metrics import (
+    record_ai_insight_depth_below_target,
+    record_ai_insight_generated,
+)
 from app.models.ai_insight import AIInsight, InsightType
 from app.models.ai_insight_run import AIInsightRun, AIInsightRunStatus
 from app.models.budget import Budget
@@ -1163,6 +1166,7 @@ class AIAdvisoryService:
             llm_resp = self._provider.generate_with_usage(
                 prompt,
                 response_schema=_FINANCIAL_INSIGHT_RESPONSE_SCHEMA,
+                max_tokens=_period_max_tokens(normalized_period_type),
             )
         except LLMProviderError as exc:
             log.warning(
@@ -1253,6 +1257,25 @@ class AIAdvisoryService:
                 self._user_id,
                 normalized_period_type,
             )
+
+        # Depth gate (#1481): advisory-only — flag shallow generations for
+        # monitoring. We never re-call the LLM (that would double the cost);
+        # the signal feeds prompt/max_tokens tuning over time.
+        word_count = _insight_reading_word_count(summary, items)
+        target = _DEPTH_WORD_TARGETS.get(normalized_period_type, 0)
+        if target and word_count < target:
+            log.info(
+                "ai_advisory.financial_insights.below_depth_target "
+                "user=%s period=%s words=%s target=%s",
+                self._user_id,
+                normalized_period_type,
+                word_count,
+                target,
+            )
+            try:
+                record_ai_insight_depth_below_target(period_type=normalized_period_type)
+            except Exception:  # pragma: no cover — metrics are fire-and-forget
+                pass
 
         return {
             "id": str(saved_insight.id),
@@ -2193,6 +2216,60 @@ def _build_monthly_budget_by_category(
 # ---------------------------------------------------------------------------
 
 
+# Depth targets (#1481): reading-time-driven verbosity per period. Daily stays
+# lean (~3 min); weekly/monthly are deep reports (~15 min).
+_DEPTH_INSTRUCTIONS: dict[str, str] = {
+    "daily": (
+        "PROFUNDIDADE ALVO: aproximadamente 3 minutos de leitura (cerca de 500 a "
+        "700 palavras no total da resposta). Vá além de uma frase por dimensão: "
+        "para cada dimensão com dados, escreva itens substantivos com 'message' "
+        "denso (2 a 4 frases), trazendo números concretos do snapshot, ao menos "
+        "uma comparação e uma recomendação acionável. Use markdown leve (negrito "
+        "em valores) quando ajudar a leitura. Não seja telegráfico nem repita."
+    ),
+    "weekly": (
+        "PROFUNDIDADE ALVO: aproximadamente 15 minutos de leitura (cerca de 2500 a "
+        "3500 palavras no total). Para cada dimensão com dados, produza MÚLTIPLOS "
+        "itens ricos, com 'message' longo em markdown (parágrafos), cobrindo "
+        "tendências da semana, comparações período-a-período, causas prováveis, "
+        "riscos e recomendações priorizadas. Aprofunde as projeções (3/6/12m) "
+        "quando 'projections' existir. Cada item agrega informação nova — não repita."
+    ),
+    "monthly": (
+        "PROFUNDIDADE ALVO: aproximadamente 15 minutos de leitura (cerca de 2500 a "
+        "3500 palavras no total). Faça um relatório mensal completo: para cada "
+        "dimensão com dados, vários itens com 'message' longo em markdown "
+        "(parágrafos) cobrindo o panorama do mês, extremos, tendências, "
+        "comparações, riscos e um plano de ação priorizado. Aprofunde as projeções "
+        "(3/6/12m) quando 'projections' existir. Cada item agrega informação nova."
+    ),
+}
+
+# Approximate reading-time word targets used by the advisory depth gate (#1481).
+_DEPTH_WORD_TARGETS: dict[str, int] = {"daily": 450, "weekly": 2200, "monthly": 2200}
+
+
+def _period_max_tokens(period_type: str) -> int:
+    """Output token budget per period — deep reports need a much larger budget."""
+    if period_type == "daily":
+        env_key, default = "AI_INSIGHT_MAX_TOKENS_DAILY", 1500
+    else:
+        env_key, default = "AI_INSIGHT_MAX_TOKENS_LONG", 6000
+    try:
+        return max(1, int(os.getenv(env_key, str(default))))
+    except (TypeError, ValueError):
+        return default
+
+
+def _insight_reading_word_count(summary: str, items: list[dict[str, Any]]) -> int:
+    """Approximate human reading length: words in summary + each item title+message."""
+    parts = [summary or ""]
+    for item in items:
+        parts.append(str(item.get("title", "")))
+        parts.append(str(item.get("message", "")))
+    return sum(len(part.split()) for part in parts)
+
+
 def _build_financial_insight_prompt(
     snapshot: dict[str, Any],
     *,
@@ -2234,6 +2311,10 @@ def _build_financial_insight_prompt(
             ),
         }[period_type]
 
+    depth_instruction = _DEPTH_INSTRUCTIONS.get(
+        period_type, _DEPTH_INSTRUCTIONS["daily"]
+    )
+
     insight_types = ", ".join(_SPENDING_INSIGHT_TYPES)
     contract = snapshot.get("insight_contract")
     required_dimensions_raw = (
@@ -2271,6 +2352,7 @@ def _build_financial_insight_prompt(
         "financeiro estruturado abaixo e gere insights em português brasileiro, "
         "objetivos, personalizados e acionáveis.\n"
         f"{period_instruction}\n"
+        f"{depth_instruction}\n"
         f"{coverage_instruction}"
         f"Presença de dados por domínio: {domain_presence_json}.\n"
         "Use somente os dados do snapshot fornecido. Não invente transações, metas, "

--- a/app/services/llm_provider.py
+++ b/app/services/llm_provider.py
@@ -54,6 +54,33 @@ class LLMResponse:
         ) / 1_000_000
 
 
+_DEFAULT_MAX_TOKENS = 512
+
+
+def _resolve_max_tokens(max_tokens: int | None) -> int:
+    """Resolve the output token budget for a single LLM call.
+
+    Callers (e.g. the AI advisory service) pass a period-specific budget so deep
+    reports (~15 min reading) get enough room while daily insights stay lean.
+    Falls back to ``AI_INSIGHT_MAX_TOKENS_DEFAULT`` (then 512) for back-compat.
+    """
+    if max_tokens is not None and max_tokens > 0:
+        return int(max_tokens)
+    try:
+        return max(1, int(os.getenv("AI_INSIGHT_MAX_TOKENS_DEFAULT", "512")))
+    except (TypeError, ValueError):
+        return _DEFAULT_MAX_TOKENS
+
+
+def _timeout_for_max_tokens(max_tokens: int) -> int:
+    """Scale the HTTP timeout with the output budget.
+
+    A 6k-token report can take far longer than the old 20s default; scale up
+    (capped at 120s) so long generations are not cut off mid-stream.
+    """
+    return min(120, max(20, max_tokens // 25))
+
+
 @runtime_checkable
 class LLMProvider(Protocol):
     def generate(self, prompt: str) -> str:
@@ -65,6 +92,7 @@ class LLMProvider(Protocol):
         prompt: str,
         *,
         response_schema: dict[str, Any] | None = None,
+        max_tokens: int | None = None,
     ) -> LLMResponse:
         """Generate a response and return structured usage data."""
         ...
@@ -90,8 +118,9 @@ class StubLLMProvider:
         prompt: str,
         *,
         response_schema: dict[str, Any] | None = None,
+        max_tokens: int | None = None,
     ) -> LLMResponse:
-        del prompt
+        del prompt, max_tokens
         content = self._STUB_CONTENT
         if (
             response_schema
@@ -137,16 +166,18 @@ class OpenAILLMProvider:
         prompt: str,
         *,
         response_schema: dict[str, Any] | None = None,
+        max_tokens: int | None = None,
     ) -> LLMResponse:
         if not self._api_key:
             raise LLMProviderError("OPENAI_API_KEY is not configured.")
         import requests  # lazy import to keep startup fast
 
+        resolved_max_tokens = _resolve_max_tokens(max_tokens)
         start = time.monotonic()
         payload: dict[str, Any] = {
             "model": self._model,
             "messages": [{"role": "user", "content": prompt}],
-            "max_tokens": 512,
+            "max_tokens": resolved_max_tokens,
             "temperature": 0.4,
         }
         if response_schema is not None:
@@ -163,7 +194,7 @@ class OpenAILLMProvider:
                     "Content-Type": "application/json",
                 },
                 json=payload,
-                timeout=20,
+                timeout=_timeout_for_max_tokens(resolved_max_tokens),
             )
             resp.raise_for_status()
             latency_ms = int((time.monotonic() - start) * 1000)
@@ -199,12 +230,14 @@ class ClaudeLLMProvider:
         prompt: str,
         *,
         response_schema: dict[str, Any] | None = None,
+        max_tokens: int | None = None,
     ) -> LLMResponse:
         _ = response_schema
         if not self._api_key:
             raise LLMProviderError("ANTHROPIC_API_KEY is not configured.")
         import requests
 
+        resolved_max_tokens = _resolve_max_tokens(max_tokens)
         start = time.monotonic()
         try:
             resp = requests.post(
@@ -216,10 +249,10 @@ class ClaudeLLMProvider:
                 },
                 json={
                     "model": self._model,
-                    "max_tokens": 512,
+                    "max_tokens": resolved_max_tokens,
                     "messages": [{"role": "user", "content": prompt}],
                 },
-                timeout=20,
+                timeout=_timeout_for_max_tokens(resolved_max_tokens),
             )
             resp.raise_for_status()
             latency_ms = int((time.monotonic() - start) * 1000)

--- a/tests/test_ai_insight_depth.py
+++ b/tests/test_ai_insight_depth.py
@@ -1,0 +1,177 @@
+"""Deep reports + per-period max_tokens for AI insights (#1481).
+
+The daily insight stays lean (~3 min reading); weekly/monthly are deep reports
+(~15 min). The output token budget scales per period and a (advisory-only) depth
+gate flags generations that fall short of the reading-time target.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+from app.services.llm_provider import (
+    LLMResponse,
+    _resolve_max_tokens,
+    _timeout_for_max_tokens,
+)
+
+
+def _financial_llm_response(*, summary: str = "Resumo.") -> LLMResponse:
+    dims = [
+        ("general", "current_period.paid.balance"),
+        ("transactions", "transactions.included_count"),
+        ("credit_cards", "data_quality.domain_presence.credit_cards"),
+        ("goals", "data_quality.domain_presence.goals"),
+        ("budgets", "data_quality.domain_presence.budgets"),
+        ("wallet", "data_quality.domain_presence.wallet"),
+    ]
+    items = ",".join(
+        (
+            '{"type":"saude_financeira",'
+            f'"dimension":"{d}","title":"Item",'
+            '"message":"Os dados foram analisados.",'
+            f'"evidence":["{e}"]}}'
+        )
+        for d, e in dims
+    )
+    return LLMResponse(
+        content=f'{{"summary":"{summary}","items":[{items}]}}',
+        prompt_tokens=100,
+        completion_tokens=40,
+        total_tokens=140,
+        model="gpt-4o-mini",
+        latency_ms=120,
+    )
+
+
+class TestDepthPrompt:
+    def test_daily_prompt_targets_3_min_reading(self) -> None:
+        from app.services.ai_advisory_service import _build_financial_insight_prompt
+
+        prompt = _build_financial_insight_prompt(
+            {"schema_version": "v1", "data_quality": {}, "insight_contract": {}},
+            period_type="daily",
+        )
+        assert "3 minutos de leitura" in prompt
+
+    def test_long_prompts_target_15_min_reading(self) -> None:
+        from app.services.ai_advisory_service import _build_financial_insight_prompt
+
+        for period in ("weekly", "monthly"):
+            prompt = _build_financial_insight_prompt(
+                {"schema_version": "v1", "data_quality": {}, "insight_contract": {}},
+                period_type=period,
+            )
+            assert "15 minutos de leitura" in prompt
+
+
+class TestPeriodMaxTokens:
+    def test_daily_default_budget(self) -> None:
+        from app.services.ai_advisory_service import _period_max_tokens
+
+        assert _period_max_tokens("daily") == 1500
+
+    def test_long_default_budget(self) -> None:
+        from app.services.ai_advisory_service import _period_max_tokens
+
+        assert _period_max_tokens("weekly") == 6000
+        assert _period_max_tokens("monthly") == 6000
+
+    def test_env_override(self) -> None:
+        from app.services.ai_advisory_service import _period_max_tokens
+
+        with patch.dict(
+            "os.environ",
+            {
+                "AI_INSIGHT_MAX_TOKENS_DAILY": "999",
+                "AI_INSIGHT_MAX_TOKENS_LONG": "8000",
+            },
+        ):
+            assert _period_max_tokens("daily") == 999
+            assert _period_max_tokens("monthly") == 8000
+
+    def test_generate_passes_daily_budget_to_provider(self, app) -> None:
+        with app.app_context():
+            from app.services.ai_advisory_service import AIAdvisoryService
+
+            provider = MagicMock()
+            provider.generate_with_usage.return_value = _financial_llm_response()
+            service = AIAdvisoryService(user_id=uuid.uuid4(), llm_provider=provider)
+            service.generate_financial_insights(
+                period_type="daily", anchor_date=date(2026, 5, 17)
+            )
+            assert provider.generate_with_usage.call_args.kwargs["max_tokens"] == 1500
+
+    def test_generate_passes_long_budget_to_provider(self, app) -> None:
+        with app.app_context():
+            from app.services.ai_advisory_service import AIAdvisoryService
+
+            provider = MagicMock()
+            provider.generate_with_usage.return_value = _financial_llm_response()
+            service = AIAdvisoryService(user_id=uuid.uuid4(), llm_provider=provider)
+            service.generate_financial_insights(
+                period_type="monthly", anchor_date=date(2026, 5, 17)
+            )
+            assert provider.generate_with_usage.call_args.kwargs["max_tokens"] == 6000
+
+
+class TestDepthGate:
+    def test_reading_word_count_sums_summary_and_items(self) -> None:
+        from app.services.ai_advisory_service import _insight_reading_word_count
+
+        count = _insight_reading_word_count(
+            "um dois tres",
+            [{"title": "quatro cinco", "message": "seis sete oito"}],
+        )
+        assert count == 8
+
+    def test_below_target_records_metric(self, app) -> None:
+        with app.app_context():
+            from app.services.ai_advisory_service import AIAdvisoryService
+
+            provider = MagicMock()
+            # Short canned response → far below the daily 450-word target.
+            provider.generate_with_usage.return_value = _financial_llm_response()
+            service = AIAdvisoryService(user_id=uuid.uuid4(), llm_provider=provider)
+            with patch(
+                "app.services.ai_advisory_service.record_ai_insight_depth_below_target"
+            ) as rec:
+                service.generate_financial_insights(
+                    period_type="daily", anchor_date=date(2026, 5, 17)
+                )
+            rec.assert_called_once()
+            assert rec.call_args.kwargs["period_type"] == "daily"
+
+
+class TestProviderMaxTokens:
+    def test_resolve_max_tokens_explicit_and_default(self) -> None:
+        assert _resolve_max_tokens(3000) == 3000
+        assert _resolve_max_tokens(None) == 512
+        with patch.dict("os.environ", {"AI_INSIGHT_MAX_TOKENS_DEFAULT": "777"}):
+            assert _resolve_max_tokens(None) == 777
+
+    def test_timeout_scales_with_budget(self) -> None:
+        assert _timeout_for_max_tokens(512) == 20
+        assert _timeout_for_max_tokens(1500) == 60
+        assert _timeout_for_max_tokens(6000) == 120  # capped
+
+    def test_openai_payload_uses_max_tokens_and_timeout(self) -> None:
+        from app.services.llm_provider import OpenAILLMProvider
+
+        with patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}):
+            provider = OpenAILLMProvider()
+
+        fake = MagicMock()
+        fake.raise_for_status.return_value = None
+        fake.json.return_value = {
+            "choices": [{"message": {"content": "{}"}}],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            "model": "gpt-4o",
+        }
+        with patch("requests.post", return_value=fake) as post:
+            provider.generate_with_usage("hi", max_tokens=6000)
+
+        assert post.call_args.kwargs["json"]["max_tokens"] == 6000
+        assert post.call_args.kwargs["timeout"] == 120

--- a/tests/test_ai_monthly_recap_batch.py
+++ b/tests/test_ai_monthly_recap_batch.py
@@ -79,7 +79,9 @@ def _seed_monthly_recap(user_id: uuid.UUID, *, period_label: str) -> None:
 
 
 class _RecapProvider:
-    def generate_with_usage(self, prompt: str, response_schema=None) -> LLMResponse:
+    def generate_with_usage(
+        self, prompt: str, response_schema=None, max_tokens=None
+    ) -> LLMResponse:
         dimensions = [
             "general",
             "transactions",

--- a/tests/test_ai_monthly_report_service.py
+++ b/tests/test_ai_monthly_report_service.py
@@ -164,7 +164,9 @@ class StaticProvider:
     def __init__(self) -> None:
         self.calls = 0
 
-    def generate_with_usage(self, prompt: str, response_schema=None) -> LLMResponse:
+    def generate_with_usage(
+        self, prompt: str, response_schema=None, max_tokens=None
+    ) -> LLMResponse:
         self.calls += 1
         assert "monthly_report_context" in prompt
         assert "Daily 1" in prompt
@@ -173,7 +175,9 @@ class StaticProvider:
 
 
 class FailingProvider:
-    def generate_with_usage(self, prompt: str, response_schema=None) -> LLMResponse:
+    def generate_with_usage(
+        self, prompt: str, response_schema=None, max_tokens=None
+    ) -> LLMResponse:
         raise RuntimeError("provider unavailable")
 
 


### PR DESCRIPTION
## Summary

Parte do épico **Insights de IA v2** (platform #835). Torna os relatórios muito mais profundos e dá orçamento de tokens por período.

### Profundidade por período
- `_build_financial_insight_prompt` agora injeta uma instrução de **profundidade alvo** por período: diário ~**3 min** de leitura (~500–700 palavras, itens densos por dimensão); semanal/mensal ~**15 min** (~2500–3500 palavras, múltiplos itens ricos em markdown, projeções aprofundadas). Schema inalterado (não-quebrante).

### max_tokens configurável
- `LLMProvider.generate_with_usage` ganha `max_tokens`; OpenAI/Claude usam orçamento resolvido + **timeout escalado** (até 120s) p/ não cortar relatórios longos.
- Service passa `_period_max_tokens`: diário **1500**, semanal/mensal **6000** (envs `AI_INSIGHT_MAX_TOKENS_DAILY` / `AI_INSIGHT_MAX_TOKENS_LONG`). Antes era `512` hardcoded.

### Depth gate (advisory)
- Após gerar, conta palavras (summary + itens) e, se abaixo do alvo do período, emite log estruturado + métrica `auraxis_ai_insight_depth_below_target_total{period_type}`. **Nunca re-chama o LLM** (não dobra custo) — só sinaliza p/ tuning.

## Tests
- `tests/test_ai_insight_depth.py` — prompt por período, max_tokens passado ao provider (1500/6000) + override por env, contagem de palavras, depth gate dispara métrica, provider OpenAI usa max_tokens + timeout escalado.
- Regressão verde em advisory/observability/weekly/graphql; ruff + mypy limpos.

## Refs
Closes #1481
Épico #835

🤖 Generated with [Claude Code](https://claude.com/claude-code)
