### PR TITLE
feat(insights): lead editorial Fluida (severity/title/lead/readMin/next_step)

### DIFF
--- a/app/controllers/ai/resources.py
+++ b/app/controllers/ai/resources.py
@@ -317,6 +317,13 @@ class AIInsightGenerateResource(MethodResource):
                     "model": "gpt-4o-mini",
                     "tokens_used": 420,
                     "cost_usd": 0.000063,
+                    "lead": {
+                        "severity": "ok",
+                        "read_min": 15,
+                        "title": "Saldo positivo no período.",
+                        "lead": "Você terminou o período com saldo positivo.",
+                        "next_step": "Continue acompanhando os gastos da semana.",
+                    },
                 },
             ),
             400: json_error_response(

--- a/app/graphql/mutations/ai_insight.py
+++ b/app/graphql/mutations/ai_insight.py
@@ -68,6 +68,22 @@ class AIInsightHighlightType(graphene.ObjectType):
     sub = graphene.String(required=True)
 
 
+class AIInsightLeadType(graphene.ObjectType):
+    """Editorial lead (masthead) for the Fluida screen (#1503).
+
+    ``severity`` is a deterministic heuristic over the calculated retro/highlights
+    (``ok`` | ``attention`` | ``alert``); ``read_min`` is fixed by cadence;
+    ``title`` / ``lead`` / ``next_step`` are derived from the AI ``summary`` (no
+    extra LLM call).
+    """
+
+    severity = graphene.String(required=True)
+    read_min = graphene.Int(required=True)
+    title = graphene.String(required=True)
+    lead = graphene.String(required=True)
+    next_step = graphene.String(required=True)
+
+
 class GenerateAiInsightPayload(graphene.ObjectType):
     ok = graphene.Boolean(required=True)
     id = graphene.String()
@@ -89,6 +105,8 @@ class GenerateAiInsightPayload(graphene.ObjectType):
     retro = graphene.List(AIInsightRetroEntryType)
     series = graphene.Field(AIInsightSeriesType)
     highlights = graphene.List(AIInsightHighlightType)
+    # Editorial lead (#1503) — additive, deterministic (no extra LLM call).
+    lead = graphene.Field(AIInsightLeadType)
 
 
 def _to_item_type(item: dict[str, Any]) -> AIInsightItemType:
@@ -125,6 +143,18 @@ def _to_highlight_type(highlight: dict[str, Any]) -> AIInsightHighlightType:
         label=str(highlight.get("label", "")),
         value=float(highlight.get("value", 0.0) or 0.0),
         sub=str(highlight.get("sub", "")),
+    )
+
+
+def _to_lead_type(lead: dict[str, Any] | None) -> AIInsightLeadType | None:
+    if not isinstance(lead, dict):
+        return None
+    return AIInsightLeadType(
+        severity=str(lead.get("severity", "ok")),
+        read_min=int(lead.get("read_min", 0) or 0),
+        title=str(lead.get("title", "")),
+        lead=str(lead.get("lead", "")),
+        next_step=str(lead.get("next_step", "")),
     )
 
 
@@ -219,6 +249,7 @@ class GenerateAiInsightMutation(graphene.Mutation):
             highlights=[
                 _to_highlight_type(h) for h in result.get("highlights", []) or []
             ],
+            lead=_to_lead_type(result.get("lead")),
         )
 
 

--- a/app/services/insight_fluida_builder.py
+++ b/app/services/insight_fluida_builder.py
@@ -31,9 +31,14 @@ from app.models.transaction import (
     TransactionStatus,
     TransactionType,
 )
+from app.services.insight_lead_builder import WeekOverWeek, build_lead
 from app.services.weekly_summary import _aggregate_range
 
 Sign = Literal["pos", "neg", "neutral"]
+
+# The masthead lead is the cross-cutting reading of the whole period.
+_GENERAL_DIMENSION = "general"
+_DEFAULT_CADENCE = "weekly"
 
 _DAILY_WINDOW = 7
 _WEEKLY_WINDOW = 6
@@ -77,6 +82,24 @@ def _sign_for_spend(*, current: float, previous: float) -> Sign:
     return "neg" if current > previous else "pos"
 
 
