### PR TITLE
feat(insights): structured Fluida payload (retro/series/highlights/paragraphs)

### DIFF
--- a/app/graphql/mutations/ai_insight.py
+++ b/app/graphql/mutations/ai_insight.py
@@ -43,6 +43,31 @@ class AIInsightItemType(graphene.ObjectType):
     evidence = graphene.List(graphene.String)
 
 
+class AIInsightRetroEntryType(graphene.ObjectType):
+    """One calculated retrospective metric for the Fluida screen (#1501)."""
+
+    key = graphene.String(required=True)
+    label = graphene.String(required=True)
+    value = graphene.Float(required=True)
+    caption = graphene.String(required=True)
+    sign = graphene.String(required=True)
+
+
+class AIInsightSeriesType(graphene.ObjectType):
+    """Calculated outflow series: daily over 7 days, weekly over 6 weeks."""
+
+    daily = graphene.List(graphene.Float, required=True)
+    weekly = graphene.List(graphene.Float, required=True)
+
+
+class AIInsightHighlightType(graphene.ObjectType):
+    """One calculated per-theme highlight for the Fluida screen (#1501)."""
+
+    label = graphene.String(required=True)
+    value = graphene.Float(required=True)
+    sub = graphene.String(required=True)
+
+
 class GenerateAiInsightPayload(graphene.ObjectType):
     ok = graphene.Boolean(required=True)
     id = graphene.String()
@@ -58,6 +83,12 @@ class GenerateAiInsightPayload(graphene.ObjectType):
     tokens_used = graphene.Int()
     cost_usd = graphene.Float()
     forecast = graphene.Boolean()
+    # Structured Fluida fields (#1501) — additive, deterministically computed
+    # by the backend (paragraphs derive from `summary`).
+    paragraphs = graphene.List(graphene.String)
+    retro = graphene.List(AIInsightRetroEntryType)
+    series = graphene.Field(AIInsightSeriesType)
+    highlights = graphene.List(AIInsightHighlightType)
 
 
 def _to_item_type(item: dict[str, Any]) -> AIInsightItemType:
@@ -67,6 +98,33 @@ def _to_item_type(item: dict[str, Any]) -> AIInsightItemType:
         title=item.get("title", ""),
         message=item.get("message", ""),
         evidence=list(item.get("evidence", []) or []),
+    )
+
+
+def _to_retro_entry(entry: dict[str, Any]) -> AIInsightRetroEntryType:
+    return AIInsightRetroEntryType(
+        key=str(entry.get("key", "")),
+        label=str(entry.get("label", "")),
+        value=float(entry.get("value", 0.0) or 0.0),
+        caption=str(entry.get("caption", "")),
+        sign=str(entry.get("sign", "neutral")),
+    )
+
+
+def _to_series_type(series: dict[str, Any] | None) -> AIInsightSeriesType | None:
+    if not isinstance(series, dict):
+        return None
+    return AIInsightSeriesType(
+        daily=[float(v) for v in series.get("daily", []) or []],
+        weekly=[float(v) for v in series.get("weekly", []) or []],
+    )
+
+
+def _to_highlight_type(highlight: dict[str, Any]) -> AIInsightHighlightType:
+    return AIInsightHighlightType(
+        label=str(highlight.get("label", "")),
+        value=float(highlight.get("value", 0.0) or 0.0),
+        sub=str(highlight.get("sub", "")),
     )
 
 
@@ -155,6 +213,12 @@ class GenerateAiInsightMutation(graphene.Mutation):
             tokens_used=int(result.get("tokens_used") or 0),
             cost_usd=float(result.get("cost_usd") or 0),
             forecast=bool(result.get("forecast", False)),
+            paragraphs=list(result.get("paragraphs", []) or []),
+            retro=[_to_retro_entry(e) for e in result.get("retro", []) or []],
+            series=_to_series_type(result.get("series")),
+            highlights=[
+                _to_highlight_type(h) for h in result.get("highlights", []) or []
+            ],
         )
 
 

--- a/app/services/ai_advisory_service.py
+++ b/app/services/ai_advisory_service.py
@@ -55,6 +55,7 @@ from app.services.financial_insight_context_builder import (
 )
 from app.services.goal_projection_service import GoalProjectionService
 from app.services.insight_evidence_validator import filter_valid_items
+from app.services.insight_fluida_builder import enrich_insight_payload
 from app.services.llm_provider import LLMProvider, LLMProviderError, get_llm_provider
 from app.services.weekly_summary import compute_weekly_summary
 from app.utils import timezone_utils
@@ -678,27 +679,31 @@ def _cached_financial_insight_payload(
         )
         return None
 
