### PR TITLE
feat(deploy): validação hard de env auth-crítico + wrapper deploy-prod seguro

### DIFF
--- a/docs/env_manifest_prod.md
+++ b/docs/env_manifest_prod.md
@@ -1,0 +1,37 @@
+# Manifesto de env de produção
+
+Fonte canônica das variáveis de ambiente de **produção**. O `.env.prod` real (no host,
+`/opt/auraxis/.env.prod`) **não** é versionado — este manifesto + `.env.prod.example`
+são a fonte da verdade. O deploy (`scripts/aws_deploy_i6.py`) valida as chaves
+**obrigatórias** e **avisa** sobre as recomendadas ausentes.
+
+> Motivação: em 2026-07-03 o drift de `JWT_COOKIE_DOMAIN` (ausente no `.env.prod`)
+> quebrou o F5 silenciosamente — o deploy passava "healthy" com auth quebrada.
+> Ver `docs/wiki/INF-incident-env-drift.md` (platform).
+
+## Obrigatórias (deploy **bloqueia** se ausentes)
+
+| Chave | Por quê |
+|-------|---------|
+| `SECRET_KEY`, `JWT_SECRET_KEY` | Assinatura de sessão/JWT (força validada ≥32 chars). |
+| `DOMAIN`, `CERTBOT_EMAIL` (prod) | TLS/nginx. |
+| `POSTGRES_DB/USER/PASSWORD`, `DB_HOST/PORT/NAME/USER/PASS` | Banco. |
+| `RATE_LIMIT_*`, `LOGIN_GUARD_*` | Rate limit / brute-force guard (fail-closed). |
+| **`JWT_COOKIE_DOMAIN`** | **Cookie CSRF cross-subdomínio.** Ausente → F5 desloga (incidente 2026-07-03). |
+| **`CORS_ALLOWED_ORIGINS`** | CORS com credentials; ausente/errado bloqueia o refresh. |
+| **`AURAXIS_CSRF_ENFORCE`** | Liga o double-submit CSRF; acopla com `JWT_COOKIE_DOMAIN`. |
+
+## Recomendadas (deploy **avisa**, não bloqueia)
+
+| Chave | Impacto se ausente |
+|-------|--------------------|
+| `SENTRY_DSN` | Sem observabilidade de erros. |
+| `EMAIL_PROVIDER`, `EMAIL_FROM` | Emails (confirmação, recap) silenciosamente não saem. |
+| `BILLING_PROVIDER`, `BILLING_ASAAS_*` | Checkout/assinatura quebra. |
+| `JWT_COOKIE_SAMESITE` | Default `Lax` no config; explicitar em prod é preferível. |
+
+## Regras
+- Ao adicionar env crítica nova: registrar aqui + em `.env.prod.example` + na validação
+  de `aws_deploy_i6.py` (obrigatória) ou no loop de warn (recomendada).
+- Recreate/deploy sempre via `scripts/deploy-prod.sh` ou o fluxo `aws_deploy_i6.py`
+  (skill `auraxis:prod-deploy`). Nunca `docker compose` pelado (ver `INF-incident-image-stale.md`).

--- a/scripts/aws_deploy_i6.py
+++ b/scripts/aws_deploy_i6.py
@@ -552,6 +552,17 @@ done
 
 if [ "{env_name}" = "prod" ]; then
   require_env_key CERTBOT_EMAIL
+  # Auth-crítico em prod. O drift de JWT_COOKIE_DOMAIN (ausente no .env.prod)
+  # quebrou o F5 silenciosamente em 2026-07-03 — sem esta validação o deploy
+  # passava "healthy" com auth quebrada. Ver docs/wiki/INF-incident-env-drift.md.
+  require_env_key JWT_COOKIE_DOMAIN
+  require_env_key CORS_ALLOWED_ORIGINS
+  require_env_key AURAXIS_CSRF_ENFORCE
+  # Recomendadas: avisa (não bloqueia) para não travar o deploy, mas torna o
+  # drift visível. Ver docs/env_manifest_prod.md.
+  for rkey in SENTRY_DSN EMAIL_PROVIDER EMAIL_FROM BILLING_PROVIDER JWT_COOKIE_SAMESITE; do
+    grep -qE "^${{rkey}}=" "$ENV_FILE" || echo "[i6] WARN: env recomendada ausente em prod: $rkey"
+  done
 fi
 
 echo "[i6] mode=$MODE git_ref=$GIT_REF image=$WEB_IMAGE"