+def build_week_over_week(*, user_id: UUID, anchor: date) -> tuple[float, float]:
+    """Return ``(current_week_outflow, previous_week_outflow)`` around *anchor*.
+
+    The weekly baseline feeds both the ``vs_week`` retro entry and the lead
+    severity heuristic, so it lives in one place to stay consistent.
+    """
+    cur_week_start = anchor - timedelta(days=anchor.weekday())
+    cur_week_end = cur_week_start + timedelta(days=6)
+    prev_week_start = cur_week_start - timedelta(days=7)
+    prev_week_end = cur_week_start - timedelta(days=1)
+
+    cur_week_total = _outflow(user_id=user_id, start=cur_week_start, end=cur_week_end)
+    prev_week_total = _outflow(
+        user_id=user_id, start=prev_week_start, end=prev_week_end
+    )
+    return cur_week_total, prev_week_total
+
+
 def build_retro(*, user_id: UUID, anchor: date) -> list[dict[str, Any]]:
     """Outflow retrospective: yesterday, day-before and this-week-vs-last.
 
@@ -89,14 +112,8 @@ def build_retro(*, user_id: UUID, anchor: date) -> list[dict[str, Any]]:
     yesterday_total = _outflow(user_id=user_id, start=yesterday, end=yesterday)
     daybefore_total = _outflow(user_id=user_id, start=daybefore, end=daybefore)
 
-    cur_week_start = anchor - timedelta(days=anchor.weekday())
-    cur_week_end = cur_week_start + timedelta(days=6)
-    prev_week_start = cur_week_start - timedelta(days=7)
-    prev_week_end = cur_week_start - timedelta(days=1)
-
-    cur_week_total = _outflow(user_id=user_id, start=cur_week_start, end=cur_week_end)
-    prev_week_total = _outflow(
-        user_id=user_id, start=prev_week_start, end=prev_week_end
+    cur_week_total, prev_week_total = build_week_over_week(
+        user_id=user_id, anchor=anchor
     )
     week_delta = round(cur_week_total - prev_week_total, 2)
 
@@ -153,6 +170,26 @@ def _month_bounds(anchor: date) -> tuple[date, date]:
     else:
         next_month = start.replace(month=start.month + 1)
     return start, next_month - timedelta(days=1)
+
+
+def _dominant_spend_share(*, user_id: UUID, anchor: date) -> float:
+    """Share of the month's outflow taken by its single biggest expense.
+
+    ``0.0`` when there are no expenses. Feeds the lead severity heuristic so a
+    concentrated/dominant expense raises an ``alert`` (see
+    :func:`app.services.insight_lead_builder.derive_severity`).
+    """
+    start, end = _month_bounds(anchor)
+    total = _outflow(user_id=user_id, start=start, end=end)
+    if total <= 0:
+        return 0.0
+    expenses = _paid_rows(
+        user_id=user_id, tx_type=TransactionType.EXPENSE, start=start, end=end
+    )
+    if not expenses:
+        return 0.0
+    biggest = float(expenses[0].amount)
+    return biggest / total
 
 
 def _paid_rows(
@@ -243,6 +280,19 @@ def build_highlights(*, user_id: UUID, anchor: date) -> list[dict[str, Any]]:
     return highlights[:_MAX_HIGHLIGHTS]
 
 
+def _resolve_cadence(payload: dict[str, Any]) -> str:
+    """Cadence for the lead's read_min, from ``period_type``/``insight_type``.
+
+    ``recap`` is an end-of-month deliverable → treated as ``monthly``. Anything
+    unknown falls back to the deepest (weekly) reading time.
+    """
+    raw = payload.get("period_type") or payload.get("insight_type")
+    cadence = str(raw).strip().lower() if raw else _DEFAULT_CADENCE
+    if cadence == "recap":
+        return "monthly"
+    return cadence
+
+
 def _resolve_anchor(payload: dict[str, Any], anchor: date | None) -> date:
     if anchor is not None:
         return anchor
@@ -274,12 +324,27 @@ def enrich_insight_payload(
     resolved_anchor = _resolve_anchor(payload, anchor)
 
     summary = payload.get("summary")
-    payload["paragraphs"] = build_paragraphs(
-        summary if isinstance(summary, str) else None
-    )
-    payload["retro"] = build_retro(user_id=user_id, anchor=resolved_anchor)
+    summary_text = summary if isinstance(summary, str) else None
+    payload["paragraphs"] = build_paragraphs(summary_text)
+    retro = build_retro(user_id=user_id, anchor=resolved_anchor)
+    highlights = build_highlights(user_id=user_id, anchor=resolved_anchor)
+    payload["retro"] = retro
     payload["series"] = build_series(user_id=user_id, anchor=resolved_anchor)
-    payload["highlights"] = build_highlights(user_id=user_id, anchor=resolved_anchor)
+    payload["highlights"] = highlights
+    # Editorial lead for the cross-cutting (general) reading at this cadence.
+    # `period_type`/`insight_type` carries the cadence (daily|weekly|monthly).
+    current_week, previous_week = build_week_over_week(
+        user_id=user_id, anchor=resolved_anchor
+    )
+    payload["lead"] = build_lead(
+        summary=summary_text,
+        cadence=_resolve_cadence(payload),
+        dimension=_GENERAL_DIMENSION,
+        week_over_week=WeekOverWeek(current=current_week, previous=previous_week),
+        dominant_spend_share=_dominant_spend_share(
+            user_id=user_id, anchor=resolved_anchor
+        ),
+    )
     return payload
 
 

--- a/app/services/insight_lead_builder.py
+++ b/app/services/insight_lead_builder.py
@@ -1,0 +1,191 @@
+"""Deterministic editorial *lead* for the "Insights Fluida" screen (#1503).
+
+The Fluida masthead renders an editorial **lead** above the body the previous
+step (:mod:`app.services.insight_fluida_builder`) already produces. The lead has
+five fields and NONE of them costs an extra LLM call:
+
+``severity`` (``ok`` | ``attention`` | ``alert``)
+    A **heuristic** over the deterministic numbers the builder already computed
+    (week-over-week outflow variation + the biggest expense's share of the
+    month) — never the LLM. See :func:`derive_severity`.
+
+``read_min`` (int)
+    A **fixed** reading-time table by cadence × scope. See
+    :func:`resolve_read_min` — Daily: 15 (general) / 3 (theme); Weekly &
+    Monthly: 30 (general) / 5 (theme).
+
+``title`` / ``lead`` / ``next_step`` (str)
+    **Derived deterministically from the AI ``summary``** the generation already
+    produced — we do NOT add a second LLM round-trip nor change the existing
+    prompt/response schema. Deriving (instead of re-prompting) is what keeps the
+    fresh, cached *and* by-id paths consistent: all three only persist/replay the
+    ``summary`` string, so a prompt-only field would be absent on cache hits and
+    historic rows. See :func:`derive_title_and_lead` / :func:`derive_next_step`.
+
+The contract mirrors the canonical mobile view-model
+(``auraxis-app/features/insights/fluida/contracts.ts``): English ``severity``
+enum (``ok``/``attention``/``alert``), ``title``, ``lead`` (opening paragraph)
+and ``read_min``; snake_case to match the sibling Fluida fields
+(``paragraphs``/``retro``/``series``/``highlights``).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Literal, NamedTuple
+
+Severity = Literal["ok", "attention", "alert"]
+
+
+class WeekOverWeek(NamedTuple):
+    """Current vs previous week outflow totals feeding the severity heuristic."""
+
+    current: float
+    previous: float
+
+
+# --- severity heuristic thresholds (documented, testable) -------------------
+# Weekly outflow variation, measured as (current_week - previous_week) /
+# previous_week. Spending MORE than the prior week is the only direction that
+# can raise severity; spending less is always favourable (``ok``).
+_ALERT_WEEK_RATIO = 1.0  # +100% week-over-week or more → alert
+_ATTENTION_WEEK_RATIO = 0.30  # +30%..+100% → attention
+# Spend concentration: a single expense worth this share (or more) of the
+# month's total outflow is a structural alert regardless of weekly variation.
+_DOMINANT_SPEND_SHARE = 0.55
+
+# --- read_min table ---------------------------------------------------------
+# General is the cross-cutting masthead reading (long); themes are focused tabs
+# (short). Monthly recaps reuse the weekly (deepest) reading times.
+_READ_MIN: dict[str, dict[str, int]] = {
+    "daily": {"general": 15, "theme": 3},
+    "weekly": {"general": 30, "theme": 5},
+}
+_GENERAL_DIMENSION = "general"
+
+# --- summary derivation -----------------------------------------------------
+_SENTENCE_SPLIT_RE = re.compile(r"(?<=[.!?])\s+")
+# A trailing sentence that reads like a recommendation becomes ``next_step``.
+_RECOMMENDATION_RE = re.compile(
+    r"\b("
+    r"recomend|priorize|priorizar|sugiro|sugest|consider|considere|"
+    r"vale|evite|evitar|comece|construa|defina|revise|reveja|mantenha|"
+    r"foque|foco|distribua|antecipe|quite|quitar|classifique|crie|"
+    r"pr[oó]xim[oa]\s+(passo|semana|m[eê]s)|continue"
+    r")",
+    re.IGNORECASE,
+)
+
+
+def _sentences(summary: str) -> list[str]:
+    return [s.strip() for s in _SENTENCE_SPLIT_RE.split(summary.strip()) if s.strip()]
+
+
+def derive_severity(
+    *,
+    week_over_week: WeekOverWeek,
+    dominant_spend_share: float = 0.0,
+) -> Severity:
+    """Heuristically classify the period's urgency from deterministic numbers.
+
+    Rule (no AI):
+
+    * ``alert`` when the weekly outflow rose by ``>= 100%`` versus the prior
+      week, **or** the single biggest expense is ``>= 55%`` of the month's total
+      outflow (``dominant_spend_share``, a concentrated/dominant spend).
+    * ``attention`` when the weekly outflow rose by ``>= 30%`` (and ``< 100%``).
+    * ``ok`` otherwise — including when spending fell or there is no prior-week
+      baseline to compare against.
+    """
+    if dominant_spend_share >= _DOMINANT_SPEND_SHARE:
+        return "alert"
+
+    ratio = _weekly_increase_ratio(week_over_week)
+    if ratio is None:
+        return "ok"
+    if ratio >= _ALERT_WEEK_RATIO:
+        return "alert"
+    if ratio >= _ATTENTION_WEEK_RATIO:
+        return "attention"
+    return "ok"
+
+
+def _weekly_increase_ratio(week_over_week: WeekOverWeek) -> float | None:
+    """Fractional week-over-week outflow increase, or ``None`` when not rising.
+
+    Expressed as ``(current - previous) / previous``. Returns ``None`` when
+    spending did not rise or there is no positive baseline to compare against
+    (e.g. the user's first week ever).
+    """
+    current = float(week_over_week.current or 0.0)
+    previous = float(week_over_week.previous or 0.0)
+    if previous <= 0 or current <= previous:
+        return None
+    return (current - previous) / previous
+
+
+def resolve_read_min(*, cadence: str, dimension: str) -> int:
+    """Fixed reading-time (minutes) by cadence × scope (general vs theme)."""
+    table = _READ_MIN.get(cadence.strip().lower(), _READ_MIN["weekly"])
+    scope = "general" if dimension == _GENERAL_DIMENSION else "theme"
+    return table[scope]
+
+
+def derive_title_and_lead(summary: str | None) -> tuple[str, str]:
+    """First sentence of the summary becomes the title; the whole summary is the
+    opening ``lead`` paragraph. Empty/blank summaries yield empty strings."""
+    if not summary or not summary.strip():
+        return "", ""
+    cleaned = summary.strip()
+    sentences = _sentences(cleaned)
+    title = sentences[0] if sentences else cleaned
+    return title, cleaned
+
+
+def derive_next_step(summary: str | None) -> str:
+    """The recommendation to surface as "para onde seguir".
+
+    Prefer the last sentence that reads like a recommendation; otherwise fall
+    back to the final sentence of the summary. Empty when there is no summary.
+    """
+    if not summary or not summary.strip():
+        return ""
+    sentences = _sentences(summary)
+    if not sentences:
+        return ""
+    for sentence in reversed(sentences):
+        if _RECOMMENDATION_RE.search(sentence):
+            return sentence
+    return sentences[-1]
+
+
+def build_lead(
+    *,
+    summary: str | None,
+    cadence: str,
+    dimension: str,
+    week_over_week: WeekOverWeek,
+    dominant_spend_share: float = 0.0,
+) -> dict[str, Any]:
+    """Compose the full editorial lead for one (dimension, cadence) reading."""
+    title, lead_text = derive_title_and_lead(summary)
+    return {
+        "severity": derive_severity(
+            week_over_week=week_over_week,
+            dominant_spend_share=dominant_spend_share,
+        ),
+        "read_min": resolve_read_min(cadence=cadence, dimension=dimension),
+        "title": title,
+        "lead": lead_text,
+        "next_step": derive_next_step(summary),
+    }
+
+
+__all__ = [
+    "WeekOverWeek",
+    "build_lead",
+    "derive_next_step",
+    "derive_severity",
+    "derive_title_and_lead",
+    "resolve_read_min",
+]

--- a/graphql.introspection.json
+++ b/graphql.introspection.json
@@ -17439,6 +17439,18 @@
                   "ofType": null
                 }
               }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "lead",