-    return {
-        "id": str(cached.id),
-        "period_type": normalized_period_type,
-        "period_label": cached.period_label,
-        "period_start": cached.period_start.isoformat(),
-        "period_end": cached.period_end.isoformat(),
-        "summary": cached_summary,
-        "items": cached_items,
-        "context_version": cached_metadata.get(
-            "context_schema_version", context_version
-        ),
-        "context_hash": cached_metadata.get("context_hash"),
-        "tokens_used": cached.tokens_used,
-        "cost_usd": float(cached.cost_usd),
-        "model": cached.model,
-        "cached": True,
-        # Mirror the fresh-generation `forecast` flag so cache hits stay
-        # consistent: an insight whose period still lies in the future is a
-        # forecast regardless of whether it was just generated or replayed.
-        "forecast": cached.period_start > date.today(),
-    }
+    return enrich_insight_payload(
+        {
+            "id": str(cached.id),
+            "period_type": normalized_period_type,
+            "period_label": cached.period_label,
+            "period_start": cached.period_start.isoformat(),
+            "period_end": cached.period_end.isoformat(),
+            "summary": cached_summary,
+            "items": cached_items,
+            "context_version": cached_metadata.get(
+                "context_schema_version", context_version
+            ),
+            "context_hash": cached_metadata.get("context_hash"),
+            "tokens_used": cached.tokens_used,
+            "cost_usd": float(cached.cost_usd),
+            "model": cached.model,
+            "cached": True,
+            # Mirror the fresh-generation `forecast` flag so cache hits stay
+            # consistent: an insight whose period still lies in the future is a
+            # forecast regardless of whether it was just generated or replayed.
+            "forecast": cached.period_start > date.today(),
+        },
+        user_id=user_id,
+        anchor=cached.period_start,
+    )
 
 
 def _log_llm_call(
@@ -1277,22 +1282,26 @@ class AIAdvisoryService:
             except Exception:  # pragma: no cover — metrics are fire-and-forget
                 pass
 
-        return {
-            "id": str(saved_insight.id),
-            "period_type": normalized_period_type,
-            "period_label": period_label,
-            "period_start": period_start.isoformat(),
-            "period_end": period_end.isoformat(),
-            "summary": summary,
-            "items": items,
-            "context_version": context_version,
-            "context_hash": context_hash,
-            "tokens_used": llm_resp.total_tokens,
-            "cost_usd": llm_resp.estimated_cost_usd,
-            "model": llm_resp.model,
-            "cached": False,
-            "forecast": forecast,
-        }
+        return enrich_insight_payload(
+            {
+                "id": str(saved_insight.id),
+                "period_type": normalized_period_type,
+                "period_label": period_label,
+                "period_start": period_start.isoformat(),
+                "period_end": period_end.isoformat(),
+                "summary": summary,
+                "items": items,
+                "context_version": context_version,
+                "context_hash": context_hash,
+                "tokens_used": llm_resp.total_tokens,
+                "cost_usd": llm_resp.estimated_cost_usd,
+                "model": llm_resp.model,
+                "cached": False,
+                "forecast": forecast,
+            },
+            user_id=self._user_id,
+            anchor=period_start,
+        )
 
     def financial_insight_change_status(
         self,

--- a/app/services/ai_monthly_report_service.py
+++ b/app/services/ai_monthly_report_service.py
@@ -34,6 +34,7 @@ from app.services.ai_insight_runs import create_ai_insight_run
 from app.services.ai_lgpd import minimize_prompt_data, minimize_text
 from app.services.email_templates.base import render_monthly_analysis_ready_email
 from app.services.financial_insight_context_builder import truncate_snapshot
+from app.services.insight_fluida_builder import enrich_insight_payload
 from app.services.llm_provider import LLMProvider
 from app.services.outbound_queue import get_default_outbound_queue
 
@@ -495,23 +496,29 @@ def get_ai_insight_by_id(*, user_id: UUID, insight_id: UUID) -> dict[str, Any]:
         raise ValueError("insight_id não encontrado")
     summary, items = _extract_insight_content(insight)
     metadata = insight.metadata_dict
-    return {
-        "id": str(insight.id),
-        "content": insight.content,
-        "summary": summary,
-        "items": items,
-        "insight_type": insight.insight_type.value,
-        "period_type": insight.insight_type.value,
-        "period_label": insight.period_label,
-        "period_start": insight.period_start.isoformat(),
-        "period_end": insight.period_end.isoformat(),
-        "context_schema_version": metadata.get("context_schema_version"),
-        "context_hash": metadata.get("context_hash"),
-        "model": insight.model,
-        "tokens_used": insight.tokens_used,
-        "cost_usd": float(insight.cost_usd),
-        "created_at": insight.created_at.isoformat() if insight.created_at else None,
-    }
+    return enrich_insight_payload(
+        {
+            "id": str(insight.id),
+            "content": insight.content,
+            "summary": summary,
+            "items": items,
+            "insight_type": insight.insight_type.value,
+            "period_type": insight.insight_type.value,
+            "period_label": insight.period_label,
+            "period_start": insight.period_start.isoformat(),
+            "period_end": insight.period_end.isoformat(),
+            "context_schema_version": metadata.get("context_schema_version"),
+            "context_hash": metadata.get("context_hash"),
+            "model": insight.model,
+            "tokens_used": insight.tokens_used,
+            "cost_usd": float(insight.cost_usd),
+            "created_at": (
+                insight.created_at.isoformat() if insight.created_at else None
+            ),
+        },
+        user_id=user_id,
+        anchor=insight.period_start,
+    )
 
 
 __all__ = [

--- a/app/services/insight_fluida_builder.py
+++ b/app/services/insight_fluida_builder.py
@@ -1,0 +1,292 @@
+"""Deterministic structured fields for the "Insights Fluida" screen (#1501).
+
+The Fluida screen (auraxis-web / auraxis-app) renders structured blocks that the
+backend CALCULATES from the user's real transactions — the LLM only writes prose
+(``summary``); every number here is anchored to the ledger.
+
+This module is purely additive: it computes ``paragraphs``, ``retro``, ``series``
+and ``highlights`` and exposes :func:`enrich_insight_payload`, which composes them
+into an existing insight payload dict without removing or mutating prior keys.
+
+Aggregation rules mirror the canonical analytics layer
+(:mod:`app.services.weekly_summary`): outflow = ``PAID`` ``EXPENSE`` on
+``due_date``, excluding soft-deleted rows and ``impact_policy == CARDS_ONLY``.
+Amounts are decimal currency units (``Numeric(12, 2)``) — never cents.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import date, timedelta
+from decimal import Decimal
+from typing import Any, Literal
+from uuid import UUID
+
+from sqlalchemy import func
+
+from app.extensions.database import db
+from app.models.transaction import (
+    Transaction,
+    TransactionImpactPolicy,
+    TransactionStatus,
+    TransactionType,
+)
+from app.services.weekly_summary import _aggregate_range
+
+Sign = Literal["pos", "neg", "neutral"]
+
+_DAILY_WINDOW = 7
+_WEEKLY_WINDOW = 6
+_MAX_HIGHLIGHTS = 3
+# A single block (no blank-line breaks) longer than this is split on sentence
+# boundaries so the Fluida cards stay short; a lone short sentence is kept whole.
+_LONG_BLOCK_THRESHOLD = 90
+
+_SENTENCE_SPLIT_RE = re.compile(r"(?<=[.!?])\s+")
+
+
+def build_paragraphs(summary: str | None) -> list[str]:
+    """Split AI prose into short paragraphs for the Fluida layout.
+
+    Blank lines are the primary delimiter. A single long block with no blank
+    lines is split on sentence boundaries so no card holds a wall of text.
+    """
+    if not summary or not summary.strip():
+        return []
+
+    blocks = [block.strip() for block in re.split(r"\n\s*\n", summary)]
+    blocks = [block for block in blocks if block]
+
+    if len(blocks) <= 1 and blocks and len(blocks[0]) > _LONG_BLOCK_THRESHOLD:
+        sentences = [s.strip() for s in _SENTENCE_SPLIT_RE.split(blocks[0])]
+        return [s for s in sentences if s]
+
+    return blocks
+
+
+def _outflow(*, user_id: UUID, start: date, end: date) -> float:
+    """Outflow (expense) total for [start, end], reusing weekly_summary."""
+    _income, expense, _count = _aggregate_range(user_id=user_id, start=start, end=end)
+    return round(expense, 2)
+
+
+def _sign_for_spend(*, current: float, previous: float) -> Sign:
+    """Spending more than the comparison baseline is a negative signal."""
+    if current == previous:
+        return "neutral"
+    return "neg" if current > previous else "pos"
+
+
+def build_retro(*, user_id: UUID, anchor: date) -> list[dict[str, Any]]:
+    """Outflow retrospective: yesterday, day-before and this-week-vs-last.
+
+    Belongs to the ``general`` dimension. ``value`` is a decimal amount; ``sign``
+    encodes whether the movement is favourable (less spending = ``pos``).
+    """
+    yesterday = anchor - timedelta(days=1)
+    daybefore = anchor - timedelta(days=2)
+
+    yesterday_total = _outflow(user_id=user_id, start=yesterday, end=yesterday)
+    daybefore_total = _outflow(user_id=user_id, start=daybefore, end=daybefore)
+
+    cur_week_start = anchor - timedelta(days=anchor.weekday())
+    cur_week_end = cur_week_start + timedelta(days=6)
+    prev_week_start = cur_week_start - timedelta(days=7)
+    prev_week_end = cur_week_start - timedelta(days=1)
+
+    cur_week_total = _outflow(user_id=user_id, start=cur_week_start, end=cur_week_end)
+    prev_week_total = _outflow(
+        user_id=user_id, start=prev_week_start, end=prev_week_end
+    )
+    week_delta = round(cur_week_total - prev_week_total, 2)
+
+    return [
+        {
+            "key": "yesterday",
+            "label": "Ontem",
+            "value": yesterday_total,
+            "caption": "Saídas de ontem",
+            "sign": _sign_for_spend(current=yesterday_total, previous=daybefore_total),
+        },
+        {
+            "key": "daybefore",
+            "label": "Anteontem",
+            "value": daybefore_total,
+            "caption": "Saídas de anteontem",
+            "sign": "neutral",
+        },
+        {
+            "key": "vs_week",
+            "label": "Semana vs. anterior",
+            "value": week_delta,
+            "caption": "Variação de saídas da semana",
+            "sign": _sign_for_spend(current=cur_week_total, previous=prev_week_total),
+        },
+    ]
+
+
+def build_series(*, user_id: UUID, anchor: date) -> dict[str, list[float]]:
+    """Outflow series: daily over the last 7 days, weekly over the last 6 weeks.
+
+    Both windows end on (and include) the anchor. ``daily[-1]`` and
+    ``weekly[-1]`` are the anchor day / anchor week respectively.
+    """
+    daily: list[float] = []
+    for offset in range(_DAILY_WINDOW - 1, -1, -1):
+        day = anchor - timedelta(days=offset)
+        daily.append(_outflow(user_id=user_id, start=day, end=day))
+
+    cur_week_start = anchor - timedelta(days=anchor.weekday())
+    weekly: list[float] = []
+    for offset in range(_WEEKLY_WINDOW - 1, -1, -1):
+        week_start = cur_week_start - timedelta(days=7 * offset)
+        week_end = week_start + timedelta(days=6)
+        weekly.append(_outflow(user_id=user_id, start=week_start, end=week_end))
+
+    return {"daily": daily, "weekly": weekly}
+
+
+def _month_bounds(anchor: date) -> tuple[date, date]:
+    start = anchor.replace(day=1)
+    if start.month == 12:
+        next_month = start.replace(year=start.year + 1, month=1)
+    else:
+        next_month = start.replace(month=start.month + 1)
+    return start, next_month - timedelta(days=1)
+
+
+def _paid_rows(
+    *,
+    user_id: UUID,
+    tx_type: TransactionType,
+    start: date,
+    end: date,
+) -> list[Transaction]:
+    rows: list[Transaction] = (
+        db.session.query(Transaction)
+        .filter(
+            Transaction.user_id == user_id,
+            Transaction.deleted.is_(False),
+            Transaction.impact_policy != TransactionImpactPolicy.CARDS_ONLY,
+            Transaction.status == TransactionStatus.PAID,
+            Transaction.type == tx_type,
+            Transaction.due_date >= start,
+            Transaction.due_date <= end,
+        )
+        .order_by(Transaction.amount.desc())
+        .all()
+    )
+    return rows
+
+
+def build_highlights(*, user_id: UUID, anchor: date) -> list[dict[str, Any]]:
+    """Per-theme highlights for the month containing *anchor* (2-3 items)."""
+    start, end = _month_bounds(anchor)
+    highlights: list[dict[str, Any]] = []
+
+    expenses = _paid_rows(
+        user_id=user_id, tx_type=TransactionType.EXPENSE, start=start, end=end
+    )
+    if expenses:
+        biggest = expenses[0]
+        highlights.append(
+            {
+                "label": "Maior gasto do mês",
+                "value": round(float(biggest.amount), 2),
+                "sub": biggest.title or "",
+            }
+        )
+
+    incomes = _paid_rows(
+        user_id=user_id, tx_type=TransactionType.INCOME, start=start, end=end
+    )
+    if len(incomes) == 1:
+        only_credit = incomes[0]
+        highlights.append(
+            {
+                "label": "Único crédito",
+                "value": round(float(only_credit.amount), 2),
+                "sub": only_credit.title or "",
+            }
+        )
+    elif len(incomes) > 1:
+        total_income = (
+            db.session.query(func.coalesce(func.sum(Transaction.amount), 0))
+            .filter(
+                Transaction.user_id == user_id,
+                Transaction.deleted.is_(False),
+                Transaction.impact_policy != TransactionImpactPolicy.CARDS_ONLY,
+                Transaction.status == TransactionStatus.PAID,
+                Transaction.type == TransactionType.INCOME,
+                Transaction.due_date >= start,
+                Transaction.due_date <= end,
+            )
+            .scalar()
+        )
+        highlights.append(
+            {
+                "label": "Maior crédito do mês",
+                "value": round(float(incomes[0].amount), 2),
+                "sub": incomes[0].title or "",
+            }
+        )
+        # Keep total available for a possible second income highlight.
+        if len(highlights) < _MAX_HIGHLIGHTS:
+            highlights.append(
+                {
+                    "label": "Total de créditos",
+                    "value": round(float(Decimal(str(total_income or 0))), 2),
+                    "sub": f"{len(incomes)} entradas",
+                }
+            )
+
+    return highlights[:_MAX_HIGHLIGHTS]
+
+
+def _resolve_anchor(payload: dict[str, Any], anchor: date | None) -> date:
+    if anchor is not None:
+        return anchor
+    raw_start = payload.get("period_start")
+    if isinstance(raw_start, str) and raw_start:
+        try:
+            return date.fromisoformat(raw_start)
+        except ValueError:
+            pass
+    return date.today()
+
+
+def enrich_insight_payload(
+    payload: dict[str, Any],
+    *,
+    user_id: UUID,
+    anchor: date | None = None,
+) -> dict[str, Any]:
+    """Add the structured Fluida fields to *payload* (additive, in place).
+
+    ``paragraphs`` is derived from the AI ``summary``; ``retro`` (general
+    dimension), ``series`` and ``highlights`` (per theme) are computed from the
+    user's transactions. Pre-existing keys are never removed or modified — the
+    REST/GraphQL contract stays backward compatible.
+
+    When *anchor* is omitted it defaults to the payload's ``period_start`` so the
+    calculation window aligns with the insight period.
+    """
+    resolved_anchor = _resolve_anchor(payload, anchor)
+
+    summary = payload.get("summary")
+    payload["paragraphs"] = build_paragraphs(
+        summary if isinstance(summary, str) else None
+    )
+    payload["retro"] = build_retro(user_id=user_id, anchor=resolved_anchor)
+    payload["series"] = build_series(user_id=user_id, anchor=resolved_anchor)
+    payload["highlights"] = build_highlights(user_id=user_id, anchor=resolved_anchor)
+    return payload
+
+
+__all__ = [
+    "build_highlights",
+    "build_paragraphs",
+    "build_retro",
+    "build_series",
+    "enrich_insight_payload",
+]

--- a/graphql.introspection.json
+++ b/graphql.introspection.json
@@ -17379,6 +17379,66 @@
                 "name": "Boolean",
                 "ofType": null
               }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "paragraphs",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "retro",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "AIInsightRetroEntryType",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "series",
+              "type": {
+                "kind": "OBJECT",
+                "name": "AIInsightSeriesType",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "highlights",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "AIInsightHighlightType",
+                  "ofType": null
+                }
+              }
             }
           ],
           "inputFields": null,
@@ -17477,6 +17537,210 @@
           "interfaces": [],
           "kind": "OBJECT",
           "name": "AIInsightItemType",
+          "possibleTypes": null,
+          "specifiedByURL": null
+        },
+        {
+          "description": "One calculated retrospective metric for the Fluida screen (#1501).",
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "key",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "label",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "value",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "caption",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "sign",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "AIInsightRetroEntryType",
+          "possibleTypes": null,
+          "specifiedByURL": null
+        },
+        {
+          "description": "Calculated outflow series: daily over 7 days, weekly over 6 weeks.",
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "daily",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Float",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "weekly",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Float",
+                    "ofType": null
+                  }
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "AIInsightSeriesType",
+          "possibleTypes": null,
+          "specifiedByURL": null
+        },
+        {
+          "description": "One calculated per-theme highlight for the Fluida screen (#1501).",
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "label",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "value",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "sub",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "AIInsightHighlightType",
           "possibleTypes": null,
           "specifiedByURL": null
         },

--- a/schema.graphql
+++ b/schema.graphql
@@ -1388,6 +1388,10 @@ type GenerateAiInsightPayload {
   tokensUsed: Int
   costUsd: Float
   forecast: Boolean
+  paragraphs: [String]
+  retro: [AIInsightRetroEntryType]
+  series: AIInsightSeriesType
+  highlights: [AIInsightHighlightType]
 }
 
 """A single LLM-produced insight item, tagged by dimension."""
@@ -1397,6 +1401,28 @@ type AIInsightItemType {
   title: String!
   message: String!
   evidence: [String]
+}
+
+"""One calculated retrospective metric for the Fluida screen (#1501)."""
+type AIInsightRetroEntryType {
+  key: String!
+  label: String!
+  value: Float!
+  caption: String!
+  sign: String!
+}
+
+"""Calculated outflow series: daily over 7 days, weekly over 6 weeks."""
+type AIInsightSeriesType {
+  daily: [Float]!
+  weekly: [Float]!
+}
+
+"""One calculated per-theme highlight for the Fluida screen (#1501)."""
+type AIInsightHighlightType {
+  label: String!
+  value: Float!
+  sub: String!
 }
 
 type AIInsightFeedbackPayload {

--- a/tests/test_ai_insights_fluida_rest_contract.py
+++ b/tests/test_ai_insights_fluida_rest_contract.py
@@ -1,0 +1,154 @@
+"""End-to-end REST contract test for the Fluida fields (#1501).
+
+Drives ``POST /ai/insights/generate`` through the real HTTP stack with a stubbed
+LLM provider and asserts the response carries the structured Fluida fields while
+keeping every pre-existing contract key (no regression).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.llm_provider import LLMResponse
+
+
+def _register_and_login(client, prefix: str) -> str:
+    suffix = uuid.uuid4().hex[:8]
+    email = f"{prefix}-{suffix}@test.com"
+    password = "StrongPass@123"
+    reg = client.post(
+        "/auth/register",
+        json={"name": f"{prefix}-{suffix}", "email": email, "password": password},
+    )
+    assert reg.status_code == 201
+    login = client.post("/auth/login", json={"email": email, "password": password})
+    assert login.status_code == 200
+    return login.get_json()["token"]
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _grant_premium(app, token: str) -> uuid.UUID:
+    with app.app_context():
+        from flask_jwt_extended import decode_token
+
+        from app.extensions.database import db
+        from app.models.entitlement import Entitlement, EntitlementSource
+
+        user_id = uuid.UUID(decode_token(token)["sub"])
+        db.session.add(
+            Entitlement(
+                user_id=user_id,
+                feature_key="advanced_simulations",
+                source=EntitlementSource.MANUAL,
+                expires_at=None,
+            )
+        )
+        db.session.commit()
+        return user_id
+
+
+def _seed_expense(app, user_id: uuid.UUID, *, amount: str, due_date: date) -> None:
+    with app.app_context():
+        from app.extensions.database import db
+        from app.models.transaction import (
+            Transaction,
+            TransactionStatus,
+            TransactionType,
+        )
+
+        db.session.add(
+            Transaction(
+                user_id=user_id,
+                title="gasto",
+                description="gasto",
+                amount=Decimal(amount),
+                type=TransactionType.EXPENSE,
+                status=TransactionStatus.PAID,
+                due_date=due_date,
+            )
+        )
+        db.session.commit()
+
+
+def _financial_llm_response() -> LLMResponse:
+    item = (
+        '{"type":"saude_financeira","dimension":"general","title":"Item",'
+        '"message":"Os dados foram analisados.",'
+        '"evidence":["current_period.paid.balance"]}'
+    )
+    return LLMResponse(
+        content=f'{{"summary":"Resumo do dia.","items":[{item}]}}',
+        prompt_tokens=100,
+        completion_tokens=40,
+        total_tokens=140,
+        model="gpt-4o-mini",
+        latency_ms=120,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_ai_counter():
+    from app.middleware.ai_rate_limit import _InMemoryAICounter
+
+    _InMemoryAICounter.reset()
+    yield
+    _InMemoryAICounter.reset()
+
+
+_LEGACY_KEYS = {
+    "id",
+    "period_type",
+    "period_label",
+    "period_start",
+    "period_end",
+    "summary",
+    "items",
+    "context_version",
+    "cached",
+    "model",
+    "tokens_used",
+    "cost_usd",
+}
+_FLUIDA_KEYS = {"paragraphs", "retro", "series", "highlights"}
+
+
+class TestGenerateEndpointFluidaContract:
+    def test_response_carries_fluida_and_legacy_keys(self, app, client) -> None:
+        token = _register_and_login(client, "fluida-rest")
+        user_id = _grant_premium(app, token)
+        _seed_expense(app, user_id, amount="42.00", due_date=date(2026, 6, 14))
+
+        provider = MagicMock()
+        provider.generate_with_usage.return_value = _financial_llm_response()
+
+        with patch(
+            "app.services.ai_advisory_service.get_llm_provider",
+            return_value=provider,
+        ):
+            resp = client.post(
+                "/ai/insights/generate",
+                json={"period_type": "daily", "anchor_date": "2026-06-15"},
+                headers=_auth(token),
+            )
+
+        assert resp.status_code == 200
+        body = resp.get_json()
+        data = body.get("data", body)
+
+        # No contract regression.
+        assert _LEGACY_KEYS <= set(data), sorted(_LEGACY_KEYS - set(data))
+        # New structured fields present and well-formed.
+        assert _FLUIDA_KEYS <= set(data)
+        assert isinstance(data["paragraphs"], list)
+        assert len(data["series"]["daily"]) == 7
+        assert len(data["series"]["weekly"]) == 6
+        retro = {e["key"]: e for e in data["retro"]}
+        assert retro["yesterday"]["value"] == 42.0

--- a/tests/test_graphql_generate_ai_insight.py
+++ b/tests/test_graphql_generate_ai_insight.py
@@ -284,3 +284,89 @@ class TestGenerateAiInsightMutation:
             timezone_name="Pacific/Kiritimati",
             timezone_fallback=False,
         )
+
+
+_FLUIDA_MUTATION = """
+mutation Gen($periodType: String!, $anchorDate: String) {
+  generateAiInsight(periodType: $periodType, anchorDate: $anchorDate) {
+    ok
+    summary
+    paragraphs
+    retro { key label value caption sign }
+    series { daily weekly }
+    highlights { label value sub }
+  }
+}
+"""
+
+
+class TestGenerateAiInsightFluidaFields:
+    def test_exposes_structured_fluida_fields(self, app, client):
+        token = _register_and_login(client, prefix="gql-gen-fluida")
+        from flask_jwt_extended import decode_token
+
+        from app.services.entitlement_service import grant_entitlement
+
+        with app.app_context():
+            user_id = UUID(decode_token(token)["sub"])
+            grant_entitlement(
+                user_id=user_id,
+                feature_key="advanced_simulations",
+                source="trial",
+            )
+            from app.extensions.database import db
+
+            db.session.commit()
+
+        fake_result = {
+            "id": "dddddddd-dddd-dddd-dddd-dddddddddddd",
+            "period_type": "daily",
+            "period_label": "2026-06-15",
+            "period_start": "2026-06-15",
+            "period_end": "2026-06-15",
+            "summary": "Resumo do dia.",
+            "items": [],
+            "context_version": "financial_insight_snapshot.v1",
+            "context_hash": "abc",
+            "cached": False,
+            "model": "gpt-4o-mini",
+            "tokens_used": 50,
+            "cost_usd": 0.0001,
+            "forecast": False,
+            "paragraphs": ["Resumo do dia."],
+            "retro": [
+                {
+                    "key": "yesterday",
+                    "label": "Ontem",
+                    "value": 42.0,
+                    "caption": "Saídas de ontem",
+                    "sign": "neg",
+                }
+            ],
+            "series": {"daily": [0.0] * 7, "weekly": [0.0] * 6},
+            "highlights": [
+                {"label": "Maior gasto do mês", "value": 1800.0, "sub": "Aluguel"}
+            ],
+        }
+        with patch("app.graphql.mutations.ai_insight.AIAdvisoryService") as MockSvc:
+            instance = MockSvc.return_value
+            instance.generate_financial_insights.return_value = fake_result
+            response = _gql(
+                client,
+                _FLUIDA_MUTATION,
+                token,
+                variables={"periodType": "daily", "anchorDate": "2026-06-15"},
+            )
+
+        body = response.get_json()
+        assert "errors" not in body or not body["errors"], body
+        data = body["data"]["generateAiInsight"]
+        assert data["paragraphs"] == ["Resumo do dia."]
+        assert data["retro"][0]["key"] == "yesterday"
+        assert data["retro"][0]["value"] == 42.0
+        assert data["retro"][0]["sign"] == "neg"
+        assert data["series"]["daily"] == [0.0] * 7
+        assert data["series"]["weekly"] == [0.0] * 6
+        assert data["highlights"][0]["label"] == "Maior gasto do mês"
+        assert data["highlights"][0]["value"] == 1800.0
+        assert data["highlights"][0]["sub"] == "Aluguel"

--- a/tests/test_insight_fluida_builder.py
+++ b/tests/test_insight_fluida_builder.py
@@ -1,0 +1,444 @@
+"""Unit tests for the deterministic "Insights Fluida" structured fields (#1501).
+
+The Fluida screen consumes structured data that the backend CALCULATES from the
+user's real transactions (the LLM only writes prose; numbers are anchored). These
+tests cover the pure builders:
+
+  - build_paragraphs(summary)        — split AI prose into short paragraphs
+  - build_retro(user_id, anchor)     — yesterday / day-before / week-vs-week outflow
+  - build_series(user_id, anchor)    — daily[7] + weekly[6] outflow sums
+  - build_highlights(user_id, anchor)— per-theme highlights (biggest expense, etc.)
+
+All money is decimal (Numeric(12,2)) — never cents. Aggregations exclude
+soft-deleted rows and ``impact_policy == CARDS_ONLY`` and only count ``PAID``
+transactions on ``due_date``, mirroring weekly_summary / analytics services.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime
+from decimal import Decimal
+
+from app.extensions.database import db
+from app.models.transaction import (
+    Transaction,
+    TransactionCategory,
+    TransactionImpactPolicy,
+    TransactionStatus,
+    TransactionType,
+)
+from app.models.user import User
+from app.services.insight_fluida_builder import (
+    build_highlights,
+    build_paragraphs,
+    build_retro,
+    build_series,
+)
+
+
+def _make_user() -> uuid.UUID:
+    user = User(
+        name="Fluida Cliente",
+        email=f"fluida-{uuid.uuid4().hex[:8]}@example.com",
+        password="hashed",
+    )
+    db.session.add(user)
+    db.session.commit()
+    return user.id
+
+
+def _make_transaction(
+    user_id: uuid.UUID,
+    *,
+    title: str,
+    amount: str,
+    tx_type: TransactionType,
+    status: TransactionStatus,
+    due_date: date,
+    category: TransactionCategory | None = None,
+    impact_policy: TransactionImpactPolicy = TransactionImpactPolicy.FULL,
+    deleted: bool = False,
+    created_at: datetime | None = None,
+) -> Transaction:
+    tx = Transaction(
+        user_id=user_id,
+        title=title,
+        description=title,
+        amount=Decimal(amount),
+        type=tx_type,
+        status=status,
+        due_date=due_date,
+        category=category,
+        impact_policy=impact_policy,
+        deleted=deleted,
+    )
+    if created_at is not None:
+        tx.created_at = created_at
+    db.session.add(tx)
+    db.session.commit()
+    db.session.refresh(tx)
+    return tx
+
+
+# ---------------------------------------------------------------------------
+# build_paragraphs — pure, no DB
+# ---------------------------------------------------------------------------
+
+
+class TestBuildParagraphs:
+    def test_splits_on_blank_lines(self) -> None:
+        summary = "Primeiro parágrafo.\n\nSegundo parágrafo."
+        assert build_paragraphs(summary) == [
+            "Primeiro parágrafo.",
+            "Segundo parágrafo.",
+        ]
+
+    def test_splits_long_single_block_into_sentences(self) -> None:
+        summary = (
+            "Você gastou bastante esta semana. "
+            "O maior gasto foi com alimentação. "
+            "Considere revisar o orçamento."
+        )
+        paragraphs = build_paragraphs(summary)
+        assert len(paragraphs) == 3
+        assert paragraphs[0] == "Você gastou bastante esta semana."
+        assert paragraphs[2] == "Considere revisar o orçamento."
+
+    def test_strips_whitespace_and_drops_empty_chunks(self) -> None:
+        summary = "  Um.  \n\n\n   \n\n Dois.  "
+        assert build_paragraphs(summary) == ["Um.", "Dois."]
+
+    def test_empty_summary_returns_empty_list(self) -> None:
+        assert build_paragraphs("") == []
+        assert build_paragraphs("   ") == []
+
+
+# ---------------------------------------------------------------------------
+# build_retro — calculated outflow comparison
+# ---------------------------------------------------------------------------
+
+
+class TestBuildRetro:
+    def test_returns_three_entries_with_expected_keys(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            entries = build_retro(user_id=user_id, anchor=date(2026, 6, 15))
+        assert [e["key"] for e in entries] == ["yesterday", "daybefore", "vs_week"]
+        for entry in entries:
+            assert set(entry) == {"key", "label", "value", "caption", "sign"}
+
+    def test_yesterday_and_daybefore_sum_only_expense_outflow(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            anchor = date(2026, 6, 15)
+            # Yesterday (2026-06-14): two expenses + one income (income ignored)
+            _make_transaction(
+                user_id,
+                title="ontem-1",
+                amount="40.00",
+                tx_type=TransactionType.EXPENSE,
+                status=TransactionStatus.PAID,
+                due_date=date(2026, 6, 14),
+            )
+            _make_transaction(
+                user_id,
+                title="ontem-2",
+                amount="10.50",
+                tx_type=TransactionType.EXPENSE,
+                status=TransactionStatus.PAID,
+                due_date=date(2026, 6, 14),
+            )
+            _make_transaction(
+                user_id,
+                title="ontem-income",
+                amount="999.00",
+                tx_type=TransactionType.INCOME,
+                status=TransactionStatus.PAID,
+                due_date=date(2026, 6, 14),
+            )
+            # Day before (2026-06-13): one expense
+            _make_transaction(
+                user_id,
+                title="anteontem-1",
+                amount="25.00",
+                tx_type=TransactionType.EXPENSE,
+                status=TransactionStatus.PAID,
+                due_date=date(2026, 6, 13),
+            )
+            entries = {e["key"]: e for e in build_retro(user_id=user_id, anchor=anchor)}
+
+        assert entries["yesterday"]["value"] == 50.5
+        assert entries["daybefore"]["value"] == 25.0
+
+    def test_yesterday_sign_is_negative_when_higher_than_daybefore(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            anchor = date(2026, 6, 15)
+            _make_transaction(
+                user_id,
+                title="ontem",
+                amount="80.00",
+                tx_type=TransactionType.EXPENSE,
+                status=TransactionStatus.PAID,
+                due_date=date(2026, 6, 14),
+            )
+            _make_transaction(
+                user_id,
+                title="anteontem",
+                amount="30.00",
+                tx_type=TransactionType.EXPENSE,
+                status=TransactionStatus.PAID,
+                due_date=date(2026, 6, 13),
+            )
+            entries = {e["key"]: e for e in build_retro(user_id=user_id, anchor=anchor)}
+
+        # Spending MORE yesterday than the day before is a negative signal.
+        assert entries["yesterday"]["sign"] == "neg"
+
+    def test_excludes_cards_only_and_unpaid_and_deleted(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            anchor = date(2026, 6, 15)
+            _make_transaction(
+                user_id,
+                title="valida",
+                amount="40.00",
+                tx_type=TransactionType.EXPENSE,
+                status=TransactionStatus.PAID,
+                due_date=date(2026, 6, 14),
+            )
+            _make_transaction(
+                user_id,
+                title="cards-only",
+                amount="500.00",
+                tx_type=TransactionType.EXPENSE,
+                status=TransactionStatus.PAID,
+                due_date=date(2026, 6, 14),
+                impact_policy=TransactionImpactPolicy.CARDS_ONLY,
+            )
+            _make_transaction(
+                user_id,
+                title="pending",
+                amount="500.00",
+                tx_type=TransactionType.EXPENSE,
+                status=TransactionStatus.PENDING,
+                due_date=date(2026, 6, 14),
+            )
+            _make_transaction(
+                user_id,
+                title="deleted",
+                amount="500.00",
+                tx_type=TransactionType.EXPENSE,
+                status=TransactionStatus.PAID,
+                due_date=date(2026, 6, 14),
+                deleted=True,
+            )
+            entries = {e["key"]: e for e in build_retro(user_id=user_id, anchor=anchor)}
+
+        assert entries["yesterday"]["value"] == 40.0
+
+    def test_vs_week_sign_neutral_when_no_history(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            entries = {
+                e["key"]: e
+                for e in build_retro(user_id=user_id, anchor=date(2026, 6, 15))
+            }
+        assert entries["vs_week"]["sign"] == "neutral"
+        assert entries["vs_week"]["value"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# build_series — calculated daily[7] + weekly[6] outflow
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSeries:
+    def test_shape_is_seven_daily_and_six_weekly(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            series = build_series(user_id=user_id, anchor=date(2026, 6, 15))
+        assert set(series) == {"daily", "weekly"}
+        assert len(series["daily"]) == 7
+        assert len(series["weekly"]) == 6
+        assert all(isinstance(v, float) for v in series["daily"])
+        assert all(isinstance(v, float) for v in series["weekly"])
+
+    def test_daily_buckets_expense_on_correct_day(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            anchor = date(2026, 6, 15)
+            # Anchor day (last bucket) gets 100; the day before gets 40.
+            _make_transaction(
+                user_id,
+                title="hoje",
+                amount="100.00",
+                tx_type=TransactionType.EXPENSE,
+                status=TransactionStatus.PAID,
+                due_date=anchor,
+            )
+            _make_transaction(
+                user_id,
+                title="ontem",
+                amount="40.00",
+                tx_type=TransactionType.EXPENSE,
+                status=TransactionStatus.PAID,
+                due_date=date(2026, 6, 14),
+            )
+            # Income on anchor must NOT appear in an outflow series.
+            _make_transaction(
+                user_id,
+                title="salario",
+                amount="5000.00",
+                tx_type=TransactionType.INCOME,
+                status=TransactionStatus.PAID,
+                due_date=anchor,
+            )
+            series = build_series(user_id=user_id, anchor=anchor)
+
+        # daily[-1] is the anchor day, daily[-2] is the day before.
+        assert series["daily"][-1] == 100.0
+        assert series["daily"][-2] == 40.0
+        assert series["daily"][0] == 0.0
+
+    def test_weekly_last_bucket_sums_anchor_week_outflow(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            # 2026-06-15 is a Monday → anchor week is 06-15..06-21.
+            anchor = date(2026, 6, 15)
+            _make_transaction(
+                user_id,
+                title="seg",
+                amount="30.00",
+                tx_type=TransactionType.EXPENSE,
+                status=TransactionStatus.PAID,
+                due_date=date(2026, 6, 15),
+            )
+            _make_transaction(
+                user_id,
+                title="qua",
+                amount="20.00",
+                tx_type=TransactionType.EXPENSE,
+                status=TransactionStatus.PAID,
+                due_date=date(2026, 6, 17),
+            )
+            series = build_series(user_id=user_id, anchor=anchor)
+
+        assert series["weekly"][-1] == 50.0
+
+
+# ---------------------------------------------------------------------------
+# build_highlights — per-theme calculated highlights
+# ---------------------------------------------------------------------------
+
+
+class TestBuildHighlights:
+    def test_includes_biggest_expense_of_month(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            anchor = date(2026, 6, 15)
+            _make_transaction(
+                user_id,
+                title="Aluguel",
+                amount="1800.00",
+                tx_type=TransactionType.EXPENSE,
+                status=TransactionStatus.PAID,
+                due_date=date(2026, 6, 5),
+                category=TransactionCategory.moradia,
+            )
+            _make_transaction(
+                user_id,
+                title="Mercado",
+                amount="320.00",
+                tx_type=TransactionType.EXPENSE,
+                status=TransactionStatus.PAID,
+                due_date=date(2026, 6, 7),
+                category=TransactionCategory.alimentacao,
+            )
+            highlights = build_highlights(user_id=user_id, anchor=anchor)
+
+        labels = [h["label"] for h in highlights]
+        assert "Maior gasto do mês" in labels
+        biggest = next(h for h in highlights if h["label"] == "Maior gasto do mês")
+        assert biggest["value"] == 1800.0
+        assert biggest["sub"] == "Aluguel"
+
+    def test_includes_single_credit_when_only_one_income(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            anchor = date(2026, 6, 15)
+            _make_transaction(
+                user_id,
+                title="Salário",
+                amount="5000.00",
+                tx_type=TransactionType.INCOME,
+                status=TransactionStatus.PAID,
+                due_date=date(2026, 6, 5),
+            )
+            _make_transaction(
+                user_id,
+                title="Padaria",
+                amount="20.00",
+                tx_type=TransactionType.EXPENSE,
+                status=TransactionStatus.PAID,
+                due_date=date(2026, 6, 7),
+            )
+            highlights = build_highlights(user_id=user_id, anchor=anchor)
+
+        labels = [h["label"] for h in highlights]
+        assert "Único crédito" in labels
+        credit = next(h for h in highlights if h["label"] == "Único crédito")
+        assert credit["value"] == 5000.0
+
+    def test_each_highlight_has_label_value_sub(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            anchor = date(2026, 6, 15)
+            _make_transaction(
+                user_id,
+                title="Mercado",
+                amount="320.00",
+                tx_type=TransactionType.EXPENSE,
+                status=TransactionStatus.PAID,
+                due_date=date(2026, 6, 7),
+            )
+            highlights = build_highlights(user_id=user_id, anchor=anchor)
+
+        assert highlights, "expected at least one highlight"
+        assert len(highlights) <= 3
+        for h in highlights:
+            assert set(h) == {"label", "value", "sub"}
+
+    def test_empty_when_no_transactions(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            highlights = build_highlights(user_id=user_id, anchor=date(2026, 6, 15))
+        assert highlights == []
+
+    def test_multiple_incomes_yield_biggest_and_total_credit(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            anchor = date(2026, 6, 15)
+            for title, amount, day in (
+                ("Salário", "5000.00", 5),
+                ("Freela", "1200.00", 9),
+                ("Reembolso", "300.00", 11),
+            ):
+                _make_transaction(
+                    user_id,
+                    title=title,
+                    amount=amount,
+                    tx_type=TransactionType.INCOME,
+                    status=TransactionStatus.PAID,
+                    due_date=date(2026, 6, day),
+                )
+            highlights = build_highlights(user_id=user_id, anchor=anchor)
+
+        by_label = {h["label"]: h for h in highlights}
+        assert "Maior crédito do mês" in by_label
+        assert by_label["Maior crédito do mês"]["value"] == 5000.0
+        assert by_label["Maior crédito do mês"]["sub"] == "Salário"
+        assert "Total de créditos" in by_label
+        assert by_label["Total de créditos"]["value"] == 6500.0
+        assert by_label["Total de créditos"]["sub"] == "3 entradas"

--- a/tests/test_insight_fluida_enrichment.py
+++ b/tests/test_insight_fluida_enrichment.py
@@ -1,0 +1,147 @@
+"""Tests for enrich_insight_payload — additive Fluida composition (#1501).
+
+``enrich_insight_payload`` takes an existing insight payload dict (as returned by
+``AIAdvisoryService.generate_financial_insights`` / ``get_ai_insight_by_id``) and
+adds the structured Fluida fields WITHOUT removing or mutating prior keys.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date, timedelta
+from decimal import Decimal
+
+from app.extensions.database import db
+from app.models.transaction import (
+    Transaction,
+    TransactionStatus,
+    TransactionType,
+)
+from app.models.user import User
+from app.services.insight_fluida_builder import enrich_insight_payload
+
+
+def _make_user() -> uuid.UUID:
+    user = User(
+        name="Enrich Cliente",
+        email=f"enrich-{uuid.uuid4().hex[:8]}@example.com",
+        password="hashed",
+    )
+    db.session.add(user)
+    db.session.commit()
+    return user.id
+
+
+def _make_expense(user_id: uuid.UUID, *, amount: str, due_date: date) -> None:
+    tx = Transaction(
+        user_id=user_id,
+        title="gasto",
+        description="gasto",
+        amount=Decimal(amount),
+        type=TransactionType.EXPENSE,
+        status=TransactionStatus.PAID,
+        due_date=due_date,
+    )
+    db.session.add(tx)
+    db.session.commit()
+
+
+def _base_payload() -> dict[str, object]:
+    return {
+        "id": "abc",
+        "period_type": "daily",
+        "period_label": "2026-06-15",
+        "period_start": "2026-06-15",
+        "period_end": "2026-06-15",
+        "summary": "Primeiro.\n\nSegundo.",
+        "items": [{"type": "saude_financeira", "dimension": "general"}],
+        "context_version": "financial_insight_snapshot.v1",
+        "context_hash": "deadbeef",
+        "tokens_used": 100,
+        "cost_usd": 0.0001,
+        "model": "gpt-4o-mini",
+        "cached": False,
+        "forecast": False,
+    }
+
+
+class TestEnrichInsightPayload:
+    def test_adds_all_four_structured_fields(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            enriched = enrich_insight_payload(
+                _base_payload(), user_id=user_id, anchor=date(2026, 6, 15)
+            )
+        assert "paragraphs" in enriched
+        assert "retro" in enriched
+        assert "series" in enriched
+        assert "highlights" in enriched
+
+    def test_preserves_all_existing_keys_unchanged(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            original = _base_payload()
+            enriched = enrich_insight_payload(
+                dict(original), user_id=user_id, anchor=date(2026, 6, 15)
+            )
+        for key, value in original.items():
+            assert enriched[key] == value
+
+    def test_paragraphs_derive_from_summary(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            enriched = enrich_insight_payload(
+                _base_payload(), user_id=user_id, anchor=date(2026, 6, 15)
+            )
+        assert enriched["paragraphs"] == ["Primeiro.", "Segundo."]
+
+    def test_series_has_seven_daily_six_weekly(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            enriched = enrich_insight_payload(
+                _base_payload(), user_id=user_id, anchor=date(2026, 6, 15)
+            )
+        assert len(enriched["series"]["daily"]) == 7
+        assert len(enriched["series"]["weekly"]) == 6
+
+    def test_retro_reflects_calculated_outflow(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            _make_expense(user_id, amount="42.00", due_date=date(2026, 6, 14))
+            enriched = enrich_insight_payload(
+                _base_payload(), user_id=user_id, anchor=date(2026, 6, 15)
+            )
+        retro = {e["key"]: e for e in enriched["retro"]}
+        assert retro["yesterday"]["value"] == 42.0
+
+    def test_anchor_defaults_to_period_start_when_omitted(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            # Expense on the day before period_start (2026-06-15) → "yesterday".
+            _make_expense(user_id, amount="15.00", due_date=date(2026, 6, 14))
+            enriched = enrich_insight_payload(_base_payload(), user_id=user_id)
+        retro = {e["key"]: e for e in enriched["retro"]}
+        assert retro["yesterday"]["value"] == 15.0
+
+    def test_does_not_mutate_input_dict_in_place_for_existing_keys(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            original = _base_payload()
+            enrich_insight_payload(original, user_id=user_id, anchor=date(2026, 6, 15))
+        # The four new keys may be added, but original business keys keep value.
+        assert original["summary"] == "Primeiro.\n\nSegundo."
+        assert original["items"] == [
+            {"type": "saude_financeira", "dimension": "general"}
+        ]
+
+    def test_falls_back_to_today_when_no_anchor_and_no_period_start(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            today = date.today()
+            yesterday = today - timedelta(days=1)
+            _make_expense(user_id, amount="17.00", due_date=yesterday)
+            payload = _base_payload()
+            payload.pop("period_start")
+            enriched = enrich_insight_payload(payload, user_id=user_id)
+        retro = {e["key"]: e for e in enriched["retro"]}
+        assert retro["yesterday"]["value"] == 17.0

--- a/tests/test_insight_fluida_service_integration.py
+++ b/tests/test_insight_fluida_service_integration.py
@@ -1,0 +1,182 @@
+"""Service-level wiring of Fluida fields into the insight payload (#1501).
+
+Confirms ``AIAdvisoryService.generate_financial_insights`` and
+``get_ai_insight_by_id`` expose the structured Fluida fields, and that NONE of
+the pre-existing contract keys regress (backward compatibility).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+from app.extensions.database import db
+from app.models.transaction import (
+    Transaction,
+    TransactionStatus,
+    TransactionType,
+)
+from app.models.user import User
+from app.services.ai_advisory_service import AIAdvisoryService
+from app.services.ai_monthly_report_service import get_ai_insight_by_id
+from app.services.llm_provider import LLMResponse
+
+_LEGACY_FINANCIAL_KEYS = {
+    "id",
+    "period_type",
+    "period_label",
+    "period_start",
+    "period_end",
+    "summary",
+    "items",
+    "context_version",
+    "context_hash",
+    "tokens_used",
+    "cost_usd",
+    "model",
+    "cached",
+    "forecast",
+}
+_FLUIDA_KEYS = {"paragraphs", "retro", "series", "highlights"}
+
+
+def _make_user() -> uuid.UUID:
+    user = User(
+        name="Svc Cliente",
+        email=f"svc-{uuid.uuid4().hex[:8]}@example.com",
+        password="hashed",
+    )
+    db.session.add(user)
+    db.session.commit()
+    return user.id
+
+
+def _make_expense(user_id: uuid.UUID, *, amount: str, due_date: date) -> None:
+    tx = Transaction(
+        user_id=user_id,
+        title="gasto",
+        description="gasto",
+        amount=Decimal(amount),
+        type=TransactionType.EXPENSE,
+        status=TransactionStatus.PAID,
+        due_date=due_date,
+    )
+    db.session.add(tx)
+    db.session.commit()
+
+
+_SUMMARY = (
+    "Você manteve as contas em dia este mês. "
+    "O maior gasto continua sendo a moradia. "
+    "Vale revisar os gastos com lazer na próxima semana."
+)
+
+
+def _financial_llm_response(summary: str = _SUMMARY) -> LLMResponse:
+    item = (
+        '{"type":"saude_financeira","dimension":"general","title":"Item",'
+        '"message":"Os dados foram analisados.",'
+        '"evidence":["current_period.paid.balance"]}'
+    )
+    return LLMResponse(
+        content=f'{{"summary":"{summary}","items":[{item}]}}',
+        prompt_tokens=100,
+        completion_tokens=40,
+        total_tokens=140,
+        model="gpt-4o-mini",
+        latency_ms=120,
+    )
+
+
+class TestGenerateFinancialInsightsEnriched:
+    def test_fresh_payload_has_fluida_and_legacy_keys(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            _make_expense(user_id, amount="42.00", due_date=date(2026, 6, 14))
+            provider = MagicMock()
+            provider.generate_with_usage.return_value = _financial_llm_response()
+            service = AIAdvisoryService(user_id=user_id, llm_provider=provider)
+
+            result = service.generate_financial_insights(
+                period_type="daily", anchor_date=date(2026, 6, 15)
+            )
+
+        # No contract regression: every legacy key still present.
+        assert _LEGACY_FINANCIAL_KEYS <= set(result)
+        # New structured fields present.
+        assert _FLUIDA_KEYS <= set(result)
+        # Calculated outflow reflects the seeded transaction.
+        retro = {e["key"]: e for e in result["retro"]}
+        assert retro["yesterday"]["value"] == 42.0
+        # Paragraphs derived from the AI summary (long block → sentences).
+        assert result["paragraphs"] == [
+            "Você manteve as contas em dia este mês.",
+            "O maior gasto continua sendo a moradia.",
+            "Vale revisar os gastos com lazer na próxima semana.",
+        ]
+        # Series anchored on period_start.
+        assert len(result["series"]["daily"]) == 7
+        assert result["series"]["daily"][-2] == 42.0
+
+    def test_cached_payload_also_enriched(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            _make_expense(user_id, amount="30.00", due_date=date(2026, 6, 14))
+            provider = MagicMock()
+            provider.generate_with_usage.return_value = _financial_llm_response()
+            service = AIAdvisoryService(user_id=user_id, llm_provider=provider)
+
+            first = service.generate_financial_insights(
+                period_type="daily", anchor_date=date(2026, 6, 15)
+            )
+            assert first["cached"] is False
+
+            # Second identical call hits the snapshot cache (no new LLM call).
+            second = service.generate_financial_insights(
+                period_type="daily", anchor_date=date(2026, 6, 15)
+            )
+
+        assert second["cached"] is True
+        assert _FLUIDA_KEYS <= set(second)
+        retro = {e["key"]: e for e in second["retro"]}
+        assert retro["yesterday"]["value"] == 30.0
+
+
+class TestGetAiInsightByIdEnriched:
+    def test_detail_payload_has_fluida_and_legacy_keys(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            _make_expense(user_id, amount="55.00", due_date=date(2026, 6, 14))
+            provider = MagicMock()
+            provider.generate_with_usage.return_value = _financial_llm_response()
+            service = AIAdvisoryService(user_id=user_id, llm_provider=provider)
+            generated = service.generate_financial_insights(
+                period_type="daily", anchor_date=date(2026, 6, 15)
+            )
+            insight_id = uuid.UUID(generated["id"])
+
+            detail = get_ai_insight_by_id(user_id=user_id, insight_id=insight_id)
+
+        # Legacy detail keys preserved.
+        for key in (
+            "id",
+            "content",
+            "summary",
+            "items",
+            "insight_type",
+            "period_type",
+            "period_label",
+            "period_start",
+            "period_end",
+            "model",
+            "tokens_used",
+            "cost_usd",
+            "created_at",
+        ):
+            assert key in detail
+        # Fluida fields added.
+        assert _FLUIDA_KEYS <= set(detail)
+        retro = {e["key"]: e for e in detail["retro"]}
+        assert retro["yesterday"]["value"] == 55.0


### PR DESCRIPTION
## Resumo

Estende o payload de insight de forma **aditiva** com os blocos estruturados consumidos pela tela **Fluida** (auraxis-web / auraxis-app). Todos os números são **calculados no backend** a partir das transações reais do usuário; a IA escreve apenas a prosa (`summary`).

Closes #1501

## Campos adicionados (aditivos — nenhum campo antigo removido)

- **`paragraphs: string[]`** — `summary` da IA quebrado em parágrafos curtos (por linha em branco; bloco único longo é dividido por frase).
- **`retro: [{ key, label, value, caption, sign }]`** — retrospectiva de saídas (dimensão `general`): `yesterday`, `daybefore`, `vs_week`. `sign ∈ {pos, neg, neutral}` (gastar mais = `neg`).
- **`series: { daily: float[7], weekly: float[6] }`** — soma de saídas por dia (últimos 7) e por semana (últimas 6); o último bucket é o dia/semana âncora.
- **`highlights: [{ label, value, sub }]`** — destaques por tema do mês (maior gasto; crédito único / maior crédito + total de créditos). Máx. 3.

## Regras de agregação

Reaproveita `weekly_summary._aggregate_range`: apenas `PAID` em `due_date`, excluindo soft-deleted e `impact_policy == CARDS_ONLY`. Valores em unidades decimais de moeda (`Numeric(12,2)`), nunca centavos.

## Não-regressão

- REST (`POST /ai/insights/generate`, `get_ai_insight_by_id`) e GraphQL (`generateAiInsight`) mantêm **todas** as chaves anteriores; os 4 campos são puramente adicionais. Testes de contrato asseguram a presença simultânea de chaves legadas + novas.
- Bundle GraphQL committado (`schema.graphql` + `graphql.introspection.json`) regenerado para casar com o schema runtime — diff é apenas adição de 3 tipos + 4 campos.

## Testes (TDD)

Novos: `test_insight_fluida_builder.py`, `test_insight_fluida_enrichment.py`, `test_insight_fluida_service_integration.py`, `test_ai_insights_fluida_rest_contract.py`, e `TestGenerateAiInsightFluidaFields` em `test_graphql_generate_ai_insight.py`.

## Quality gates

`bash scripts/run_ci_quality_local.sh --local` — verde: ruff format/check, mypy, bandit, pip-audit, e **2612 passed, 2 skipped**, cobertura **91.31%** (≥85%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jZX5Ur2XsT1DqQcEP4tjx