### PR TITLE
test(ai): fix UTC-boundary flake in weekly-recap goals test

### DIFF
--- a/tests/test_ai_insight_weekly_recap.py
+++ b/tests/test_ai_insight_weekly_recap.py
@@ -16,7 +16,7 @@ Coverage (#1242 — recap):
 from __future__ import annotations
 
 import uuid
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 
 import pytest
@@ -132,7 +132,13 @@ def _make_goal_with_contribution(
                 goal_id=goal.id,
                 user_id=user_id,
                 amount=Decimal(str(contribution_amount)),
-                created_at=datetime.utcnow() - timedelta(days=days_ago),
+                # Anchor to local midday so the timestamp stays inside the
+                # `date.today()`-based windows the tests build, regardless of the
+                # local-vs-UTC offset (utcnow() drifts to the next day in the
+                # evening in UTC-3, falling outside week_end on Mondays).
+                created_at=datetime.combine(
+                    date.today() - timedelta(days=days_ago), time(hour=12)
+                ),
             )
         )
         db.session.commit()


### PR DESCRIPTION
## O que muda

Corrige flake determinístico em `test_returns_contributions_this_week`: o helper criava a
contribuição com `datetime.utcnow()`, mas as janelas dos testes usam `date.today()` (local). À
noite no fuso UTC-3, `utcnow()` já é o dia seguinte → cai fora da janela e o teste falha às
segundas (week_start==week_end==hoje). Ancorei o `created_at` ao **meio-dia local** da data
relativa, eliminando a fronteira UTC. Código de produção não muda (já estava correto).

## Contexto

Closes #1517

## Quality gates

- [x] ruff/mypy/bandit: PASS
- [x] testes: 21/21 no arquivo; determinístico em qualquer dia/horário
- [x] `run_ci_quality_local.sh --local`: desbloqueado (esse teste era o único vermelho hoje)

## Risco

LOW — mudança test-only, sem alteração de código de produção.