+              "type": {
+                "kind": "OBJECT",
+                "name": "AIInsightLeadType",
+                "ofType": null
+              }
             }
           ],
           "inputFields": null,
@@ -17741,6 +17753,98 @@
           "interfaces": [],
           "kind": "OBJECT",
           "name": "AIInsightHighlightType",
+          "possibleTypes": null,
+          "specifiedByURL": null
+        },
+        {
+          "description": "Editorial lead (masthead) for the Fluida screen (#1503).\n\n``severity`` is a deterministic heuristic over the calculated retro/highlights\n(``ok`` | ``attention`` | ``alert``); ``read_min`` is fixed by cadence;\n``title`` / ``lead`` / ``next_step`` are derived from the AI ``summary`` (no\nextra LLM call).",
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "severity",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "readMin",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "title",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "lead",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "nextStep",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "AIInsightLeadType",
           "possibleTypes": null,
           "specifiedByURL": null
         },

--- a/openapi.json
+++ b/openapi.json
@@ -367,6 +367,17 @@
             "readOnly": true,
             "type": "string"
           },
+          "impact_policy": {
+            "default": "full",
+            "description": "Política de impacto do lançamento: full reflete em todas as áreas; cards_only fica restrito a cartões/fatura; planned_until_bill mantém o lançamento para planejamento da fatura.",
+            "enum": [
+              "full",
+              "cards_only",
+              "planned_until_bill"
+            ],
+            "example": "full",
+            "type": "string"
+          },
           "installment_count": {
             "description": "Número de parcelas (apenas se is_installment=True)",
             "example": 12,
@@ -566,6 +577,17 @@
             "description": "ID único da transação (gerado automaticamente)",
             "format": "uuid",
             "readOnly": true,
+            "type": "string"
+          },
+          "impact_policy": {
+            "default": "full",
+            "description": "Política de impacto do lançamento: full reflete em todas as áreas; cards_only fica restrito a cartões/fatura; planned_until_bill mantém o lançamento para planejamento da fatura.",
+            "enum": [
+              "full",
+              "cards_only",
+              "planned_until_bill"
+            ],
+            "example": "full",
             "type": "string"
           },
           "installment_count": {
@@ -1633,6 +1655,13 @@
                         "type": "saude_financeira"
                       }
                     ],
