### PR TITLE
fix(transactions): lançamentos de cartão seguem o mês da fatura

### DIFF
--- a/app/application/services/transaction/list_queries.py
+++ b/app/application/services/transaction/list_queries.py
@@ -44,6 +44,7 @@ def fetch_active_transactions(
     query = Transaction.query.filter_by(user_id=user_id, deleted=False)
     query = apply_active_transaction_filters(
         query,
+        user_id=user_id,
         transaction_type=transaction_type,
         status=status,
         start_date=start_date,

--- a/app/application/services/transaction/mutations.py
+++ b/app/application/services/transaction/mutations.py
@@ -36,6 +36,10 @@ from app.models.transaction import (
     TransactionStatus,
     TransactionType,
 )
+from app.services.credit_card_bill_service import (
+    build_competence_month_filter,
+    month_span_if_full_calendar_month,
+)
 from app.services.transaction_reference_authorization_service import (
     TransactionReferenceAuthorizationError,
     enforce_transaction_reference_ownership,
@@ -184,6 +188,7 @@ def build_installment_transactions(
 def apply_active_transaction_filters(
     query: Any,
     *,
+    user_id: UUID,
     transaction_type: str | None,
     status: str | None,
     start_date: date | None,
@@ -192,17 +197,28 @@ def apply_active_transaction_filters(
     account_id: UUID | None,
     credit_card_id: UUID | None,
 ) -> Any:
-    """Apply optional filters to an active-transactions list query."""
+    """Apply optional filters to an active-transactions list query.
+
+    When ``start_date``/``end_date`` span exactly one calendar month, the raw
+    ``due_date`` range is replaced by a competence-month filter so credit-card
+    transactions are grouped by the bill cycle they belong to (matching the
+    Cartões/fatura view) while non-card transactions and incomes stay on the
+    calendar month. Custom or partial ranges keep the raw ``due_date`` filter.
+    """
     if transaction_type:
         query = query.filter(
             Transaction.type == normalize_transaction_type(transaction_type)
         )
     if status:
         query = query.filter(Transaction.status == normalize_transaction_status(status))
-    if start_date:
-        query = query.filter(Transaction.due_date >= start_date)
-    if end_date:
-        query = query.filter(Transaction.due_date <= end_date)
+    competence_month = month_span_if_full_calendar_month(start_date, end_date)
+    if competence_month is not None:
+        query = query.filter(build_competence_month_filter(user_id, competence_month))
+    else:
+        if start_date:
+            query = query.filter(Transaction.due_date >= start_date)
+        if end_date:
+            query = query.filter(Transaction.due_date <= end_date)
     if tag_id:
         query = query.filter(Transaction.tag_id == tag_id)
     if account_id:

--- a/app/application/services/transaction_query_service.py
+++ b/app/application/services/transaction_query_service.py
@@ -37,6 +37,10 @@ from app.application.services.transaction_application_service import (
 )
 from app.extensions.database import db
 from app.models.transaction import Transaction, TransactionType
+from app.services.credit_card_bill_service import (
+    build_competence_month_filter,
+    month_span_if_full_calendar_month,
+)
 from app.services.transaction_analytics_service import (
     TransactionAnalyticsService,
 )
@@ -218,6 +222,33 @@ class TransactionQueryService:
             end_date=end_date,
         )
 
+    def _apply_period_date_filter(
+        self,
+        query: Any,
+        *,
+        start_date: date | None,
+        end_date: date | None,
+    ) -> Any:
+        """Apply the period date filter, switching to competence-month grouping.
+
+        When ``[start_date, end_date]`` spans exactly one calendar month, the
+        raw ``due_date`` range is replaced by a competence-month filter so
+        credit-card transactions are grouped by their bill cycle (matching the
+        Cartões/fatura view). Custom/partial ranges keep the raw ``due_date``
+        filter. Applied identically to the items and counts queries so totals
+        and pagination stay consistent.
+        """
+        competence_month = month_span_if_full_calendar_month(start_date, end_date)
+        if competence_month is not None:
+            return query.filter(
+                build_competence_month_filter(self._user_id, competence_month)
+            )
+        if start_date is not None:
+            query = query.filter(Transaction.due_date >= start_date)
+        if end_date is not None:
+            query = query.filter(Transaction.due_date <= end_date)
+        return query
+
     def _build_period_query(
         self,
         *,
@@ -225,11 +256,9 @@ class TransactionQueryService:
         end_date: date | None,
     ) -> Any:
         query = Transaction.query.filter_by(user_id=self._user_id, deleted=False)
-        if start_date is not None:
-            query = query.filter(Transaction.due_date >= start_date)
-        if end_date is not None:
-            query = query.filter(Transaction.due_date <= end_date)
-        return query
+        return self._apply_period_date_filter(
+            query, start_date=start_date, end_date=end_date
+        )
 
     def _build_period_counts(
         self,
@@ -252,10 +281,9 @@ class TransactionQueryService:
                 0,
             ).label("expense_transactions"),
         ).filter(Transaction.user_id == self._user_id, Transaction.deleted.is_(False))
-        if start_date is not None:
-            counts_query = counts_query.filter(Transaction.due_date >= start_date)
-        if end_date is not None:
-            counts_query = counts_query.filter(Transaction.due_date <= end_date)
+        counts_query = self._apply_period_date_filter(
+            counts_query, start_date=start_date, end_date=end_date
+        )
         row = counts_query.one()
         return (
             int(row.total_transactions or 0),

--- a/app/services/credit_card_bill_service.py
+++ b/app/services/credit_card_bill_service.py
@@ -18,13 +18,17 @@ import calendar
 from dataclasses import dataclass
 from datetime import date, timedelta
 from decimal import Decimal
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
+from uuid import UUID
 
-from sqlalchemy import and_, func
+from sqlalchemy import and_, func, or_
 
 from app.extensions.database import db
 from app.models.credit_card import CreditCard
 from app.models.transaction import Transaction, TransactionStatus, TransactionType
+
+if TYPE_CHECKING:
+    from sqlalchemy.sql.elements import ColumnElement
 
 BillCycleStatus = Literal["open", "closed", "paid"]
 
@@ -142,6 +146,108 @@ def compute_bill_cycle(*, closing_day: int, due_day: int, anchor: date) -> BillC
         due_date=due_date,
         status=status,
     )
+
+
+def bill_month_for(*, due_date: date, closing_day: int, due_day: int) -> str:
+    """Return the ``YYYY-MM`` of the bill cycle that contains ``due_date``.
+
+    A credit-card purchase belongs to the cycle that closes on ``closing_day``;
+    the month it is billed in is the month that cycle CLOSES in (its
+    ``end_date``). A purchase after the closing day rolls into the following
+    month's bill; on or before closing it stays in the current month.
+    """
+    cycle = compute_bill_cycle(
+        closing_day=closing_day,
+        due_day=due_day,
+        anchor=due_date,
+    )
+    return f"{cycle.end_date.year:04d}-{cycle.end_date.month:02d}"
+
+
+def month_span_if_full_calendar_month(
+    start_date: date | None, end_date: date | None
+) -> str | None:
+    """Return ``YYYY-MM`` when ``[start_date, end_date]`` is one whole month.
+
+    The range covers exactly one calendar month when it starts on the first
+    day, ends on that month's last day, and both endpoints share the same year
+    and month. Otherwise (partial range, cross-month range, or a missing
+    endpoint) returns ``None``.
+    """
+    if start_date is None or end_date is None:
+        return None
+    if start_date.day != 1:
+        return None
+    if (start_date.year, start_date.month) != (end_date.year, end_date.month):
+        return None
+    last_day = calendar.monthrange(end_date.year, end_date.month)[1]
+    if end_date.day != last_day:
+        return None
+    return f"{start_date.year:04d}-{start_date.month:02d}"
+
+
+def _calendar_month_bounds(month: str) -> tuple[date, date]:
+    """Return the (first_day, last_day) calendar bounds for a ``YYYY-MM``."""
+    try:
+        year_str, month_str = month.split("-", 1)
+        year = int(year_str)
+        m = int(month_str)
+        if not 1 <= m <= 12:
+            raise ValueError
+    except (ValueError, AttributeError) as exc:
+        raise ValueError(f"month must be in YYYY-MM format (got {month!r})") from exc
+    last_day = calendar.monthrange(year, m)[1]
+    return date(year, m, 1), date(year, m, last_day)
+
+
+def build_competence_month_filter(user_id: UUID, month: str) -> ColumnElement[bool]:
+    """Build a SQLAlchemy predicate grouping transactions by competence month.
+
+    For the calendar month ``month`` (``YYYY-MM``):
+
+    - Non-card transactions (``credit_card_id IS NULL``) match when their
+      ``due_date`` falls in the calendar month.
+    - For each credit card owned by ``user_id``, its transactions match when
+      ``due_date`` falls inside the bill cycle that CLOSES in ``month``
+      (anchored on the card's ``closing_day`` for that month). Cards missing
+      ``closing_day``/``due_day`` fall back to the calendar month.
+
+    The returned predicate is meant to replace a raw ``due_date BETWEEN
+    start AND end`` filter on a query already scoped to ``user_id``. It does
+    not itself scope by user, so callers must keep their own ``user_id``
+    filter.
+    """
+    month_start, month_end = _calendar_month_bounds(month)
+
+    non_card = and_(
+        Transaction.credit_card_id.is_(None),
+        Transaction.due_date >= month_start,
+        Transaction.due_date <= month_end,
+    )
+
+    branches: list[ColumnElement[bool]] = [non_card]
+
+    cards = CreditCard.query.filter_by(user_id=user_id).all()
+    for card in cards:
+        if card.closing_day is None or card.due_day is None:
+            cycle_start, cycle_end = month_start, month_end
+        else:
+            anchor = _safe_date(month_start.year, month_start.month, card.closing_day)
+            cycle = compute_bill_cycle(
+                closing_day=card.closing_day,
+                due_day=card.due_day,
+                anchor=anchor,
+            )
+            cycle_start, cycle_end = cycle.start_date, cycle.end_date
+        branches.append(
+            and_(
+                Transaction.credit_card_id == card.id,
+                Transaction.due_date >= cycle_start,
+                Transaction.due_date <= cycle_end,
+            )
+        )
+
+    return or_(*branches)
 
 
 _COMMITTED_STATUSES = (

--- a/tests/test_transaction_competence_listing.py
+++ b/tests/test_transaction_competence_listing.py
@@ -1,0 +1,198 @@
+"""Integration tests: active-transactions listing follows the bill cycle.
+
+Reproduces the bug where a credit-card purchase made right after the card's
+closing day was listed under the calendar month of its ``due_date`` instead of
+the month of the bill it belongs to. After the fix, when the listing is scoped
+to a full calendar month, credit-card transactions are grouped by their bill
+cycle while non-card transactions and incomes stay on the calendar month.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from uuid import UUID
+
+from app.extensions.database import db
+from app.models.transaction import Transaction, TransactionStatus, TransactionType
+
+
+def _register_and_login(client, *, prefix: str) -> str:
+    from uuid import uuid4
+
+    suffix = uuid4().hex[:8]
+    email = f"{prefix}-{suffix}@email.com"
+    password = "StrongPass@123"
+    register = client.post(
+        "/auth/register",
+        json={"name": f"user-{suffix}", "email": email, "password": password},
+    )
+    assert register.status_code == 201
+    login = client.post("/auth/login", json={"email": email, "password": password})
+    assert login.status_code == 200
+    return login.get_json()["token"]
+
+
+def _auth_headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}", "X-API-Contract": "v2"}
+
+
+def _user_id_from_token(app, token: str) -> str:
+    from flask_jwt_extended import decode_token
+
+    with app.app_context():
+        return str(decode_token(token)["sub"])
+
+
+def _create_card(client, headers, *, closing_day: int, due_day: int) -> dict:
+    payload = {
+        "name": "Nubank",
+        "brand": "mastercard",
+        "limit_amount": 5000.0,
+        "closing_day": closing_day,
+        "due_day": due_day,
+    }
+    response = client.post("/credit-cards", json=payload, headers=headers)
+    assert response.status_code == 201
+    return response.get_json()["data"]["credit_card"]
+
+
+def _insert_tx(
+    app,
+    *,
+    user_id: str,
+    due_date: date,
+    title: str,
+    card_id: str | None = None,
+    tx_type: TransactionType = TransactionType.EXPENSE,
+) -> None:
+    with app.app_context():
+        tx = Transaction(
+            user_id=UUID(user_id),
+            credit_card_id=UUID(card_id) if card_id else None,
+            title=title,
+            amount=Decimal("100.00"),
+            due_date=due_date,
+            status=TransactionStatus.PENDING,
+            type=tx_type,
+        )
+        db.session.add(tx)
+        db.session.commit()
+
+
+def _list_titles(client, headers, *, start_date: str, end_date: str) -> set[str]:
+    response = client.get(
+        f"/transactions?start_date={start_date}&end_date={end_date}&per_page=100",
+        headers=headers,
+    )
+    assert response.status_code == 200
+    body = response.get_json()
+    items = body["data"]["transactions"]
+    return {item["title"] for item in items}
+
+
+class TestActiveListingFollowsBillCycle:
+    """Card purchases after closing day move to the next month's listing."""
+
+    def test_card_purchase_after_closing_appears_in_following_month(
+        self, app, client
+    ) -> None:
+        token = _register_and_login(client, prefix="comp-list")
+        headers = _auth_headers(token)
+        user_id = _user_id_from_token(app, token)
+        # Closes on the 10th. July cycle is 2026-06-11 .. 2026-07-10, so a
+        # purchase on 2026-06-19 belongs to July's bill.
+        card = _create_card(client, headers, closing_day=10, due_day=15)
+        _insert_tx(
+            app,
+            user_id=user_id,
+            card_id=card["id"],
+            due_date=date(2026, 6, 19),
+            title="card-jun19",
+        )
+
+        # (1) July listing INCLUDES the June-19 card purchase.
+        july = _list_titles(
+            client, headers, start_date="2026-07-01", end_date="2026-07-31"
+        )
+        assert "card-jun19" in july
+
+        # (2) June listing EXCLUDES it (it belongs to July's bill).
+        june = _list_titles(
+            client, headers, start_date="2026-06-01", end_date="2026-06-30"
+        )
+        assert "card-jun19" not in june
+
+    def test_income_and_non_card_stay_on_calendar_month(self, app, client) -> None:
+        token = _register_and_login(client, prefix="comp-cal")
+        headers = _auth_headers(token)
+        user_id = _user_id_from_token(app, token)
+        _create_card(client, headers, closing_day=10, due_day=15)
+        _insert_tx(
+            app,
+            user_id=user_id,
+            due_date=date(2026, 7, 5),
+            title="salary-jul",
+            tx_type=TransactionType.INCOME,
+        )
+        _insert_tx(app, user_id=user_id, due_date=date(2026, 6, 30), title="rent-jun")
+
+        july = _list_titles(
+            client, headers, start_date="2026-07-01", end_date="2026-07-31"
+        )
+        assert "salary-jul" in july
+        assert "rent-jun" not in july
+
+    def test_custom_partial_range_keeps_raw_due_date_filter(self, app, client) -> None:
+        token = _register_and_login(client, prefix="comp-range")
+        headers = _auth_headers(token)
+        user_id = _user_id_from_token(app, token)
+        card = _create_card(client, headers, closing_day=10, due_day=15)
+        # Card purchase on June 19 belongs to July's bill, but a custom partial
+        # range must behave like a raw due_date filter (no competence remap).
+        _insert_tx(
+            app,
+            user_id=user_id,
+            card_id=card["id"],
+            due_date=date(2026, 6, 19),
+            title="card-jun19",
+        )
+
+        # Range 2026-06-01..2026-06-30 is a full month → competence applies →
+        # excluded. But a partial range that contains June 19 must include it.
+        partial = _list_titles(
+            client, headers, start_date="2026-06-15", end_date="2026-06-20"
+        )
+        assert "card-jun19" in partial
+
+    def test_pagination_total_matches_competence_filter(self, app, client) -> None:
+        # The total/count must agree with the competence-filtered items so the
+        # paginator stays consistent.
+        token = _register_and_login(client, prefix="comp-count")
+        headers = _auth_headers(token)
+        user_id = _user_id_from_token(app, token)
+        card = _create_card(client, headers, closing_day=10, due_day=15)
+        _insert_tx(
+            app,
+            user_id=user_id,
+            card_id=card["id"],
+            due_date=date(2026, 6, 19),
+            title="card-jun19",
+        )
+        _insert_tx(
+            app,
+            user_id=user_id,
+            card_id=card["id"],
+            due_date=date(2026, 7, 20),
+            title="card-jul20",
+        )
+
+        response = client.get(
+            "/transactions?start_date=2026-07-01&end_date=2026-07-31&per_page=100",
+            headers=headers,
+        )
+        assert response.status_code == 200
+        body = response.get_json()
+        titles = {item["title"] for item in body["data"]["transactions"]}
+        assert titles == {"card-jun19"}
+        assert body["meta"]["pagination"]["total"] == 1

--- a/tests/test_transaction_competence_month.py
+++ b/tests/test_transaction_competence_month.py
@@ -1,0 +1,263 @@
+"""Unit tests for the credit-card competence-month helpers.
+
+Pure functions — no DB. These back the "Transações follow the bill" fix:
+credit-card transactions must be grouped by the bill cycle that contains
+their ``due_date``, not by the calendar month of ``due_date``.
+
+Covers:
+- ``bill_month_for`` — the ``YYYY-MM`` of the cycle a purchase falls into.
+- ``month_span_if_full_calendar_month`` — detect a full-calendar-month range.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from typing import Any
+from uuid import UUID, uuid4
+
+from app.extensions.database import db
+from app.models.credit_card import CreditCard
+from app.models.transaction import Transaction, TransactionStatus, TransactionType
+from app.models.user import User
+from app.services.credit_card_bill_service import (
+    bill_month_for,
+    build_competence_month_filter,
+    month_span_if_full_calendar_month,
+)
+
+
+def _make_user() -> UUID:
+    user = User(
+        name="comp-user",
+        email=f"comp-{uuid4().hex[:8]}@email.com",
+        password="x",
+    )
+    db.session.add(user)
+    db.session.commit()
+    return user.id
+
+
+def _make_card(
+    user_id: UUID,
+    *,
+    closing_day: int | None,
+    due_day: int | None,
+) -> UUID:
+    card = CreditCard(
+        user_id=user_id,
+        name="card",
+        brand="mastercard",
+        closing_day=closing_day,
+        due_day=due_day,
+    )
+    db.session.add(card)
+    db.session.commit()
+    return card.id
+
+
+def _make_tx(
+    user_id: UUID,
+    *,
+    due_date: date,
+    card_id: UUID | None = None,
+    tx_type: TransactionType = TransactionType.EXPENSE,
+    title: str = "tx",
+) -> UUID:
+    tx = Transaction(
+        user_id=user_id,
+        credit_card_id=card_id,
+        title=title,
+        amount=Decimal("100.00"),
+        due_date=due_date,
+        status=TransactionStatus.PENDING,
+        type=tx_type,
+    )
+    db.session.add(tx)
+    db.session.commit()
+    return tx.id
+
+
+def _titles_matching(user_id: UUID, predicate: Any) -> set[str]:
+    rows = (
+        Transaction.query.filter_by(user_id=user_id, deleted=False)
+        .filter(predicate)
+        .all()
+    )
+    return {row.title for row in rows}
+
+
+class TestBillMonthForAfterClosing:
+    """A purchase AFTER the closing day belongs to the FOLLOWING month's bill."""
+
+    def test_purchase_after_closing_rolls_to_next_month(self) -> None:
+        # Card closes on the 10th; a purchase on 2026-06-19 is past closing,
+        # so it lands on the cycle ending 2026-07-10 → July's bill.
+        assert (
+            bill_month_for(due_date=date(2026, 6, 19), closing_day=10, due_day=15)
+            == "2026-07"
+        )
+
+
+class TestBillMonthForOnOrBeforeClosing:
+    """A purchase ON or BEFORE the closing day stays in the CURRENT month."""
+
+    def test_purchase_before_closing_stays_in_current_month(self) -> None:
+        # Card closes on the 20th; a purchase on 2026-06-19 is before closing,
+        # so it lands on the cycle ending 2026-06-20 → June's bill.
+        assert (
+            bill_month_for(due_date=date(2026, 6, 19), closing_day=20, due_day=25)
+            == "2026-06"
+        )
+
+    def test_purchase_exactly_on_closing_day_stays_in_current_month(self) -> None:
+        assert (
+            bill_month_for(due_date=date(2026, 6, 20), closing_day=20, due_day=25)
+            == "2026-06"
+        )
+
+
+class TestBillMonthForYearBoundary:
+    """December purchases after closing roll into January of the next year."""
+
+    def test_december_purchase_after_closing_rolls_to_january(self) -> None:
+        assert (
+            bill_month_for(due_date=date(2026, 12, 20), closing_day=10, due_day=15)
+            == "2027-01"
+        )
+
+
+class TestBillMonthForMonthEndClamp:
+    """closing_day 31 clamps to the last valid day in short months."""
+
+    def test_closing_day_31_in_february_keeps_current_month(self) -> None:
+        # Feb 2026 has 28 days; a day-31 card closes Feb 28, so a purchase on
+        # 2026-02-15 is before closing → February's bill.
+        assert (
+            bill_month_for(due_date=date(2026, 2, 15), closing_day=31, due_day=10)
+            == "2026-02"
+        )
+
+
+class TestMonthSpanIfFullCalendarMonth:
+    """Detect a [start, end] range that covers exactly one calendar month."""
+
+    def test_full_month_returns_year_month_string(self) -> None:
+        assert (
+            month_span_if_full_calendar_month(date(2026, 6, 1), date(2026, 6, 30))
+            == "2026-06"
+        )
+
+    def test_full_february_non_leap_returns_string(self) -> None:
+        assert (
+            month_span_if_full_calendar_month(date(2026, 2, 1), date(2026, 2, 28))
+            == "2026-02"
+        )
+
+    def test_partial_range_returns_none(self) -> None:
+        assert (
+            month_span_if_full_calendar_month(date(2026, 6, 1), date(2026, 6, 15))
+            is None
+        )
+
+    def test_not_starting_on_first_returns_none(self) -> None:
+        assert (
+            month_span_if_full_calendar_month(date(2026, 6, 2), date(2026, 6, 30))
+            is None
+        )
+
+    def test_spanning_two_months_returns_none(self) -> None:
+        assert (
+            month_span_if_full_calendar_month(date(2026, 6, 1), date(2026, 7, 31))
+            is None
+        )
+
+    def test_none_start_returns_none(self) -> None:
+        assert month_span_if_full_calendar_month(None, date(2026, 6, 30)) is None
+
+    def test_none_end_returns_none(self) -> None:
+        assert month_span_if_full_calendar_month(date(2026, 6, 1), None) is None
+
+
+class TestBuildCompetenceMonthFilter:
+    """``build_competence_month_filter`` groups card txns by bill cycle.
+
+    Card transactions are matched by the closing cycle that contains their
+    ``due_date``; non-card transactions and incomes are matched by the
+    calendar month.
+    """
+
+    def test_card_purchase_after_closing_matches_following_month(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            # Closes on the 10th: July cycle is 2026-06-11 .. 2026-07-10.
+            card_id = _make_card(user_id, closing_day=10, due_day=15)
+            # Purchase 2026-06-19 (June calendar) is past June closing →
+            # belongs to July's bill.
+            _make_tx(
+                user_id, due_date=date(2026, 6, 19), card_id=card_id, title="jun19-card"
+            )
+            # Purchase 2026-07-20 is past July closing → August's bill.
+            _make_tx(
+                user_id, due_date=date(2026, 7, 20), card_id=card_id, title="jul20-card"
+            )
+
+            predicate = build_competence_month_filter(user_id, "2026-07")
+            matched = _titles_matching(user_id, predicate)
+
+        assert "jun19-card" in matched
+        assert "jul20-card" not in matched
+
+    def test_non_card_and_income_follow_calendar_month(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            _make_card(user_id, closing_day=10, due_day=15)
+            _make_tx(user_id, due_date=date(2026, 7, 5), title="jul-nocard")
+            _make_tx(user_id, due_date=date(2026, 6, 30), title="jun-nocard")
+            _make_tx(
+                user_id,
+                due_date=date(2026, 7, 9),
+                tx_type=TransactionType.INCOME,
+                title="jul-income",
+            )
+
+            predicate = build_competence_month_filter(user_id, "2026-07")
+            matched = _titles_matching(user_id, predicate)
+
+        assert matched == {"jul-nocard", "jul-income"}
+
+    def test_card_without_closing_day_uses_calendar_month(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            card_id = _make_card(user_id, closing_day=None, due_day=None)
+            _make_tx(
+                user_id, due_date=date(2026, 7, 15), card_id=card_id, title="jul-card"
+            )
+            _make_tx(
+                user_id, due_date=date(2026, 6, 15), card_id=card_id, title="jun-card"
+            )
+
+            predicate = build_competence_month_filter(user_id, "2026-07")
+            matched = _titles_matching(user_id, predicate)
+
+        assert matched == {"jul-card"}
+
+    def test_only_owners_cards_scope_the_filter(self, app) -> None:
+        # A purchase on another user's card must not leak into this user's
+        # competence filter results.
+        with app.app_context():
+            user_id = _make_user()
+            other_id = _make_user()
+            other_card = _make_card(other_id, closing_day=10, due_day=15)
+            _make_tx(
+                other_id,
+                due_date=date(2026, 6, 19),
+                card_id=other_card,
+                title="other-card",
+            )
+
+            predicate = build_competence_month_filter(user_id, "2026-07")
+            # Scope by user explicitly to mirror production list queries.
+            matched = _titles_matching(user_id, predicate)
+
+        assert matched == set()

--- a/tests/test_transaction_expense_period_competence.py
+++ b/tests/test_transaction_expense_period_competence.py
@@ -1,0 +1,158 @@
+"""Integration tests: expense-period query follows the bill cycle.
+
+``get_expense_period`` powers the monthly expense listing (and its counts).
+When the requested range is a full calendar month, credit-card expenses must
+be grouped by the bill cycle they belong to — keeping items and counts
+consistent with the Cartões/fatura view — while non-card expenses stay on the
+calendar month. Custom/partial ranges keep the raw ``due_date`` filter.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from typing import Any, cast
+from uuid import UUID, uuid4
+
+from app.application.services.transaction_application_service import (
+    TransactionApplicationService,
+)
+from app.application.services.transaction_query_service import (
+    TransactionQueryDependencies,
+    TransactionQueryService,
+)
+from app.extensions.database import db
+from app.models.credit_card import CreditCard
+from app.models.transaction import Transaction, TransactionStatus, TransactionType
+from app.models.user import User
+from app.services.transaction_analytics_service import TransactionAnalyticsService
+
+
+def _make_user() -> UUID:
+    user = User(
+        name="exp-comp",
+        email=f"exp-comp-{uuid4().hex[:8]}@email.com",
+        password="hash",
+    )
+    db.session.add(user)
+    db.session.commit()
+    return user.id
+
+
+def _make_card(user_id: UUID, *, closing_day: int, due_day: int) -> UUID:
+    card = CreditCard(
+        user_id=user_id,
+        name="card",
+        brand="mastercard",
+        closing_day=closing_day,
+        due_day=due_day,
+    )
+    db.session.add(card)
+    db.session.commit()
+    return card.id
+
+
+def _make_expense(
+    user_id: UUID, *, due_date: date, title: str, card_id: UUID | None = None
+) -> None:
+    db.session.add(
+        Transaction(
+            id=uuid4(),
+            user_id=user_id,
+            credit_card_id=card_id,
+            title=title,
+            amount=Decimal("100.00"),
+            type=TransactionType.EXPENSE,
+            status=TransactionStatus.PENDING,
+            due_date=due_date,
+            currency="BRL",
+            source="manual",
+        )
+    )
+    db.session.commit()
+
+
+def _service(user_id: UUID) -> TransactionQueryService:
+    return TransactionQueryService(
+        user_id=user_id,
+        dependencies=TransactionQueryDependencies(
+            transaction_application_service_factory=lambda _uid: cast(
+                TransactionApplicationService, object()
+            ),
+            analytics_service_factory=lambda _uid: cast(
+                TransactionAnalyticsService, object()
+            ),
+        ),
+    )
+
+
+class TestExpensePeriodFollowsBillCycle:
+    def test_card_expense_after_closing_counts_in_following_month(
+        self, app: Any
+    ) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            card_id = _make_card(user_id, closing_day=10, due_day=15)
+            # July cycle 2026-06-11 .. 2026-07-10 → June-19 belongs to July.
+            _make_expense(
+                user_id, card_id=card_id, due_date=date(2026, 6, 19), title="card-jun19"
+            )
+
+            july = _service(user_id).get_expense_period(
+                start_date=date(2026, 7, 1),
+                end_date=date(2026, 7, 31),
+                page=1,
+                per_page=10,
+                ordering_clause=Transaction.created_at.asc(),
+            )
+            june = _service(user_id).get_expense_period(
+                start_date=date(2026, 6, 1),
+                end_date=date(2026, 6, 30),
+                page=1,
+                per_page=10,
+                ordering_clause=Transaction.created_at.asc(),
+            )
+
+        assert [item["title"] for item in july["expenses"]] == ["card-jun19"]
+        assert july["counts"]["expense_transactions"] == 1
+        assert july["pagination"]["total"] == 1
+        # Not in June (its calendar month).
+        assert june["counts"]["expense_transactions"] == 0
+        assert june["expenses"] == []
+
+    def test_non_card_expense_stays_on_calendar_month(self, app: Any) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            _make_card(user_id, closing_day=10, due_day=15)
+            _make_expense(user_id, due_date=date(2026, 7, 5), title="rent-jul")
+            _make_expense(user_id, due_date=date(2026, 6, 30), title="rent-jun")
+
+            july = _service(user_id).get_expense_period(
+                start_date=date(2026, 7, 1),
+                end_date=date(2026, 7, 31),
+                page=1,
+                per_page=10,
+                ordering_clause=Transaction.created_at.asc(),
+            )
+
+        assert [item["title"] for item in july["expenses"]] == ["rent-jul"]
+        assert july["counts"]["expense_transactions"] == 1
+
+    def test_partial_range_keeps_raw_due_date(self, app: Any) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            card_id = _make_card(user_id, closing_day=10, due_day=15)
+            _make_expense(
+                user_id, card_id=card_id, due_date=date(2026, 6, 19), title="card-jun19"
+            )
+
+            partial = _service(user_id).get_expense_period(
+                start_date=date(2026, 6, 15),
+                end_date=date(2026, 6, 20),
+                page=1,
+                per_page=10,
+                ordering_clause=Transaction.created_at.asc(),
+            )
+
+        assert [item["title"] for item in partial["expenses"]] == ["card-jun19"]
+        assert partial["counts"]["expense_transactions"] == 1


### PR DESCRIPTION
## Problema

Na tela de **Transações**, lançamentos de cartão eram listados pelo mês calendário da `due_date`, enquanto na tela de **Cartões** apareciam no mês da **fatura** (ciclo via `closing_day`). Uma compra logo após o fechamento aparecia um mês antes em Transações do que na fatura.

Closes #1498

## Abordagem

On-the-fly, reusando a função pura `compute_bill_cycle`. **Sem migration** e **sem alterar o modelo `Transaction`**. O endpoint de fatura (`compute_bill`) **não** foi tocado.

Quando o período navegado cobre **exatamente um mês calendário cheio**, o filtro `due_date` cru é substituído por um filtro de competência:
- lançamentos **com** `credit_card_id` são agrupados pelo **ciclo de fechamento** que contém a `due_date` (mesma matemática da fatura);
- lançamentos **sem** cartão e **receitas** continuam pelo mês calendário (`due_date`).

Ranges custom/parciais mantêm o comportamento `due_date` atual.

## Mudanças

### Helpers puros (`app/services/credit_card_bill_service.py`)
- `bill_month_for(*, due_date, closing_day, due_day) -> str` — `YYYY-MM` do ciclo que contém a compra.
- `month_span_if_full_calendar_month(start, end) -> str | None` — detecta range = 1 mês calendário cheio.
- `build_competence_month_filter(user_id, month) -> or_(...)` — predicado SQLAlchemy: não-cartão por mês calendário; cada cartão do usuário por seu ciclo de fechamento naquele mês (cartões sem `closing_day`/`due_day` caem no calendário).

### Integração
- `apply_active_transaction_filters` (`transaction/mutations.py`) — aplica o filtro de competência quando o range é mês cheio; afeta itens **e** total da lista principal (`GET /transactions`, GraphQL `transactions`).
- `TransactionQueryService._build_period_query` + `_build_period_counts` — mesmo critério na query de expense-period (`GET /transactions/expenses`), aplicado de forma idêntica a itens **e** counts para manter totais/paginação consistentes.

## Testes (TDD)

- `tests/test_transaction_competence_month.py` — unit dos 3 helpers (bordas: pós/pré-fechamento, virada de ano, `closing_day=31` em fevereiro, mês cheio vs parcial vs cross-month vs `None`; predicado com DB: cartão pós-fechamento, não-cartão/receita por calendário, cartão sem fechamento, escopo por usuário).
- `tests/test_transaction_competence_listing.py` — integração HTTP `GET /transactions`: mês seguinte inclui a compra; mês da compra exclui; receita/sem-cartão por `due_date`; range parcial inalterado; total bate com os itens.
- `tests/test_transaction_expense_period_competence.py` — integração do expense-period (itens + counts) com o mesmo critério.

## Quality gates (local, CI-parity)

`bash scripts/run_ci_quality_local.sh --local` → **exit 0** (todos os estágios verdes).
- ruff format/check, mypy (466 arquivos), bandit, pip-audit: OK
- pytest: **2582 passed, 2 skipped**, cobertura global **91.28%** (≥85)
- Módulos tocados: `transaction_query_service.py` 100%, `transaction/mutations.py` 99%, `transaction/list_queries.py` 97%, `credit_card_bill_service.py` 90%.

## Fora de escopo (follow-up)

dashboard/summary/weekly_summary não foram alterados (fase posterior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jZX5Ur2XsT1DqQcEP4tjx