### PR TITLE
feat(transactions): auto-settle (agendador) — marca opt-in como paga no vencimento

### DIFF
--- a/.github/workflows/auto-settle.yml
+++ b/.github/workflows/auto-settle.yml
@@ -1,0 +1,149 @@
+name: Daily Transaction Auto-Settle
+
+on:
+  schedule:
+    # Every day at 04:30 UTC = 01:30 BRT (after the recurrence reconcile at 04:00).
+    - cron: "30 4 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry-run only (count due opted-in transactions, settle nothing)"
+        type: boolean
+        default: false
+
+concurrency:
+  group: daily-auto-settle
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+  issues: write
+
+jobs:
+  auto-settle:
+    name: Auto-settle due opted-in transactions
+    runs-on: ubuntu-latest
+    environment: prod
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate required variables
+        run: |
+          [ -n "${AWS_REGION:-}" ] || { echo "Missing var AWS_REGION"; exit 1; }
+          [ -n "${AWS_ROLE_ARN_PROD:-}" ] || { echo "Missing var AWS_ROLE_ARN_PROD"; exit 1; }
+          [ -n "${AURAXIS_PROD_INSTANCE_ID:-}" ] || { echo "Missing var AURAXIS_PROD_INSTANCE_ID"; exit 1; }
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+          AWS_ROLE_ARN_PROD: ${{ vars.AWS_ROLE_ARN_PROD }}
+          AURAXIS_PROD_INSTANCE_ID: ${{ vars.AURAXIS_PROD_INSTANCE_ID }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN_PROD }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Run transactions auto-settle via SSM
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+          PROD_INSTANCE_ID: ${{ vars.AURAXIS_PROD_INSTANCE_ID }}
+          DIAGNOSTICS_PATH: ${{ runner.temp }}/daily-auto-settle-diagnostics.json
+        run: |
+          python scripts/aws_recurrence_job.py \
+            --profile "" \
+            --region "${AWS_REGION}" \
+            --env prod \
+            --instance-id "${PROD_INSTANCE_ID}" \
+            --flask-command "transactions auto-settle" \
+            --diagnostics-json-path "${DIAGNOSTICS_PATH}"
+
+      - name: Upload diagnostics artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: daily-auto-settle-diagnostics
+          path: ${{ runner.temp }}/daily-auto-settle-diagnostics.json
+          if-no-files-found: ignore
+
+      - name: Notify failure via GitHub Issue
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const now = new Date().toISOString();
+            const title = '🚨 [auto-settle] Falha no job diário de auto-settle de transações';
+            const issueBody = [
+              '## Daily Transaction Auto-Settle falhou',
+              '',
+              `**Última falha:** ${now}`,
+              `**Run:** ${runUrl}`,
+              '',
+              'O job diário que marca transações opt-in como pagas no vencimento falhou via SSM.',
+              '',
+              '### Ações sugeridas',
+              '- Revisar logs da execução no link acima',
+              '- Verificar o artifact `daily-auto-settle-diagnostics`',
+              '- Executar `flask transactions auto-settle --dry-run` no container para validar',
+              '',
+              '_Issue criada automaticamente pelo GitHub Actions._',
+            ].join('\n');
+            const commentBody = [
+              'Nova falha detectada no daily auto-settle job.',
+              '',
+              `- Data: ${now}`,
+              `- Run: ${runUrl}`,
+            ].join('\n');
+            const query = [
+              `repo:${context.repo.owner}/${context.repo.repo}`,
+              'is:issue',
+              'in:title',
+              `"${title}"`,
+            ].join(' ');
+            const search = await github.rest.search.issuesAndPullRequests({
+              q: query,
+              per_page: 10,
+            });
+            const matchingIssue = search.data.items.find(
+              (item) => item.title === title,
+            );
+            if (matchingIssue) {
+              if (matchingIssue.state === 'closed') {
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: matchingIssue.number,
+                  state: 'open',
+                });
+              }
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: matchingIssue.number,
+                body: commentBody,
+              });
+              return;
+            }
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body: issueBody,
+              labels: ['bug', 'ops'],
+            });

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -16,6 +16,7 @@ from app.cli.ai_insights_cli import register_ai_insights_commands
 from app.cli.features import features as features_cli_group
 from app.cli.openapi_export import openapi_export_command
 from app.cli.recurrence_cli import register_recurrence_commands
