### PR TITLE
fix(cors): incluir X-Auraxis-Timezone no allow-headers (preflight do change-status) (#1485)

### DIFF
--- a/app/middleware/cors.py
+++ b/app/middleware/cors.py
@@ -42,9 +42,13 @@ def _build_cors_policy_from_env() -> CorsPolicy:
     # the browser preflights POST /auth/refresh with this header whenever
     # AURAXIS_CSRF_ENFORCE=true, so omitting it blocks session restore on every
     # hard reload (#1436).
+    # X-Auraxis-Timezone is sent by GET /ai/insights/change-status (#1482); the
+    # browser preflights it, so it must be advertised or the request is blocked
+    # by CORS (#1485).
     allowed_headers = os.getenv(
         "CORS_ALLOWED_HEADERS",
-        "Authorization,Content-Type,X-API-Contract,Idempotency-Key,X-CSRF-TOKEN",
+        "Authorization,Content-Type,X-API-Contract,Idempotency-Key,"
+        "X-CSRF-TOKEN,X-Auraxis-Timezone",
     ).strip()
     return CorsPolicy(
         allowed_origins=_parse_allowed_origins(os.getenv("CORS_ALLOWED_ORIGINS")),

--- a/tests/test_cors_policy.py
+++ b/tests/test_cors_policy.py
@@ -76,7 +76,8 @@ def test_build_cors_policy_from_env_respects_defaults(
     assert policy.allow_credentials is True
     assert policy.allow_methods == "GET,POST,PUT,PATCH,DELETE,OPTIONS"
     assert policy.allow_headers == (
-        "Authorization,Content-Type,X-API-Contract,Idempotency-Key,X-CSRF-TOKEN"
+        "Authorization,Content-Type,X-API-Contract,Idempotency-Key,"
+        "X-CSRF-TOKEN,X-Auraxis-Timezone"
     )
     assert policy.max_age_seconds == 600
     assert policy.is_production is True
@@ -99,6 +100,23 @@ def test_default_allowed_headers_include_csrf_token(
     policy = _build_cors_policy_from_env()
 
     assert "X-CSRF-TOKEN" in policy.allow_headers.split(",")
+
+
+def test_default_allowed_headers_include_timezone(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """X-Auraxis-Timezone must be in the default CORS allow-list.
+
+    GET /ai/insights/change-status (#1482) sends the user's timezone as the
+    X-Auraxis-Timezone header. If it is absent from Access-Control-Allow-Headers
+    the browser preflight blocks the request. Regression guard for #1485.
+    """
+    monkeypatch.delenv("CORS_ALLOWED_HEADERS", raising=False)
+    monkeypatch.setenv("CORS_ALLOWED_ORIGINS", "https://app.auraxis.com.br")
+
+    policy = _build_cors_policy_from_env()
+
+    assert "X-Auraxis-Timezone" in policy.allow_headers.split(",")
 
 
 def test_build_cors_policy_marks_non_production_when_testing_enabled(


### PR DESCRIPTION
## Summary

Corrige o erro de **CORS** em `GET /ai/insights/change-status` (modal "nada mudou" do épico #835).

**Causa-raiz:** o `change-status` é a primeira chamada do front a enviar `X-Auraxis-Timezone` como **header** (o `/generate` manda o timezone no body, por isso funciona). O `Access-Control-Allow-Headers` default não incluía `X-Auraxis-Timezone`, então o **preflight** era bloqueado pelo navegador. Mesmo padrão do #1436 (faltava `X-CSRF-TOKEN`).

**Fix:** adiciona `X-Auraxis-Timezone` ao allow-headers default em `app/middleware/cors.py` + teste anti-regressão.

## Tests
- `test_default_allowed_headers_include_timezone` (novo) + atualização do exact-match. Suíte `test_cors_policy.py` verde; ruff + mypy limpos.

## Deploy
⚠️ Se houver `CORS_ALLOWED_HEADERS` setado via SSM/env em prod, ele **sobrescreve** o default — nesse caso, adicionar `X-Auraxis-Timezone` lá também. Se prod usa o default do código (como no #1436), o deploy resolve.

## Refs
Closes #1485
Épico #835
