### PR TITLE
feat(ai): Ask Anything — chat financeiro IA snapshot-grounded (/ai/chat)

### DIFF
--- a/api-tests/postman/auraxis.postman_collection.json
+++ b/api-tests/postman/auraxis.postman_collection.json
@@ -5163,7 +5163,7 @@
             },
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"question\": \"Quanto gastei com alimentação até agora?\"\n}"
+              "raw": "{\n  \"question\": \"Quanto gastei at\\u00e9 agora?\"\n}"
             }
           },
           "event": [
@@ -5171,8 +5171,8 @@
               "listen": "test",
               "script": {
                 "exec": [
-                  "pm.test('Perguntar sobre as próprias finanças com IA (Premium) — status 200', function () {",
-                  "  pm.response.to.have.status(200);",
+                  "pm.test('AI chat — expected 200, 400, 403 or 429', function () {",
+                  "  pm.expect(pm.response.code).to.be.oneOf([200, 400, 403, 429]);",
                   "});"
                 ],
                 "type": "text/javascript"

--- a/api-tests/postman/auraxis.postman_collection.json
+++ b/api-tests/postman/auraxis.postman_collection.json
@@ -1,7 +1,7 @@
 {
   "info": {
     "name": "Auraxis API",
-    "description": "Auto-generated from openapi.json (87 paths). Do not edit manually — regenerate with: npm run postman:build",
+    "description": "Auto-generated from openapi.json (88 paths). Do not edit manually — regenerate with: npm run postman:build",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "item": [
@@ -5126,6 +5126,53 @@
                 "exec": [
                   "pm.test('AI goal projection — expected 200 or 400 or 403 or 404', function () {",
                   "  pm.expect(pm.response.code).to.be.oneOf([200, 400, 403, 404]);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "POST — Perguntar sobre as próprias finanças com IA (Premium)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-API-Contract",
+                "value": "v2"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/ai/chat",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "ai",
+                "chat"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"question\": \"Quanto gastei com alimentação até agora?\"\n}"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Perguntar sobre as próprias finanças com IA (Premium) — status 200', function () {",
+                  "  pm.response.to.have.status(200);",
                   "});"
                 ],
                 "type": "text/javascript"

--- a/app/controllers/ai/resources.py
+++ b/app/controllers/ai/resources.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import uuid
 from datetime import date
 from decimal import Decimal, InvalidOperation
@@ -38,6 +39,7 @@ from app.docs.openapi_helpers import (
     json_success_response,
 )
 from app.middleware.ai_rate_limit import ai_daily_limit
+from app.schemas.ai_chat_schema import AIChatRequestSchema
 from app.schemas.ai_insight_feedback_schema import AIInsightFeedbackSchema
 from app.schemas.ai_insight_schema import (
     AIInsightGenerateRequestSchema,
@@ -415,6 +417,130 @@ class AIInsightGenerateResource(MethodResource):
             legacy_payload=result,
             status_code=200,
             message="Insight financeiro gerado com sucesso",
+            data=result,
+        )
+
+
+def _ai_chat_daily_limit() -> int:
+    """Per-user daily cap for the Ask-anything chat (shared AI-call counter)."""
+    return max(1, int(os.getenv("AI_CHAT_DAILY_LIMIT", "20")))
+
+
+class AIChatAskAnythingResource(MethodResource):
+    """POST /ai/chat — snapshot-grounded finance chat (Ask anything)."""
+
+    @doc(
+        summary="Perguntar sobre as próprias finanças com IA (Premium)",
+        description=(
+            "Responde perguntas do usuário usando exclusivamente o snapshot "
+            "financeiro do próprio usuário. Recusa perguntas fora de finanças e "
+            "informa quando o dado não está disponível no período atual."
+        ),
+        tags=["AI Advisory"],
+        security=[{"BearerAuth": []}],
+        requestBody=json_request_body(
+            schema=AIChatRequestSchema,
+            description="Pergunta em linguagem natural sobre as finanças do usuário.",
+            example={"question": "Quanto gastei com alimentação até agora?"},
+        ),
+        responses={
+            200: json_success_response(
+                description="Resposta gerada com sucesso",
+                message="Resposta gerada com sucesso",
+                data_example={
+                    "answer": "Até agora você gastou R$320,00 com alimentação.",
+                    "model": "gpt-4o-mini",
+                    "tokens_used": 380,
+                    "cost_usd": 0.000057,
+                },
+            ),
+            400: json_error_response(
+                description="Pergunta inválida",
+                message="Pergunta inválida.",
+                error_code="VALIDATION_ERROR",
+                status_code=400,
+            ),
+            403: json_error_response(
+                description="Entitlement insuficiente",
+                message="Recurso exclusivo para assinantes Premium.",
+                error_code="ENTITLEMENT_REQUIRED",
+                status_code=403,
+            ),
+            429: json_error_response(
+                description="Limite diário ou orçamento de IA atingido",
+                message="Orçamento de IA atingido.",
+                error_code="AI_INSIGHT_BUDGET_EXCEEDED",
+                status_code=429,
+            ),
+            500: json_error_response(
+                description="Erro interno ou falha do provider LLM",
+                message="Erro ao processar a pergunta",
+                error_code="INTERNAL_ERROR",
+                status_code=500,
+            ),
+        },
+    )
+    @jwt_required()
+    @ai_daily_limit(max_calls=_ai_chat_daily_limit())
+    def post(self) -> Response:
+        token_error = _guard_revoked_token()
+        if token_error is not None:
+            return token_error
+
+        user_id = current_user_id()
+
+        entitlement_error = _check_entitlement(user_id)
+        if entitlement_error is not None:
+            return entitlement_error
+
+        body = request.get_json(silent=True) or {}
+        try:
+            parsed = AIChatRequestSchema().load(body)
+        except ValidationError as exc:
+            return compat_error_response(
+                legacy_payload={"error": exc.messages},
+                status_code=400,
+                message="Pergunta inválida.",
+                error_code="VALIDATION_ERROR",
+            )
+
+        question = str(parsed["question"])
+        timezone_resolution = _resolve_ai_insight_request_timezone(body)
+        service = AIAdvisoryService(user_id=user_id)
+        try:
+            result = service.answer_financial_question(
+                question,
+                timezone_name=timezone_resolution.name,
+                timezone_fallback=timezone_resolution.fallback_used,
+            )
+        except AIConsentRequiredError as exc:
+            return _ai_consent_required_response(exc)
+        except AIInsightCostBudgetExceededError as exc:
+            return compat_error_response(
+                legacy_payload={"error": str(exc)},
+                status_code=429,
+                message=str(exc),
+                error_code="AI_INSIGHT_BUDGET_EXCEEDED",
+            )
+        except LLMProviderError as exc:
+            return compat_error_response(
+                legacy_payload={"error": str(exc)},
+                status_code=500,
+                message="Erro ao processar a pergunta",
+                error_code="INTERNAL_ERROR",
+            )
+        except Exception:
+            return compat_error_response(
+                legacy_payload={"error": "Erro interno ao processar a pergunta"},
+                status_code=500,
+                message="Erro interno ao processar a pergunta",
+                error_code="INTERNAL_ERROR",
+            )
+
+        return compat_success_response(
+            legacy_payload=result,
+            status_code=200,
+            message="Resposta gerada com sucesso",
             data=result,
         )
 

--- a/app/controllers/ai/routes.py
+++ b/app/controllers/ai/routes.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from .blueprint import ai_bp
 from .resources import (
+    AIChatAskAnythingResource,
     AIGoalProjectionResource,
     AIInsightChangeStatusResource,
     AIInsightDetailResource,
@@ -27,6 +28,11 @@ def register_ai_routes() -> None:
     ai_bp.add_url_rule(
         "/insights/generate",
         view_func=AIInsightGenerateResource.as_view("ai_insight_generate"),
+        methods=["POST"],
+    )
+    ai_bp.add_url_rule(
+        "/chat",
+        view_func=AIChatAskAnythingResource.as_view("ai_chat_ask_anything"),
         methods=["POST"],
     )
     ai_bp.add_url_rule(

--- a/app/graphql/docs_catalog.py
+++ b/app/graphql/docs_catalog.py
@@ -915,6 +915,19 @@ GRAPHQL_OPERATION_CATALOG: tuple[GraphQLOperationDoc, ...] = (
         ),
         source_module="app.graphql.mutations.ai_insight",
     ),
+    # AI Advisory — Ask anything chat (#1521)
+    GraphQLOperationDoc(
+        name="askFinancialQuestion",
+        operation_type="mutation",
+        domain="ai_advisory",
+        access="auth_required",
+        summary=(
+            "Responde uma pergunta em linguagem natural sobre as finanças do "
+            "próprio usuário, ancorada exclusivamente no snapshot financeiro. "
+            "Paridade com POST /ai/chat."
+        ),
+        source_module="app.graphql.mutations.ai_insight",
+    ),
     # AI Advisory — feedback (#1387)
     GraphQLOperationDoc(
         name="submitAiInsightFeedback",

--- a/app/graphql/mutations/__init__.py
+++ b/app/graphql/mutations/__init__.py
@@ -8,6 +8,7 @@ from app.graphql.mutations.account import (
     UpdateAccountMutation,
 )
 from app.graphql.mutations.ai_insight import (
+    AskFinancialQuestionMutation,
     GenerateAiInsightMutation,
     SubmitAiInsightFeedbackMutation,
 )
@@ -192,6 +193,8 @@ class Mutation(graphene.ObjectType):
     # AI Advisory — canonical GraphQL parity for POST /ai/insights/generate
     generate_ai_insight = GenerateAiInsightMutation.Field()
     submit_ai_insight_feedback = SubmitAiInsightFeedbackMutation.Field()
+    # AI Advisory — GraphQL parity for POST /ai/chat (Ask anything)
+    ask_financial_question = AskFinancialQuestionMutation.Field()
     # Onboarding completion — REST parity: POST /user/onboarding/complete (#1471)
     complete_onboarding = CompleteOnboardingMutation.Field()
 

--- a/app/graphql/mutations/ai_insight.py
+++ b/app/graphql/mutations/ai_insight.py
@@ -253,6 +253,65 @@ class GenerateAiInsightMutation(graphene.Mutation):
         )
 
 
+class AskFinancialQuestionPayload(graphene.ObjectType):
+    ok = graphene.Boolean(required=True)
+    answer = graphene.String()
+    model = graphene.String()
+    tokens_used = graphene.Int()
+    cost_usd = graphene.Float()
+
+
+class AskFinancialQuestionMutation(graphene.Mutation):
+    """GraphQL parity for POST /ai/chat (Ask anything).
+
+    Snapshot-grounded finance chat. Entitlement, LGPD consent, per-user cost
+    budget and audit are enforced inside AIAdvisoryService.
+    """
+
+    class Arguments:
+        question = graphene.String(required=True)
+
+    Output = AskFinancialQuestionPayload
+
+    @log_graphql_resolver("askFinancialQuestion")
+    def mutate(
+        self,
+        _info: graphene.ResolveInfo,
+        question: str,
+    ) -> AskFinancialQuestionPayload:
+        user = get_current_user_required()
+
+        normalized = (question or "").strip()
+        if not normalized:
+            raise build_public_graphql_error(
+                "question is required",
+                code="VALIDATION_ERROR",
+            )
+
+        service = AIAdvisoryService(user_id=user.id)
+        raw_timezone = request.headers.get(timezone_utils.USER_TIMEZONE_HEADER)
+        timezone_resolution = timezone_utils.resolve_user_timezone(raw_timezone)
+        try:
+            result = service.answer_financial_question(
+                normalized,
+                timezone_name=timezone_resolution.name,
+                timezone_fallback=timezone_resolution.fallback_used,
+            )
+        except LLMProviderError as exc:
+            raise build_public_graphql_error(
+                "Erro ao processar a pergunta",
+                code="LLM_PROVIDER_ERROR",
+            ) from exc
+
+        return AskFinancialQuestionPayload(
+            ok=True,
+            answer=result.get("answer"),
+            model=result.get("model"),
+            tokens_used=int(result.get("tokens_used") or 0),
+            cost_usd=float(result.get("cost_usd") or 0),
+        )
+
+
 class AIInsightFeedbackPayload(graphene.ObjectType):
     ok = graphene.Boolean(required=True)
     id = graphene.String()

--- a/app/schemas/ai_chat_schema.py
+++ b/app/schemas/ai_chat_schema.py
@@ -1,0 +1,17 @@
+from marshmallow import Schema, fields, validate
+
+
+class AIChatRequestSchema(Schema):
+    """Request body for POST /ai/chat (Ask anything)."""
+
+    class Meta:
+        name = "AIChatRequest"
+
+    question = fields.Str(
+        required=True,
+        validate=validate.Length(min=1, max=1000),
+        metadata={
+            "description": "Pergunta do usuário sobre as próprias finanças.",
+            "example": "Quanto gastei com alimentação até agora?",
+        },
+    )

--- a/app/services/ai_advisory_service.py
+++ b/app/services/ai_advisory_service.py
@@ -162,6 +162,7 @@ _AI_INSIGHT_COST_ENDPOINTS = (
     "financial_insights_daily",
     "financial_insights_weekly",
     "financial_insights_monthly",
+    "chat_ask_anything",
 )
 
 
@@ -1060,6 +1061,80 @@ class AIAdvisoryService:
     ) -> None:
         self._user_id = user_id
         self._provider = llm_provider or get_llm_provider()
+
+    # ------------------------------------------------------------------
+    # 0. Ask anything (snapshot-grounded chat)
+    # ------------------------------------------------------------------
+
+    def answer_financial_question(
+        self,
+        question: str,
+        *,
+        anchor_date: date | None = None,
+        timezone_name: str | None = None,
+        timezone_fallback: bool = False,
+    ) -> dict[str, Any]:
+        """Answer a free-form finance question grounded ONLY in the user snapshot.
+
+        Reuses the insights pipeline (consent, snapshot, LGPD minimisation,
+        per-user cost budget, audit log). The model is instructed to stay on
+        finance, use only snapshot numbers, and admit when data is missing.
+
+        :param question: The user's natural-language question.
+        :returns: ``{answer, model, tokens_used, cost_usd}``.
+        :raises ValueError: when the question is empty.
+        """
+        normalized_question = (question or "").strip()
+        if not normalized_question:
+            raise ValueError("question is required")
+
+        consent_version = ensure_ai_consent_granted(self._user_id)
+        timezone_resolution = timezone_utils.resolve_user_timezone(timezone_name)
+        fallback_used = timezone_fallback or (
+            timezone_resolution.fallback_used and timezone_name is not None
+        )
+        anchor = anchor_date or timezone_utils.local_today(timezone_resolution)
+
+        snapshot = _build_period_snapshot(
+            insight_type=InsightType.daily,
+            user_id=self._user_id,
+            anchor=anchor,
+            timezone_name=timezone_resolution.name,
+            timezone_fallback=fallback_used,
+        )
+        prompt_snapshot = minimize_prompt_data(snapshot)
+        prompt_snapshot, _ = truncate_snapshot(prompt_snapshot)
+
+        _enforce_ai_insight_user_cost_budget(user_id=self._user_id)
+
+        prompt = _build_chat_prompt(prompt_snapshot, normalized_question)
+        try:
+            llm_resp = self._provider.generate_with_usage(
+                prompt,
+                max_tokens=_chat_max_tokens(),
+            )
+        except LLMProviderError as exc:
+            log.warning(
+                "ai_advisory.chat.llm_error user=%s error=%s",
+                self._user_id,
+                exc,
+            )
+            raise
+
+        _log_llm_call(
+            user_id=self._user_id,
+            endpoint="chat_ask_anything",
+            prompt=prompt,
+            llm_response=llm_resp,
+            consent_version=consent_version,
+        )
+
+        return {
+            "answer": llm_resp.content.strip(),
+            "model": llm_resp.model,
+            "tokens_used": llm_resp.total_tokens,
+            "cost_usd": float(llm_resp.estimated_cost_usd),
+        }
 
     # ------------------------------------------------------------------
     # 1. Spending insights
@@ -2355,6 +2430,41 @@ def _insight_reading_word_count(summary: str, items: list[dict[str, Any]]) -> in
         parts.append(str(item.get("title", "")))
         parts.append(str(item.get("message", "")))
     return sum(len(part.split()) for part in parts)
+
+
+def _chat_max_tokens() -> int:
+    """Output token cap for the Ask-anything chat (bounded to control cost)."""
+    return max(1, int(os.getenv("AI_CHAT_MAX_TOKENS", "600")))
+
+
+def _build_chat_prompt(snapshot: dict[str, Any], question: str) -> str:
+    """Build the snapshot-grounded prompt for the Ask-anything chat.
+
+    The model must answer ONLY from the user's own financial snapshot, stay on
+    finance, refuse off-topic questions, and admit when data is outside the
+    snapshot — never inventing values.
+    """
+    context = json.dumps(snapshot, ensure_ascii=False, default=str)
+    return (
+        "Você é o assistente financeiro do Auraxis. Responda à pergunta do usuário "
+        "EXCLUSIVAMENTE com base nos dados financeiros (snapshot do próprio usuário) "
+        "fornecidos abaixo.\n\n"
+        "Regras invioláveis:\n"
+        "- Responda apenas perguntas sobre finanças pessoais e sobre os dados "
+        "do usuário.\n"
+        "- Se a pergunta não for sobre finanças, recuse com gentileza e explique "
+        "que você só ajuda com as finanças do usuário no Auraxis.\n"
+        "- Use SOMENTE números presentes no snapshot. Nunca invente valores, "
+        "transações, categorias ou datas.\n"
+        "- Se o dado necessário não estiver no snapshot (ex.: um período fora da "
+        "janela atual), diga claramente que não tem essa informação disponível "
+        "e sugira onde o usuário pode encontrá-la no app.\n"
+        "- Responda em português do Brasil, de forma direta e objetiva, em no "
+        "máximo 180 palavras.\n\n"
+        f"Snapshot financeiro (JSON):\n{context}\n\n"
+        f"Pergunta do usuário: {question}\n\n"
+        "Resposta:"
+    )
 
 
 def _build_financial_insight_prompt(

--- a/graphql.introspection.json
+++ b/graphql.introspection.json
@@ -14181,6 +14181,35 @@
               }
             },
             {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "question",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "GraphQL parity for POST /ai/chat (Ask anything).\n\nSnapshot-grounded finance chat. Entitlement, LGPD consent, per-user cost\nbudget and audit are enforced inside AIAdvisoryService.",
+              "isDeprecated": false,
+              "name": "askFinancialQuestion",
+              "type": {
+                "kind": "OBJECT",
+                "name": "AskFinancialQuestionPayload",
+                "ofType": null
+              }
+            },
+            {
               "args": [],
               "deprecationReason": null,
               "description": "Mark the authenticated user's onboarding as completed (idempotent).\n\nREST parity: ``POST /user/onboarding/complete``.",
@@ -17993,6 +18022,82 @@
           "interfaces": [],
           "kind": "OBJECT",
           "name": "AIInsightFeedbackPayload",
+          "possibleTypes": null,
+          "specifiedByURL": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "ok",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "answer",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "model",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "tokensUsed",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "costUsd",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "AskFinancialQuestionPayload",
           "possibleTypes": null,
           "specifiedByURL": null
         },

--- a/graphql.operations.manifest.json
+++ b/graphql.operations.manifest.json
@@ -761,6 +761,14 @@
   {
     "access": "auth_required",
     "domain": "ai_advisory",
+    "name": "askFinancialQuestion",
+    "operation_type": "mutation",
+    "source_module": "app.graphql.mutations.ai_insight",
+    "summary": "Responde uma pergunta em linguagem natural sobre as finanças do próprio usuário, ancorada exclusivamente no snapshot financeiro. Paridade com POST /ai/chat."
+  },
+  {
+    "access": "auth_required",
+    "domain": "ai_advisory",
     "name": "submitAiInsightFeedback",
     "operation_type": "mutation",
     "source_module": "app.graphql.mutations.ai_insight",

--- a/openapi.json
+++ b/openapi.json
@@ -1,6 +1,22 @@
 {
   "components": {
     "schemas": {
+      "AIChatRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "question": {
+            "description": "Pergunta do usuário sobre as próprias finanças.",
+            "example": "Quanto gastei com alimentação até agora?",
+            "maxLength": 1000,
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "required": [
+          "question"
+        ],
+        "type": "object"
+      },
       "InstallmentVsCashCalculation": {
         "additionalProperties": false,
         "properties": {
@@ -1207,6 +1223,248 @@
   },
   "openapi": "3.0.2",
   "paths": {
+    "/ai/chat": {
+      "post": {
+        "description": "Responde perguntas do usuário usando exclusivamente o snapshot financeiro do próprio usuário. Recusa perguntas fora de finanças e informa quando o dado não está disponível no período atual.",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "description": "Pergunta em linguagem natural sobre as finanças do usuário.",
+              "example": {
+                "question": "Quanto gastei com alimentação até agora?"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/AIChatRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "answer": "Até agora você gastou R$320,00 com alimentação.",
+                    "cost_usd": 5.7e-05,
+                    "model": "gpt-4o-mini",
+                    "tokens_used": 380
+                  },
+                  "message": "Resposta gerada com sucesso"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Resposta gerada com sucesso",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "VALIDATION_ERROR",
+                  "message": "Pergunta inválida.",
+                  "status_code": 400
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Pergunta inválida",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "ENTITLEMENT_REQUIRED",
+                  "message": "Recurso exclusivo para assinantes Premium.",
+                  "status_code": 403
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Entitlement insuficiente",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "AI_INSIGHT_BUDGET_EXCEEDED",
+                  "message": "Orçamento de IA atingido.",
+                  "status_code": 429
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Limite diário ou orçamento de IA atingido",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Erro ao processar a pergunta",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno ou falha do provider LLM",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "9fcd2e4f4d8747b4a7d8a2b1b930f52a",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Perguntar sobre as próprias finanças com IA (Premium)",
+        "tags": [
+          "AI Advisory"
+        ]
+      }
+    },
     "/ai/goals/{goal_id}/projection": {
       "post": {
         "description": "Gera uma narrativa motivacional e prática para uma meta financeira específica, combinando projeção matemática com contexto do usuário. Requer entitlement 'advanced_simulations' (plano Premium).",

--- a/schema.graphql
+++ b/schema.graphql
@@ -973,6 +973,14 @@ type Mutation {
   submitAiInsightFeedback(comment: String, depth: Int!, insightId: String!, relevance: Int!, truthfulness: Int!, usefulness: Int!): AIInsightFeedbackPayload
 
   """
+  GraphQL parity for POST /ai/chat (Ask anything).
+  
+  Snapshot-grounded finance chat. Entitlement, LGPD consent, per-user cost
+  budget and audit are enforced inside AIAdvisoryService.
+  """
+  askFinancialQuestion(question: String!): AskFinancialQuestionPayload
+
+  """
   Mark the authenticated user's onboarding as completed (idempotent).
   
   REST parity: ``POST /user/onboarding/complete``.
@@ -1452,6 +1460,14 @@ type AIInsightFeedbackPayload {
   depth: Int
   usefulness: Int
   comment: String
+}
+
+type AskFinancialQuestionPayload {
+  ok: Boolean!
+  answer: String
+  model: String
+  tokensUsed: Int
+  costUsd: Float
 }
 
 """Canonical payload for completeOnboarding mutation."""

--- a/scripts/openapi_to_postman.py
+++ b/scripts/openapi_to_postman.py
@@ -947,6 +947,17 @@ ENRICHMENT: dict[str, dict[str, Any]] = {
             "});",
         ],
     },
+    "POST /ai/chat": {
+        "body_override": json.dumps(
+            {"question": "Quanto gastei até agora?"},
+            indent=2,
+        ),
+        "test_lines": [
+            "pm.test('AI chat — expected 200, 400, 403 or 429', function () {",
+            "  pm.expect(pm.response.code).to.be.oneOf([200, 400, 403, 429]);",
+            "});",
+        ],
+    },
     "POST /ai/goals/{goal_id}/projection": {
         "test_lines": [
             "pm.test('AI goal projection — expected 200 or 400 or 403 or 404', function () {",

--- a/tests/test_ai_chat.py
+++ b/tests/test_ai_chat.py
@@ -8,9 +8,39 @@ Covers:
 from __future__ import annotations
 
 import uuid
+from decimal import Decimal
 from unittest.mock import patch
 
-from app.services.llm_provider import StubLLMProvider
+from app.services.llm_provider import LLMProviderError, StubLLMProvider
+
+_SERVICE_TARGET = (
+    "app.services.ai_advisory_service.AIAdvisoryService.answer_financial_question"
+)
+
+
+def _gql(client, query: str, token: str, variables: dict | None = None):
+    return client.post(
+        "/graphql",
+        json={"query": query, "variables": variables or {}},
+        headers={
+            "Content-Type": "application/json",
+            "X-API-Contract": "v2",
+            "Authorization": f"Bearer {token}",
+        },
+    )
+
+
+_ASK_MUTATION = """
+mutation Ask($question: String!) {
+  askFinancialQuestion(question: $question) {
+    ok
+    answer
+    model
+    tokensUsed
+    costUsd
+  }
+}
+"""
 
 
 def _register_and_login(client, prefix: str) -> str:
@@ -129,3 +159,105 @@ class TestAIChatEndpoint:
         data = body.get("data") or body
         assert "Você gastou" in data["answer"]
         mocked.assert_called_once()
+
+    def test_budget_exceeded_returns_429(self, app, client) -> None:
+        from app.services.ai_advisory_service import AIInsightCostBudgetExceededError
+
+        token = _register_and_login(client, prefix="ai-chat-budget")
+        _grant_premium(app, _current_user_id(app, token))
+        with patch(
+            _SERVICE_TARGET,
+            side_effect=AIInsightCostBudgetExceededError(
+                "Orçamento mensal atingido.",
+                scope="user_monthly",
+                limit_usd=Decimal("2.72"),
+                spent_usd=Decimal("3.00"),
+            ),
+        ):
+            resp = client.post(
+                "/ai/chat", json={"question": "E aí?"}, headers=_auth(token)
+            )
+        assert resp.status_code == 429
+
+    def test_consent_required_returns_403(self, app, client) -> None:
+        from app.services.ai_lgpd import AIConsentRequiredError
+
+        token = _register_and_login(client, prefix="ai-chat-consent")
+        _grant_premium(app, _current_user_id(app, token))
+        with patch(_SERVICE_TARGET, side_effect=AIConsentRequiredError()):
+            resp = client.post(
+                "/ai/chat", json={"question": "E aí?"}, headers=_auth(token)
+            )
+        assert resp.status_code == 403
+
+    def test_llm_error_returns_500(self, app, client) -> None:
+        token = _register_and_login(client, prefix="ai-chat-llm")
+        _grant_premium(app, _current_user_id(app, token))
+        with patch(_SERVICE_TARGET, side_effect=LLMProviderError("boom")):
+            resp = client.post(
+                "/ai/chat", json={"question": "E aí?"}, headers=_auth(token)
+            )
+        assert resp.status_code == 500
+
+    def test_unexpected_error_returns_500(self, app, client) -> None:
+        token = _register_and_login(client, prefix="ai-chat-boom")
+        _grant_premium(app, _current_user_id(app, token))
+        with patch(_SERVICE_TARGET, side_effect=RuntimeError("unexpected")):
+            resp = client.post(
+                "/ai/chat", json={"question": "E aí?"}, headers=_auth(token)
+            )
+        assert resp.status_code == 500
+
+
+class TestAskFinancialQuestionGraphQL:
+    def test_happy_path(self, app, client) -> None:
+        token = _register_and_login(client, prefix="gql-chat-ok")
+        _grant_premium(app, _current_user_id(app, token))
+        with patch(
+            _SERVICE_TARGET,
+            return_value={
+                "answer": "Saldo positivo.",
+                "model": "stub",
+                "tokens_used": 10,
+                "cost_usd": 0.0,
+            },
+        ):
+            resp = _gql(client, _ASK_MUTATION, token, {"question": "Como estou?"})
+        body = resp.get_json()
+        assert not body.get("errors")
+        payload = body["data"]["askFinancialQuestion"]
+        assert payload["ok"] is True
+        assert payload["answer"] == "Saldo positivo."
+
+    def test_rejects_empty_question(self, app, client) -> None:
+        token = _register_and_login(client, prefix="gql-chat-empty")
+        resp = _gql(client, _ASK_MUTATION, token, {"question": "   "})
+        body = resp.get_json()
+        assert body.get("errors")
+
+    def test_maps_llm_provider_error(self, app, client) -> None:
+        token = _register_and_login(client, prefix="gql-chat-llm")
+        _grant_premium(app, _current_user_id(app, token))
+        with patch(_SERVICE_TARGET, side_effect=LLMProviderError("boom")):
+            resp = _gql(client, _ASK_MUTATION, token, {"question": "Como estou?"})
+        body = resp.get_json()
+        assert body.get("errors")
+
+
+class TestAnswerFinancialQuestionProviderError:
+    def test_propagates_llm_provider_error(self, app) -> None:
+        with app.app_context():
+            from app.services.ai_advisory_service import AIAdvisoryService
+
+            class _RaisingProvider:
+                def generate_with_usage(self, prompt, **_kwargs):
+                    raise LLMProviderError("boom")
+
+            service = AIAdvisoryService(
+                user_id=uuid.uuid4(), llm_provider=_RaisingProvider()
+            )
+            try:
+                service.answer_financial_question("Quanto tenho?")
+            except LLMProviderError:
+                return
+            raise AssertionError("expected LLMProviderError to propagate")

--- a/tests/test_ai_chat.py
+++ b/tests/test_ai_chat.py
@@ -1,0 +1,131 @@
+"""Tests for the Ask-anything finance chat (#1521).
+
+Covers:
+- AIAdvisoryService.answer_financial_question (snapshot-grounded answer + audit)
+- POST /ai/chat REST endpoint (entitlement gate, validation, happy path)
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import patch
+
+from app.services.llm_provider import StubLLMProvider
+
+
+def _register_and_login(client, prefix: str) -> str:
+    email = f"{prefix}-{uuid.uuid4().hex[:8]}@test.com"
+    password = "StrongPass@123"
+    client.post(
+        "/auth/register",
+        json={"name": prefix, "email": email, "password": password},
+    )
+    login = client.post("/auth/login", json={"email": email, "password": password})
+    assert login.status_code == 200
+    return login.get_json()["token"]
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _current_user_id(app, token: str) -> uuid.UUID:
+    with app.app_context():
+        from flask_jwt_extended import decode_token
+
+        return uuid.UUID(decode_token(token)["sub"])
+
+
+def _grant_premium(app, user_id: uuid.UUID) -> None:
+    with app.app_context():
+        from app.extensions.database import db
+        from app.models.entitlement import Entitlement, EntitlementSource
+
+        db.session.add(
+            Entitlement(
+                user_id=user_id,
+                feature_key="advanced_simulations",
+                source=EntitlementSource.MANUAL,
+                expires_at=None,
+            )
+        )
+        db.session.commit()
+
+
+class TestAnswerFinancialQuestionService:
+    def test_returns_answer_and_writes_audit(self, app) -> None:
+        with app.app_context():
+            from app.models.llm_audit_log import LLMAuditLog
+            from app.services.ai_advisory_service import AIAdvisoryService
+
+            user_id = uuid.uuid4()
+            service = AIAdvisoryService(user_id=user_id, llm_provider=StubLLMProvider())
+
+            result = service.answer_financial_question("Quanto gastei hoje?")
+
+            assert result["answer"]
+            assert result["model"] == "stub"
+            assert result["tokens_used"] > 0
+            log_row = LLMAuditLog.query.filter_by(
+                user_id=user_id, endpoint="chat_ask_anything"
+            ).first()
+            assert log_row is not None
+
+    def test_empty_question_raises_value_error(self, app) -> None:
+        with app.app_context():
+            from app.services.ai_advisory_service import AIAdvisoryService
+
+            service = AIAdvisoryService(
+                user_id=uuid.uuid4(), llm_provider=StubLLMProvider()
+            )
+            try:
+                service.answer_financial_question("   ")
+            except ValueError:
+                return
+            raise AssertionError("expected ValueError for empty question")
+
+
+class TestAIChatEndpoint:
+    def test_requires_premium(self, app, client) -> None:
+        token = _register_and_login(client, prefix="ai-chat-free")
+        user_id = _current_user_id(app, token)
+        # New users get a trial entitlement; revoke it to exercise the gate.
+        with app.app_context():
+            from app.services.entitlement_service import deactivate_premium
+
+            deactivate_premium(user_id)
+        resp = client.post(
+            "/ai/chat", json={"question": "Quanto gastei?"}, headers=_auth(token)
+        )
+        assert resp.status_code == 403
+
+    def test_rejects_missing_question(self, app, client) -> None:
+        token = _register_and_login(client, prefix="ai-chat-bad")
+        _grant_premium(app, _current_user_id(app, token))
+        resp = client.post("/ai/chat", json={}, headers=_auth(token))
+        assert resp.status_code == 400
+
+    def test_happy_path_returns_answer(self, app, client) -> None:
+        token = _register_and_login(client, prefix="ai-chat-ok")
+        _grant_premium(app, _current_user_id(app, token))
+
+        with patch(
+            "app.services.ai_advisory_service.AIAdvisoryService.answer_financial_question",
+            return_value={
+                "answer": "Você gastou R$120,00 hoje.",
+                "model": "stub",
+                "tokens_used": 42,
+                "cost_usd": 0.0,
+            },
+        ) as mocked:
+            resp = client.post(
+                "/ai/chat",
+                json={"question": "Quanto gastei hoje?"},
+                headers=_auth(token),
+            )
+
+        assert resp.status_code == 200
+        body = resp.get_json()
+        data = body.get("data") or body
+        assert "Você gastou" in data["answer"]
+        mocked.assert_called_once()


### PR DESCRIPTION
## O que muda

Feature 1 (Ask Anything): endpoint de chat de IA que responde perguntas do usuário sobre as
próprias finanças, **ancorado exclusivamente no snapshot financeiro** (Opção A). Reusa toda a
infra de IA existente — zero infra nova.

- `AIAdvisoryService.answer_financial_question(question)`: monta o snapshot diário
  (FinancialInsightContextBuilder) + minimização LGPD + truncamento (12 KiB), enforça budget
  mensal por usuário, chama o LLM e audita em `llm_audit_logs` (endpoint `chat_ask_anything`).
- Prompt com **guardrails**: responde só sobre finanças + dados do próprio usuário; usa apenas
  números do snapshot; recusa off-topic; diz "não tenho esse dado" para o que está fora do
  snapshot; máx. 180 palavras; pt-BR.
- `POST /ai/chat` (REST) + `askFinancialQuestion` (GraphQL) — paridade. Gate Premium
  (`advanced_simulations`), LGPD consent, rate-limit por usuário/dia (cap chat, default 20,
  contador de IA compartilhado), budget mensal por usuário (compartilhado com insights).
- Snapshots OpenAPI + GraphQL + manifesto + collection Postman regenerados.

## Contexto

Closes #1521
Próxima na sequência do roadmap (F3/F4 já entregues). Frontend (barra de chat web) virá em seguida.

## Controle de custo (orçamento ~US$40/mês)

- Modelo barato (gpt-4o-mini / advisory model), input limitado ao snapshot (~12 KiB).
- Cap por usuário/dia (`AI_CHAT_DAILY_LIMIT`, default 20) + budget mensal por usuário
  (~US$2,72, compartilhado com insights) → cost-recoverable e atrás de gate Premium.

## Como testar

- [ ] `POST /ai/chat {question}` como Premium → responde a partir do snapshot.
- [ ] Sem Premium → 403; sem `question` → 400; off-topic → recusa; dado fora do snapshot →
      "não tenho essa informação".
- [ ] `askFinancialQuestion(question)` no GraphQL → mesmo resultado.

## Quality gates (local)

- [x] ruff/mypy/bandit: PASS
- [x] `run_ci_quality_local.sh --local`: 2109+ testes PASS (incl. novos do chat), postman/graphql
      contract OK após regen de snapshots
- [x] REST+GraphQL parity; OpenAPI/GraphQL/Postman atualizados

## Impacto de contrato

Aditivo — novo endpoint `POST /ai/chat` + mutation `askFinancialQuestion`. Snapshots atualizados.

## Risco

MEDIUM — endpoint que chama LLM (custo variável), mitigado por gate Premium + cap diário + budget
mensal por usuário + auditoria. Guardrails de escopo no prompt reduzem alucinação/off-topic.