+from app.cli.transactions_cli import register_transactions_commands
 from app.cli.worker_cli import worker_cli_group
 from app.controllers.account import account_bp
 from app.controllers.admin.ai_insights import admin_ai_insights_bp
@@ -305,6 +306,7 @@ def create_app(*, enable_http_runtime: bool = True) -> Flask:
     register_reminders_commands(app)
     register_ai_insights_commands(app)
     register_recurrence_commands(app)
+    register_transactions_commands(app)
     register_email_dlq_commands(app)
     app.cli.add_command(features_cli_group, "features")
     app.cli.add_command(openapi_export_command)

--- a/app/application/services/transaction/mutations.py
+++ b/app/application/services/transaction/mutations.py
@@ -134,6 +134,7 @@ def build_transaction_kwargs(
         "account_id": normalized.get("account_id"),
         "credit_card_id": normalized.get("credit_card_id"),
         "impact_policy": normalize_impact_policy(normalized.get("impact_policy")),
+        "auto_settle": bool(normalized.get("auto_settle", False)),
         "status": tx_status,
         "currency": normalize_currency(normalized.get("currency")),
     }
@@ -177,6 +178,7 @@ def build_installment_transactions(
             account_id=normalized.get("account_id"),
             credit_card_id=normalized.get("credit_card_id"),
             impact_policy=impact_policy,
+            auto_settle=bool(normalized.get("auto_settle", False)),
             status=tx_status,
             currency=currency,
             installment_group_id=group_id,

--- a/app/application/services/transaction/query_helpers.py
+++ b/app/application/services/transaction/query_helpers.py
@@ -51,6 +51,7 @@ _MUTABLE_TRANSACTION_FIELDS = frozenset(
         "account_id",
         "credit_card_id",
         "impact_policy",
+        "auto_settle",
         "paid_at",
     }
 )