+                    "lead": {
+                      "lead": "Você terminou o período com saldo positivo.",
+                      "next_step": "Continue acompanhando os gastos da semana.",
+                      "read_min": 15,
+                      "severity": "ok",
+                      "title": "Saldo positivo no período."
+                    },
                     "model": "gpt-4o-mini",
                     "period_end": "2026-05-17",
                     "period_label": "2026-05-17",
@@ -7298,6 +7327,7 @@
                         "end_date": null,
                         "external_id": null,
                         "id": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+                        "impact_policy": "full",
                         "installment_count": null,
                         "installment_group_id": null,
                         "is_installment": false,
@@ -7479,6 +7509,7 @@
                 "amount": "150.00",
                 "description": "Fatura mensal de energia",
                 "due_date": "2026-03-10",
+                "impact_policy": "full",
                 "observation": "Pagar antes do dia 10",
                 "status": "pending",
                 "tag_id": "73c3b094-60bf-45d5-8e32-0f673b2ab4a2",
@@ -7510,6 +7541,7 @@
                       "end_date": null,
                       "external_id": null,
                       "id": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+                      "impact_policy": "full",
                       "installment_count": null,
                       "installment_group_id": null,
                       "is_installment": false,
@@ -7963,6 +7995,7 @@
                         "end_date": null,
                         "external_id": null,
                         "id": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+                        "impact_policy": "full",
                         "installment_count": null,
                         "installment_group_id": null,
                         "is_installment": false,
@@ -8145,6 +8178,7 @@
                         "end_date": null,
                         "external_id": null,
                         "id": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+                        "impact_policy": "full",
                         "installment_count": null,
                         "installment_group_id": null,
                         "is_installment": false,
@@ -8377,6 +8411,7 @@
                         "end_date": null,
                         "external_id": null,
                         "id": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+                        "impact_policy": "full",
                         "installment_count": null,
                         "installment_group_id": null,
                         "is_installment": false,
