### PR TITLE
feat(credit-card): payload completo nas transações da fatura (/bill)

### DIFF
--- a/app/controllers/credit_card/bill_resources.py
+++ b/app/controllers/credit_card/bill_resources.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 # mypy: disable-error-code=untyped-decorator
 import re
 from datetime import date
-from decimal import Decimal
 from typing import Any
 from uuid import UUID
 
@@ -21,6 +20,7 @@ from app.services.credit_card_bill_service import (
     compute_bill,
     compute_utilization,
 )
+from app.services.transaction_serialization import serialize_transaction_payload
 from app.utils.typed_decorators import typed_jwt_required as jwt_required
 
 from .blueprint import credit_card_bp
@@ -50,27 +50,13 @@ def _serialize_cycle(cycle: BillCycle) -> dict[str, Any]:
     }
 
 
-def _serialize_transaction(tx: Any) -> dict[str, Any]:
-    impact_policy = getattr(tx, "impact_policy", None)
-    return {
-        "id": str(tx.id),
-        "title": tx.title,
-        "amount": str(Decimal(tx.amount)),
-        "due_date": tx.due_date.isoformat() if tx.due_date else None,
-        "status": tx.status.value if hasattr(tx.status, "value") else str(tx.status),
-        "type": tx.type.value if hasattr(tx.type, "value") else str(tx.type),
-        "impact_policy": (
-            impact_policy.value
-            if impact_policy is not None and hasattr(impact_policy, "value")
-            else str(impact_policy or "full")
-        ),
-    }
-
-
 def _serialize_bill(bill: BillSummary) -> dict[str, Any]:
+    # Serialize each bill transaction with the canonical full payload (same shape
+    # as GET /transactions) so the web bill view can render category/notes and
+    # edit/duplicate/remove from /bill alone — without a separate paginated fetch.
     return {
         "cycle": _serialize_cycle(bill.cycle),
-        "transactions": [_serialize_transaction(tx) for tx in bill.transactions],
+        "transactions": [serialize_transaction_payload(tx) for tx in bill.transactions],
         "total_amount": str(bill.total_amount),
         "paid_amount": str(bill.paid_amount),
         "pending_amount": str(bill.pending_amount),

--- a/tests/test_credit_card_bill_endpoints.py
+++ b/tests/test_credit_card_bill_endpoints.py
@@ -171,6 +171,66 @@ class TestBillEndpoint:
         assert Decimal(body["pending_amount"]) == Decimal("88.90")
         assert body["transactions"][0]["impact_policy"] == "cards_only"
 
+    def test_bill_transactions_expose_full_payload(self, client) -> None:
+        """Each bill transaction must carry the full transaction payload so the
+        client can render category/notes and edit/duplicate/remove without a
+        separate (paginated) /transactions fetch."""
+        token = _register_and_login(client, prefix="bill-full-payload")
+        headers = _auth_headers(token)
+        card = _create_card(client, headers, closing_day=10, due_day=15)
+
+        created = client.post(
+            "/transactions",
+            json={
+                "title": "Notebook",
+                "amount": "1234.56",
+                "type": "expense",
+                "status": "pending",
+                "due_date": "2026-05-05",
+                "credit_card_id": card["id"],
+                "description": "compra parcelada do trabalho",
+            },
+            headers=headers,
+        )
+        assert created.status_code == 201, created.get_json()
+
+        response = client.get(
+            f"/credit-cards/{card['id']}/bill?month=2026-05", headers=headers
+        )
+        assert response.status_code == 200
+        item = response.get_json()["data"]["transactions"][0]
+
+        # Existing magras fields preserved (no contract regression).
+        for legacy_field in (
+            "id",
+            "title",
+            "amount",
+            "due_date",
+            "status",
+            "type",
+            "impact_policy",
+        ):
+            assert legacy_field in item, f"missing legacy field {legacy_field}"
+
+        # Newly exposed fields the web bill view needs.
+        assert item["description"] == "compra parcelada do trabalho"
+        assert item["credit_card_id"] == card["id"]
+        for new_field in (
+            "tag_id",
+            "observation",
+            "account_id",
+            "is_recurring",
+            "is_installment",
+            "installment_count",
+            "installment_group_id",
+            "paid_at",
+            "currency",
+            "category",
+            "created_at",
+            "updated_at",
+        ):
+            assert new_field in item, f"missing enriched field {new_field}"
+
     def test_returns_404_when_card_belongs_to_other_user(self, client) -> None:
         owner = _register_and_login(client, prefix="bill-owner")
         owner_headers = _auth_headers(owner)


### PR DESCRIPTION
Closes #1509

## Problema
A tela de Cartões (web) mostra a fatura em R$ 0,00 mesmo quando a `/credit-cards/{id}/bill` retorna o valor correto. Causa raiz no frontend: ele deriva a fatura de uma lista de transações **paginada** (`GET /transactions`, só 10 de N) em vez de usar a `/bill`. Decisão: **`/bill` como fonte de verdade**.

Para o frontend renderizar a fatura inteiramente a partir da `/bill` (categoria, observações, e ações editar/duplicar/remover), cada transação precisa do payload completo — antes expunha só 7 campos.

## Mudança
`app/controllers/credit_card/bill_resources.py`: serializa cada transação da fatura com `serialize_transaction_payload` (o mesmo serializer de `GET /transactions`) em vez do `_serialize_transaction` local magro. Remove a função magra e o import `Decimal` agora ocioso.

**Backward-compatible**: os 7 campos antigos (`id, title, amount, due_date, status, type, impact_policy`) são preservados; adiciona ~21 (`tag_id, description, observation, account_id, credit_card_id, is_recurring, is_installment, installment_count, installment_group_id, paid_at, currency, recurrence_*, category, source, created_at, updated_at, ...`).

Sem GraphQL equivalente para a `/bill` (sem paridade a manter). `/bill` não está no `openapi.json` → sem snapshot de contrato a regenerar.

## Testes
- Novo `test_bill_transactions_expose_full_payload`: valida campos legados preservados + novos campos (`description`, `credit_card_id`, `tag_id`, etc.).
- Testes existentes do bill seguem verdes (impact_policy, totais, ciclo).
- `scripts/run_ci_quality_local.sh --local` verde: 2643 passed, cobertura 91.33%.

## Deploy
Este backend deve ir a produção **antes** do frontend que o consome (auraxis-web #1080-equivalente, a ser aberto).