--- a/app/cli/transactions_cli.py
+++ b/app/cli/transactions_cli.py
@@ -1,0 +1,59 @@
+"""Flask CLI commands for transaction batch jobs (F4, #1516).
+
+Command:
+  flask transactions auto-settle  — mark opted-in transactions (``auto_settle``)
+                                     as paid once they come due.
+
+Intended to run daily (see ``.github/workflows/auto-settle.yml``). The underlying
+service is idempotent: already-paid rows are skipped, and future occurrences are
+never touched.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import date
+
+import click
+from flask import Flask
+from flask.cli import AppGroup
+
+from app.services.transaction_auto_settle_service import TransactionAutoSettleService
+
+transactions_cli = AppGroup("transactions", help="Transaction batch commands.")
+
+
+@transactions_cli.command("auto-settle")
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Report how many due opted-in transactions exist without settling them.",
+)
+def auto_settle(dry_run: bool) -> None:
+    """Mark due, opted-in transactions as paid.
+
+    Idempotent and safe to run repeatedly. Exits non-zero only on an unhandled
+    error so the scheduler can surface failures.
+    """
+    if dry_run:
+        count = TransactionAutoSettleService.count_due(reference_date=date.today())
+        click.echo(f"transactions auto-settle dry-run: {count} due transaction(s).")
+        sys.exit(0)
+
+    try:
+        settled = TransactionAutoSettleService.settle_due(reference_date=date.today())
+    except Exception as exc:  # noqa: BLE001
+        click.echo(f"transactions auto-settle ERROR: {exc}", err=True)
+        sys.exit(1)
+
+    click.echo(f"transactions auto-settle: settled={settled}")
+    sys.exit(0)
+
+
+def register_transactions_commands(app: Flask) -> None:
+    """Register the ``transactions`` CLI group on *app*."""
+    app.cli.add_command(transactions_cli)
+
+
+__all__ = ["transactions_cli", "register_transactions_commands"]

--- a/app/graphql/mutations/transaction.py
+++ b/app/graphql/mutations/transaction.py
@@ -44,6 +44,7 @@ class CreateTransactionMutation(graphene.Mutation):
         account_id = graphene.UUID()
         credit_card_id = graphene.UUID()
         impact_policy = graphene.String(default_value="full")
+        auto_settle = graphene.Boolean(default_value=False)
 
     items = graphene.List(TransactionTypeObject, required=True)
     message = graphene.String(required=True)
@@ -132,6 +133,7 @@ class UpdateTransactionMutation(graphene.Mutation):
         account_id = graphene.UUID()
         credit_card_id = graphene.UUID()
         impact_policy = graphene.String()
+        auto_settle = graphene.Boolean()
         paid_at = graphene.String()
 
     transaction = graphene.Field(TransactionTypeObject, required=True)

--- a/app/graphql/types.py
+++ b/app/graphql/types.py
@@ -62,6 +62,7 @@ class TransactionTypeObject(graphene.ObjectType):
     account_id = graphene.String()
     credit_card_id = graphene.String()
     impact_policy = graphene.String(required=True)
+    auto_settle = graphene.Boolean()
     status = graphene.String(required=True)
     currency = graphene.String(required=True)
     source = graphene.String(required=True)

--- a/app/models/transaction.py
+++ b/app/models/transaction.py
@@ -120,6 +120,12 @@ class Transaction(db.Model):
         default=TransactionImpactPolicy.FULL,
         server_default=TransactionImpactPolicy.FULL.value,
     )
+    # Opt-in "auto-settle" (F4): when true, the daily auto-settle job marks this
+    # transaction as paid once it comes due. Default false — never mutates the
+    # ledger for transactions the user did not opt in.
+    auto_settle = db.Column(
+        db.Boolean, default=False, nullable=False, server_default=db.text("false")
+    )
     installment_group_id = db.Column(UUID(as_uuid=True), nullable=True)
     # Links all occurrences of one recurring series so a user can delete a
     # single occurrence or the whole series. Backfilled from

--- a/app/schemas/transaction_schema.py
+++ b/app/schemas/transaction_schema.py
@@ -161,6 +161,16 @@ class TransactionSchema(Schema):
             "example": "full",
         },
     )
+    auto_settle = fields.Bool(
+        load_default=False,
+        metadata={
+            "description": (
+                "Quando true, a transação é marcada automaticamente como paga/recebida "
+                "no vencimento pelo job diário de auto-settle (opt-in, padrão false)."
+            ),
+            "example": False,
+        },
+    )
     installment_group_id = fields.UUID(
         dump_only=True,
         metadata={"description": "ID do grupo de parcelas (gerado automaticamente)"},
@@ -258,6 +268,9 @@ class TransactionResponseSchema(Schema):
     )
     impact_policy = fields.Str(
         metadata={"description": "Política de impacto do lançamento"}
+    )
+    auto_settle = fields.Bool(
+        metadata={"description": "Se marca automaticamente como paga no vencimento"}
     )
     installment_group_id = fields.UUID(
         allow_none=True, metadata={"description": "ID do grupo de parcelas"}

--- a/app/services/recurrence_service.py
+++ b/app/services/recurrence_service.py
@@ -180,6 +180,7 @@ class RecurrenceService:
                     account_id=template.account_id,
                     credit_card_id=template.credit_card_id,
                     impact_policy=template.impact_policy,
+                    auto_settle=template.auto_settle,
                     installment_group_id=(template.installment_group_id or template.id),
                     recurrence_series_id=(
                         template.recurrence_series_id

--- a/app/services/transaction_auto_settle_service.py
+++ b/app/services/transaction_auto_settle_service.py
@@ -1,0 +1,63 @@
+"""Auto-settle service for opt-in transactions (F4, #1516).
+
+Marks transactions the user opted into (``auto_settle=True``) as paid once they
+come due. Runs from the daily ``flask transactions auto-settle`` job. Safe by
+design: only touches open (pending/postponed) opted-in rows whose ``due_date``
+has arrived — never future occurrences and never rows the user did not opt in.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+from app.extensions.database import db
+from app.models.transaction import Transaction, TransactionStatus
+from app.utils.datetime_utils import utc_now_naive
+
+# Only open statuses are auto-settled; paid/cancelled/overdue are left untouched.
+_SETTLEABLE_STATUSES = (TransactionStatus.PENDING, TransactionStatus.POSTPONED)
+
+
+class TransactionAutoSettleService:
+    """Settles due, opted-in transactions in a single batch."""
+
+    @staticmethod
+    def _due_query(reference_date: date) -> Any:
+        """Builds the query for due, opted-in, open transactions."""
+        return Transaction.query.filter(
+            Transaction.auto_settle.is_(True),
+            Transaction.deleted.is_(False),
+            Transaction.due_date <= reference_date,
+            Transaction.status.in_(_SETTLEABLE_STATUSES),
+        )
+
+    @classmethod
+    def count_due(cls, reference_date: date | None = None) -> int:
+        """Counts how many transactions would be auto-settled (dry-run)."""
+        today = reference_date or date.today()
+        return int(cls._due_query(today).count())
+
+    @classmethod
+    def settle_due(cls, reference_date: date | None = None) -> int:
+        """Marks due, opted-in, open transactions as paid.
+
+        Idempotent: a second run finds nothing because settled rows are no longer
+        in an open status.
+
+        :param reference_date: "today" override (defaults to ``date.today()``).
+        :returns: number of transactions settled.
+        """
+        today = reference_date or date.today()
+        settled_at = utc_now_naive()
+        settled = 0
+        for transaction in cls._due_query(today).all():
+            transaction.status = TransactionStatus.PAID
+            transaction.paid_at = settled_at
+            settled += 1
+        if settled:
+            db.session.commit()
+        return settled
+
+
+__all__ = ["TransactionAutoSettleService"]

--- a/app/services/transaction_serialization.py
+++ b/app/services/transaction_serialization.py
@@ -25,6 +25,7 @@ class TransactionPayload(TypedDict):
     account_id: str | None
     credit_card_id: str | None
     impact_policy: str
+    auto_settle: bool
     status: str
     currency: str
     source: str
@@ -81,6 +82,7 @@ def serialize_transaction_payload(transaction: Transaction) -> TransactionPayloa
         "account_id": _str_or_none(transaction.account_id),
         "credit_card_id": _str_or_none(transaction.credit_card_id),
         "impact_policy": _enum_value_or_default(impact_policy, "full"),
+        "auto_settle": bool(getattr(transaction, "auto_settle", False)),
         "status": transaction.status.value,
         "currency": transaction.currency,
         "source": transaction.source or "manual",

--- a/graphql.introspection.json
+++ b/graphql.introspection.json
@@ -8819,6 +8819,18 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "autoSettle",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "status",
               "type": {
                 "kind": "NON_NULL",
@@ -10824,6 +10836,18 @@
                   }
                 },
                 {
+                  "defaultValue": "false",
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "autoSettle",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  }
+                },
+                {
                   "defaultValue": null,
                   "deprecationReason": null,
                   "description": null,
@@ -11085,6 +11109,18 @@
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "autoSettle",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
                     "ofType": null
                   }
                 },