--- a/scripts/deploy-prod.sh
+++ b/scripts/deploy-prod.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Recreate seguro do serviço `web` de PRODUÇÃO — único caminho sancionado para
+# recreate manual (fora do fluxo aws_deploy_i6.py). Evita os footguns de
+# 2026-07-03: (a) `docker compose` sem `-f docker-compose.prod.yml` pega o `.env`
+# errado (secrets vazios → 502); (b) `:latest` obsoleto → rollback silencioso de
+# ~1 mês de código. Ver skill auraxis:prod-deploy e docs/wiki/INF-incident-image-stale.md.
+set -euo pipefail
+
+COMPOSE_DIR="${AURAXIS_COMPOSE_DIR:-/opt/auraxis}"
+COMPOSE_FILE="docker-compose.prod.yml"
+ENV_FILE=".env.prod"
+COMPOSE_ENV=".env"   # arquivo de interpolação de variáveis do compose
+IMAGE_REPO="ghcr.io/italofelipe/auraxis-api"
+HEALTH_URL="${AURAXIS_HEALTH_URL:-https://api.auraxis.com.br/healthz}"
+
+usage() {
+  echo "Uso: $0 <image-sha-ou-tag>" >&2
+  echo "  Ex.: $0 aff08ab1b6e41f716c40cbab88bc9ccf02ad4df5" >&2
+  echo "  Descubra o SHA da ultima imagem deployada:" >&2
+  echo "    docker images ${IMAGE_REPO} --format '{{.Tag}} {{.CreatedAt}}' | head" >&2
+  exit 2
+}
+
+[ "$#" -eq 1 ] || usage
+SHA="$1"
+IMAGE="${IMAGE_REPO}:${SHA}"
+
+cd "$COMPOSE_DIR"
+[ -f "$COMPOSE_FILE" ] || { echo "FATAL: $COMPOSE_DIR/$COMPOSE_FILE nao encontrado" >&2; exit 3; }
+[ -f "$ENV_FILE" ] || { echo "FATAL: $COMPOSE_DIR/$ENV_FILE nao encontrado" >&2; exit 3; }
+
+# 1. Garantir a imagem localmente.
+if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+  echo "[deploy-prod] imagem nao local; pull: $IMAGE"
+  docker pull "$IMAGE"
+fi
+
+# 2. Persistir WEB_IMAGE no .env de interpolacao do compose. Assim QUALQUER
+#    invocacao futura (mesmo `docker compose` bare) usa o SHA correto — mata o
+#    rollback silencioso por :latest.
+touch "$COMPOSE_ENV"
+if grep -qE '^WEB_IMAGE=' "$COMPOSE_ENV"; then
+  sed -i "s#^WEB_IMAGE=.*#WEB_IMAGE=${IMAGE}#" "$COMPOSE_ENV"
+else
+  printf '\nWEB_IMAGE=%s\n' "$IMAGE" >> "$COMPOSE_ENV"
+fi
+echo "[deploy-prod] WEB_IMAGE persistido: $IMAGE"
+
+# 3. Recriar SO o web, com o compose de PROD (env_file .env.prod) e a imagem certa.
+WEB_IMAGE="$IMAGE" docker compose -f "$COMPOSE_FILE" up -d --force-recreate --no-deps web
+
+# 4. Realinhar :latest local ao SHA (defesa extra contra rollback).
+docker tag "$IMAGE" "${IMAGE_REPO}:latest"
+
+# 5. Verificacao pos-deploy.
+sleep 8
+RUNNING="$(docker inspect auraxis-web-1 --format '{{.Config.Image}}' 2>/dev/null || echo '?')"
+echo "[deploy-prod] imagem rodando: $RUNNING"
+HEALTH="$(curl -sS -o /dev/null -w '%{http_code}' "$HEALTH_URL" --max-time 20 || echo 000)"
+echo "[deploy-prod] healthz=$HEALTH"
+[ "$RUNNING" = "$IMAGE" ] || { echo "FATAL: imagem rodando != esperada ($RUNNING != $IMAGE)" >&2; exit 4; }
+[ "$HEALTH" = "200" ] || { echo "FATAL: healthz != 200 (=$HEALTH)" >&2; exit 5; }
+echo "[deploy-prod] OK — web recriado em $IMAGE, healthz 200."