@@ -8777,6 +8812,7 @@
                         "end_date": null,
                         "external_id": null,
                         "id": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+                        "impact_policy": "full",
                         "installment_count": null,
                         "installment_group_id": null,
                         "is_installment": false,
@@ -8997,6 +9033,7 @@
                       "end_date": null,
                       "external_id": null,
                       "id": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+                      "impact_policy": "full",
                       "installment_count": null,
                       "installment_group_id": null,
                       "is_installment": false,
@@ -9225,6 +9262,7 @@
                         "end_date": null,
                         "external_id": null,
                         "id": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+                        "impact_policy": "full",
                         "installment_count": null,
                         "installment_group_id": null,
                         "is_installment": false,
@@ -9698,6 +9736,7 @@
                       "end_date": null,
                       "external_id": null,
                       "id": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+                      "impact_policy": "full",
                       "installment_count": null,
                       "installment_group_id": null,
                       "is_installment": false,
@@ -9986,6 +10025,7 @@
                       "end_date": null,
                       "external_id": null,
                       "id": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+                      "impact_policy": "full",
                       "installment_count": null,
                       "installment_group_id": null,
                       "is_installment": false,
@@ -10316,6 +10356,7 @@
                       "end_date": null,
                       "external_id": null,
                       "id": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+                      "impact_policy": "full",
                       "installment_count": null,
                       "installment_group_id": null,
                       "is_installment": false,

--- a/schema.graphql
+++ b/schema.graphql
@@ -1392,6 +1392,7 @@ type GenerateAiInsightPayload {
   retro: [AIInsightRetroEntryType]
   series: AIInsightSeriesType
   highlights: [AIInsightHighlightType]
+  lead: AIInsightLeadType
 }
 
 """A single LLM-produced insight item, tagged by dimension."""