--- a/migrations/versions/as1_transaction_auto_settle.py
+++ b/migrations/versions/as1_transaction_auto_settle.py
@@ -1,0 +1,50 @@
+"""add transactions.auto_settle — #1516
+
+Opt-in flag for the auto-settle job (F4): when true, the daily
+``flask transactions auto-settle`` job marks the transaction as paid once it
+comes due. Default false so the ledger is never mutated for transactions the
+user did not opt in.
+
+Revision ID: as1_transaction_auto_settle
+Revises: cc3_transaction_impact_policy
+Create Date: 2026-06-29
+
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "as1_transaction_auto_settle"
+down_revision = "cc3_transaction_impact_policy"
+branch_labels = None
+depends_on = None
+
+TABLE = "transactions"
+COLUMN = "auto_settle"
+
+
+def _has_column(table: str, column: str) -> bool:
+    """Return True when *column* already exists on *table*."""
+    inspector = sa.inspect(op.get_context().connection)
+    return any(col["name"] == column for col in inspector.get_columns(table))
+
+
+def upgrade() -> None:
+    # Idempotent: tolerate prod drift where the column already exists.
+    if not _has_column(TABLE, COLUMN):
+        op.add_column(
+            TABLE,
+            sa.Column(
+                COLUMN,
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.text("false"),
+            ),
+        )
+
+
+def downgrade() -> None:
+    if _has_column(TABLE, COLUMN):
+        op.drop_column(TABLE, COLUMN)

--- a/openapi.json
+++ b/openapi.json
@@ -302,6 +302,12 @@
             "minimum": 0.01,
             "type": "number"
           },
+          "auto_settle": {
+            "default": false,
+            "description": "Quando true, a transação é marcada automaticamente como paga/recebida no vencimento pelo job diário de auto-settle (opt-in, padrão false).",
+            "example": false,
+            "type": "boolean"
+          },
           "category": {
             "default": null,
             "description": "Categoria estruturada para controle de orçamento",
@@ -513,6 +519,12 @@
             "example": "150.50",
             "minimum": 0.01,
             "type": "number"
+          },
+          "auto_settle": {
+            "default": false,
+            "description": "Quando true, a transação é marcada automaticamente como paga/recebida no vencimento pelo job diário de auto-settle (opt-in, padrão false).",
+            "example": false,
+            "type": "boolean"
           },
           "category": {
             "default": null,

--- a/schema.graphql
+++ b/schema.graphql
@@ -703,6 +703,7 @@ type TransactionTypeObject {
   accountId: String
   creditCardId: String
   impactPolicy: String!
+  autoSettle: Boolean
   status: String!
   currency: String!
   source: String!
@@ -846,8 +847,8 @@ type Mutation {
   resetPassword(newPassword: String!, token: String!): AuthPayloadType
   confirmEmail(token: String!): AuthPayloadType
   updateUserProfile(birthDate: String, financialObjectives: String, gender: String, initialInvestment: DecimalScalar, investmentGoalDate: String, investorProfile: String, investorProfileSuggested: String, monthlyExpenses: DecimalScalar, monthlyIncome: DecimalScalar, monthlyIncomeNet: DecimalScalar, monthlyInvestment: DecimalScalar, netWorth: DecimalScalar, occupation: String, profileQuizScore: Int, stateUf: String, taxonomyVersion: String): UpdateUserProfileMutation
-  createTransaction(accountId: UUID, amount: String!, category: String, creditCardId: UUID, currency: String = "BRL", description: String, dueDate: String!, endDate: String, impactPolicy: String = "full", installmentCount: Int, isInstallment: Boolean = false, isRecurring: Boolean = false, observation: String, recurrenceInterval: Int, recurrenceUnit: String, startDate: String, status: TransactionStatus, tagId: UUID, title: String!, type: TransactionType!): CreateTransactionMutation @deprecated(reason: "ADR-0002: use POST /transactions")
-  updateTransaction(accountId: UUID, amount: String, category: String, creditCardId: UUID, currency: String, description: String, dueDate: String, endDate: String, impactPolicy: String, installmentCount: Int, isInstallment: Boolean, isRecurring: Boolean, observation: String, paidAt: String, startDate: String, status: TransactionStatus, tagId: UUID, title: String, transactionId: UUID!, type: TransactionType): UpdateTransactionMutation @deprecated(reason: "ADR-0002: use PATCH /transactions/{id}")
+  createTransaction(accountId: UUID, amount: String!, autoSettle: Boolean = false, category: String, creditCardId: UUID, currency: String = "BRL", description: String, dueDate: String!, endDate: String, impactPolicy: String = "full", installmentCount: Int, isInstallment: Boolean = false, isRecurring: Boolean = false, observation: String, recurrenceInterval: Int, recurrenceUnit: String, startDate: String, status: TransactionStatus, tagId: UUID, title: String!, type: TransactionType!): CreateTransactionMutation @deprecated(reason: "ADR-0002: use POST /transactions")
+  updateTransaction(accountId: UUID, amount: String, autoSettle: Boolean, category: String, creditCardId: UUID, currency: String, description: String, dueDate: String, endDate: String, impactPolicy: String, installmentCount: Int, isInstallment: Boolean, isRecurring: Boolean, observation: String, paidAt: String, startDate: String, status: TransactionStatus, tagId: UUID, title: String, transactionId: UUID!, type: TransactionType): UpdateTransactionMutation @deprecated(reason: "ADR-0002: use PATCH /transactions/{id}")
   deleteTransaction(scope: String, transactionId: UUID!): DeleteTransactionMutation @deprecated(reason: "ADR-0002: use DELETE /transactions/{id}")
   createGoal(category: String, currentAmount: String, description: String, priority: Int, status: GoalStatus, targetAmount: String!, targetDate: String, title: String!): CreateGoalMutation @deprecated(reason: "ADR-0002: use POST /goals")
   updateGoal(category: String, currentAmount: String, description: String, goalId: UUID!, priority: Int, status: GoalStatus, targetAmount: String, targetDate: String, title: String): UpdateGoalMutation @deprecated(reason: "ADR-0002: use PATCH /goals/{id}")

--- a/scripts/aws_recurrence_job.py
+++ b/scripts/aws_recurrence_job.py
@@ -204,7 +204,7 @@ def _wait(ctx: AwsCtx, *, command_id: str, instance_id: str) -> dict[str, Any]:
     )
 
 
-def _build_script(*, env_name: str) -> str:
+def _build_script(*, env_name: str, flask_command: str = "recurrence reconcile") -> str:
     env_file = ".env.prod" if env_name == "prod" else ".env.dev"
     compose_file = (
         "docker-compose.prod.yml" if env_name == "prod" else "docker-compose.dev.yml"
@@ -290,7 +290,7 @@ done
 # the correct DATABASE_URL and exits cleanly when reconciliation finishes.
 docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" exec -T \\
   -e FLASK_APP=run.py \\
-  web flask recurrence reconcile
+  web flask {flask_command}
 """
 
 