--- a/tests/test_aws_deploy_i6.py
+++ b/tests/test_aws_deploy_i6.py
@@ -174,6 +174,40 @@ def test_build_script_deploy_runs_flask_db_upgrade_before_healthz_validation() -
     )
 
 
+def test_build_script_requires_auth_critical_env_keys_in_prod() -> None:
+    """Regressão do incidente 2026-07-03: o deploy de prod deve BLOQUEAR quando
+    as chaves auth-críticas de cookie/CSRF/CORS estão ausentes."""
+    script = aws_deploy_i6._build_script(
+        env_name="prod",
+        aws_region="us-east-1",
+        git_ref="origin/master",
+        mode="deploy",
+    )
+    for key in ("JWT_COOKIE_DOMAIN", "CORS_ALLOWED_ORIGINS", "AURAXIS_CSRF_ENFORCE"):
+        assert f"require_env_key {key}" in script, (
+            f"{key} deve ser obrigatória no deploy de prod"
+        )
+    # Recomendadas: apenas avisam (não bloqueiam).
+    assert "WARN: env recomendada ausente em prod" in script
+
+
+def test_build_script_cookie_keys_guarded_by_prod_block() -> None:
+    """As chaves auth-críticas ficam dentro do bloco `if [ ... = "prod" ]` (guard
+    runtime), então dev/localhost sem CSRF/domain não são bloqueados."""
+    script = aws_deploy_i6._build_script(
+        env_name="prod",
+        aws_region="us-east-1",
+        git_ref="origin/master",
+        mode="deploy",
+    )
+    prod_guard_idx = script.find('= "prod" ]; then')
+    domain_req_idx = script.find("require_env_key JWT_COOKIE_DOMAIN")
+    assert prod_guard_idx != -1
+    assert domain_req_idx > prod_guard_idx, (
+        "require_env_key JWT_COOKIE_DOMAIN deve estar dentro do bloco prod-only"
+    )
+
+
 def test_build_script_aborts_when_alembic_upgrade_fails() -> None:
     script = aws_deploy_i6._build_script(
         env_name="prod",


### PR DESCRIPTION
## Onda 1 da faxina de robustez — fecha os footguns do incidente 2026-07-03

### W1.1 — Validação hard de env no deploy (Closes #1531)
O deploy de prod (`scripts/aws_deploy_i6.py`) agora **bloqueia** se faltar `JWT_COOKIE_DOMAIN`, `CORS_ALLOWED_ORIGINS` ou `AURAXIS_CSRF_ENFORCE` — o drift de `JWT_COOKIE_DOMAIN` (ausente no `.env.prod`) quebrou o F5 silenciosamente e o deploy passava "healthy". **Avisa** (não bloqueia) em recomendadas ausentes (`SENTRY_DSN`, `EMAIL_*`, `BILLING_*`). Manifesto canônico em `docs/env_manifest_prod.md`. +2 testes de regressão.

### W1.2 — Wrapper de recreate seguro (Closes #1532)
`scripts/deploy-prod.sh` — único caminho sancionado p/ recreate manual: persiste `WEB_IMAGE` no `.env` de interpolação do compose (mata o rollback silencioso por `:latest` **sem** quebrar `ps`/`logs`), usa `-f docker-compose.prod.yml`, retag `:latest`, verifica imagem+healthz.

**Decisão de engenharia:** troquei o `${WEB_IMAGE:?}` sugerido no plano (quebraria toda op de leitura sem `WEB_IMAGE`) pela persistência no `.env` + wrapper — mesma prevenção, sem efeito colateral. O guard soft de `docker compose` pelado ficou no hook da platform (PR #856).

## Verificação
- Gate canônico local `run_ci_quality_local.sh --local` **verde**: 2669 testes, coverage 91.38%.
- `bash -n` + `shellcheck` do wrapper OK; script gerado passa `bash -n`.
- Testes de regressão: prod exige as 3 chaves; guard prod-only.

Closes #1531
Closes #1532