### PR TITLE
feat(ai): snapshot v3 — tags, pendências rotuladas, saúde do mês e mix de modelos

### DIFF
--- a/app/services/ai_advisory_service.py
+++ b/app/services/ai_advisory_service.py
@@ -59,6 +59,8 @@ from app.services.ai_lgpd import (
     redact_response_for_audit,
 )
 from app.services.financial_insight_context_builder import (
+    DEFAULT_MAX_SNAPSHOT_BYTES,
+    DEFAULT_MAX_SNAPSHOT_BYTES_LONG,
     INSIGHT_DIMENSIONS,
     FinancialInsightContextBuilder,
     truncate_snapshot,
@@ -739,17 +741,7 @@ def _stable_context_projection(snapshot: dict[str, Any]) -> dict[str, Any]:
     consistent with the generation cache.
     """
     projection = copy.deepcopy(snapshot)
-
-    wallet = projection.get("wallet")
-    if isinstance(wallet, dict):
-        for key in _VOLATILE_WALLET_KEYS:
-            wallet.pop(key, None)
-        items = wallet.get("items")
-        if isinstance(items, list):
-            for item in items:
-                if isinstance(item, dict):
-                    for key in _VOLATILE_WALLET_ITEM_KEYS:
-                        item.pop(key, None)
+    _strip_volatile_wallet_fields(projection)
 
     # Derived from wallet valuation + balances — market-volatile.
     projection.pop("projections", None)
@@ -759,7 +751,36 @@ def _stable_context_projection(snapshot: dict[str, Any]) -> dict[str, Any]:
     if isinstance(transactions, dict):
         transactions.pop("changes_since_last_generation", None)
 
+    _strip_calendar_drift_fields(projection)
     return projection
+
+
+def _strip_volatile_wallet_fields(projection: dict[str, Any]) -> None:
+    wallet = projection.get("wallet")
+    if not isinstance(wallet, dict):
+        return
+    for key in _VOLATILE_WALLET_KEYS:
+        wallet.pop(key, None)
+    items = wallet.get("items")
+    if not isinstance(items, list):
+        return
+    for item in items:
+        if isinstance(item, dict):
+            for key in _VOLATILE_WALLET_ITEM_KEYS:
+                item.pop(key, None)
+
+
+def _strip_calendar_drift_fields(projection: dict[str, Any]) -> None:
+    """days_overdue grows with the calendar, not with user action (#1547)."""
+    pending = projection.get("pending_commitments")
+    if not isinstance(pending, dict):
+        return
+    overdue = pending.get("overdue")
+    if not isinstance(overdue, dict):
+        return
+    for item in overdue.get("items") or []:
+        if isinstance(item, dict):
+            item.pop("days_overdue", None)
 
 
 def _snapshot_byte_size(snapshot: dict[str, Any]) -> int:
@@ -1418,7 +1439,10 @@ class AIAdvisoryService:
             # whatever we actually send to the LLM. The hash itself is computed
             # over the stable projection (no market-driven fields) so price
             # drift never busts the cache (#1546).
-            prompt_snapshot, truncation_info = truncate_snapshot(prompt_snapshot)
+            prompt_snapshot, truncation_info = truncate_snapshot(
+                prompt_snapshot,
+                max_bytes=_snapshot_max_bytes(normalized_period_type),
+            )
             context_hash = _financial_context_hash(
                 _stable_context_projection(prompt_snapshot)
             )
@@ -1465,6 +1489,7 @@ class AIAdvisoryService:
                 prompt,
                 response_schema=_FINANCIAL_INSIGHT_RESPONSE_SCHEMA,
                 max_tokens=_period_max_tokens(normalized_period_type),
+                **_period_model_kwargs(normalized_period_type),
             )
         except LLMProviderError as exc:
             log.warning(
@@ -1648,7 +1673,10 @@ class AIAdvisoryService:
         period_label = str(snapshot["period"]["label"])
 
         prompt_snapshot = minimize_prompt_data(snapshot)
-        prompt_snapshot, _ = truncate_snapshot(prompt_snapshot)
+        prompt_snapshot, _ = truncate_snapshot(
+            prompt_snapshot,
+            max_bytes=_snapshot_max_bytes(normalized_period_type),
+        )
         context_hash = _financial_context_hash(
             _stable_context_projection(prompt_snapshot)
         )
@@ -2695,6 +2723,40 @@ _DEPTH_INSTRUCTIONS: dict[str, str] = {
 _DEPTH_WORD_TARGETS: dict[str, int] = {"daily": 450, "weekly": 2200, "monthly": 2200}
 
 
+def _snapshot_max_bytes(period_type: str) -> int:
+    """Per-period snapshot byte cap (#1547): deep reports get more context."""
+    if period_type == "daily":
+        env_key, default = "AI_SNAPSHOT_MAX_BYTES", DEFAULT_MAX_SNAPSHOT_BYTES
+    else:
+        env_key, default = (
+            "AI_SNAPSHOT_MAX_BYTES_LONG",
+            DEFAULT_MAX_SNAPSHOT_BYTES_LONG,
+        )
+    try:
+        return max(1024, int(os.getenv(env_key, str(default))))
+    except (TypeError, ValueError):
+        return default
+
+
+def _period_model_kwargs(period_type: str) -> dict[str, Any]:
+    """kwargs de modelo por período — vazio quando o default do provider vale."""
+    period_model = _period_model(period_type)
+    return {"model": period_model} if period_model else {}
+
+
+def _period_model(period_type: str) -> str | None:
+    """Model mix per period (#1547, PO 2026-07-10, ADR R$5/user/month).
+
+    Daily manual insights are extraction over a precomputed snapshot —
+    gpt-4o-mini handles them well at ~6% of the cost. Weekly/monthly deep
+    reports keep the provider default (gpt-4o) where the quality pays off.
+    Returns None to use the provider's default model.
+    """
+    if period_type == "daily":
+        return os.getenv("OPENAI_ADVISORY_MODEL_DAILY", "gpt-4o-mini") or None
+    return None
+
+
 def _period_max_tokens(period_type: str) -> int:
     """Output token budget per period — deep reports need a much larger budget."""
     if period_type == "daily":
@@ -2839,6 +2901,21 @@ def _build_financial_insight_prompt(
         "Use somente os dados do snapshot fornecido. Não invente transações, metas, "
         "orçamentos, rendas, despesas, nomes, datas ou valores ausentes. Quando uma "
         "comparação não existir, mencione a ausência apenas se ela for relevante.\n"
+        "ESTRUTURA OBRIGATÓRIA (v3): cubra, na medida em que os dados existirem, "
+        "estas frentes — (1) panorama do período e do mês até agora (use "
+        "'month_summary': income_mtd, expense_mtd, savings_rate_pct, "
+        "burn_rate_daily, projected_eom_balance); (2) pendências e vencimentos — "
+        "cite NOMINALMENTE os itens vencidos de 'pending_commitments.overdue.items' "
+        "(título, valor, dias de atraso) e o que vence em 7/30 dias em "
+        "'pending_commitments.upcoming_7d/upcoming_30d'; (3) categorias e TAGS do "
+        "usuário — use 'tags.top_by_expense' e 'tags.top_by_income' (as tags são o "
+        "vocabulário do próprio usuário, ex.: 'academia'), além de "
+        "'categories.top_expense_categories' e orçamentos por tag em 'budgets'; "
+        "(4) carteira (regras próprias abaixo); (5) recomendações acionáveis.\n"
+        "PROIBIDO conselho genérico: toda recomendação precisa citar um número do "
+        "snapshot E uma ação concreta (ex.: 'os 3 vencidos somam R$X — priorize "
+        "o Condomínio de R$Y, atrasado há Z dias'). Frases como 'reavalie seus "
+        "gastos' sem número e sem alvo são inaceitáveis.\n"
         "Cada item deve conter evidências que apontem para chaves conhecidas do "
         "snapshot, como current_period.paid.balance, "
         "current_period.created_today.pending_expense_total, "

--- a/app/services/financial_insight_context_builder.py
+++ b/app/services/financial_insight_context_builder.py
@@ -17,6 +17,8 @@ from decimal import Decimal, InvalidOperation
 from typing import Any, cast
 from uuid import UUID
 
+from sqlalchemy.orm import QueryableAttribute, joinedload
+
 from app.models.budget import Budget
 from app.models.credit_card import CreditCard
 from app.models.goal import Goal
@@ -53,7 +55,14 @@ surface it belongs to so contextual pages can filter, while the global
 `/insights` hub renders all dimensions grouped.
 """
 
-_SNAPSHOT_VERSION = "financial_insight_snapshot.v1"
+_SNAPSHOT_VERSION = "financial_insight_snapshot.v3"
+
+
+def _tag_loader() -> Any:
+    """joinedload(Transaction.tag) — cast for legacy (non-Mapped) relationships."""
+    return joinedload(cast("QueryableAttribute[Any]", Transaction.tag))
+
+
 _CURRENCY = "BRL"
 _TIMEZONE = "America/Sao_Paulo"
 _GOAL_PACE_WINDOW_DAYS = 90
@@ -63,6 +72,7 @@ _GOAL_PACE_WINDOW_DAYS = 90
 # while preserving the structural backbone (schema_version, current_period,
 # comparisons). Override via AI_SNAPSHOT_MAX_BYTES env for cost experiments.
 DEFAULT_MAX_SNAPSHOT_BYTES = 12 * 1024
+DEFAULT_MAX_SNAPSHOT_BYTES_LONG = 24 * 1024
 MAX_SNAPSHOT_BYTES = int(
     os.getenv("AI_SNAPSHOT_MAX_BYTES", str(DEFAULT_MAX_SNAPSHOT_BYTES))
 )
@@ -637,6 +647,7 @@ class FinancialInsightContextBuilder:
             include_goals=True,
             include_credit_cards=True,
             include_wallet=True,
+            include_commitments=True,
             previous_generated_at=previous_generated_at,
             timezone_name=timezone_name,
             timezone_fallback=timezone_fallback,
@@ -759,6 +770,7 @@ class FinancialInsightContextBuilder:
             include_goals=True,
             include_credit_cards=True,
             include_wallet=True,
+            include_commitments=True,
             previous_generated_at=previous_generated_at,
             timezone_name=timezone_name,
             timezone_fallback=timezone_fallback,
@@ -801,6 +813,7 @@ class FinancialInsightContextBuilder:
             include_goals=True,
             include_credit_cards=True,
             include_wallet=True,
+            include_commitments=True,
             previous_generated_at=previous_generated_at,
             timezone_name=timezone_name,
             timezone_fallback=timezone_fallback,
@@ -852,6 +865,7 @@ class FinancialInsightContextBuilder:
         include_goals: bool = False,
         include_credit_cards: bool = False,
         include_wallet: bool = False,
+        include_commitments: bool = False,
         market_rates: MarketRatesProvider | None = None,
         previous_generated_at: datetime | None = None,
         timezone_name: str = _TIMEZONE,
@@ -923,6 +937,18 @@ class FinancialInsightContextBuilder:
                 "missing_comparison_periods": [],
             },
         }
+        snapshot["tags"] = self._tags_payload(
+            [tx for tx in non_cancelled if tx.status == TransactionStatus.PAID]
+        )
+        if include_commitments:
+            snapshot["pending_commitments"] = self._pending_commitments_payload(
+                user_id=user_id,
+                anchor=end,
+            )
+            snapshot["month_summary"] = self._month_summary_payload(
+                user_id=user_id,
+                anchor=end,
+            )
         if timezone_fallback:
             snapshot["data_quality"]["timezone_fallback"] = True
         snapshot["data_quality"].update(goal_data_quality)
@@ -1181,7 +1207,8 @@ class FinancialInsightContextBuilder:
         end: date,
     ) -> list[Transaction]:
         rows = (
-            Transaction.query.filter(
+            Transaction.query.options(_tag_loader())
+            .filter(
                 Transaction.user_id == user_id,
                 Transaction.deleted.is_(False),
                 Transaction.due_date >= start,
@@ -1202,7 +1229,8 @@ class FinancialInsightContextBuilder:
         start_dt = datetime.combine(start, datetime.min.time())
         end_dt = datetime.combine(end + timedelta(days=1), datetime.min.time())
         rows = (
-            Transaction.query.filter(
+            Transaction.query.options(_tag_loader())
+            .filter(
                 Transaction.user_id == user_id,
                 Transaction.deleted.is_(False),
                 Transaction.created_at >= start_dt,
@@ -1433,6 +1461,161 @@ class FinancialInsightContextBuilder:
             )
         ]
 
+    def _tags_payload(
+        self,
+        transactions: list[Transaction],
+        *,
+        cap: int = 8,
+    ) -> dict[str, Any]:
+        """Aggregate PAID transactions by user tag (#1547).
+
+        Tags are the user's own catalogue (e.g. "academia"); surfacing them
+        lets the LLM talk about spend in the user's vocabulary. Deterministic
+        aggregation — costs a few hundred prompt tokens at most.
+        """
+
+        def _top(tx_type: TransactionType) -> list[dict[str, Any]]:
+            totals: dict[str, tuple[Decimal, int]] = {}
+            for tx in transactions:
+                if tx.type != tx_type:
+                    continue
+                tag_name = self._transaction_tag_name(tx)
+                if not tag_name:
+                    continue
+                total, count = totals.get(tag_name, (Decimal("0.00"), 0))
+                totals[tag_name] = (total + _money(tx.amount), count + 1)
+            ranked = sorted(
+                totals.items(),
+                key=lambda item: (-item[1][0], item[0]),
+            )[:cap]
+            return [
+                {"tag": tag, "total": _money_str(total), "count": count}
+                for tag, (total, count) in ranked
+            ]
+
+        return {
+            "top_by_expense": _top(TransactionType.EXPENSE),
+            "top_by_income": _top(TransactionType.INCOME),
+        }
+
+    def _pending_commitments_payload(
+        self,
+        *,
+        user_id: UUID,
+        anchor: date,
+    ) -> dict[str, Any]:
+        """Labelled overdue items + upcoming due dates (7/30 days) (#1547).
+
+        The old snapshot only carried aggregate totals — the LLM could never
+        say WHICH bill is late or WHAT is due next week.
+        """
+        unpaid_statuses = (TransactionStatus.PENDING, TransactionStatus.OVERDUE)
+        rows = (
+            Transaction.query.options(_tag_loader())
+            .filter(
+                Transaction.user_id == user_id,
+                Transaction.deleted.is_(False),
+                Transaction.status.in_(unpaid_statuses),
+                Transaction.due_date <= anchor + timedelta(days=30),
+            )
+            .order_by(Transaction.due_date.asc())
+            .all()
+        )
+        unpaid = cast(list[Transaction], rows)
+        overdue = [tx for tx in unpaid if tx.due_date < anchor]
+        upcoming = [tx for tx in unpaid if tx.due_date > anchor]
+        upcoming_7d = [
+            tx for tx in upcoming if tx.due_date <= anchor + timedelta(days=7)
+        ]
+
+        def _block(
+            items: list[Transaction],
+            *,
+            item_limit: int,
+            with_days_overdue: bool = False,
+        ) -> dict[str, Any]:
+            serialized = []
+            for tx in items[:item_limit]:
+                entry = self._serialize_transaction(tx)
+                if with_days_overdue:
+                    entry["days_overdue"] = (anchor - tx.due_date).days
+                serialized.append(entry)
+            return {
+                "count": len(items),
+                "expense_total": _money_str(self._sum(items, TransactionType.EXPENSE)),
+                "income_total": _money_str(self._sum(items, TransactionType.INCOME)),
+                "items": serialized,
+            }
+
+        return {
+            "overdue": _block(overdue, item_limit=10, with_days_overdue=True),
+            "upcoming_7d": _block(upcoming_7d, item_limit=5),
+            "upcoming_30d": _block(upcoming, item_limit=5),
+        }
+
+    def _month_summary_payload(
+        self,
+        *,
+        user_id: UUID,
+        anchor: date,
+    ) -> dict[str, Any]:
+        """Deterministic month-to-date health block (#1547).
+
+        Projection is commitments-based: current paid balance plus every
+        still-unpaid commitment of the calendar month (incl. overdue) — no
+        extrapolation the LLM could mistake for fact.
+        """
+        month_start = anchor.replace(day=1)
+        month_end = date(
+            anchor.year, anchor.month, monthrange(anchor.year, anchor.month)[1]
+        )
+        month_txs = [
+            tx
+            for tx in self._fetch_transactions(
+                user_id=user_id, start=month_start, end=month_end
+            )
+            if tx.status != TransactionStatus.CANCELLED
+        ]
+        paid_mtd = [
+            tx
+            for tx in month_txs
+            if tx.status == TransactionStatus.PAID and tx.due_date <= anchor
+        ]
+        unpaid_month = [
+            tx
+            for tx in month_txs
+            if tx.status in (TransactionStatus.PENDING, TransactionStatus.OVERDUE)
+        ]
+        income_mtd = self._sum(paid_mtd, TransactionType.INCOME)
+        expense_mtd = self._sum(paid_mtd, TransactionType.EXPENSE)
+        balance_mtd = income_mtd - expense_mtd
+        savings_rate = (
+            (balance_mtd / income_mtd * Decimal("100")).quantize(Decimal("0.01"))
+            if income_mtd > 0
+            else Decimal("0.00")
+        )
+        days_elapsed = max(1, anchor.day)
+        burn_rate = (expense_mtd / Decimal(days_elapsed)).quantize(Decimal("0.01"))
+        pending_income = self._sum(unpaid_month, TransactionType.INCOME)
+        pending_expense = self._sum(unpaid_month, TransactionType.EXPENSE)
+        projected_eom = balance_mtd + pending_income - pending_expense
+        overdue_expense = self._sum(
+            [tx for tx in unpaid_month if tx.due_date < anchor],
+            TransactionType.EXPENSE,
+        )
+        return {
+            "month": f"{anchor:%Y-%m}",
+            "income_mtd": _money_str(income_mtd),
+            "expense_mtd": _money_str(expense_mtd),
+            "balance_mtd": _money_str(balance_mtd),
+            "savings_rate_pct": _percent_str(savings_rate),
+            "burn_rate_daily": _money_str(burn_rate),
+            "pending_income_month": _money_str(pending_income),
+            "pending_expense_month": _money_str(pending_expense),
+            "projected_eom_balance": _money_str(projected_eom),
+            "overdue_total": _money_str(overdue_expense),
+        }
+
     def _transactions_payload(
         self,
         transactions: list[Transaction],
@@ -1527,7 +1710,17 @@ class FinancialInsightContextBuilder:
             payload["description"] = description
         if category:
             payload["category"] = category
+        tag_name = self._transaction_tag_name(transaction)
+        if tag_name:
+            payload["tag"] = tag_name
         return payload
+
+    @staticmethod
+    def _transaction_tag_name(transaction: Transaction) -> str | None:
+        tag = getattr(transaction, "tag", None)
+        if tag is None:
+            return None
+        return _sanitize_text(str(tag.name or ""), max_length=30) or None
 
     def _budgets_payload(
         self,
@@ -1556,23 +1749,39 @@ class FinancialInsightContextBuilder:
         result: list[dict[str, Any]] = []
         for budget in budgets:
             category = str(budget.category) if budget.category else None
+            tag_name: str | None = None
             spent = Decimal("0.00")
-            for tx in paid:
-                if category is None or _enum_value(tx.category) == category:
-                    spent += _money(tx.amount)
+            if budget.tag_id is not None:
+                # Tag-linked budget (#1547): spend is scoped to the tag, not
+                # the whole period — these budgets used to be excluded from
+                # the AI snapshot entirely.
+                tag_obj = getattr(budget, "tag", None)
+                tag_name = (
+                    _sanitize_text(str(tag_obj.name), max_length=30)
+                    if tag_obj is not None
+                    else None
+                )
+                for tx in paid:
+                    if tx.tag_id == budget.tag_id:
+                        spent += _money(tx.amount)
+            else:
+                for tx in paid:
+                    if category is None or _enum_value(tx.category) == category:
+                        spent += _money(tx.amount)
 
             amount = _money(budget.amount)
-            result.append(
-                {
-                    "name": _sanitize_text(budget.name) or "Orçamento",
-                    "category": category,
-                    "period": str(budget.period),
-                    "amount": _money_str(amount),
-                    "spent": _money_str(spent),
-                    "utilization_pct": _safe_pct(spent, amount),
-                    "exceeded": spent > amount,
-                }
-            )
+            entry: dict[str, Any] = {
+                "name": _sanitize_text(budget.name) or "Orçamento",
+                "category": category,
+                "period": str(budget.period),
+                "amount": _money_str(amount),
+                "spent": _money_str(spent),
+                "utilization_pct": _safe_pct(spent, amount),
+                "exceeded": spent > amount,
+            }
+            if tag_name:
+                entry["tag"] = tag_name
+            result.append(entry)
         return result
 
     def _goals_payload(
@@ -1752,7 +1961,10 @@ def _trim_transactions(snapshot: dict[str, Any]) -> bool:
     txs = snapshot.get("transactions")
     if not isinstance(txs, dict):
         return False
-    items = txs.get("items")
+    # Real snapshots emit "sample" (#1547 fixed a silent no-op that looked for
+    # "items" only); keep accepting "items" for synthetic/legacy payloads.
+    key = "sample" if isinstance(txs.get("sample"), list) else "items"
+    items = txs.get(key)
     if not (isinstance(items, list) and len(items) > 15):
         return False
     expenses = [i for i in items if i.get("type") == "expense"]
@@ -1765,7 +1977,7 @@ def _trim_transactions(snapshot: dict[str, Any]) -> bool:
             :5
         ]
     )
-    snapshot["transactions"] = {**txs, "items": kept}
+    snapshot["transactions"] = {**txs, key: kept}
     return True
 
 
@@ -1883,5 +2095,6 @@ __all__ = [
     "FinancialInsightContextBuilder",
     "INSIGHT_DIMENSIONS",
     "MAX_SNAPSHOT_BYTES",
+    "DEFAULT_MAX_SNAPSHOT_BYTES_LONG",
     "truncate_snapshot",
 ]

--- a/app/services/llm_provider.py
+++ b/app/services/llm_provider.py
@@ -93,8 +93,14 @@ class LLMProvider(Protocol):
         *,
         response_schema: dict[str, Any] | None = None,
         max_tokens: int | None = None,
+        model: str | None = None,
     ) -> LLMResponse:
-        """Generate a response and return structured usage data."""
+        """Generate a response and return structured usage data.
+
+        ``model`` optionally overrides the provider's default for this single
+        call (#1547 — per-period model mix); providers without multi-model
+        support may ignore it.
+        """
         ...
 
 
@@ -119,8 +125,9 @@ class StubLLMProvider:
         *,
         response_schema: dict[str, Any] | None = None,
         max_tokens: int | None = None,
+        model: str | None = None,
     ) -> LLMResponse:
-        del prompt, max_tokens
+        del prompt, max_tokens, model
         content = self._STUB_CONTENT
         if (
             response_schema
@@ -167,6 +174,7 @@ class OpenAILLMProvider:
         *,
         response_schema: dict[str, Any] | None = None,
         max_tokens: int | None = None,
+        model: str | None = None,
     ) -> LLMResponse:
         if not self._api_key:
             raise LLMProviderError("OPENAI_API_KEY is not configured.")
@@ -175,7 +183,7 @@ class OpenAILLMProvider:
         resolved_max_tokens = _resolve_max_tokens(max_tokens)
         start = time.monotonic()
         payload: dict[str, Any] = {
-            "model": self._model,
+            "model": model or self._model,
             "messages": [{"role": "user", "content": prompt}],
             "max_tokens": resolved_max_tokens,
             "temperature": 0.4,
@@ -206,7 +214,7 @@ class OpenAILLMProvider:
                 prompt_tokens=int(usage.get("prompt_tokens", 0)),
                 completion_tokens=int(usage.get("completion_tokens", 0)),
                 total_tokens=int(usage.get("total_tokens", 0)),
-                model=str(data.get("model", self._model)),
+                model=str(data.get("model", model or self._model)),
                 latency_ms=latency_ms,
             )
         except Exception as exc:
@@ -231,8 +239,9 @@ class ClaudeLLMProvider:
         *,
         response_schema: dict[str, Any] | None = None,
         max_tokens: int | None = None,
+        model: str | None = None,
     ) -> LLMResponse:
-        _ = response_schema
+        _ = response_schema, model
         if not self._api_key:
             raise LLMProviderError("ANTHROPIC_API_KEY is not configured.")
         import requests

--- a/tests/test_ai_advisory_service.py
+++ b/tests/test_ai_advisory_service.py
@@ -372,13 +372,13 @@ class TestAIAdvisoryServiceFinancialInsights:
                 "budgets",
                 "wallet",
             ]
-            assert result["context_version"] == "financial_insight_snapshot.v1"
+            assert result["context_version"] == "financial_insight_snapshot.v3"
             assert result["cached"] is False
             assert result["tokens_used"] == 140
 
             call = provider.generate_with_usage.call_args
             prompt = call.args[0]
-            assert "financial_insight_snapshot.v1" in prompt
+            assert "financial_insight_snapshot.v3" in prompt
             assert "Não invente transações" in prompt
             assert (
                 call.kwargs["response_schema"]["name"] == "financial_insight_response"

--- a/tests/test_ai_daily_rate_limit.py
+++ b/tests/test_ai_daily_rate_limit.py
@@ -272,7 +272,7 @@ class TestAIDailyRateLimitHTTP:
             _failed = False
 
             def generate_with_usage(
-                self, prompt, *, response_schema=None, max_tokens=None
+                self, prompt, *, response_schema=None, max_tokens=None, model=None
             ):
                 if not _FlakyProvider._failed:
                     _FlakyProvider._failed = True
@@ -281,6 +281,7 @@ class TestAIDailyRateLimitHTTP:
                     prompt,
                     response_schema=response_schema,
                     max_tokens=max_tokens,
+                    model=model,
                 )
 
         with patch(

--- a/tests/test_ai_insight_generation_governance.py
+++ b/tests/test_ai_insight_generation_governance.py
@@ -87,17 +87,24 @@ class _CountingStubProvider(StubLLMProvider):
     def __init__(self) -> None:
         self.calls = 0
 
-    def generate_with_usage(self, prompt, *, response_schema=None, max_tokens=None):
+    def generate_with_usage(
+        self, prompt, *, response_schema=None, max_tokens=None, model=None
+    ):
         self.calls += 1
         return super().generate_with_usage(
-            prompt, response_schema=response_schema, max_tokens=max_tokens
+            prompt,
+            response_schema=response_schema,
+            max_tokens=max_tokens,
+            model=model,
         )
 
 
 class _ExplodingProvider(StubLLMProvider):
     """Provider that fails the test if the LLM is ever invoked."""
 
-    def generate_with_usage(self, prompt, *, response_schema=None, max_tokens=None):
+    def generate_with_usage(
+        self, prompt, *, response_schema=None, max_tokens=None, model=None
+    ):
         raise AssertionError("LLM must not be called on a read-only path")
 
     def generate(self, prompt):  # pragma: no cover — defensive

--- a/tests/test_ai_insight_observability.py
+++ b/tests/test_ai_insight_observability.py
@@ -197,7 +197,7 @@ class TestMetadataPersistenceAndMetrics:
             )
             assert row is not None
             md = row.metadata_dict
-            assert md["snapshot_version"] == "financial_insight_snapshot.v1"
+            assert md["snapshot_version"] == "financial_insight_snapshot.v3"
             assert md["dimensions_present"] == _SORTED_FINANCIAL_DIMENSIONS
             assert "snapshot_bytes_original" in md
             assert "snapshot_bytes_final" in md

--- a/tests/test_ai_snapshot_v3.py
+++ b/tests/test_ai_snapshot_v3.py
@@ -1,0 +1,410 @@
+"""Snapshot v3 + prompt v3 + mix de modelos (#1547).
+
+Covers the enriched AI snapshot:
+- user tags on transaction samples + ``tags`` aggregations (top by expense/income)
+- tag-linked budgets included with tag name and tag-scoped spent
+- ``pending_commitments``: labelled overdue items + upcoming 7/30d
+- ``month_summary``: savings rate, burn rate, projected end-of-month balance
+- per-period snapshot byte caps (daily 12KiB; weekly/monthly 24KiB)
+- ``_trim_transactions`` handles the real ``sample`` key (was a silent no-op)
+- per-period model mix: daily manual → gpt-4o-mini; weekly/monthly → provider default
+- prompt v3 mandates sections with numbers and references the new snapshot keys
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.extensions.database import db
+from app.models.budget import Budget
+from app.models.tag import Tag
+from app.models.transaction import (
+    Transaction,
+    TransactionStatus,
+    TransactionType,
+)
+from app.models.user import User
+from app.services.financial_insight_context_builder import (
+    FinancialInsightContextBuilder,
+    truncate_snapshot,
+)
+from app.services.llm_provider import LLMResponse
+
+_ANCHOR = date(2026, 7, 10)
+
+
+@pytest.fixture(autouse=True)
+def _bypass_premium_gate():
+    """Raw uuid users; the Premium gate (#1546) has dedicated coverage."""
+    with patch("app.services.ai_advisory_service._ensure_premium_entitlement"):
+        yield
+
+
+def _make_user() -> uuid.UUID:
+    user = User(
+        name="Tag Cliente",
+        email=f"tags-{uuid.uuid4().hex[:8]}@example.com",
+        password="hashed",
+    )
+    db.session.add(user)
+    db.session.commit()
+    return user.id
+
+
+def _make_tag(user_id: uuid.UUID, name: str) -> Tag:
+    tag = Tag(user_id=user_id, name=name)
+    db.session.add(tag)
+    db.session.commit()
+    return tag
+
+
+def _make_tx(
+    user_id: uuid.UUID,
+    *,
+    title: str,
+    amount: str,
+    tx_type: TransactionType = TransactionType.EXPENSE,
+    status: TransactionStatus = TransactionStatus.PAID,
+    due_date: date = _ANCHOR,
+    tag_id: uuid.UUID | None = None,
+) -> Transaction:
+    tx = Transaction(
+        user_id=user_id,
+        title=title,
+        description=title,
+        amount=Decimal(amount),
+        type=tx_type,
+        status=status,
+        due_date=due_date,
+        tag_id=tag_id,
+    )
+    db.session.add(tx)
+    db.session.commit()
+    return tx
+
+
+def _build_daily(user_id: uuid.UUID) -> dict:
+    return FinancialInsightContextBuilder().build_daily(
+        user_id=user_id,
+        anchor_date=_ANCHOR,
+    )
+
+
+class TestTagsInSnapshot:
+    def test_sample_items_carry_tag_name(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            academia = _make_tag(user_id, "Academia")
+            _make_tx(user_id, title="Mensalidade", amount="120.00", tag_id=academia.id)
+
+            snapshot = _build_daily(user_id)
+
+        sample = snapshot["transactions"]["sample"]
+        assert sample[0]["tag"] == "Academia"
+
+    def test_tags_aggregation_top_by_expense_and_income(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            academia = _make_tag(user_id, "Academia")
+            freela = _make_tag(user_id, "Freela")
+            _make_tx(user_id, title="Plano", amount="120.00", tag_id=academia.id)
+            _make_tx(user_id, title="Whey", amount="80.00", tag_id=academia.id)
+            _make_tx(
+                user_id,
+                title="Projeto X",
+                amount="900.00",
+                tx_type=TransactionType.INCOME,
+                tag_id=freela.id,
+            )
+            _make_tx(user_id, title="Sem tag", amount="50.00")
+
+            snapshot = _build_daily(user_id)
+
+        tags = snapshot["tags"]
+        expense_by_tag = {entry["tag"]: entry for entry in tags["top_by_expense"]}
+        assert expense_by_tag["Academia"]["total"] == "200.00"
+        assert expense_by_tag["Academia"]["count"] == 2
+        income_by_tag = {entry["tag"]: entry for entry in tags["top_by_income"]}
+        assert income_by_tag["Freela"]["total"] == "900.00"
+
+    def test_tag_budget_included_with_tag_scoped_spent(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            academia = _make_tag(user_id, "Academia")
+            db.session.add(
+                Budget(
+                    user_id=user_id,
+                    name="Academia mensal",
+                    amount=Decimal("200.00"),
+                    period="monthly",
+                    tag_id=academia.id,
+                    is_active=True,
+                )
+            )
+            db.session.commit()
+            _make_tx(user_id, title="Plano", amount="120.00", tag_id=academia.id)
+            _make_tx(user_id, title="Outros gastos", amount="500.00")
+
+            snapshot = _build_daily(user_id)
+
+        tagged = [b for b in snapshot["budgets"] if b.get("tag") == "Academia"]
+        assert tagged, "tag-linked budget must be present in the snapshot"
+        assert tagged[0]["spent"] == "120.00"  # tag-scoped, not the 500.00
+
+
+class TestPendingCommitments:
+    def test_overdue_items_are_labelled_with_days_overdue(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            _make_tx(
+                user_id,
+                title="Condomínio",
+                amount="1400.00",
+                status=TransactionStatus.PENDING,
+                due_date=date(2026, 7, 6),
+            )
+            _make_tx(
+                user_id,
+                title="Fatura Julho",
+                amount="12055.51",
+                status=TransactionStatus.OVERDUE,
+                due_date=date(2026, 7, 5),
+            )
+
+            snapshot = _build_daily(user_id)
+
+        overdue = snapshot["pending_commitments"]["overdue"]
+        assert overdue["count"] == 2
+        titles = {item["title"]: item for item in overdue["items"]}
+        assert titles["Condomínio"]["days_overdue"] == 4
+        assert titles["Fatura Julho"]["days_overdue"] == 5
+        assert overdue["expense_total"] == "13455.51"
+
+    def test_upcoming_windows_split_7d_and_30d(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            _make_tx(
+                user_id,
+                title="Parcela financiamento",
+                amount="2650.00",
+                status=TransactionStatus.PENDING,
+                due_date=date(2026, 7, 15),  # within 7d
+            )
+            _make_tx(
+                user_id,
+                title="Fatura de agosto",
+                amount="900.00",
+                status=TransactionStatus.PENDING,
+                due_date=date(2026, 8, 5),  # within 30d, beyond 7d
+            )
+            _make_tx(
+                user_id,
+                title="IPVA distante",
+                amount="300.00",
+                status=TransactionStatus.PENDING,
+                due_date=date(2026, 9, 20),  # beyond 30d — excluded
+            )
+
+            snapshot = _build_daily(user_id)
+
+        pending = snapshot["pending_commitments"]
+        titles_7d = [item["title"] for item in pending["upcoming_7d"]["items"]]
+        titles_30d = [item["title"] for item in pending["upcoming_30d"]["items"]]
+        assert titles_7d == ["Parcela financiamento"]
+        assert "Fatura de agosto" in titles_30d
+        assert "IPVA distante" not in titles_30d
+        assert pending["upcoming_30d"]["expense_total"] == "3550.00"
+
+
+class TestMonthSummary:
+    def test_month_summary_fields(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            _make_tx(
+                user_id,
+                title="Salário BRQ",
+                amount="10754.00",
+                tx_type=TransactionType.INCOME,
+                due_date=date(2026, 7, 1),
+            )
+            _make_tx(
+                user_id, title="Aluguel", amount="5000.00", due_date=date(2026, 7, 4)
+            )
+            _make_tx(
+                user_id,
+                title="Parcela",
+                amount="2650.00",
+                status=TransactionStatus.PENDING,
+                due_date=date(2026, 7, 15),
+            )
+
+            snapshot = _build_daily(user_id)
+
+        summary = snapshot["month_summary"]
+        assert summary["month"] == "2026-07"
+        assert summary["income_mtd"] == "10754.00"
+        assert summary["expense_mtd"] == "5000.00"
+        assert summary["balance_mtd"] == "5754.00"
+        assert Decimal(summary["savings_rate_pct"]) > 0
+        assert Decimal(summary["burn_rate_daily"]) > 0
+        # Commitments-based projection: balance minus pending expenses of the
+        # rest of the month.
+        assert summary["projected_eom_balance"] == "3104.00"
+
+
+class TestPerPeriodCapsAndTrim:
+    def test_trim_transactions_handles_sample_key(self) -> None:
+        from app.services.financial_insight_context_builder import _trim_transactions
+
+        sample = [
+            {"type": "expense", "amount": f"{100 + i}.00", "title": f"tx {i}"}
+            for i in range(30)
+        ]
+        snapshot = {"transactions": {"included_count": 30, "sample": sample}}
+        assert _trim_transactions(snapshot) is True
+        assert len(snapshot["transactions"]["sample"]) <= 15
+
+    def test_snapshot_max_bytes_per_period(self, monkeypatch) -> None:
+        from app.services.ai_advisory_service import _snapshot_max_bytes
+
+        monkeypatch.delenv("AI_SNAPSHOT_MAX_BYTES", raising=False)
+        monkeypatch.delenv("AI_SNAPSHOT_MAX_BYTES_LONG", raising=False)
+        assert _snapshot_max_bytes("daily") == 12 * 1024
+        assert _snapshot_max_bytes("weekly") == 24 * 1024
+        assert _snapshot_max_bytes("monthly") == 24 * 1024
+
+    def test_truncate_respects_explicit_cap(self) -> None:
+        sample = [
+            {"type": "expense", "amount": f"{i}.00", "title": "x" * 80}
+            for i in range(200)
+        ]
+        snapshot = {
+            "schema_version": "financial_insight_snapshot.v3",
+            "current_period": {},
+            "comparisons": {},
+            "transactions": {"included_count": 200, "sample": sample},
+        }
+        _, info = truncate_snapshot(snapshot, max_bytes=2048)
+        assert info["truncated"] is True
+        assert "transactions.items" in info["dropped_sections"]
+
+
+class TestPerPeriodModelMix:
+    @staticmethod
+    def _llm_response() -> LLMResponse:
+        item = (
+            '{"type":"saude_financeira","dimension":"general","title":"Item",'
+            '"message":"Os dados foram analisados.",'
+            '"evidence":["current_period.paid.balance"]}'
+        )
+        return LLMResponse(
+            content=f'{{"summary":"Resumo.","items":[{item}]}}',
+            prompt_tokens=100,
+            completion_tokens=40,
+            total_tokens=140,
+            model="gpt-4o-mini",
+            latency_ms=10,
+        )
+
+    def test_daily_manual_generation_uses_mini_model(self, app, monkeypatch) -> None:
+        monkeypatch.delenv("OPENAI_ADVISORY_MODEL_DAILY", raising=False)
+        with app.app_context():
+            from app.services.ai_advisory_service import AIAdvisoryService
+
+            user_id = _make_user()
+            provider = MagicMock()
+            provider.generate_with_usage.return_value = self._llm_response()
+            service = AIAdvisoryService(user_id=user_id, llm_provider=provider)
+            service.generate_financial_insights(
+                period_type="daily", anchor_date=_ANCHOR
+            )
+
+            assert provider.generate_with_usage.call_args.kwargs["model"] == (
+                "gpt-4o-mini"
+            )
+
+    def test_weekly_generation_uses_provider_default_model(self, app) -> None:
+        with app.app_context():
+            from app.services.ai_advisory_service import AIAdvisoryService
+
+            user_id = _make_user()
+            provider = MagicMock()
+            provider.generate_with_usage.return_value = self._llm_response()
+            service = AIAdvisoryService(user_id=user_id, llm_provider=provider)
+            service.generate_financial_insights(
+                period_type="weekly", anchor_date=_ANCHOR
+            )
+
+            assert "model" not in provider.generate_with_usage.call_args.kwargs
+
+    def test_openai_provider_accepts_model_override(self, monkeypatch) -> None:
+        from app.services.llm_provider import OpenAILLMProvider
+
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        provider = OpenAILLMProvider()
+        captured: dict = {}
+
+        class _Resp:
+            def raise_for_status(self) -> None:
+                return None
+
+            @staticmethod
+            def json() -> dict:
+                return {
+                    "choices": [{"message": {"content": "ok"}}],
+                    "usage": {
+                        "prompt_tokens": 1,
+                        "completion_tokens": 1,
+                        "total_tokens": 2,
+                    },
+                    "model": "gpt-4o-mini-2024-07-18",
+                }
+
+        def _fake_post(url, headers=None, json=None, timeout=None):
+            captured["payload"] = json
+            return _Resp()
+
+        with patch("requests.post", _fake_post):
+            provider.generate_with_usage("prompt", model="gpt-4o-mini")
+
+        assert captured["payload"]["model"] == "gpt-4o-mini"
+
+
+class TestPromptV3:
+    def test_prompt_mandates_sections_and_new_keys(self, app) -> None:
+        with app.app_context():
+            from app.services.ai_advisory_service import (
+                _build_financial_insight_prompt,
+            )
+
+            user_id = _make_user()
+            _make_tx(user_id, title="Mercado", amount="100.00")
+            snapshot = _build_daily(user_id)
+            prompt = _build_financial_insight_prompt(
+                snapshot, period_type="daily", forecast=False
+            )
+
+        for required in (
+            "pending_commitments",
+            "month_summary",
+            "tags.top_by_expense",
+            "panorama do período",
+            "pendências e vencimentos",
+            "recomendações acionáveis",
+        ):
+            assert required in prompt, f"prompt v3 must mention: {required}"
+        # Generic advice without numbers is forbidden explicitly.
+        assert "número" in prompt
+
+
+class TestSnapshotVersionBump:
+    def test_schema_version_is_v3(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            snapshot = _build_daily(user_id)
+        assert snapshot["schema_version"] == "financial_insight_snapshot.v3"

--- a/tests/test_financial_insight_context_builder.py
+++ b/tests/test_financial_insight_context_builder.py
@@ -316,7 +316,7 @@ class TestFinancialInsightContextBuilderDaily:
                 anchor_date=anchor,
             )
 
-        assert snapshot["schema_version"] == "financial_insight_snapshot.v1"
+        assert snapshot["schema_version"] == "financial_insight_snapshot.v3"
         assert snapshot["period_type"] == "daily"
         assert snapshot["period"] == {
             "start": "2026-05-17",


### PR DESCRIPTION
## Summary
Onda "Insights v3" — iniciativa I3 (plano PO 2026-07-10; ADR platform#859). Empilhada sobre #1549 (mergeado).

**Snapshot v3 (`financial_insight_snapshot.v3`):**
- **Tags do usuário** entram no snapshot: cada transação da amostra carrega `tag`; nova seção `tags.top_by_expense`/`top_by_income` (`{tag,total,count}`, cap 8); **budgets por tag** agora incluídos com `spent` escopado pela tag (antes eram invisíveis à IA).
- **Pendências rotuladas**: `pending_commitments.overdue.items[]` (título, valor, `days_overdue`, cap 10) + `upcoming_7d`/`upcoming_30d` (agregados + top itens) — a IA finalmente consegue dizer QUAL conta está atrasada e O QUE vence essa semana.
- **Saúde do mês**: `month_summary` (income/expense MTD, `savings_rate_pct`, `burn_rate_daily`, `projected_eom_balance` determinístico por compromissos, `overdue_total`).
- **Prompt v3**: estrutura obrigatória (panorama, pendências/vencimentos nominais, categorias+tags, carteira, recomendações acionáveis) e proibição explícita de conselho genérico sem número+ação (mata o "reavaliar gastos após recebimentos").
- **Caps por período**: diário 12KiB; semanal/mensal 24KiB (`AI_SNAPSHOT_MAX_BYTES_LONG`); corrigido o no-op silencioso de `_trim_transactions` (procurava `items`, o snapshot emite `sample`).
- **Mix de modelos (ADR R\$5/usuário/mês)**: diário manual → `gpt-4o-mini` (`OPENAI_ADVISORY_MODEL_DAILY`); semanal/mensal seguem no default do provider (`gpt-4o`). Provider ganhou override de `model` por chamada.
- Hash estável estende exclusões: `days_overdue` (drift de calendário) não invalida cache/change-status.

## Validation
- `bash scripts/run_ci_quality_local.sh --local` verde: **2717 passed**, cov ≥85%.
- Suíte nova `tests/test_ai_snapshot_v3.py` (14 testes): tags/aggregations/tag-budgets, overdue+upcoming, month_summary, caps por período, trim de `sample`, mix de modelos (incl. payload OpenAI), prompt v3, bump de versão.
- Sem mudança de contrato REST/GraphQL (snapshot é interno).

## Residual risk
- Bump de `_SNAPSHOT_VERSION` invalida cache/change-status uma vez no deploy (esperado).
- Tokens do semanal/mensal sobem com o cap de 24KiB — contabilizado na conta do ADR (~US\$0,78/usuário/mês típico).

## Refs
Closes #1547