@@ -300,12 +300,13 @@ def run_once(
     env_name: str,
     instance_id: str,
     diagnostics_json_path: str | None = None,
+    flask_command: str = "recurrence reconcile",
 ) -> dict[str, Any]:
     command_id = _ssm_send_shell(
         ctx,
         instance_id,
-        _build_script(env_name=env_name),
-        f"auraxis: recurrence job ({env_name})",
+        _build_script(env_name=env_name, flask_command=flask_command),
+        f"auraxis: {flask_command} job ({env_name})",
     )
     try:
         invocation = _wait(ctx, command_id=command_id, instance_id=instance_id)
@@ -358,6 +359,12 @@ def main() -> int:
         default="",
         help="Optional path for diagnostics JSON.",
     )
+    parser.add_argument(
+        "--flask-command",
+        default="recurrence reconcile",
+        help="Flask CLI command to exec in the web container "
+        "(e.g. 'recurrence reconcile' or 'transactions auto-settle').",
+    )
     args = parser.parse_args()
 
     instance_id = args.instance_id or (
@@ -369,6 +376,7 @@ def main() -> int:
         env_name=args.env,
         instance_id=instance_id,
         diagnostics_json_path=args.diagnostics_json_path or None,
+        flask_command=args.flask_command,
     )
     return 0
 

