### PR TITLE
fix(transactions): allow auto_settle in PATCH (was silently dropped)

### DIFF
--- a/app/controllers/transaction/utils.py
+++ b/app/controllers/transaction/utils.py
@@ -30,6 +30,12 @@ from app.utils.response_builder import json_response
 
 INVALID_TOKEN_MESSAGE = "Token inválido."
 DEFAULT_DEPRECATION_SUNSET = "Tue, 30 Jun 2026 23:59:59 GMT"
+# PATCH updates are filtered through this set (see _apply_transaction_updates),
+# so a field missing here is silently dropped even when the schema accepts it.
+# Keep it in sync with app.application.services.transaction.query_helpers
+# ._MUTABLE_TRANSACTION_FIELDS. NOTE: `category` is intentionally still absent —
+# it is an enum needing coercion (like type/status) that this setattr path does
+# not yet do; adding it safely is a separate follow-up.
 MUTABLE_TRANSACTION_FIELDS = frozenset(
     {
         "title",
@@ -49,6 +55,7 @@ MUTABLE_TRANSACTION_FIELDS = frozenset(
         "account_id",
         "credit_card_id",
         "impact_policy",
+        "auto_settle",
         "paid_at",
     }
 )

--- a/tests/test_transaction_controller_utils.py
+++ b/tests/test_transaction_controller_utils.py
@@ -26,6 +26,7 @@ def _build_transaction() -> Transaction:
         currency="BRL",
         is_recurring=False,
         is_installment=False,
+        auto_settle=False,
         created_at=now,
         updated_at=now,
     )
@@ -211,6 +212,7 @@ def test_enforce_reference_ownership_and_updates(monkeypatch) -> None:
             "status": "paid",
             "type": "income",
             "currency": "USD",
+            "auto_settle": True,
             "unknown_field": "ignored",
         },
     )
@@ -218,6 +220,8 @@ def test_enforce_reference_ownership_and_updates(monkeypatch) -> None:
     assert transaction.status == TransactionStatus.PAID
     assert transaction.type == TransactionType.INCOME
     assert transaction.currency == "USD"
+    # Regression: auto_settle must be PATCH-mutable (was silently dropped).
+    assert transaction.auto_settle is True
     assert not hasattr(transaction, "unknown_field")
 
 


### PR DESCRIPTION
## Problem
`PATCH /transactions/{id}` silently ignored `auto_settle`. `_apply_transaction_updates` (`controllers/transaction/utils.py`) filters updates through `MUTABLE_TRANSACTION_FIELDS`, which had drifted from the service's `query_helpers._MUTABLE_TRANSACTION_FIELDS` and omitted `auto_settle` — so the schema accepted it but the update dropped it.

Found while diagnosing the `auto_settle: Unknown field` production incident (that one was a deploy lag; this is the adjacent PATCH bug).

## Fix
- Add `auto_settle` to the controller's mutable set (it's a `Bool`; the plain `setattr` path handles it).
- Regression test: PATCH `auto_settle` False→True now persists.
- Comment documenting the sync requirement and that `category` is still absent on purpose (it's an enum needing coercion like type/status — separate follow-up).

## Validation
ruff + mypy + all pre-commit gates green; `test_transaction_controller_utils.py` 6 passed.

## Refs
Closes #1524