### PR TITLE
fix(auth): warn at boot when CSRF enforced but JWT_COOKIE_DOMAIN unset

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 
@@ -61,6 +62,35 @@ def validate_security_configuration() -> None:
             "Weak/invalid secrets for production runtime: "
             + ", ".join(weak)
             + ". Configure strong values in environment variables."
+        )
+
+    _warn_if_csrf_cookie_domain_missing()
+
+
+def _warn_if_csrf_cookie_domain_missing() -> None:
+    """Surface the CSRF-cookie/domain coupling that silently breaks reload/F5.
+
+    When ``AURAXIS_CSRF_ENFORCE=true`` the backend sets a non-httpOnly
+    ``auraxis_csrf_refresh`` cookie that the SPA must read from JavaScript and
+    echo back as ``X-CSRF-TOKEN`` on ``POST /auth/refresh`` (double-submit). If
+    ``JWT_COOKIE_DOMAIN`` is unset the cookie is host-only on the API host
+    (e.g. ``api.auraxis.com.br``) and is invisible to JS running on a different
+    subdomain (e.g. ``app.auraxis.com.br``) — so the header is never sent, the
+    refresh 401s, and every reload logs the user out.
+
+    This is a boot-time **warning**, not a hard failure: refusing to boot would
+    turn a UX regression into a full outage on the next env drift/recreate. The
+    warning makes the drift loud in ``docker logs`` instead of silent.
+    """
+    csrf_enforced = _read_bool_env("AURAXIS_CSRF_ENFORCE", False)
+    cookie_domain = os.getenv("JWT_COOKIE_DOMAIN")
+    if csrf_enforced and not (cookie_domain and cookie_domain.strip()):
+        logging.getLogger(__name__).warning(
+            "AURAXIS_CSRF_ENFORCE=true but JWT_COOKIE_DOMAIN is unset: the CSRF "
+            "refresh cookie will be host-only and unreadable by JavaScript on a "
+            "different subdomain (e.g. app.auraxis.com.br), so POST /auth/refresh "
+            "will 401 and users get logged out on reload/F5. Set "
+            "JWT_COOKIE_DOMAIN=.<base-domain> (e.g. .auraxis.com.br)."
         )
 
 

--- a/tests/test_runtime_config.py
+++ b/tests/test_runtime_config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import logging
 
 import config as config_module
 
@@ -93,3 +94,48 @@ def test_validate_security_configuration_can_be_disabled_in_debug_runtime(
     module = _reload_config_module()
 
     module.validate_security_configuration()
+
+
+def _secure_runtime_with_strong_secrets(monkeypatch) -> None:
+    monkeypatch.setenv("SECURITY_ENFORCE_STRONG_SECRETS", "true")
+    monkeypatch.setenv("AURAXIS_ENV", "production")
+    monkeypatch.setenv("FLASK_DEBUG", "false")
+    monkeypatch.setenv("FLASK_TESTING", "false")
+    monkeypatch.setenv("SECRET_KEY", "s" * 40)
+    monkeypatch.setenv("JWT_SECRET_KEY", "j" * 40)
+
+
+def test_warns_when_csrf_enforced_without_cookie_domain(monkeypatch, caplog) -> None:
+    _secure_runtime_with_strong_secrets(monkeypatch)
+    monkeypatch.setenv("AURAXIS_CSRF_ENFORCE", "true")
+    monkeypatch.delenv("JWT_COOKIE_DOMAIN", raising=False)
+    module = _reload_config_module()
+
+    with caplog.at_level(logging.WARNING):
+        module.validate_security_configuration()
+
+    assert any("JWT_COOKIE_DOMAIN" in record.message for record in caplog.records)
+
+
+def test_no_cookie_domain_warning_when_domain_is_set(monkeypatch, caplog) -> None:
+    _secure_runtime_with_strong_secrets(monkeypatch)
+    monkeypatch.setenv("AURAXIS_CSRF_ENFORCE", "true")
+    monkeypatch.setenv("JWT_COOKIE_DOMAIN", ".auraxis.com.br")
+    module = _reload_config_module()
+
+    with caplog.at_level(logging.WARNING):
+        module.validate_security_configuration()
+
+    assert not any("JWT_COOKIE_DOMAIN" in record.message for record in caplog.records)
+
+
+def test_no_cookie_domain_warning_when_csrf_disabled(monkeypatch, caplog) -> None:
+    _secure_runtime_with_strong_secrets(monkeypatch)
+    monkeypatch.setenv("AURAXIS_CSRF_ENFORCE", "false")
+    monkeypatch.delenv("JWT_COOKIE_DOMAIN", raising=False)
+    module = _reload_config_module()
+
+    with caplog.at_level(logging.WARNING):
+        module.validate_security_configuration()
+
+    assert not any("JWT_COOKIE_DOMAIN" in record.message for record in caplog.records)


### PR DESCRIPTION
## Contexto
Hardening durável para o bug de **logout no F5** em produção (diagnosticado e corrigido no env de prod em 2026-07-03).

## Causa raiz (recap)
Com `AURAXIS_CSRF_ENFORCE=true` mas `JWT_COOKIE_DOMAIN` ausente, o cookie CSRF `auraxis_csrf_refresh` fica **host-only** em `api.auraxis.com.br`. O JS em `app.auraxis.com.br` não o enxerga (`document.cookie` só vê o próprio host) → não envia `X-CSRF-TOKEN` no `POST /auth/refresh` → **401 → logout em todo F5**. Era um **drift de env silencioso** (o `.env.prod` perdeu a chave numa reconstrução).

## O que muda
Adiciona `_warn_if_csrf_cookie_domain_missing()` em `validate_security_configuration()`: emite um **warning de boot** (via `logging`) quando CSRF está enforced e `JWT_COOKIE_DOMAIN` está ausente, em runtime seguro. Assim o drift **grita nos `docker logs`** em vez de quebrar o F5 sem deixar rastro.

## Por que warning e não fail-fast
Recusar o boot (como a checagem de secrets faz) transformaria uma regressão de UX numa **queda total da API** no próximo recreate com env driftado — risco real (aconteceu hoje durante o fix). O warning surfaça o problema sem downtime.

## Testes
- 3 novos casos em `tests/test_runtime_config.py`: warning quando enforced+sem-domínio; sem warning quando domínio setado; sem warning quando CSRF off.
- Gate canônico local (`run_ci_quality_local.sh --local`) **verde**: ruff + mypy (471 files) + bandit + 2667 testes, cobertura 91.38%.

Closes #1528