--- a/tests/test_transaction_auto_settle_service.py
+++ b/tests/test_transaction_auto_settle_service.py
@@ -1,0 +1,109 @@
+from datetime import date
+from decimal import Decimal
+
+from app.extensions.database import db
+from app.models.transaction import Transaction, TransactionStatus, TransactionType
+from app.models.user import User
+from app.services.transaction_auto_settle_service import TransactionAutoSettleService
+
+TODAY = date(2026, 6, 29)
+
+
+def _create_user() -> User:
+    user = User(name="settle-user", email="settle-user@email.com", password="x")
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+def _make_transaction(
+    user_id: object,
+    *,
+    title: str,
+    due_date: date,
+    status: TransactionStatus = TransactionStatus.PENDING,
+    auto_settle: bool = True,
+) -> Transaction:
+    transaction = Transaction(
+        user_id=user_id,
+        title=title,
+        amount=Decimal("100.00"),
+        type=TransactionType.INCOME,
+        status=status,
+        due_date=due_date,
+        auto_settle=auto_settle,
+        currency="BRL",
+    )
+    db.session.add(transaction)
+    db.session.commit()
+    return transaction
+
+
+def test_settles_due_opted_in_open_transactions(app) -> None:
+    with app.app_context():
+        user = _create_user()
+        due = _make_transaction(user.id, title="Salário", due_date=date(2026, 6, 1))
+        postponed = _make_transaction(
+            user.id,
+            title="Adiantamento",
+            due_date=date(2026, 5, 10),
+            status=TransactionStatus.POSTPONED,
+        )
+
+        settled = TransactionAutoSettleService.settle_due(reference_date=TODAY)
+
+        assert settled == 2
+        db.session.refresh(due)
+        db.session.refresh(postponed)
+        assert due.status == TransactionStatus.PAID
+        assert due.paid_at is not None
+        assert postponed.status == TransactionStatus.PAID
+
+
+def test_does_not_settle_future_or_non_opted_or_closed(app) -> None:
+    with app.app_context():
+        user = _create_user()
+        future = _make_transaction(user.id, title="Futuro", due_date=date(2026, 7, 15))
+        not_opted = _make_transaction(
+            user.id, title="Manual", due_date=date(2026, 6, 1), auto_settle=False
+        )
+        already_paid = _make_transaction(
+            user.id,
+            title="Pago",
+            due_date=date(2026, 6, 1),
+            status=TransactionStatus.PAID,
+        )
+
+        settled = TransactionAutoSettleService.settle_due(reference_date=TODAY)
+
+        assert settled == 0
+        db.session.refresh(future)
+        db.session.refresh(not_opted)
+        db.session.refresh(already_paid)
+        assert future.status == TransactionStatus.PENDING
+        assert not_opted.status == TransactionStatus.PENDING
+        assert already_paid.paid_at is None
+
+
+def test_settle_due_is_idempotent(app) -> None:
+    with app.app_context():
+        user = _create_user()
+        _make_transaction(user.id, title="Salário", due_date=date(2026, 6, 1))
+
+        first = TransactionAutoSettleService.settle_due(reference_date=TODAY)
+        second = TransactionAutoSettleService.settle_due(reference_date=TODAY)
+
+        assert first == 1
+        assert second == 0
+
+
+def test_count_due_does_not_mutate(app) -> None:
+    with app.app_context():
+        user = _create_user()
+        tx = _make_transaction(user.id, title="Salário", due_date=date(2026, 6, 1))
+
+        count = TransactionAutoSettleService.count_due(reference_date=TODAY)
+
+        assert count == 1
+        db.session.refresh(tx)
+        assert tx.status == TransactionStatus.PENDING

