### PR TITLE
test(regression): trava de campos mutáveis + paginação sem truncamento

### DIFF
--- a/tests/regression/__init__.py
+++ b/tests/regression/__init__.py
@@ -1,0 +1,6 @@
+"""Regression suite for already-fixed bugs.
+
+Each module here locks in the fix for a specific production bug so it cannot be
+silently reintroduced. Tests are named after the bug they guard and reference the
+originating fix (commit or issue) in their docstring.
+"""

--- a/tests/regression/test_pagination_no_truncation.py
+++ b/tests/regression/test_pagination_no_truncation.py
@@ -1,0 +1,128 @@
+"""Regression: list/aggregation reads must not truncate to the first page.
+
+Bug history: the credit-cards trend chart and rail (auraxis-web) rendered zeroed
+values because the backend list endpoint returned only the first page (default
+``per_page`` = 10) while the client aggregated over that truncated slice
+(fixes #1082 / #1083, client-side ``listAllTransactions``). The backend contract
+that fix depends on is exercised here:
+
+1. Pagination metadata reports the *full* matching ``total`` (and page count), so a
+   client can iterate every page and reconstruct the complete set.
+2. Month aggregates (``income_total`` / ``expense_total``) are computed over ALL
+   matching rows — never just the current page.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+from app.application.services.transaction_query_service import TransactionQueryService
+from app.extensions.database import db
+from app.models.transaction import Transaction, TransactionStatus, TransactionType
+from app.models.user import User
+
+_PER_PAGE = 10
+_EXPENSE_COUNT = 25
+_EXPENSE_AMOUNT = Decimal("10.00")
+_INCOME_AMOUNT = Decimal("1000.00")
+_TOTAL = _EXPENSE_COUNT + 1  # + one income row
+
+
+def _seed_user_with_month_transactions(month: date) -> UUID:
+    user = User(name="Pag", email=f"pag-{uuid4().hex[:8]}@email.com", password="hash")
+    db.session.add(user)
+    db.session.commit()
+
+    rows = [
+        Transaction(
+            id=uuid4(),
+            user_id=user.id,
+            title=f"Expense {index}",
+            amount=_EXPENSE_AMOUNT,
+            type=TransactionType.EXPENSE,
+            status=TransactionStatus.PENDING,
+            due_date=month.replace(day=1 + (index % 27)),
+            currency="BRL",
+            source="manual",
+        )
+        for index in range(_EXPENSE_COUNT)
+    ]
+    rows.append(
+        Transaction(
+            id=uuid4(),
+            user_id=user.id,
+            title="Salary",
+            amount=_INCOME_AMOUNT,
+            type=TransactionType.INCOME,
+            status=TransactionStatus.PENDING,
+            due_date=month.replace(day=5),
+            currency="BRL",
+            source="manual",
+        )
+    )
+    db.session.add_all(rows)
+    db.session.commit()
+    return user.id
+
+
+def test_month_summary_aggregates_over_all_rows_not_page(app) -> None:
+    with app.app_context():
+        user_id = _seed_user_with_month_transactions(date(2026, 3, 1))
+        service = TransactionQueryService.with_defaults(user_id)
+
+        result = service.get_month_summary(month="2026-03", page=1, per_page=_PER_PAGE)
+
+        # Aggregations must reflect ALL rows, never the truncated first page.
+        assert result["expense_total"] == float(_EXPENSE_AMOUNT) * _EXPENSE_COUNT
+        assert result["income_total"] == float(_INCOME_AMOUNT)
+
+        paginated = result["paginated"]
+        assert paginated["total"] == _TOTAL
+        assert paginated["page_size"] == _PER_PAGE
+        assert len(paginated["data"]) == _PER_PAGE
+        assert paginated["has_next_page"] is True
+
+
+def test_month_summary_last_page_returns_remaining_rows(app) -> None:
+    with app.app_context():
+        user_id = _seed_user_with_month_transactions(date(2026, 3, 1))
+        service = TransactionQueryService.with_defaults(user_id)
+
+        last_page = (_TOTAL + _PER_PAGE - 1) // _PER_PAGE  # 3
+        result = service.get_month_summary(
+            month="2026-03", page=last_page, per_page=_PER_PAGE
+        )
+
+        paginated = result["paginated"]
+        assert paginated["total"] == _TOTAL
+        assert len(paginated["data"]) == _TOTAL - _PER_PAGE * (last_page - 1)  # 6
+        assert paginated["has_next_page"] is False
+
+
+def test_active_transactions_pagination_reports_full_total(app) -> None:
+    with app.app_context():
+        user_id = _seed_user_with_month_transactions(date(2026, 3, 1))
+        service = TransactionQueryService.with_defaults(user_id)
+
+        common = dict(
+            per_page=_PER_PAGE,
+            transaction_type=None,
+            status=None,
+            start_date=None,
+            end_date=None,
+            tag_id=None,
+            account_id=None,
+            credit_card_id=None,
+        )
+        page1 = service.get_active_transactions(page=1, **common)
+        assert int(page1["pagination"]["total"]) == _TOTAL
+        assert len(page1["items"]) == _PER_PAGE
+
+        # Page 2 must return the *next* slice — proving no first-page truncation.
+        page2 = service.get_active_transactions(page=2, **common)
+        page1_titles = {item["title"] for item in page1["items"]}
+        page2_titles = {item["title"] for item in page2["items"]}
+        assert page1_titles.isdisjoint(page2_titles)
+        assert len(page2["items"]) == _PER_PAGE

--- a/tests/regression/test_transaction_mutable_fields_contract.py
+++ b/tests/regression/test_transaction_mutable_fields_contract.py
@@ -1,0 +1,79 @@
+"""Regression: PATCH must not silently drop mutable transaction fields.
+
+Bug history: ``auto_settle`` was added to ``TransactionSchema`` but not to the
+``_MUTABLE_TRANSACTION_FIELDS`` registry consumed by ``_apply_transaction_updates``
+(``app/application/services/transaction/query_helpers.py``). Because the update
+loop skips any field not in that registry, PATCH silently ignored ``auto_settle``
+until fix ``0d8dfbe``. This suite keeps the registry and the schema in agreement so
+any future loadable field that is forgotten fails CI instead of being dropped at
+runtime.
+"""
+
+from __future__ import annotations
+
+from app.application.services.transaction.query_helpers import (
+    _MUTABLE_TRANSACTION_FIELDS,
+)
+from app.models.transaction import Transaction
+from app.schemas.transaction_schema import TransactionSchema
+
+# Fields the API accepts at *creation* but intentionally does NOT allow mutating
+# via PATCH. Recurrence cadence is fixed when the series is created; changing it
+# after occurrences exist would desync the already-generated schedule. Anything
+# listed here is a deliberate, reviewed decision — not a silent drop. New entries
+# require justification in review.
+_KNOWN_CREATE_ONLY_FIELDS = frozenset({"recurrence_interval", "recurrence_unit"})
+
+
+def _loadable_schema_fields() -> set[str]:
+    """Fields the transaction schema accepts on load (i.e. not ``dump_only``)."""
+    return {
+        name
+        for name, field in TransactionSchema().fields.items()
+        if not field.dump_only
+    }
+
+
+def test_mutable_fields_are_real_transaction_columns() -> None:
+    """Every mutable field must map to a real Transaction column (no typos/drift)."""
+    columns = set(Transaction.__table__.columns.keys())
+    unknown = _MUTABLE_TRANSACTION_FIELDS - columns
+    assert not unknown, (
+        "_MUTABLE_TRANSACTION_FIELDS references columns that do not exist on the "
+        f"Transaction model: {sorted(unknown)}"
+    )
+
+
+def test_mutable_fields_are_loadable_in_schema() -> None:
+    """Every mutable field must be loadable via the transaction schema."""
+    not_loadable = _MUTABLE_TRANSACTION_FIELDS - _loadable_schema_fields()
+    assert not not_loadable, (
+        "_MUTABLE_TRANSACTION_FIELDS lists fields the schema cannot load (they would "
+        f"never reach _apply_transaction_updates): {sorted(not_loadable)}"
+    )
+
+
+def test_no_loadable_field_is_silently_dropped_on_patch() -> None:
+    """Guards the original bug directly.
+
+    A schema-loadable field that is missing from ``_MUTABLE_TRANSACTION_FIELDS`` is
+    silently ignored by PATCH. Any new loadable field must be added either to the
+    registry (to make it mutable) or to ``_KNOWN_CREATE_ONLY_FIELDS`` (to document
+    it as create-only) — otherwise this test fails.
+    """
+    silently_dropped = (
+        _loadable_schema_fields()
+        - _MUTABLE_TRANSACTION_FIELDS
+        - _KNOWN_CREATE_ONLY_FIELDS
+    )
+    assert not silently_dropped, (
+        "These schema-loadable fields would be silently dropped by PATCH because "
+        f"they are not in _MUTABLE_TRANSACTION_FIELDS: {sorted(silently_dropped)}. "
+        "Add them to the registry (mutable) or to _KNOWN_CREATE_ONLY_FIELDS "
+        "(create-only)."
+    )
+
+
+def test_auto_settle_is_mutable_regression() -> None:
+    """Direct guard for the exact field from the original bug (fix 0d8dfbe)."""
+    assert "auto_settle" in _MUTABLE_TRANSACTION_FIELDS


### PR DESCRIPTION
## Onda 3 (Closes #1537)
Suíte `tests/regression/` que trava bugs já corrigidos para não regredirem:
- `test_transaction_mutable_fields_contract.py` — garante que a lista de campos mutáveis de transação concorda com o schema (o bug do PATCH que dropava campos silenciosamente).
- `test_pagination_no_truncation.py` — trava o fix de truncamento de paginação (listar tudo vs per_page:10).

Só adiciona testes (sem código de produção) → sem risco de regressão; cobertura só sobe. 7 testes verdes + ruff OK localmente. CI (auto-merge) confirma o gate completo.

Closes #1537