### PR TITLE
feat(health): commit SHA em /healthz para detecção de drift

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,6 +63,8 @@ jobs:
           context: .
           file: Dockerfile.prod
           push: true
+          build-args: |
+            AURAXIS_COMMIT_SHA=${{ github.sha }}
           tags: |
             ${{ steps.image.outputs.tag }}
             ghcr.io/${{ github.repository_owner }}/auraxis-api:latest

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -27,6 +27,12 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PATH="/opt/venv/bin:${PATH}"
 
+# Commit SHA gravado no build (passado via --build-arg pelo deploy.yml) e exposto
+# em GET /healthz para detecção de drift/rollback de imagem sem SSH. Default
+# "unknown" quando não informado, então builds locais/dev não quebram.
+ARG AURAXIS_COMMIT_SHA=unknown
+ENV AURAXIS_COMMIT_SHA=${AURAXIS_COMMIT_SHA}
+
 WORKDIR /app
 
 RUN apt-get update \

--- a/app/controllers/health_controller.py
+++ b/app/controllers/health_controller.py
@@ -105,9 +105,18 @@ def _secure_compare(a: str, b: str) -> bool:
     responses={200: {"description": "Serviço saudável"}},
 )
 def healthz() -> tuple[dict[str, str], int]:
-    """Liveness probe endpoint (public)."""
+    """Liveness probe endpoint (public).
 
-    return {"status": "ok"}, 200
+    Expõe o ``commit`` (SHA gravado no build via AURAXIS_COMMIT_SHA) para
+    detecção externa de drift/rollback de imagem sem SSH — o gate de deploy e o
+    ``verify-prod-state`` comparam com o SHA esperado. "unknown" em builds sem o
+    build-arg (dev/local).
+    """
+
+    return {
+        "status": "ok",
+        "commit": os.getenv("AURAXIS_COMMIT_SHA", "unknown"),
+    }, 200
 
 
 @health_bp.get("/readiness")

--- a/tests/test_health_controller.py
+++ b/tests/test_health_controller.py
@@ -1,4 +1,8 @@
 def test_healthz_is_public(client) -> None:
     resp = client.get("/healthz")
     assert resp.status_code == 200
-    assert resp.get_json() == {"status": "ok"}
+    body = resp.get_json()
+    assert body["status"] == "ok"
+    # `commit` (SHA do build, "unknown" em dev/local) foi adicionado para
+    # detecção de drift de imagem — ver #1533. Não é mais igualdade exata.
+    assert "commit" in body

--- a/tests/test_smoke_health.py
+++ b/tests/test_smoke_health.py
@@ -12,3 +12,15 @@ def test_health_endpoint_not_5xx(client) -> None:
     """GET /healthz must never return a 5xx response."""
     response = client.get("/healthz")
     assert response.status_code < 500
+
+
+def test_health_endpoint_exposes_commit_sha(client, monkeypatch) -> None:
+    """GET /healthz expõe o commit SHA gravado no build (drift detection).
+
+    Sem AURAXIS_COMMIT_SHA no ambiente → 'unknown' (não quebra dev/local).
+    """
+    monkeypatch.delenv("AURAXIS_COMMIT_SHA", raising=False)
+    assert client.get("/healthz").json["commit"] == "unknown"
+
+    monkeypatch.setenv("AURAXIS_COMMIT_SHA", "abc1234")
+    assert client.get("/healthz").json["commit"] == "abc1234"


### PR DESCRIPTION
## Onda 1 (W1.3) — Closes #1533
`GET /healthz` passa a expor o `commit` SHA gravado no build (`AURAXIS_COMMIT_SHA` via `--build-arg` no deploy.yml → Dockerfile.prod), fallback `unknown`. Detecta rollback/drift de imagem sem SSH.

## Nota sobre #1534 (auth-4xx + Redis)
Verifiquei o código:
- **auth-4xx já é observável**: `auraxis_http_requests_total{status_code,endpoint}` já conta 401/403 por rota — o gap é só uma regra de alerta (infra), não código.
- **"bypass de revogação por Redis" não existe**: o cache é read-through com fallback pro DB (`user.current_jti`) e já loga warning. Sem mudança de código necessária.

Métrica de logout em massa no web fica na #1102.

Verificação: testes de health/correlation/prometheus verdes; ruff+mypy OK. CI (auto-merge) roda o gate completo.

Closes #1533