@@ -1423,6 +1424,22 @@ type AIInsightHighlightType {
   label: String!
   value: Float!
   sub: String!
+}
+
+"""
+Editorial lead (masthead) for the Fluida screen (#1503).
+
+``severity`` is a deterministic heuristic over the calculated retro/highlights
+(``ok`` | ``attention`` | ``alert``); ``read_min`` is fixed by cadence;
+``title`` / ``lead`` / ``next_step`` are derived from the AI ``summary`` (no
+extra LLM call).
+"""
+type AIInsightLeadType {
+  severity: String!
+  readMin: Int!
+  title: String!
+  lead: String!
+  nextStep: String!
 }
 
 type AIInsightFeedbackPayload {

--- a/tests/test_ai_insights_fluida_rest_contract.py
+++ b/tests/test_ai_insights_fluida_rest_contract.py
@@ -152,3 +152,32 @@ class TestGenerateEndpointFluidaContract:
         assert len(data["series"]["weekly"]) == 6
         retro = {e["key"]: e for e in data["retro"]}
         assert retro["yesterday"]["value"] == 42.0
+
+    def test_response_carries_editorial_lead(self, app, client) -> None:
+        token = _register_and_login(client, "fluida-lead-rest")
+        user_id = _grant_premium(app, token)
+        _seed_expense(app, user_id, amount="42.00", due_date=date(2026, 6, 14))
+
+        provider = MagicMock()
+        provider.generate_with_usage.return_value = _financial_llm_response()
+
+        with patch(
+            "app.services.ai_advisory_service.get_llm_provider",
+            return_value=provider,
+        ):
+            resp = client.post(
+                "/ai/insights/generate",
+                json={"period_type": "daily", "anchor_date": "2026-06-15"},
+                headers=_auth(token),
+            )
+
+        assert resp.status_code == 200
+        body = resp.get_json()
+        data = body.get("data", body)
+        assert "lead" in data
+        lead = data["lead"]
+        assert set(lead) == {"severity", "read_min", "title", "lead", "next_step"}
+        # Daily general reading time, derived title from the stubbed summary.
+        assert lead["read_min"] == 15
+        assert lead["severity"] in {"ok", "attention", "alert"}
+        assert lead["title"] == "Resumo do dia."

--- a/tests/test_graphql_generate_ai_insight.py
+++ b/tests/test_graphql_generate_ai_insight.py
@@ -370,3 +370,122 @@ class TestGenerateAiInsightFluidaFields:
         assert data["highlights"][0]["label"] == "Maior gasto do mês"
         assert data["highlights"][0]["value"] == 1800.0
         assert data["highlights"][0]["sub"] == "Aluguel"
+
+
+_LEAD_MUTATION = """
+mutation Gen($periodType: String!, $anchorDate: String) {
+  generateAiInsight(periodType: $periodType, anchorDate: $anchorDate) {
+    ok
+    lead { severity readMin title lead nextStep }
+  }
+}
+"""
+
+
+class TestGenerateAiInsightLead:
+    def test_exposes_editorial_lead(self, app, client):
+        token = _register_and_login(client, prefix="gql-gen-lead")
+        from flask_jwt_extended import decode_token
+
+        from app.services.entitlement_service import grant_entitlement
+
+        with app.app_context():
+            user_id = UUID(decode_token(token)["sub"])
+            grant_entitlement(
+                user_id=user_id,
+                feature_key="advanced_simulations",
+                source="trial",
+            )
+            from app.extensions.database import db
+
+            db.session.commit()
+
+        fake_result = {
+            "id": "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee",
+            "period_type": "daily",
+            "period_label": "2026-06-15",
+            "period_start": "2026-06-15",
+            "period_end": "2026-06-15",
+            "summary": "Dia leve. Continue acompanhando.",
+            "items": [],
+            "context_version": "financial_insight_snapshot.v1",
+            "cached": False,
+            "model": "gpt-4o-mini",
+            "tokens_used": 50,
+            "cost_usd": 0.0001,
+            "forecast": False,
+            "paragraphs": ["Dia leve.", "Continue acompanhando."],
+            "retro": [],
+            "series": {"daily": [0.0] * 7, "weekly": [0.0] * 6},
+            "highlights": [],
+            "lead": {
+                "severity": "ok",
+                "read_min": 15,
+                "title": "Dia leve.",
+                "lead": "Dia leve. Continue acompanhando.",
+                "next_step": "Continue acompanhando.",
+            },
+        }
+        with patch("app.graphql.mutations.ai_insight.AIAdvisoryService") as MockSvc:
+            instance = MockSvc.return_value
+            instance.generate_financial_insights.return_value = fake_result
+            response = _gql(
+                client,
+                _LEAD_MUTATION,
+                token,
+                variables={"periodType": "daily", "anchorDate": "2026-06-15"},
+            )
+
+        body = response.get_json()
+        assert "errors" not in body or not body["errors"], body
+        lead = body["data"]["generateAiInsight"]["lead"]
+        assert lead["severity"] == "ok"
+        assert lead["readMin"] == 15
+        assert lead["title"] == "Dia leve."
+        assert lead["lead"] == "Dia leve. Continue acompanhando."
+        assert lead["nextStep"] == "Continue acompanhando."
+
+    def test_lead_is_null_when_absent_from_result(self, app, client):
+        """A result without a lead key resolves to null (defensive)."""
+        token = _register_and_login(client, prefix="gql-gen-nolead")
+        from flask_jwt_extended import decode_token
+
+        from app.services.entitlement_service import grant_entitlement
+
+        with app.app_context():
+            user_id = UUID(decode_token(token)["sub"])
+            grant_entitlement(
+                user_id=user_id,
+                feature_key="advanced_simulations",
+                source="trial",
+            )
+            from app.extensions.database import db
+
+            db.session.commit()
+
+        fake_result = {
+            "period_type": "daily",
+            "period_label": "2026-06-15",
+            "period_start": "2026-06-15",
+            "period_end": "2026-06-15",
+            "summary": "Sem lead.",
+            "items": [],
+            "context_version": "financial_insight_snapshot.v1",
+            "cached": False,
+            "model": "gpt-4o-mini",
+            "tokens_used": 50,
+            "cost_usd": 0.0001,
+        }
+        with patch("app.graphql.mutations.ai_insight.AIAdvisoryService") as MockSvc:
+            instance = MockSvc.return_value
+            instance.generate_financial_insights.return_value = fake_result
+            response = _gql(
+                client,
+                _LEAD_MUTATION,
+                token,
+                variables={"periodType": "daily", "anchorDate": "2026-06-15"},
+            )
+
+        body = response.get_json()
+        assert "errors" not in body or not body["errors"], body
+        assert body["data"]["generateAiInsight"]["lead"] is None

--- a/tests/test_insight_fluida_enrichment.py
+++ b/tests/test_insight_fluida_enrichment.py
@@ -145,3 +145,82 @@ class TestEnrichInsightPayload:
             enriched = enrich_insight_payload(payload, user_id=user_id)
         retro = {e["key"]: e for e in enriched["retro"]}
         assert retro["yesterday"]["value"] == 17.0
+
+
+class TestEnrichInsightPayloadLead:
+    """The editorial lead is added per cadence for the general reading (#1503)."""
+
+    def test_adds_lead_object(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            enriched = enrich_insight_payload(
+                _base_payload(), user_id=user_id, anchor=date(2026, 6, 15)
+            )
+        assert "lead" in enriched
+        lead = enriched["lead"]
+        assert set(lead) == {"severity", "read_min", "title", "lead", "next_step"}
+
+    def test_lead_read_min_is_general_daily_for_daily_payload(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            enriched = enrich_insight_payload(
+                _base_payload(), user_id=user_id, anchor=date(2026, 6, 15)
+            )
+        assert enriched["lead"]["read_min"] == 15
+
+    def test_lead_read_min_is_general_weekly_for_weekly_payload(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            payload = _base_payload()
+            payload["period_type"] = "weekly"
+            enriched = enrich_insight_payload(
+                payload, user_id=user_id, anchor=date(2026, 6, 15)
+            )
+        assert enriched["lead"]["read_min"] == 30
+
+    def test_lead_title_and_text_derive_from_summary(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            payload = _base_payload()
+            payload["summary"] = "Mês tranquilo. Recomendo manter o ritmo."
+            enriched = enrich_insight_payload(
+                payload, user_id=user_id, anchor=date(2026, 6, 15)
+            )
+        lead = enriched["lead"]
+        assert lead["title"] == "Mês tranquilo."
+        assert lead["lead"] == "Mês tranquilo. Recomendo manter o ritmo."
+        assert lead["next_step"] == "Recomendo manter o ritmo."
+
+    def test_lead_severity_is_ok_for_calm_data(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            # No transactions at all → flat outflow → ok.
+            enriched = enrich_insight_payload(
+                _base_payload(), user_id=user_id, anchor=date(2026, 6, 15)
+            )
+        assert enriched["lead"]["severity"] == "ok"
+
+    def test_lead_severity_alerts_on_weekly_spike(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            # Previous week (2026-06-01..07) low, current week (06-08..14) high
+            # for an anchor in that current week → strong week-over-week rise.
+            _make_expense(user_id, amount="50.00", due_date=date(2026, 6, 2))
+            _make_expense(user_id, amount="5000.00", due_date=date(2026, 6, 9))
+            enriched = enrich_insight_payload(
+                _base_payload(), user_id=user_id, anchor=date(2026, 6, 10)
+            )
+        assert enriched["lead"]["severity"] == "alert"
+
+    def test_lead_severity_alerts_on_dominant_monthly_spend(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            # One expense is ~92% of the month's outflow (1100 / 1200) but it is
+            # the SAME (and only) week as the small one → no week-over-week spike,
+            # so the alert must come from the dominant-spend rule.
+            _make_expense(user_id, amount="1100.00", due_date=date(2026, 6, 3))
+            _make_expense(user_id, amount="100.00", due_date=date(2026, 6, 4))
+            enriched = enrich_insight_payload(
+                _base_payload(), user_id=user_id, anchor=date(2026, 6, 5)
+            )
+        assert enriched["lead"]["severity"] == "alert"

--- a/tests/test_insight_lead_builder.py
+++ b/tests/test_insight_lead_builder.py
@@ -1,0 +1,156 @@
+"""Unit tests for the deterministic Fluida editorial lead (#1503).
+
+The lead (``severity`` / ``read_min`` / ``title`` / ``lead`` / ``next_step``) is
+derived WITHOUT any extra LLM call:
+
+* ``severity`` is a heuristic over the deterministic ``retro`` block (weekly
+  outflow variation) and ``highlights`` (spend concentration).
+* ``read_min`` is a fixed table by cadence × scope (general vs theme).
+* ``title`` / ``lead`` / ``next_step`` are derived from the AI ``summary`` that
+  the generation already produced (first sentence → title, opening → lead, last
+  recommendation-like sentence → next_step).
+
+These cover every severity band, every read_min cell and the summary derivation.
+"""
+
+from __future__ import annotations
+
+from app.services.insight_lead_builder import (
+    WeekOverWeek,
+    build_lead,
+    derive_next_step,
+    derive_severity,
+    derive_title_and_lead,
+    resolve_read_min,
+)
+
+
+def _wow(*, week_delta: float, prev_week: float = 100.0) -> WeekOverWeek:
+    """Build a ``WeekOverWeek`` from a delta over a baseline."""
+    return WeekOverWeek(current=prev_week + week_delta, previous=prev_week)
+
+
+class TestDeriveSeverity:
+    def test_alert_when_weekly_outflow_spikes_above_high_threshold(self) -> None:
+        # +120% week-over-week → far above the alert band.
+        wow = _wow(week_delta=120.0, prev_week=100.0)
+        assert derive_severity(week_over_week=wow) == "alert"
+
+    def test_alert_when_a_single_expense_dominates_the_month(self) -> None:
+        # No weekly spike, but the biggest expense is >= 55% of month outflow.
+        wow = _wow(week_delta=0.0, prev_week=100.0)
+        assert derive_severity(week_over_week=wow, dominant_spend_share=0.55) == "alert"
+
+    def test_attention_on_moderate_weekly_variation(self) -> None:
+        # +40% week-over-week → moderate band.
+        wow = _wow(week_delta=40.0, prev_week=100.0)
+        assert derive_severity(week_over_week=wow) == "attention"
+
+    def test_ok_when_variation_is_small_and_no_dominant_spend(self) -> None:
+        wow = _wow(week_delta=5.0, prev_week=100.0)
+        assert derive_severity(week_over_week=wow, dominant_spend_share=0.20) == "ok"
+
+    def test_ok_when_spending_dropped(self) -> None:
+        # Spending less than last week is favourable → never an alert/attention.
+        wow = _wow(week_delta=-80.0, prev_week=100.0)
+        assert derive_severity(week_over_week=wow) == "ok"
+
+    def test_ok_when_there_is_no_prior_week_baseline(self) -> None:
+        # First week ever: prev_week == 0 → no ratio, so no spike signal.
+        wow = _wow(week_delta=500.0, prev_week=0.0)
+        assert derive_severity(week_over_week=wow) == "ok"
+
+
+class TestResolveReadMin:
+    def test_daily_general(self) -> None:
+        assert resolve_read_min(cadence="daily", dimension="general") == 15
+
+    def test_daily_theme(self) -> None:
+        assert resolve_read_min(cadence="daily", dimension="transactions") == 3
+
+    def test_weekly_general(self) -> None:
+        assert resolve_read_min(cadence="weekly", dimension="general") == 30
+
+    def test_weekly_theme(self) -> None:
+        assert resolve_read_min(cadence="weekly", dimension="goals") == 5
+
+    def test_monthly_falls_back_to_weekly_table(self) -> None:
+        # Monthly is a long recap → reuse the weekly (deepest) reading times.
+        assert resolve_read_min(cadence="monthly", dimension="general") == 30
+        assert resolve_read_min(cadence="monthly", dimension="budgets") == 5
+
+
+class TestDeriveTitleAndLead:
+    def test_first_sentence_becomes_title_rest_is_lead(self) -> None:
+        summary = (
+            "Você manteve as contas em dia. "
+            "O maior gasto foi a moradia. "
+            "Vale revisar o lazer."
+        )
+        title, lead = derive_title_and_lead(summary)
+        assert title == "Você manteve as contas em dia."
+        assert lead == summary
+
+    def test_single_sentence_summary(self) -> None:
+        title, lead = derive_title_and_lead("Tudo certo por aqui.")
+        assert title == "Tudo certo por aqui."
+        assert lead == "Tudo certo por aqui."
+
+    def test_empty_summary_yields_empty_strings(self) -> None:
+        assert derive_title_and_lead(None) == ("", "")
+        assert derive_title_and_lead("   ") == ("", "")
+
+
+class TestDeriveNextStep:
+    def test_picks_last_recommendation_sentence(self) -> None:
+        summary = "As contas seguem apertadas. Recomendo priorizar a fatura em atraso."
+        assert derive_next_step(summary) == "Recomendo priorizar a fatura em atraso."
+
+    def test_falls_back_to_last_sentence_when_no_keyword(self) -> None:
+        summary = "Mês tranquilo. Saldo positivo no fim do período."
+        assert derive_next_step(summary) == "Saldo positivo no fim do período."
+
+    def test_empty_summary_yields_empty_string(self) -> None:
+        assert derive_next_step(None) == ""
+        assert derive_next_step("") == ""
+
+
+class TestBuildLead:
+    def test_general_daily_lead_shape(self) -> None:
+        wow = _wow(week_delta=5.0, prev_week=100.0)
+        summary = "Dia leve. Continue acompanhando os gastos."
+        lead = build_lead(
+            summary=summary,
+            cadence="daily",
+            dimension="general",
+            week_over_week=wow,
+        )
+        assert lead == {
+            "severity": "ok",
+            "read_min": 15,
+            "title": "Dia leve.",
+            "lead": summary,
+            "next_step": "Continue acompanhando os gastos.",
+        }
+
+    def test_alert_weekly_general_lead(self) -> None:
+        wow = _wow(week_delta=200.0, prev_week=100.0)
+        lead = build_lead(
+            summary="Semana pesada. Quite a fatura com urgência.",
+            cadence="weekly",
+            dimension="general",
+            week_over_week=wow,
+        )
+        assert lead["severity"] == "alert"
+        assert lead["read_min"] == 30
+        assert lead["next_step"] == "Quite a fatura com urgência."
+
+    def test_theme_read_min_is_used_for_non_general_dimension(self) -> None:
+        wow = _wow(week_delta=0.0, prev_week=100.0)
+        lead = build_lead(
+            summary="Resumo do tema.",
+            cadence="daily",
+            dimension="transactions",
+            week_over_week=wow,
+        )
+        assert lead["read_min"] == 3


### PR DESCRIPTION
Closes #1507

Encadeado sobre #1502 (base: `feat/insights-estruturado-etapa2`).

## O que faz

Adiciona o **LEAD editorial** da tela Fluida ao payload de Insights (REST `/ai/insights/generate` + GraphQL `generateAiInsight`), eliminando a dependência do mock no frontend. **Aditivo, sem regressão** dos campos do corpo (`paragraphs`/`retro`/`series`/`highlights`) nem dos legados.

Novo objeto `lead` (snake_case, consistente com os campos Fluida; espelha o contrato canônico do mobile `InsightLeadVM`):

```json
"lead": {
  "severity": "ok | attention | alert",
  "read_min": 15,
  "title": "<headline — 1ª frase do summary>",
  "lead": "<parágrafo de abertura — summary>",
  "next_step": "<recomendação — última frase acionável>"
}
```

## Como cada campo é gerado

| Campo | Fonte | Como |
|---|---|---|
| `severity` | **Heurística determinística** (sem IA) | Variação semanal de saídas + share do maior gasto do mês |
| `read_min` | **Fixo** por cadência × escopo | Diário 15 (geral)/3 (tema); Semanal/Mensal 30/5 |
| `title` | **Derivado** do `summary` | 1ª frase |
| `lead` | **Derivado** do `summary` | parágrafo de abertura (summary completo) |
| `next_step` | **Derivado** do `summary` | última frase com cara de recomendação (fallback: última frase) |

### Regra de severity (documentada e testável)
- `alert`: variação semanal ≥ +100% **ou** maior gasto ≥ 55% das saídas do mês.
- `attention`: variação semanal ≥ +30% (e < +100%).
- `ok`: caso contrário (gastar menos ou sem baseline da semana anterior).

## Impacto de prompt / custo de IA

**Nenhum.** Não foi adicionada chamada ao LLM nem alterado o prompt/response schema. `title`/`lead`/`next_step` derivam do `summary` que a geração já produz. Escolhido por funcionar igual nos 3 caminhos (geração fresh, cache hit, busca por id) — todos só persistem/reproduzem o `summary`; um campo só-do-prompt ficaria ausente em cache e linhas históricas.

## Não-regressão

- Campos legados + Fluida (`paragraphs`/`retro`/`series`/`highlights`) preservados (testes de contrato REST e GraphQL).
- `retro` mantém o set exato de chaves (`key/label/value/caption/sign`); a baseline semanal usada pela severity é computada à parte, sem poluir o DTO.
- Lead presente em fresh + cache + by-id.

## TDD

RED→GREEN em cada etapa: unit (severity por faixa, read_min por célula, derivação do summary), wiring em `enrich_insight_payload`, contrato REST e GraphQL.

## Quality gates

`bash scripts/run_ci_quality_local.sh --local` ✅ — ruff/mypy/bandit + **2642 passed, 2 skipped**, cobertura **91.33%** (≥85%). Snapshots `schema.graphql` + `graphql.introspection.json` + `openapi.json` regenerados (aditivos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jZX5Ur2XsT1DqQcEP4tjx