--- a/tests/test_transactions_cli.py
+++ b/tests/test_transactions_cli.py
@@ -1,0 +1,55 @@
+"""Tests for the 'flask transactions auto-settle' CLI command (#1516)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+
+def _invoke(app, *args: str) -> object:
+    from app.cli.transactions_cli import transactions_cli
+
+    runner = CliRunner()
+    with app.app_context():
+        return runner.invoke(transactions_cli, ["auto-settle", *args])
+
+
+class TestAutoSettleCLI:
+    def test_reports_settled_count(self, app) -> None:
+        with patch(
+            "app.cli.transactions_cli.TransactionAutoSettleService.settle_due",
+            return_value=5,
+        ) as mock_settle:
+            result = _invoke(app)
+
+        assert result.exit_code == 0
+        assert "settled=5" in result.output
+        assert mock_settle.call_count == 1
+
+    def test_dry_run_counts_without_settling(self, app) -> None:
+        with (
+            patch(
+                "app.cli.transactions_cli.TransactionAutoSettleService.count_due",
+                return_value=3,
+            ),
+            patch(
+                "app.cli.transactions_cli.TransactionAutoSettleService.settle_due"
+            ) as mock_settle,
+        ):
+            result = _invoke(app, "--dry-run")
+
+        assert result.exit_code == 0
+        assert "dry-run" in result.output
+        assert "3 due transaction" in result.output
+        mock_settle.assert_not_called()
+
+    def test_exits_nonzero_on_error(self, app) -> None:
+        with patch(
+            "app.cli.transactions_cli.TransactionAutoSettleService.settle_due",
+            side_effect=RuntimeError("db down"),
+        ):
+            result = _invoke(app)
+
+        assert result.exit_code == 1
+        assert "ERROR" in result.output


### PR DESCRIPTION
## O que muda

Feature 4 (Agendador): novo campo opt-in **`auto_settle`** em transações (default false). Um job
diário marca como **paga/recebida** as transações `auto_settle=true` que venceram
(`status pending/postponed` + `due_date <= hoje`). Ex.: salário recorrente todo dia 1º é marcado
como recebido sozinho; meses futuros seguem pendentes até a data chegar. Reversível e nunca muta
em silêncio quem não optou. "Marcar pago" só atualiza o status no Auraxis — não move dinheiro real.

Inclui:
- Migração idempotente `auto_settle` (up/down testado com `test_migrations_local.sh`).
- `TransactionAutoSettleService` + CLI `flask transactions auto-settle [--dry-run]`.
- Cron diário (`.github/workflows/auto-settle.yml`) reutilizando o orquestrador SSM
  parametrizado (`--flask-command`).
- `auto_settle` exposto em REST (TransactionSchema/Response) **e** GraphQL (create/update + tipo),
  com snapshots OpenAPI + GraphQL regenerados. Ocorrências recorrentes herdam o flag.

## Contexto

Closes #1516
Companheiro das features de produto (F3 já mergeado). Frontends (toggle web/app) virão em seguida.

> **Dependência de CI:** o flake pré-existente de data em `test_ai_insight_weekly_recap.py` é
> corrigido no PR #1518 (Closes #1517). Após #1518 entrar em master, atualizar/rebase esta branch
> deixa o CI verde.

## Como testar

- [ ] POST/PATCH `/transactions` (REST) e create/update (GraphQL) aceitam `auto_settle`.
- [ ] `flask transactions auto-settle --dry-run` conta; sem flag, marca as vencidas opt-in como pagas.
- [ ] Recorrência: template com `auto_settle=true` → ocorrências herdam; futuras não são tocadas.

## Quality gates (local)

- [x] ruff/mypy/bandit: PASS
- [x] migração up/down + head único: PASS
- [x] testes da feature (serviço + CLI) + contract: PASS
- [x] snapshots OpenAPI + GraphQL regenerados
- [x] `run_ci_quality_local.sh --local`: verde exceto o flake pré-existente coberto pelo #1518

## Impacto de contrato

Aditivo — novo campo opcional `auto_settle` em REST + GraphQL (sem quebra). Snapshots atualizados.

## Risco

MEDIUM — migração de schema (aditiva, idempotente, default false) + mutação automática de dados
financeiros, mitigada por: opt-in (default OFF), só toca pending/postponed vencidas, idempotente,
reversível, e nunca afeta quem não optou.