### PR TITLE
feat(ai): chat assistente v2 — month-aware, detecção de período e function-calling

### DIFF
--- a/app/controllers/ai/resources.py
+++ b/app/controllers/ai/resources.py
@@ -502,6 +502,8 @@ class AIChatAskAnythingResource(MethodResource):
                     "model": "gpt-4o-mini",
                     "tokens_used": 380,
                     "cost_usd": 0.000057,
+                    "period_label": "julho/2026",
+                    "tool_rounds": 1,
                 },
             ),
             400: json_error_response(

--- a/app/extensions/prometheus_metrics.py
+++ b/app/extensions/prometheus_metrics.py
@@ -55,6 +55,7 @@ _AI_INSIGHT_TRUNCATED_TOTAL: Any = None
 _AI_INSIGHT_DEPTH_BELOW_TARGET_TOTAL: Any = None
 _AI_INSIGHT_DATA_QUALITY_DOMAINS: Any = None
 _AI_INSIGHT_RUNS_PURGED_TOTAL: Any = None
+_AI_CHAT_MESSAGES_TOTAL: Any = None
 
 _DURATION_BUCKETS = (0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5)
 _AI_TOKENS_BUCKETS = (100, 250, 500, 1000, 2500, 5000, 10000, 25000)
@@ -66,6 +67,7 @@ def _init_ai_insight_metrics() -> None:  # noqa: C901 — flat list of counter i
     """Lazily initialise the MVP-3 AI insight observability instruments."""
     global \
         _AI_INSIGHT_GENERATED_TOTAL, \
+        _AI_CHAT_MESSAGES_TOTAL, \
         _AI_INSIGHT_TOKENS, \
         _AI_INSIGHT_SNAPSHOT_BYTES, \
         _AI_INSIGHT_RUNS_TOTAL, \
@@ -81,6 +83,12 @@ def _init_ai_insight_metrics() -> None:  # noqa: C901 — flat list of counter i
             "auraxis_ai_insight_generated_total",
             "AI insights generated, by period_type and dimension",
             ["period_type", "dimension"],
+        )
+    if _AI_CHAT_MESSAGES_TOTAL is None:
+        _AI_CHAT_MESSAGES_TOTAL = Counter(
+            "auraxis_ai_chat_messages_total",
+            "Ask-anything chat answers, by tool usage and no-info outcome",
+            ["tools_used", "no_info"],
         )
     if _AI_INSIGHT_TOKENS is None:
         _AI_INSIGHT_TOKENS = Histogram(
@@ -307,6 +315,20 @@ def record_auth_login_cookie_only_header(*, header_present: bool) -> None:
     if _AUTH_LOGIN_COOKIE_ONLY_HEADER_TOTAL is not None:
         label = "yes" if header_present else "no"
         _AUTH_LOGIN_COOKIE_ONLY_HEADER_TOTAL.labels(header_present=label).inc()
+
+
+def record_ai_chat_answered(*, tool_rounds: int, no_info: bool) -> None:
+    """Telemetry for the Ask-anything chat (#1548).
+
+    ``no_info`` tracks answers admitting missing data — the trigger metric for
+    deepening the tool set.
+    """
+    _ensure_metrics_initialized()
+    if _AI_CHAT_MESSAGES_TOTAL is not None:
+        _AI_CHAT_MESSAGES_TOTAL.labels(
+            tools_used="true" if tool_rounds > 0 else "false",
+            no_info="true" if no_info else "false",
+        ).inc()
 
 
 def record_ai_insight_generated(

--- a/app/graphql/mutations/ai_insight.py
+++ b/app/graphql/mutations/ai_insight.py
@@ -319,6 +319,10 @@ class AskFinancialQuestionPayload(graphene.ObjectType):
     model = graphene.String()
     tokens_used = graphene.Int()
     cost_usd = graphene.Float()
+    # Additive (#1548): which period the answer context was anchored on and
+    # how many read-only tool rounds the model used.
+    period_label = graphene.String()
+    tool_rounds = graphene.Int()
 
 
 class AskFinancialQuestionMutation(graphene.Mutation):
@@ -369,6 +373,8 @@ class AskFinancialQuestionMutation(graphene.Mutation):
             model=result.get("model"),
             tokens_used=int(result.get("tokens_used") or 0),
             cost_usd=float(result.get("cost_usd") or 0),
+            period_label=result.get("period_label"),
+            tool_rounds=int(result.get("tool_rounds") or 0),
         )
 
 

--- a/app/services/ai_advisory_service.py
+++ b/app/services/ai_advisory_service.py
@@ -59,6 +59,8 @@ from app.services.ai_lgpd import (
     redact_response_for_audit,
 )
 from app.services.financial_insight_context_builder import (
+    DEFAULT_MAX_SNAPSHOT_BYTES,
+    DEFAULT_MAX_SNAPSHOT_BYTES_LONG,
     INSIGHT_DIMENSIONS,
     FinancialInsightContextBuilder,
     truncate_snapshot,
@@ -739,17 +741,7 @@ def _stable_context_projection(snapshot: dict[str, Any]) -> dict[str, Any]:
     consistent with the generation cache.
     """
     projection = copy.deepcopy(snapshot)
-
-    wallet = projection.get("wallet")
-    if isinstance(wallet, dict):
-        for key in _VOLATILE_WALLET_KEYS:
-            wallet.pop(key, None)
-        items = wallet.get("items")
-        if isinstance(items, list):
-            for item in items:
-                if isinstance(item, dict):
-                    for key in _VOLATILE_WALLET_ITEM_KEYS:
-                        item.pop(key, None)
+    _strip_volatile_wallet_fields(projection)
 
     # Derived from wallet valuation + balances — market-volatile.
     projection.pop("projections", None)
@@ -759,7 +751,36 @@ def _stable_context_projection(snapshot: dict[str, Any]) -> dict[str, Any]:
     if isinstance(transactions, dict):
         transactions.pop("changes_since_last_generation", None)
 
+    _strip_calendar_drift_fields(projection)
     return projection
+
+
+def _strip_volatile_wallet_fields(projection: dict[str, Any]) -> None:
+    wallet = projection.get("wallet")
+    if not isinstance(wallet, dict):
+        return
+    for key in _VOLATILE_WALLET_KEYS:
+        wallet.pop(key, None)
+    items = wallet.get("items")
+    if not isinstance(items, list):
+        return
+    for item in items:
+        if isinstance(item, dict):
+            for key in _VOLATILE_WALLET_ITEM_KEYS:
+                item.pop(key, None)
+
+
+def _strip_calendar_drift_fields(projection: dict[str, Any]) -> None:
+    """days_overdue grows with the calendar, not with user action (#1547)."""
+    pending = projection.get("pending_commitments")
+    if not isinstance(pending, dict):
+        return
+    overdue = pending.get("overdue")
+    if not isinstance(overdue, dict):
+        return
+    for item in overdue.get("items") or []:
+        if isinstance(item, dict):
+            item.pop("days_overdue", None)
 
 
 def _snapshot_byte_size(snapshot: dict[str, Any]) -> int:
@@ -1418,7 +1439,10 @@ class AIAdvisoryService:
             # whatever we actually send to the LLM. The hash itself is computed
             # over the stable projection (no market-driven fields) so price
             # drift never busts the cache (#1546).
-            prompt_snapshot, truncation_info = truncate_snapshot(prompt_snapshot)
+            prompt_snapshot, truncation_info = truncate_snapshot(
+                prompt_snapshot,
+                max_bytes=_snapshot_max_bytes(normalized_period_type),
+            )
             context_hash = _financial_context_hash(
                 _stable_context_projection(prompt_snapshot)
             )
@@ -1465,6 +1489,7 @@ class AIAdvisoryService:
                 prompt,
                 response_schema=_FINANCIAL_INSIGHT_RESPONSE_SCHEMA,
                 max_tokens=_period_max_tokens(normalized_period_type),
+                **_period_model_kwargs(normalized_period_type),
             )
         except LLMProviderError as exc:
             log.warning(
@@ -1648,7 +1673,10 @@ class AIAdvisoryService:
         period_label = str(snapshot["period"]["label"])
 
         prompt_snapshot = minimize_prompt_data(snapshot)
-        prompt_snapshot, _ = truncate_snapshot(prompt_snapshot)
+        prompt_snapshot, _ = truncate_snapshot(
+            prompt_snapshot,
+            max_bytes=_snapshot_max_bytes(normalized_period_type),
+        )
         context_hash = _financial_context_hash(
             _stable_context_projection(prompt_snapshot)
         )
@@ -2695,6 +2723,40 @@ _DEPTH_INSTRUCTIONS: dict[str, str] = {
 _DEPTH_WORD_TARGETS: dict[str, int] = {"daily": 450, "weekly": 2200, "monthly": 2200}
 
 
+def _snapshot_max_bytes(period_type: str) -> int:
+    """Per-period snapshot byte cap (#1547): deep reports get more context."""
+    if period_type == "daily":
+        env_key, default = "AI_SNAPSHOT_MAX_BYTES", DEFAULT_MAX_SNAPSHOT_BYTES
+    else:
+        env_key, default = (
+            "AI_SNAPSHOT_MAX_BYTES_LONG",
+            DEFAULT_MAX_SNAPSHOT_BYTES_LONG,
+        )
+    try:
+        return max(1024, int(os.getenv(env_key, str(default))))
+    except (TypeError, ValueError):
+        return default
+
+
+def _period_model_kwargs(period_type: str) -> dict[str, Any]:
+    """kwargs de modelo por período — vazio quando o default do provider vale."""
+    period_model = _period_model(period_type)
+    return {"model": period_model} if period_model else {}
+
+
+def _period_model(period_type: str) -> str | None:
+    """Model mix per period (#1547, PO 2026-07-10, ADR R$5/user/month).
+
+    Daily manual insights are extraction over a precomputed snapshot —
+    gpt-4o-mini handles them well at ~6% of the cost. Weekly/monthly deep
+    reports keep the provider default (gpt-4o) where the quality pays off.
+    Returns None to use the provider's default model.
+    """
+    if period_type == "daily":
+        return os.getenv("OPENAI_ADVISORY_MODEL_DAILY", "gpt-4o-mini") or None
+    return None
+
+
 def _period_max_tokens(period_type: str) -> int:
     """Output token budget per period — deep reports need a much larger budget."""
     if period_type == "daily":
@@ -2839,6 +2901,21 @@ def _build_financial_insight_prompt(
         "Use somente os dados do snapshot fornecido. Não invente transações, metas, "
         "orçamentos, rendas, despesas, nomes, datas ou valores ausentes. Quando uma "
         "comparação não existir, mencione a ausência apenas se ela for relevante.\n"
+        "ESTRUTURA OBRIGATÓRIA (v3): cubra, na medida em que os dados existirem, "
+        "estas frentes — (1) panorama do período e do mês até agora (use "
+        "'month_summary': income_mtd, expense_mtd, savings_rate_pct, "
+        "burn_rate_daily, projected_eom_balance); (2) pendências e vencimentos — "
+        "cite NOMINALMENTE os itens vencidos de 'pending_commitments.overdue.items' "
+        "(título, valor, dias de atraso) e o que vence em 7/30 dias em "
+        "'pending_commitments.upcoming_7d/upcoming_30d'; (3) categorias e TAGS do "
+        "usuário — use 'tags.top_by_expense' e 'tags.top_by_income' (as tags são o "
+        "vocabulário do próprio usuário, ex.: 'academia'), além de "
+        "'categories.top_expense_categories' e orçamentos por tag em 'budgets'; "
+        "(4) carteira (regras próprias abaixo); (5) recomendações acionáveis.\n"
+        "PROIBIDO conselho genérico: toda recomendação precisa citar um número do "
+        "snapshot E uma ação concreta (ex.: 'os 3 vencidos somam R$X — priorize "
+        "o Condomínio de R$Y, atrasado há Z dias'). Frases como 'reavalie seus "
+        "gastos' sem número e sem alvo são inaceitáveis.\n"
         "Cada item deve conter evidências que apontem para chaves conhecidas do "
         "snapshot, como current_period.paid.balance, "
         "current_period.created_today.pending_expense_total, "

--- a/app/services/ai_advisory_service.py
+++ b/app/services/ai_advisory_service.py
@@ -31,6 +31,7 @@ from sqlalchemy import case, func, or_
 
 from app.extensions.database import db
 from app.extensions.prometheus_metrics import (
+    record_ai_chat_answered,
     record_ai_insight_depth_below_target,
     record_ai_insight_generated,
 )
@@ -50,6 +51,7 @@ from app.models.goal import Goal
 from app.models.goal_contribution import GoalContribution
 from app.models.llm_audit_log import LLMAuditLog
 from app.models.transaction import Transaction, TransactionStatus, TransactionType
+from app.services.ai_chat_tools import CHAT_TOOLS_SPEC, execute_chat_tool
 from app.services.ai_insight_runs import transition_ai_insight_run_status
 from app.services.ai_lgpd import (
     ensure_ai_consent_granted,
@@ -58,6 +60,7 @@ from app.services.ai_lgpd import (
     redact_prompt_for_audit,
     redact_response_for_audit,
 )
+from app.services.chat_period_detection import detect_chat_period
 from app.services.financial_insight_context_builder import (
     DEFAULT_MAX_SNAPSHOT_BYTES,
     DEFAULT_MAX_SNAPSHOT_BYTES_LONG,
@@ -68,7 +71,12 @@ from app.services.financial_insight_context_builder import (
 from app.services.goal_projection_service import GoalProjectionService
 from app.services.insight_evidence_validator import filter_valid_items
 from app.services.insight_fluida_builder import enrich_insight_payload
-from app.services.llm_provider import LLMProvider, LLMProviderError, get_llm_provider
+from app.services.llm_provider import (
+    LLMProvider,
+    LLMProviderError,
+    LLMResponse,
+    get_llm_provider,
+)
 from app.services.weekly_summary import compute_weekly_summary
 from app.utils import timezone_utils
 from app.utils.datetime_utils import utc_now_naive
@@ -213,6 +221,40 @@ class AIEntitlementRequiredError(Exception):
 def _ai_chat_daily_limit() -> int:
     """Per-user daily cap for the Ask-anything chat (scoped counter)."""
     return max(1, int(os.getenv("AI_CHAT_DAILY_LIMIT", "20")))
+
+
+_CHAT_MAX_TOOL_ROUNDS = 3
+
+
+def _chat_tools_enabled() -> bool:
+    """Kill-switch for the chat function-calling loop (#1548)."""
+    return os.getenv("AI_CHAT_TOOLS_ENABLED", "1").strip().lower() not in (
+        "0",
+        "false",
+        "off",
+    )
+
+
+def _chat_model() -> str:
+    """Chat model (#1548, ADR R$5): extraction task — mini by default."""
+    return os.getenv("OPENAI_CHAT_MODEL", "gpt-4o-mini") or "gpt-4o-mini"
+
+
+def _chat_model_kwargs() -> dict[str, Any]:
+    model = _chat_model()
+    return {"model": model} if model else {}
+
+
+def _chat_snapshot_max_bytes() -> int:
+    """Chat context cap — month-aware context needs the long budget."""
+    from app.services.financial_insight_context_builder import (
+        DEFAULT_MAX_SNAPSHOT_BYTES_LONG as _long_cap,
+    )
+
+    try:
+        return max(1024, int(os.getenv("AI_CHAT_SNAPSHOT_MAX_BYTES", str(_long_cap))))
+    except (TypeError, ValueError):
+        return _long_cap
 
 
 def _ensure_premium_entitlement(user_id: UUID) -> None:
@@ -1293,38 +1335,38 @@ class AIAdvisoryService:
         fallback_used = timezone_fallback or (
             timezone_resolution.fallback_used and timezone_name is not None
         )
-        anchor = anchor_date or timezone_utils.local_today(timezone_resolution)
+        today = timezone_utils.local_today(timezone_resolution)
 
-        snapshot = _build_period_snapshot(
-            insight_type=InsightType.daily,
+        # Deterministic pt-BR period detection (#1548): "salário de julho"
+        # anchors the context on July, not on today.
+        resolution = detect_chat_period(normalized_question, today=today)
+        anchor = anchor_date or resolution.anchor
+
+        snapshot = FinancialInsightContextBuilder().build_chat_context(
             user_id=self._user_id,
-            anchor=anchor,
+            anchor_date=anchor,
+            today=today,
             timezone_name=timezone_resolution.name,
             timezone_fallback=fallback_used,
         )
         prompt_snapshot = minimize_prompt_data(snapshot)
-        prompt_snapshot, _ = truncate_snapshot(prompt_snapshot)
+        prompt_snapshot, _ = truncate_snapshot(
+            prompt_snapshot,
+            max_bytes=_chat_snapshot_max_bytes(),
+        )
 
         _enforce_ai_insight_user_cost_budget(user_id=self._user_id)
 
-        prompt = _build_chat_prompt(prompt_snapshot, normalized_question)
-        try:
-            llm_resp = self._provider.generate_with_usage(
-                prompt,
-                max_tokens=_chat_max_tokens(),
-            )
-        except LLMProviderError as exc:
-            log.warning(
-                "ai_advisory.chat.llm_error user=%s error=%s",
-                self._user_id,
-                exc,
-            )
-            raise
+        answer, llm_resp, prompt_used, tool_rounds = self._answer_chat_question(
+            prompt_snapshot=prompt_snapshot,
+            question=normalized_question,
+            period_label=resolution.label,
+        )
 
         _log_llm_call(
             user_id=self._user_id,
             endpoint="chat_ask_anything",
-            prompt=prompt,
+            prompt=prompt_used,
             llm_response=llm_resp,
             consent_version=consent_version,
         )
@@ -1334,12 +1376,140 @@ class AIAdvisoryService:
             scope=AI_CHAT_QUOTA_SCOPE,
         )
 
+        no_info = "não tenho" in answer.lower()
+        try:
+            record_ai_chat_answered(tool_rounds=tool_rounds, no_info=no_info)
+        except Exception:  # pragma: no cover — metrics are fire-and-forget
+            log.warning("ai_advisory.chat.metrics_failed user=%s", self._user_id)
+
         return {
-            "answer": llm_resp.content.strip(),
+            "answer": answer,
             "model": llm_resp.model,
             "tokens_used": llm_resp.total_tokens,
             "cost_usd": float(llm_resp.estimated_cost_usd),
+            "period_label": resolution.label,
+            "tool_rounds": tool_rounds,
         }
+
+    def _answer_chat_question(
+        self,
+        *,
+        prompt_snapshot: dict[str, Any],
+        question: str,
+        period_label: str,
+    ) -> tuple[str, LLMResponse, str, int]:
+        """Answer via the tool loop when available, else snapshot-grounded.
+
+        Returns ``(answer, aggregated_usage, prompt_for_audit, tool_rounds)``.
+        Any tool-loop failure degrades gracefully to the single-shot path —
+        the chat must never break because a tool broke.
+        """
+        if _chat_tools_enabled() and hasattr(self._provider, "generate_chat"):
+            try:
+                return self._answer_with_tools(
+                    prompt_snapshot=prompt_snapshot,
+                    question=question,
+                    period_label=period_label,
+                )
+            except LLMProviderError:
+                raise
+            except Exception as exc:
+                log.warning(
+                    "ai_advisory.chat.tools_failed user=%s error=%s — "
+                    "falling back to snapshot-grounded answer",
+                    self._user_id,
+                    exc,
+                )
+
+        prompt = _build_chat_prompt(
+            prompt_snapshot,
+            question,
+            period_label=period_label,
+        )
+        try:
+            llm_resp = self._provider.generate_with_usage(
+                prompt,
+                max_tokens=_chat_max_tokens(),
+                **_chat_model_kwargs(),
+            )
+        except LLMProviderError as exc:
+            log.warning(
+                "ai_advisory.chat.llm_error user=%s error=%s",
+                self._user_id,
+                exc,
+            )
+            raise
+        return llm_resp.content.strip(), llm_resp, prompt, 0
+
+    def _answer_with_tools(
+        self,
+        *,
+        prompt_snapshot: dict[str, Any],
+        question: str,
+        period_label: str,
+    ) -> tuple[str, LLMResponse, str, int]:
+        """OpenAI function-calling loop (#1548): max 3 read-only tool rounds."""
+        user_message = _build_chat_user_message(
+            prompt_snapshot,
+            question,
+            period_label=period_label,
+        )
+        messages: list[dict[str, Any]] = [
+            {"role": "system", "content": _chat_system_text()},
+            {"role": "user", "content": user_message},
+        ]
+
+        total_prompt_tokens = 0
+        total_completion_tokens = 0
+        rounds = 0
+        last_usage: LLMResponse | None = None
+        while True:
+            offer_tools = rounds < _CHAT_MAX_TOOL_ROUNDS
+            message, usage = self._provider.generate_chat(  # type: ignore[attr-defined]
+                messages,
+                tools=CHAT_TOOLS_SPEC if offer_tools else None,
+                max_tokens=_chat_max_tokens(),
+                model=_chat_model(),
+            )
+            last_usage = usage
+            total_prompt_tokens += usage.prompt_tokens
+            total_completion_tokens += usage.completion_tokens
+
+            tool_calls = message.get("tool_calls") or []
+            if not tool_calls or not offer_tools:
+                answer = str(message.get("content") or "").strip()
+                break
+
+            rounds += 1
+            messages.append(message)
+            for call in tool_calls:
+                function = call.get("function") or {}
+                try:
+                    arguments = json.loads(str(function.get("arguments") or "{}"))
+                except (TypeError, ValueError):
+                    arguments = {}
+                result = execute_chat_tool(
+                    user_id=self._user_id,
+                    name=str(function.get("name") or ""),
+                    arguments=arguments,
+                )
+                messages.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": str(call.get("id") or ""),
+                        "content": json.dumps(result, ensure_ascii=False, default=str),
+                    }
+                )
+
+        aggregated = LLMResponse(
+            content=answer,
+            prompt_tokens=total_prompt_tokens,
+            completion_tokens=total_completion_tokens,
+            total_tokens=total_prompt_tokens + total_completion_tokens,
+            model=last_usage.model if last_usage else _chat_model(),
+            latency_ms=last_usage.latency_ms if last_usage else 0,
+        )
+        return answer, aggregated, user_message, rounds
 
     # ------------------------------------------------------------------
     # 1. Spending insights
@@ -2780,36 +2950,65 @@ def _insight_reading_word_count(summary: str, items: list[dict[str, Any]]) -> in
 
 def _chat_max_tokens() -> int:
     """Output token cap for the Ask-anything chat (bounded to control cost)."""
-    return max(1, int(os.getenv("AI_CHAT_MAX_TOKENS", "600")))
+    return max(1, int(os.getenv("AI_CHAT_MAX_TOKENS", "900")))
 
 
-def _build_chat_prompt(snapshot: dict[str, Any], question: str) -> str:
-    """Build the snapshot-grounded prompt for the Ask-anything chat.
+def _chat_system_text() -> str:
+    """Chat guardrails as a proper system message (#1548).
 
-    The model must answer ONLY from the user's own financial snapshot, stay on
-    finance, refuse off-topic questions, and admit when data is outside the
-    snapshot — never inventing values.
+    Separating role=system from the user content reduces prompt-injection
+    surface: the question can no longer rewrite the rules mid-prompt.
     """
-    context = json.dumps(snapshot, ensure_ascii=False, default=str)
     return (
-        "Você é o assistente financeiro do Auraxis. Responda à pergunta do usuário "
-        "EXCLUSIVAMENTE com base nos dados financeiros (snapshot do próprio usuário) "
-        "fornecidos abaixo.\n\n"
+        "Você é o assistente financeiro do Auraxis. Responda EXCLUSIVAMENTE "
+        "com base nos dados financeiros do próprio usuário (snapshot fornecido "
+        "e resultados de ferramentas).\n"
         "Regras invioláveis:\n"
         "- Responda apenas perguntas sobre finanças pessoais e sobre os dados "
         "do usuário.\n"
         "- Se a pergunta não for sobre finanças, recuse com gentileza e explique "
         "que você só ajuda com as finanças do usuário no Auraxis.\n"
-        "- Use SOMENTE números presentes no snapshot. Nunca invente valores, "
-        "transações, categorias ou datas.\n"
-        "- Se o dado necessário não estiver no snapshot (ex.: um período fora da "
-        "janela atual), diga claramente que não tem essa informação disponível "
-        "e sugira onde o usuário pode encontrá-la no app.\n"
+        "- Use SOMENTE números presentes no snapshot ou retornados pelas "
+        "ferramentas. Nunca invente valores, transações, categorias ou datas.\n"
+        "- Quando a pergunta citar uma transação específica ou um período fora "
+        "do contexto fornecido, USE as ferramentas disponíveis (ex.: "
+        "search_transactions) antes de dizer que não tem a informação.\n"
+        "- Só diga que não tem a informação depois de esgotar o snapshot e as "
+        "ferramentas; nesse caso sugira onde encontrá-la no app.\n"
         "- Responda em português do Brasil, de forma direta e objetiva, em no "
-        "máximo 180 palavras.\n\n"
-        f"Snapshot financeiro (JSON):\n{context}\n\n"
-        f"Pergunta do usuário: {question}\n\n"
-        "Resposta:"
+        "máximo 220 palavras."
+    )
+
+
+def _build_chat_user_message(
+    snapshot: dict[str, Any],
+    question: str,
+    *,
+    period_label: str,
+) -> str:
+    context = json.dumps(snapshot, ensure_ascii=False, default=str)
+    return (
+        f"Contexto financeiro ancorado em {period_label} (JSON):\n{context}\n\n"
+        f"Pergunta do usuário: {question}"
+    )
+
+
+def _build_chat_prompt(
+    snapshot: dict[str, Any],
+    question: str,
+    *,
+    period_label: str = "",
+) -> str:
+    """Single-shot fallback prompt (providers without chat/tool support)."""
+    label_note = f" O contexto está ancorado em {period_label}." if period_label else ""
+    return (
+        _chat_system_text()
+        + label_note
+        + "\n\n"
+        + _build_chat_user_message(
+            snapshot, question, period_label=period_label or "período atual"
+        )
+        + "\n\nResposta:"
     )
 
 

--- a/app/services/ai_chat_tools.py
+++ b/app/services/ai_chat_tools.py
@@ -1,0 +1,276 @@
+"""Read-only function-calling tools for the Ask-anything chat (#1548).
+
+The chat's base context is a month-aware snapshot; these tools let the model
+fetch what the snapshot cannot carry (other periods, targeted searches) instead
+of answering "não tenho essa informação". Every tool is strictly read-only and
+scoped to the authenticated user. Decision PO 2026-07-10; kill-switch via
+``AI_CHAT_TOOLS_ENABLED``.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, timedelta
+from decimal import Decimal
+from typing import Any, cast
+from uuid import UUID
+
+from sqlalchemy import or_
+
+from app.models.transaction import Transaction, TransactionStatus, TransactionType
+
+log = logging.getLogger(__name__)
+
+_MAX_SEARCH_RESULTS = 20
+_DEFAULT_SEARCH_WINDOW_DAYS = 365
+
+CHAT_TOOLS_SPEC: list[dict[str, Any]] = [
+    {
+        "type": "function",
+        "function": {
+            "name": "search_transactions",
+            "description": (
+                "Busca transações do usuário por texto (título/descrição) e "
+                "período. Use quando a pergunta citar um gasto/receita "
+                "específico (ex.: 'salário', 'academia') ou um período fora "
+                "do snapshot."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Texto a procurar no título/descrição.",
+                    },
+                    "start_date": {
+                        "type": "string",
+                        "description": "Início (YYYY-MM-DD). Default: 12 meses atrás.",
+                    },
+                    "end_date": {
+                        "type": "string",
+                        "description": "Fim (YYYY-MM-DD). Default: hoje.",
+                    },
+                    "type": {
+                        "type": "string",
+                        "enum": ["income", "expense", "all"],
+                        "description": "Filtrar por tipo. Default: all.",
+                    },
+                },
+                "required": [],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_period_summary",
+            "description": (
+                "Totais pagos e pendentes (receitas, despesas, saldo) de um "
+                "período arbitrário."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "start_date": {"type": "string", "description": "YYYY-MM-DD."},
+                    "end_date": {"type": "string", "description": "YYYY-MM-DD."},
+                },
+                "required": ["start_date", "end_date"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_wallet_valuation",
+            "description": (
+                "Valuation atual da carteira de investimentos (patrimônio, "
+                "investido, lucro/prejuízo, por ativo)."
+            ),
+            "parameters": {"type": "object", "properties": {}, "required": []},
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_pending_overdue",
+            "description": (
+                "Compromissos não pagos: vencidos (com dias de atraso) e "
+                "próximos vencimentos em 7/30 dias."
+            ),
+            "parameters": {"type": "object", "properties": {}, "required": []},
+        },
+    },
+]
+
+
+def _money_str(value: Decimal | float | int | None) -> str:
+    return f"{Decimal(str(value or 0)):.2f}"
+
+
+def _parse_date(raw: Any, default: date) -> date:
+    try:
+        return date.fromisoformat(str(raw))
+    except (TypeError, ValueError):
+        return default
+
+
+def _serialize(tx: Transaction) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "date": tx.due_date.isoformat(),
+        "title": str(tx.title or ""),
+        "amount": _money_str(tx.amount),
+        "type": tx.type.value if tx.type else None,
+        "status": tx.status.value if tx.status else None,
+    }
+    tag = getattr(tx, "tag", None)
+    if tag is not None and tag.name:
+        payload["tag"] = str(tag.name)
+    return payload
+
+
+def _search_transactions(user_id: UUID, arguments: dict[str, Any]) -> dict[str, Any]:
+    today = date.today()
+    start = _parse_date(
+        arguments.get("start_date"),
+        today - timedelta(days=_DEFAULT_SEARCH_WINDOW_DAYS),
+    )
+    end = _parse_date(arguments.get("end_date"), today)
+    query = Transaction.query.filter(
+        Transaction.user_id == user_id,
+        Transaction.deleted.is_(False),
+        Transaction.status != TransactionStatus.CANCELLED,
+        Transaction.due_date >= start,
+        Transaction.due_date <= end,
+    )
+    text = str(arguments.get("query") or "").strip()
+    if text:
+        pattern = f"%{text}%"
+        query = query.filter(
+            or_(
+                Transaction.title.ilike(pattern),
+                Transaction.description.ilike(pattern),
+            )
+        )
+    tx_type = str(arguments.get("type") or "all").lower()
+    if tx_type == "income":
+        query = query.filter(Transaction.type == TransactionType.INCOME)
+    elif tx_type == "expense":
+        query = query.filter(Transaction.type == TransactionType.EXPENSE)
+
+    rows = cast(
+        list[Transaction],
+        query.order_by(Transaction.due_date.desc())
+        .limit(_MAX_SEARCH_RESULTS + 1)
+        .all(),
+    )
+    truncated = len(rows) > _MAX_SEARCH_RESULTS
+    items = [_serialize(tx) for tx in rows[:_MAX_SEARCH_RESULTS]]
+    return {
+        "period": {"start": start.isoformat(), "end": end.isoformat()},
+        "count": len(items),
+        "truncated": truncated,
+        "items": items,
+    }
+
+
+def _get_period_summary(user_id: UUID, arguments: dict[str, Any]) -> dict[str, Any]:
+    today = date.today()
+    start = _parse_date(arguments.get("start_date"), today.replace(day=1))
+    end = _parse_date(arguments.get("end_date"), today)
+    rows = cast(
+        list[Transaction],
+        Transaction.query.filter(
+            Transaction.user_id == user_id,
+            Transaction.deleted.is_(False),
+            Transaction.status != TransactionStatus.CANCELLED,
+            Transaction.due_date >= start,
+            Transaction.due_date <= end,
+        ).all(),
+    )
+
+    def _sum(txs: list[Transaction], tx_type: TransactionType) -> Decimal:
+        return sum(
+            (Decimal(str(tx.amount)) for tx in txs if tx.type == tx_type),
+            Decimal("0"),
+        )
+
+    paid = [tx for tx in rows if tx.status == TransactionStatus.PAID]
+    unpaid = [tx for tx in rows if tx.status != TransactionStatus.PAID]
+    income = _sum(paid, TransactionType.INCOME)
+    expense = _sum(paid, TransactionType.EXPENSE)
+    return {
+        "period": {"start": start.isoformat(), "end": end.isoformat()},
+        "paid": {
+            "income_total": _money_str(income),
+            "expense_total": _money_str(expense),
+            "balance": _money_str(income - expense),
+        },
+        "pending": {
+            "income_total": _money_str(_sum(unpaid, TransactionType.INCOME)),
+            "expense_total": _money_str(_sum(unpaid, TransactionType.EXPENSE)),
+        },
+        "transaction_count": len(rows),
+    }
+
+
+def _get_wallet_valuation(user_id: UUID, _: dict[str, Any]) -> dict[str, Any]:
+    from app.services.portfolio_valuation_service import PortfolioValuationService
+
+    valuation = PortfolioValuationService(user_id).get_portfolio_current_valuation()
+    items = [
+        {
+            "name": item["name"],
+            "asset_class": item["asset_class"],
+            "ticker": item["ticker"],
+            "current_value": item["current_value"],
+            "invested_amount": item["invested_amount"],
+            "profit_loss_amount": item["profit_loss_amount"],
+            "profit_loss_percent": item["profit_loss_percent"],
+            "valuation_source": item["valuation_source"],
+        }
+        for item in valuation["items"]
+    ]
+    return {"summary": valuation["summary"], "items": items}
+
+
+def _get_pending_overdue(user_id: UUID, _: dict[str, Any]) -> dict[str, Any]:
+    from app.services.financial_insight_context_builder import (
+        FinancialInsightContextBuilder,
+    )
+
+    return FinancialInsightContextBuilder()._pending_commitments_payload(  # noqa: SLF001
+        user_id=user_id,
+        anchor=date.today(),
+    )
+
+
+_EXECUTORS = {
+    "search_transactions": _search_transactions,
+    "get_period_summary": _get_period_summary,
+    "get_wallet_valuation": _get_wallet_valuation,
+    "get_pending_overdue": _get_pending_overdue,
+}
+
+
+def execute_chat_tool(
+    *,
+    user_id: UUID,
+    name: str,
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    """Execute a read-only chat tool for *user_id*; errors become payloads.
+
+    Tool failures must never abort the chat turn — the model receives an
+    ``error`` field and can degrade gracefully.
+    """
+    executor = _EXECUTORS.get(name)
+    if executor is None:
+        return {"error": f"unknown_tool: {name}"}
+    try:
+        return executor(user_id, arguments or {})
+    except Exception as exc:  # defensive: tools must not break the chat
+        log.warning("ai_chat.tool_failed user=%s tool=%s error=%s", user_id, name, exc)
+        return {"error": "tool_execution_failed"}
+
+
+__all__ = ["CHAT_TOOLS_SPEC", "execute_chat_tool"]

--- a/app/services/chat_period_detection.py
+++ b/app/services/chat_period_detection.py
@@ -1,0 +1,132 @@
+"""Deterministic pt-BR period detection for the finance chat (#1548).
+
+The Ask-anything chat used to anchor its snapshot on TODAY only, so
+"quanto foi o salário de julho?" could never be answered. This module parses
+period references in the user's question — month names, "mês passado",
+"semana passada", "ontem", "YYYY-MM" — and returns the anchor date the chat
+context should be built around. Pure regex/date arithmetic: zero LLM cost and
+fully unit-testable.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from calendar import monthrange
+from dataclasses import dataclass
+from datetime import date, timedelta
+
+_MONTHS_PT = {
+    "janeiro": 1,
+    "fevereiro": 2,
+    "marco": 3,
+    "abril": 4,
+    "maio": 5,
+    "junho": 6,
+    "julho": 7,
+    "agosto": 8,
+    "setembro": 9,
+    "outubro": 10,
+    "novembro": 11,
+    "dezembro": 12,
+}
+_MONTH_LABELS_PT = {v: k for k, v in _MONTHS_PT.items()}
+
+_YYYY_MM_RE = re.compile(r"\b(20\d{2})-(0[1-9]|1[0-2])\b")
+_MONTH_NAME_RE = re.compile(
+    r"\b(" + "|".join(_MONTHS_PT) + r")\b(?:\s+de\s+(20\d{2}))?",
+)
+
+
+@dataclass(frozen=True)
+class ChatPeriodResolution:
+    """Anchor + human label for the period referenced in a chat question."""
+
+    anchor: date
+    label: str
+    matched: bool
+
+
+def _normalize(text: str) -> str:
+    decomposed = unicodedata.normalize("NFD", text.lower())
+    return "".join(ch for ch in decomposed if unicodedata.category(ch) != "Mn")
+
+
+def _month_anchor(year: int, month: int, *, today: date) -> date:
+    """Anchor inside the referenced month: its last day, capped at today."""
+    last_day = date(year, month, monthrange(year, month)[1])
+    return (
+        min(last_day, today) if (year, month) == (today.year, today.month) else last_day
+    )
+
+
+def _month_label(year: int, month: int) -> str:
+    return f"{_MONTH_LABELS_PT[month]}/{year}"
+
+
+def detect_chat_period(question: str, *, today: date) -> ChatPeriodResolution:
+    """Resolve the period a pt-BR finance question refers to.
+
+    Precedence: explicit ``YYYY-MM`` > month name (optionally "de YYYY") >
+    "mês passado" > "semana passada" > "ontem" > default (today / current
+    month). A bare month name resolves to the nearest non-future occurrence
+    (e.g. asking "dezembro" in July refers to last December).
+    """
+    normalized = _normalize(question or "")
+
+    explicit = _YYYY_MM_RE.search(normalized)
+    if explicit:
+        year, month = int(explicit.group(1)), int(explicit.group(2))
+        return ChatPeriodResolution(
+            anchor=_month_anchor(year, month, today=today),
+            label=_month_label(year, month),
+            matched=True,
+        )
+
+    if "mes passado" in normalized:
+        first_of_month = today.replace(day=1)
+        previous = first_of_month - timedelta(days=1)
+        return ChatPeriodResolution(
+            anchor=previous,
+            label=_month_label(previous.year, previous.month),
+            matched=True,
+        )
+
+    month_match = _MONTH_NAME_RE.search(normalized)
+    if month_match:
+        month = _MONTHS_PT[month_match.group(1)]
+        year_raw = month_match.group(2)
+        if year_raw:
+            year = int(year_raw)
+        else:
+            year = today.year if month <= today.month else today.year - 1
+        return ChatPeriodResolution(
+            anchor=_month_anchor(year, month, today=today),
+            label=_month_label(year, month),
+            matched=True,
+        )
+
+    if "semana passada" in normalized:
+        anchor = today - timedelta(days=7)
+        return ChatPeriodResolution(
+            anchor=anchor,
+            label=f"semana passada ({anchor.isoformat()})",
+            matched=True,
+        )
+
+    if "ontem" in normalized:
+        anchor = today - timedelta(days=1)
+        return ChatPeriodResolution(
+            anchor=anchor,
+            label=f"ontem ({anchor.isoformat()})",
+            matched=True,
+        )
+
+    return ChatPeriodResolution(
+        anchor=today,
+        label=_month_label(today.year, today.month),
+        matched=False,
+    )
+
+
+__all__ = ["ChatPeriodResolution", "detect_chat_period"]

--- a/app/services/financial_insight_context_builder.py
+++ b/app/services/financial_insight_context_builder.py
@@ -852,6 +852,67 @@ class FinancialInsightContextBuilder:
             "data_quality": snapshot["data_quality"],
         }
 
+    def build_chat_context(
+        self,
+        *,
+        user_id: UUID,
+        anchor_date: date,
+        today: date,
+        timezone_name: str = _TIMEZONE,
+        timezone_fallback: bool = False,
+    ) -> dict[str, Any]:
+        """Month-aware context for the Ask-anything chat (#1548).
+
+        Covers the WHOLE calendar month of ``anchor_date`` (capped at *today*
+        for the current month) with a larger labelled transaction sample (40,
+        incomes included) — the old daily snapshot could not see "Salário BRQ"
+        paid on the 1st. Includes commitments/month_summary and a "today"
+        highlight block when the anchor month is the current one.
+        """
+        month_start = anchor_date.replace(day=1)
+        month_end = date(
+            anchor_date.year,
+            anchor_date.month,
+            monthrange(anchor_date.year, anchor_date.month)[1],
+        )
+        is_current_month = (anchor_date.year, anchor_date.month) == (
+            today.year,
+            today.month,
+        )
+        end = min(month_end, today) if is_current_month else month_end
+
+        snapshot = self._period_snapshot(
+            user_id=user_id,
+            start=month_start,
+            end=end,
+            label=f"{anchor_date:%Y-%m}",
+            period_type="chat_month",
+            include_daily_series=False,
+            include_budgets=True,
+            include_goals=True,
+            include_credit_cards=True,
+            include_wallet=True,
+            include_commitments=True,
+            transactions_sample_limit=40,
+            timezone_name=timezone_name,
+            timezone_fallback=timezone_fallback,
+        )
+
+        if is_current_month:
+            today_txs = [
+                tx
+                for tx in self._fetch_transactions(
+                    user_id=user_id, start=today, end=today
+                )
+                if tx.status != TransactionStatus.CANCELLED
+            ]
+            snapshot["today"] = {
+                "date": today.isoformat(),
+                "transaction_count": len(today_txs),
+                "items": [self._serialize_transaction(tx) for tx in today_txs[:10]],
+            }
+        return snapshot
+
     def _period_snapshot(
         self,
         *,
@@ -866,6 +927,7 @@ class FinancialInsightContextBuilder:
         include_credit_cards: bool = False,
         include_wallet: bool = False,
         include_commitments: bool = False,
+        transactions_sample_limit: int = 20,
         market_rates: MarketRatesProvider | None = None,
         previous_generated_at: datetime | None = None,
         timezone_name: str = _TIMEZONE,
@@ -923,6 +985,7 @@ class FinancialInsightContextBuilder:
             },
             "transactions": self._transactions_payload(
                 non_cancelled,
+                sample_limit=transactions_sample_limit,
                 previous_generated_at=previous_generated_at,
             ),
             "budgets": self._budgets_payload(user_id=user_id, start=start, end=end)

--- a/app/services/financial_insight_context_builder.py
+++ b/app/services/financial_insight_context_builder.py
@@ -17,6 +17,8 @@ from decimal import Decimal, InvalidOperation
 from typing import Any, cast
 from uuid import UUID
 
+from sqlalchemy.orm import QueryableAttribute, joinedload
+
 from app.models.budget import Budget
 from app.models.credit_card import CreditCard
 from app.models.goal import Goal
@@ -53,7 +55,14 @@ surface it belongs to so contextual pages can filter, while the global
 `/insights` hub renders all dimensions grouped.
 """
 
-_SNAPSHOT_VERSION = "financial_insight_snapshot.v1"
+_SNAPSHOT_VERSION = "financial_insight_snapshot.v3"
+
+
+def _tag_loader() -> Any:
+    """joinedload(Transaction.tag) — cast for legacy (non-Mapped) relationships."""
+    return joinedload(cast("QueryableAttribute[Any]", Transaction.tag))
+
+
 _CURRENCY = "BRL"
 _TIMEZONE = "America/Sao_Paulo"
 _GOAL_PACE_WINDOW_DAYS = 90
@@ -63,6 +72,7 @@ _GOAL_PACE_WINDOW_DAYS = 90
 # while preserving the structural backbone (schema_version, current_period,
 # comparisons). Override via AI_SNAPSHOT_MAX_BYTES env for cost experiments.
 DEFAULT_MAX_SNAPSHOT_BYTES = 12 * 1024
+DEFAULT_MAX_SNAPSHOT_BYTES_LONG = 24 * 1024
 MAX_SNAPSHOT_BYTES = int(
     os.getenv("AI_SNAPSHOT_MAX_BYTES", str(DEFAULT_MAX_SNAPSHOT_BYTES))
 )
@@ -637,6 +647,7 @@ class FinancialInsightContextBuilder:
             include_goals=True,
             include_credit_cards=True,
             include_wallet=True,
+            include_commitments=True,
             previous_generated_at=previous_generated_at,
             timezone_name=timezone_name,
             timezone_fallback=timezone_fallback,
@@ -759,6 +770,7 @@ class FinancialInsightContextBuilder:
             include_goals=True,
             include_credit_cards=True,
             include_wallet=True,
+            include_commitments=True,
             previous_generated_at=previous_generated_at,
             timezone_name=timezone_name,
             timezone_fallback=timezone_fallback,
@@ -801,6 +813,7 @@ class FinancialInsightContextBuilder:
             include_goals=True,
             include_credit_cards=True,
             include_wallet=True,
+            include_commitments=True,
             previous_generated_at=previous_generated_at,
             timezone_name=timezone_name,
             timezone_fallback=timezone_fallback,
@@ -852,6 +865,7 @@ class FinancialInsightContextBuilder:
         include_goals: bool = False,
         include_credit_cards: bool = False,
         include_wallet: bool = False,
+        include_commitments: bool = False,
         market_rates: MarketRatesProvider | None = None,
         previous_generated_at: datetime | None = None,
         timezone_name: str = _TIMEZONE,
@@ -923,6 +937,18 @@ class FinancialInsightContextBuilder:
                 "missing_comparison_periods": [],
             },
         }
+        snapshot["tags"] = self._tags_payload(
+            [tx for tx in non_cancelled if tx.status == TransactionStatus.PAID]
+        )
+        if include_commitments:
+            snapshot["pending_commitments"] = self._pending_commitments_payload(
+                user_id=user_id,
+                anchor=end,
+            )
+            snapshot["month_summary"] = self._month_summary_payload(
+                user_id=user_id,
+                anchor=end,
+            )
         if timezone_fallback:
             snapshot["data_quality"]["timezone_fallback"] = True
         snapshot["data_quality"].update(goal_data_quality)
@@ -1181,7 +1207,8 @@ class FinancialInsightContextBuilder:
         end: date,
     ) -> list[Transaction]:
         rows = (
-            Transaction.query.filter(
+            Transaction.query.options(_tag_loader())
+            .filter(
                 Transaction.user_id == user_id,
                 Transaction.deleted.is_(False),
                 Transaction.due_date >= start,
@@ -1202,7 +1229,8 @@ class FinancialInsightContextBuilder:
         start_dt = datetime.combine(start, datetime.min.time())
         end_dt = datetime.combine(end + timedelta(days=1), datetime.min.time())
         rows = (
-            Transaction.query.filter(
+            Transaction.query.options(_tag_loader())
+            .filter(
                 Transaction.user_id == user_id,
                 Transaction.deleted.is_(False),
                 Transaction.created_at >= start_dt,
@@ -1433,6 +1461,161 @@ class FinancialInsightContextBuilder:
             )
         ]
 
+    def _tags_payload(
+        self,
+        transactions: list[Transaction],
+        *,
+        cap: int = 8,
+    ) -> dict[str, Any]:
+        """Aggregate PAID transactions by user tag (#1547).
+
+        Tags are the user's own catalogue (e.g. "academia"); surfacing them
+        lets the LLM talk about spend in the user's vocabulary. Deterministic
+        aggregation — costs a few hundred prompt tokens at most.
+        """
+
+        def _top(tx_type: TransactionType) -> list[dict[str, Any]]:
+            totals: dict[str, tuple[Decimal, int]] = {}
+            for tx in transactions:
+                if tx.type != tx_type:
+                    continue
+                tag_name = self._transaction_tag_name(tx)
+                if not tag_name:
+                    continue
+                total, count = totals.get(tag_name, (Decimal("0.00"), 0))
+                totals[tag_name] = (total + _money(tx.amount), count + 1)
+            ranked = sorted(
+                totals.items(),
+                key=lambda item: (-item[1][0], item[0]),
+            )[:cap]
+            return [
+                {"tag": tag, "total": _money_str(total), "count": count}
+                for tag, (total, count) in ranked
+            ]
+
+        return {
+            "top_by_expense": _top(TransactionType.EXPENSE),
+            "top_by_income": _top(TransactionType.INCOME),
+        }
+
+    def _pending_commitments_payload(
+        self,
+        *,
+        user_id: UUID,
+        anchor: date,
+    ) -> dict[str, Any]:
+        """Labelled overdue items + upcoming due dates (7/30 days) (#1547).
+
+        The old snapshot only carried aggregate totals — the LLM could never
+        say WHICH bill is late or WHAT is due next week.
+        """
+        unpaid_statuses = (TransactionStatus.PENDING, TransactionStatus.OVERDUE)
+        rows = (
+            Transaction.query.options(_tag_loader())
+            .filter(
+                Transaction.user_id == user_id,
+                Transaction.deleted.is_(False),
+                Transaction.status.in_(unpaid_statuses),
+                Transaction.due_date <= anchor + timedelta(days=30),
+            )
+            .order_by(Transaction.due_date.asc())
+            .all()
+        )
+        unpaid = cast(list[Transaction], rows)
+        overdue = [tx for tx in unpaid if tx.due_date < anchor]
+        upcoming = [tx for tx in unpaid if tx.due_date > anchor]
+        upcoming_7d = [
+            tx for tx in upcoming if tx.due_date <= anchor + timedelta(days=7)
+        ]
+
+        def _block(
+            items: list[Transaction],
+            *,
+            item_limit: int,
+            with_days_overdue: bool = False,
+        ) -> dict[str, Any]:
+            serialized = []
+            for tx in items[:item_limit]:
+                entry = self._serialize_transaction(tx)
+                if with_days_overdue:
+                    entry["days_overdue"] = (anchor - tx.due_date).days
+                serialized.append(entry)
+            return {
+                "count": len(items),
+                "expense_total": _money_str(self._sum(items, TransactionType.EXPENSE)),
+                "income_total": _money_str(self._sum(items, TransactionType.INCOME)),
+                "items": serialized,
+            }
+
+        return {
+            "overdue": _block(overdue, item_limit=10, with_days_overdue=True),
+            "upcoming_7d": _block(upcoming_7d, item_limit=5),
+            "upcoming_30d": _block(upcoming, item_limit=5),
+        }
+
+    def _month_summary_payload(
+        self,
+        *,
+        user_id: UUID,
+        anchor: date,
+    ) -> dict[str, Any]:
+        """Deterministic month-to-date health block (#1547).
+
+        Projection is commitments-based: current paid balance plus every
+        still-unpaid commitment of the calendar month (incl. overdue) — no
+        extrapolation the LLM could mistake for fact.
+        """
+        month_start = anchor.replace(day=1)
+        month_end = date(
+            anchor.year, anchor.month, monthrange(anchor.year, anchor.month)[1]
+        )
+        month_txs = [
+            tx
+            for tx in self._fetch_transactions(
+                user_id=user_id, start=month_start, end=month_end
+            )
+            if tx.status != TransactionStatus.CANCELLED
+        ]
+        paid_mtd = [
+            tx
+            for tx in month_txs
+            if tx.status == TransactionStatus.PAID and tx.due_date <= anchor
+        ]
+        unpaid_month = [
+            tx
+            for tx in month_txs
+            if tx.status in (TransactionStatus.PENDING, TransactionStatus.OVERDUE)
+        ]
+        income_mtd = self._sum(paid_mtd, TransactionType.INCOME)
+        expense_mtd = self._sum(paid_mtd, TransactionType.EXPENSE)
+        balance_mtd = income_mtd - expense_mtd
+        savings_rate = (
+            (balance_mtd / income_mtd * Decimal("100")).quantize(Decimal("0.01"))
+            if income_mtd > 0
+            else Decimal("0.00")
+        )
+        days_elapsed = max(1, anchor.day)
+        burn_rate = (expense_mtd / Decimal(days_elapsed)).quantize(Decimal("0.01"))
+        pending_income = self._sum(unpaid_month, TransactionType.INCOME)
+        pending_expense = self._sum(unpaid_month, TransactionType.EXPENSE)
+        projected_eom = balance_mtd + pending_income - pending_expense
+        overdue_expense = self._sum(
+            [tx for tx in unpaid_month if tx.due_date < anchor],
+            TransactionType.EXPENSE,
+        )
+        return {
+            "month": f"{anchor:%Y-%m}",
+            "income_mtd": _money_str(income_mtd),
+            "expense_mtd": _money_str(expense_mtd),
+            "balance_mtd": _money_str(balance_mtd),
+            "savings_rate_pct": _percent_str(savings_rate),
+            "burn_rate_daily": _money_str(burn_rate),
+            "pending_income_month": _money_str(pending_income),
+            "pending_expense_month": _money_str(pending_expense),
+            "projected_eom_balance": _money_str(projected_eom),
+            "overdue_total": _money_str(overdue_expense),
+        }
+
     def _transactions_payload(
         self,
         transactions: list[Transaction],
@@ -1527,7 +1710,17 @@ class FinancialInsightContextBuilder:
             payload["description"] = description
         if category:
             payload["category"] = category
+        tag_name = self._transaction_tag_name(transaction)
+        if tag_name:
+            payload["tag"] = tag_name
         return payload
+
+    @staticmethod
+    def _transaction_tag_name(transaction: Transaction) -> str | None:
+        tag = getattr(transaction, "tag", None)
+        if tag is None:
+            return None
+        return _sanitize_text(str(tag.name or ""), max_length=30) or None
 
     def _budgets_payload(
         self,
@@ -1556,23 +1749,39 @@ class FinancialInsightContextBuilder:
         result: list[dict[str, Any]] = []
         for budget in budgets:
             category = str(budget.category) if budget.category else None
+            tag_name: str | None = None
             spent = Decimal("0.00")
-            for tx in paid:
-                if category is None or _enum_value(tx.category) == category:
-                    spent += _money(tx.amount)
+            if budget.tag_id is not None:
+                # Tag-linked budget (#1547): spend is scoped to the tag, not
+                # the whole period — these budgets used to be excluded from
+                # the AI snapshot entirely.
+                tag_obj = getattr(budget, "tag", None)
+                tag_name = (
+                    _sanitize_text(str(tag_obj.name), max_length=30)
+                    if tag_obj is not None
+                    else None
+                )
+                for tx in paid:
+                    if tx.tag_id == budget.tag_id:
+                        spent += _money(tx.amount)
+            else:
+                for tx in paid:
+                    if category is None or _enum_value(tx.category) == category:
+                        spent += _money(tx.amount)
 
             amount = _money(budget.amount)
-            result.append(
-                {
-                    "name": _sanitize_text(budget.name) or "Orçamento",
-                    "category": category,
-                    "period": str(budget.period),
-                    "amount": _money_str(amount),
-                    "spent": _money_str(spent),
-                    "utilization_pct": _safe_pct(spent, amount),
-                    "exceeded": spent > amount,
-                }
-            )
+            entry: dict[str, Any] = {
+                "name": _sanitize_text(budget.name) or "Orçamento",
+                "category": category,
+                "period": str(budget.period),
+                "amount": _money_str(amount),
+                "spent": _money_str(spent),
+                "utilization_pct": _safe_pct(spent, amount),
+                "exceeded": spent > amount,
+            }
+            if tag_name:
+                entry["tag"] = tag_name
+            result.append(entry)
         return result
 
     def _goals_payload(
@@ -1752,7 +1961,10 @@ def _trim_transactions(snapshot: dict[str, Any]) -> bool:
     txs = snapshot.get("transactions")
     if not isinstance(txs, dict):
         return False
-    items = txs.get("items")
+    # Real snapshots emit "sample" (#1547 fixed a silent no-op that looked for
+    # "items" only); keep accepting "items" for synthetic/legacy payloads.
+    key = "sample" if isinstance(txs.get("sample"), list) else "items"
+    items = txs.get(key)
     if not (isinstance(items, list) and len(items) > 15):
         return False
     expenses = [i for i in items if i.get("type") == "expense"]
@@ -1765,7 +1977,7 @@ def _trim_transactions(snapshot: dict[str, Any]) -> bool:
             :5
         ]
     )
-    snapshot["transactions"] = {**txs, "items": kept}
+    snapshot["transactions"] = {**txs, key: kept}
     return True
 
 
@@ -1883,5 +2095,6 @@ __all__ = [
     "FinancialInsightContextBuilder",
     "INSIGHT_DIMENSIONS",
     "MAX_SNAPSHOT_BYTES",
+    "DEFAULT_MAX_SNAPSHOT_BYTES_LONG",
     "truncate_snapshot",
 ]

--- a/app/services/llm_provider.py
+++ b/app/services/llm_provider.py
@@ -220,6 +220,61 @@ class OpenAILLMProvider:
         except Exception as exc:
             raise LLMProviderError(f"OpenAI call failed: {exc}") from exc
 
+    def generate_chat(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        tools: list[dict[str, Any]] | None = None,
+        max_tokens: int | None = None,
+        model: str | None = None,
+    ) -> tuple[dict[str, Any], LLMResponse]:
+        """Multi-message chat completion with optional function-calling (#1548).
+
+        Returns ``(assistant_message, usage)`` — the raw assistant message may
+        carry ``tool_calls`` for the caller's tool loop. ``usage.content`` is
+        the text content (empty string when the model only called tools).
+        """
+        if not self._api_key:
+            raise LLMProviderError("OPENAI_API_KEY is not configured.")
+        import requests  # lazy import to keep startup fast
+
+        resolved_max_tokens = _resolve_max_tokens(max_tokens)
+        start = time.monotonic()
+        payload: dict[str, Any] = {
+            "model": model or self._model,
+            "messages": messages,
+            "max_tokens": resolved_max_tokens,
+            "temperature": 0.4,
+        }
+        if tools:
+            payload["tools"] = tools
+
+        try:
+            resp = requests.post(
+                self._BASE_URL,
+                headers={
+                    "Authorization": f"Bearer {self._api_key}",
+                    "Content-Type": "application/json",
+                },
+                json=payload,
+                timeout=_timeout_for_max_tokens(resolved_max_tokens),
+            )
+            resp.raise_for_status()
+            latency_ms = int((time.monotonic() - start) * 1000)
+            data = resp.json()
+            usage = data.get("usage", {})
+            message = dict(data["choices"][0]["message"])
+            return message, LLMResponse(
+                content=str(message.get("content") or ""),
+                prompt_tokens=int(usage.get("prompt_tokens", 0)),
+                completion_tokens=int(usage.get("completion_tokens", 0)),
+                total_tokens=int(usage.get("total_tokens", 0)),
+                model=str(data.get("model", model or self._model)),
+                latency_ms=latency_ms,
+            )
+        except Exception as exc:
+            raise LLMProviderError(f"OpenAI chat call failed: {exc}") from exc
+
 
 class ClaudeLLMProvider:
     """Calls the Anthropic Messages API (requires `requests` + ANTHROPIC_API_KEY)."""

--- a/app/services/llm_provider.py
+++ b/app/services/llm_provider.py
@@ -93,8 +93,14 @@ class LLMProvider(Protocol):
         *,
         response_schema: dict[str, Any] | None = None,
         max_tokens: int | None = None,
+        model: str | None = None,
     ) -> LLMResponse:
-        """Generate a response and return structured usage data."""
+        """Generate a response and return structured usage data.
+
+        ``model`` optionally overrides the provider's default for this single
+        call (#1547 — per-period model mix); providers without multi-model
+        support may ignore it.
+        """
         ...
 
 
@@ -119,8 +125,9 @@ class StubLLMProvider:
         *,
         response_schema: dict[str, Any] | None = None,
         max_tokens: int | None = None,
+        model: str | None = None,
     ) -> LLMResponse:
-        del prompt, max_tokens
+        del prompt, max_tokens, model
         content = self._STUB_CONTENT
         if (
             response_schema
@@ -167,6 +174,7 @@ class OpenAILLMProvider:
         *,
         response_schema: dict[str, Any] | None = None,
         max_tokens: int | None = None,
+        model: str | None = None,
     ) -> LLMResponse:
         if not self._api_key:
             raise LLMProviderError("OPENAI_API_KEY is not configured.")
@@ -175,7 +183,7 @@ class OpenAILLMProvider:
         resolved_max_tokens = _resolve_max_tokens(max_tokens)
         start = time.monotonic()
         payload: dict[str, Any] = {
-            "model": self._model,
+            "model": model or self._model,
             "messages": [{"role": "user", "content": prompt}],
             "max_tokens": resolved_max_tokens,
             "temperature": 0.4,
@@ -206,7 +214,7 @@ class OpenAILLMProvider:
                 prompt_tokens=int(usage.get("prompt_tokens", 0)),
                 completion_tokens=int(usage.get("completion_tokens", 0)),
                 total_tokens=int(usage.get("total_tokens", 0)),
-                model=str(data.get("model", self._model)),
+                model=str(data.get("model", model or self._model)),
                 latency_ms=latency_ms,
             )
         except Exception as exc:
@@ -231,8 +239,9 @@ class ClaudeLLMProvider:
         *,
         response_schema: dict[str, Any] | None = None,
         max_tokens: int | None = None,
+        model: str | None = None,
     ) -> LLMResponse:
-        _ = response_schema
+        _ = response_schema, model
         if not self._api_key:
             raise LLMProviderError("ANTHROPIC_API_KEY is not configured.")
         import requests

--- a/graphql.introspection.json
+++ b/graphql.introspection.json
@@ -18104,6 +18104,30 @@
                 "name": "Float",
                 "ofType": null
               }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "periodLabel",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "toolRounds",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
             }
           ],
           "inputFields": null,

--- a/openapi.json
+++ b/openapi.json
@@ -1256,7 +1256,9 @@
                     "answer": "Até agora você gastou R$320,00 com alimentação.",
                     "cost_usd": 5.7e-05,
                     "model": "gpt-4o-mini",
-                    "tokens_used": 380
+                    "period_label": "julho/2026",
+                    "tokens_used": 380,
+                    "tool_rounds": 1
                   },
                   "message": "Resposta gerada com sucesso"
                 },

--- a/schema.graphql
+++ b/schema.graphql
@@ -1478,6 +1478,8 @@ type AskFinancialQuestionPayload {
   model: String
   tokensUsed: Int
   costUsd: Float
+  periodLabel: String
+  toolRounds: Int
 }
 
 """Canonical payload for completeOnboarding mutation."""

--- a/tests/test_ai_advisory_service.py
+++ b/tests/test_ai_advisory_service.py
@@ -372,13 +372,13 @@ class TestAIAdvisoryServiceFinancialInsights:
                 "budgets",
                 "wallet",
             ]
-            assert result["context_version"] == "financial_insight_snapshot.v1"
+            assert result["context_version"] == "financial_insight_snapshot.v3"
             assert result["cached"] is False
             assert result["tokens_used"] == 140
 
             call = provider.generate_with_usage.call_args
             prompt = call.args[0]
-            assert "financial_insight_snapshot.v1" in prompt
+            assert "financial_insight_snapshot.v3" in prompt
             assert "Não invente transações" in prompt
             assert (
                 call.kwargs["response_schema"]["name"] == "financial_insight_response"

--- a/tests/test_ai_chat_v2.py
+++ b/tests/test_ai_chat_v2.py
@@ -1,0 +1,399 @@
+"""Chat assistente v2 (#1548): month-aware, period detection e function-calling.
+
+Covers:
+- detect_chat_period: pt-BR month names, "mês passado", "semana passada",
+  "ontem", explicit YYYY-MM, default.
+- build_chat_context: month window with labelled income samples — the
+  "Salário BRQ de 01/07" case the daily-anchored snapshot could never answer.
+- Tool loop: scripted provider issues tool_calls → tools execute read-only →
+  final answer aggregates tokens; kill-switch and graceful fallback.
+- execute_chat_tool: search/summary/pending are user-scoped and read-only.
+- Chat payload carries period_label + tool_rounds (REST).
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import date
+from decimal import Decimal
+from unittest.mock import patch
+
+import pytest
+
+from app.extensions.database import db
+from app.models.transaction import (
+    Transaction,
+    TransactionStatus,
+    TransactionType,
+)
+from app.models.user import User
+from app.services.chat_period_detection import detect_chat_period
+from app.services.llm_provider import LLMResponse, StubLLMProvider
+
+_TODAY = date(2026, 7, 10)
+
+
+@pytest.fixture(autouse=True)
+def _bypass_premium_gate():
+    """Raw uuid users; the Premium gate (#1546) has dedicated coverage."""
+    with patch("app.services.ai_advisory_service._ensure_premium_entitlement"):
+        yield
+
+
+def _make_user() -> uuid.UUID:
+    user = User(
+        name="Chat Cliente",
+        email=f"chatv2-{uuid.uuid4().hex[:8]}@example.com",
+        password="hashed",
+    )
+    db.session.add(user)
+    db.session.commit()
+    return user.id
+
+
+def _make_tx(
+    user_id: uuid.UUID,
+    *,
+    title: str,
+    amount: str,
+    tx_type: TransactionType = TransactionType.EXPENSE,
+    status: TransactionStatus = TransactionStatus.PAID,
+    due_date: date = _TODAY,
+) -> Transaction:
+    tx = Transaction(
+        user_id=user_id,
+        title=title,
+        description=title,
+        amount=Decimal(amount),
+        type=tx_type,
+        status=status,
+        due_date=due_date,
+    )
+    db.session.add(tx)
+    db.session.commit()
+    return tx
+
+
+class TestDetectChatPeriod:
+    def test_month_name_resolves_to_nearest_non_future(self) -> None:
+        result = detect_chat_period("quanto foi o salário de julho?", today=_TODAY)
+        assert result.matched is True
+        assert result.anchor == _TODAY  # July capped at today
+        assert result.label == "julho/2026"
+
+        december = detect_chat_period("gastos de dezembro", today=_TODAY)
+        assert december.anchor == date(2025, 12, 31)
+        assert december.label == "dezembro/2025"
+
+    def test_month_name_with_explicit_year(self) -> None:
+        result = detect_chat_period("resumo de maio de 2026", today=_TODAY)
+        assert result.anchor == date(2026, 5, 31)
+        assert result.label == "maio/2026"
+
+    def test_explicit_yyyy_mm(self) -> None:
+        result = detect_chat_period("resumo de 2026-06", today=_TODAY)
+        assert result.anchor == date(2026, 6, 30)
+        assert result.label == "junho/2026"
+
+    def test_mes_passado(self) -> None:
+        result = detect_chat_period("quanto gastei mês passado?", today=_TODAY)
+        assert result.anchor == date(2026, 6, 30)
+        assert result.label == "junho/2026"
+
+    def test_semana_passada_and_ontem(self) -> None:
+        week = detect_chat_period("e semana passada?", today=_TODAY)
+        assert week.anchor == date(2026, 7, 3)
+        yesterday = detect_chat_period("quanto gastei ontem?", today=_TODAY)
+        assert yesterday.anchor == date(2026, 7, 9)
+
+    def test_default_is_current_month_unmatched(self) -> None:
+        result = detect_chat_period("qual meu maior gasto?", today=_TODAY)
+        assert result.matched is False
+        assert result.anchor == _TODAY
+        assert result.label == "julho/2026"
+
+
+class TestChatContextMonthAware:
+    def test_salary_paid_on_day_one_is_visible_labelled(self, app) -> None:
+        """The bug case: income from 01/07 must reach the model BY NAME."""
+        with app.app_context():
+            from app.services.financial_insight_context_builder import (
+                FinancialInsightContextBuilder,
+            )
+
+            user_id = _make_user()
+            _make_tx(
+                user_id,
+                title="Salário BRQ",
+                amount="10754.00",
+                tx_type=TransactionType.INCOME,
+                due_date=date(2026, 7, 1),
+            )
+            context = FinancialInsightContextBuilder().build_chat_context(
+                user_id=user_id,
+                anchor_date=_TODAY,
+                today=_TODAY,
+            )
+
+        titles = [item["title"] for item in context["transactions"]["sample"]]
+        assert "Salário BRQ" in titles
+        assert context["period"]["label"] == "2026-07"
+        assert "pending_commitments" in context
+        assert "month_summary" in context
+        assert context["today"]["date"] == _TODAY.isoformat()
+
+    def test_past_month_covers_whole_month(self, app) -> None:
+        with app.app_context():
+            from app.services.financial_insight_context_builder import (
+                FinancialInsightContextBuilder,
+            )
+
+            user_id = _make_user()
+            _make_tx(
+                user_id,
+                title="Bônus junho",
+                amount="2000.00",
+                tx_type=TransactionType.INCOME,
+                due_date=date(2026, 6, 28),
+            )
+            context = FinancialInsightContextBuilder().build_chat_context(
+                user_id=user_id,
+                anchor_date=date(2026, 6, 30),
+                today=_TODAY,
+            )
+
+        titles = [item["title"] for item in context["transactions"]["sample"]]
+        assert "Bônus junho" in titles
+        assert "today" not in context  # past month has no "today" highlight
+
+
+class TestExecuteChatTool:
+    def test_search_transactions_scoped_and_filtered(self, app) -> None:
+        with app.app_context():
+            from app.services.ai_chat_tools import execute_chat_tool
+
+            user_id = _make_user()
+            other_user = _make_user()
+            _make_tx(
+                user_id,
+                title="Salário BRQ",
+                amount="10754.00",
+                tx_type=TransactionType.INCOME,
+                due_date=date(2026, 7, 1),
+            )
+            _make_tx(
+                other_user,
+                title="Salário Alheio",
+                amount="9999.00",
+                tx_type=TransactionType.INCOME,
+                due_date=date(2026, 7, 1),
+            )
+
+            result = execute_chat_tool(
+                user_id=user_id,
+                name="search_transactions",
+                arguments={"query": "salário", "type": "income"},
+            )
+
+        titles = [item["title"] for item in result["items"]]
+        assert titles == ["Salário BRQ"]
+
+    def test_get_period_summary(self, app) -> None:
+        with app.app_context():
+            from app.services.ai_chat_tools import execute_chat_tool
+
+            user_id = _make_user()
+            _make_tx(
+                user_id,
+                title="Salário",
+                amount="1000.00",
+                tx_type=TransactionType.INCOME,
+                due_date=date(2026, 7, 1),
+            )
+            _make_tx(user_id, title="Mercado", amount="400.00")
+
+            result = execute_chat_tool(
+                user_id=user_id,
+                name="get_period_summary",
+                arguments={"start_date": "2026-07-01", "end_date": "2026-07-31"},
+            )
+
+        assert result["paid"]["income_total"] == "1000.00"
+        assert result["paid"]["expense_total"] == "400.00"
+        assert result["paid"]["balance"] == "600.00"
+
+    def test_unknown_tool_returns_error_payload(self, app) -> None:
+        with app.app_context():
+            from app.services.ai_chat_tools import execute_chat_tool
+
+            result = execute_chat_tool(
+                user_id=uuid.uuid4(), name="drop_tables", arguments={}
+            )
+        assert "error" in result
+
+
+class _ScriptedToolProvider(StubLLMProvider):
+    """Provider whose generate_chat first calls a tool, then answers."""
+
+    def __init__(self) -> None:
+        self.chat_calls = 0
+        self.seen_tool_content: str | None = None
+
+    def generate_chat(self, messages, *, tools=None, max_tokens=None, model=None):
+        self.chat_calls += 1
+        usage = LLMResponse(
+            content="",
+            prompt_tokens=100,
+            completion_tokens=20,
+            total_tokens=120,
+            model=model or "gpt-4o-mini",
+            latency_ms=5,
+        )
+        if self.chat_calls == 1:
+            assert tools, "first round must offer tools"
+            message = {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "search_transactions",
+                            "arguments": json.dumps(
+                                {"query": "salário", "type": "income"}
+                            ),
+                        },
+                    }
+                ],
+            }
+            return message, usage
+        tool_messages = [m for m in messages if m.get("role") == "tool"]
+        self.seen_tool_content = tool_messages[-1]["content"] if tool_messages else None
+        final = {
+            "role": "assistant",
+            "content": "Seu salário de julho foi de R$ 10.754,00 (Salário BRQ).",
+        }
+        return final, usage
+
+
+class TestToolLoop:
+    def test_tool_loop_answers_salary_question(self, app, monkeypatch) -> None:
+        monkeypatch.setenv("AI_CHAT_TOOLS_ENABLED", "1")
+        with app.app_context():
+            from app.services.ai_advisory_service import AIAdvisoryService
+
+            user_id = _make_user()
+            _make_tx(
+                user_id,
+                title="Salário BRQ",
+                amount="10754.00",
+                tx_type=TransactionType.INCOME,
+                due_date=date(2026, 7, 1),
+            )
+            provider = _ScriptedToolProvider()
+            service = AIAdvisoryService(user_id=user_id, llm_provider=provider)
+
+            result = service.answer_financial_question(
+                "E o salário de julho, quanto foi?"
+            )
+
+        assert "10.754" in result["answer"]
+        assert result["tool_rounds"] == 1
+        assert result["period_label"] == "julho/2026"
+        assert provider.chat_calls == 2
+        # Tokens aggregated across the two rounds.
+        assert result["tokens_used"] == 240
+        # The tool result actually reached the model.
+        assert provider.seen_tool_content is not None
+        assert "Salário BRQ" in provider.seen_tool_content
+
+    def test_kill_switch_falls_back_to_single_shot(self, app, monkeypatch) -> None:
+        monkeypatch.setenv("AI_CHAT_TOOLS_ENABLED", "0")
+        with app.app_context():
+            from app.services.ai_advisory_service import AIAdvisoryService
+
+            user_id = _make_user()
+            provider = _ScriptedToolProvider()
+            service = AIAdvisoryService(user_id=user_id, llm_provider=provider)
+
+            result = service.answer_financial_question("Quanto gastei hoje?")
+
+        assert provider.chat_calls == 0  # tool loop never engaged
+        assert result["tool_rounds"] == 0
+        assert result["answer"]
+
+    def test_tool_loop_failure_degrades_to_single_shot(self, app, monkeypatch) -> None:
+        monkeypatch.setenv("AI_CHAT_TOOLS_ENABLED", "1")
+
+        class _BrokenToolProvider(StubLLMProvider):
+            def generate_chat(self, *args, **kwargs):
+                raise RuntimeError("tool transport broke")
+
+        with app.app_context():
+            from app.services.ai_advisory_service import AIAdvisoryService
+
+            user_id = _make_user()
+            service = AIAdvisoryService(
+                user_id=user_id, llm_provider=_BrokenToolProvider()
+            )
+            result = service.answer_financial_question("Quanto gastei hoje?")
+
+        assert result["answer"]  # stub single-shot content
+        assert result["tool_rounds"] == 0
+
+
+class TestChatEndpointPayloadV2:
+    def test_rest_payload_carries_period_label(self, app, client) -> None:
+        token = _register_and_login(client, "chatv2-rest")
+        user_id = _current_user_id(app, token)
+        _grant_premium(app, user_id)
+
+        resp = client.post(
+            "/ai/chat",
+            json={"question": "Quanto gastei em junho?"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        assert resp.status_code == 200
+        body = resp.get_json()
+        data = body.get("data") or body
+        assert data["period_label"] == "junho/2026"
+        assert "tool_rounds" in data
+
+
+def _register_and_login(client, prefix: str) -> str:
+    suffix = uuid.uuid4().hex[:8]
+    email = f"{prefix}-{suffix}@test.com"
+    password = "StrongPass@123"
+    reg = client.post(
+        "/auth/register",
+        json={"name": f"{prefix}-{suffix}", "email": email, "password": password},
+    )
+    assert reg.status_code == 201
+    login = client.post("/auth/login", json={"email": email, "password": password})
+    assert login.status_code == 200
+    return str(login.get_json()["token"])
+
+
+def _current_user_id(app, token: str) -> uuid.UUID:
+    with app.app_context():
+        from flask_jwt_extended import decode_token
+
+        return uuid.UUID(str(decode_token(token)["sub"]))
+
+
+def _grant_premium(app, user_id: uuid.UUID) -> None:
+    with app.app_context():
+        from app.models.entitlement import Entitlement, EntitlementSource
+
+        db.session.add(
+            Entitlement(
+                user_id=user_id,
+                feature_key="advanced_simulations",
+                source=EntitlementSource.MANUAL,
+                expires_at=None,
+            )
+        )
+        db.session.commit()

--- a/tests/test_ai_daily_rate_limit.py
+++ b/tests/test_ai_daily_rate_limit.py
@@ -272,7 +272,7 @@ class TestAIDailyRateLimitHTTP:
             _failed = False
 
             def generate_with_usage(
-                self, prompt, *, response_schema=None, max_tokens=None
+                self, prompt, *, response_schema=None, max_tokens=None, model=None
             ):
                 if not _FlakyProvider._failed:
                     _FlakyProvider._failed = True
@@ -281,6 +281,7 @@ class TestAIDailyRateLimitHTTP:
                     prompt,
                     response_schema=response_schema,
                     max_tokens=max_tokens,
+                    model=model,
                 )
 
         with patch(

--- a/tests/test_ai_insight_generation_governance.py
+++ b/tests/test_ai_insight_generation_governance.py
@@ -87,17 +87,24 @@ class _CountingStubProvider(StubLLMProvider):
     def __init__(self) -> None:
         self.calls = 0
 
-    def generate_with_usage(self, prompt, *, response_schema=None, max_tokens=None):
+    def generate_with_usage(
+        self, prompt, *, response_schema=None, max_tokens=None, model=None
+    ):
         self.calls += 1
         return super().generate_with_usage(
-            prompt, response_schema=response_schema, max_tokens=max_tokens
+            prompt,
+            response_schema=response_schema,
+            max_tokens=max_tokens,
+            model=model,
         )
 
 
 class _ExplodingProvider(StubLLMProvider):
     """Provider that fails the test if the LLM is ever invoked."""
 
-    def generate_with_usage(self, prompt, *, response_schema=None, max_tokens=None):
+    def generate_with_usage(
+        self, prompt, *, response_schema=None, max_tokens=None, model=None
+    ):
         raise AssertionError("LLM must not be called on a read-only path")
 
     def generate(self, prompt):  # pragma: no cover — defensive

--- a/tests/test_ai_insight_observability.py
+++ b/tests/test_ai_insight_observability.py
@@ -197,7 +197,7 @@ class TestMetadataPersistenceAndMetrics:
             )
             assert row is not None
             md = row.metadata_dict
-            assert md["snapshot_version"] == "financial_insight_snapshot.v1"
+            assert md["snapshot_version"] == "financial_insight_snapshot.v3"
             assert md["dimensions_present"] == _SORTED_FINANCIAL_DIMENSIONS
             assert "snapshot_bytes_original" in md
             assert "snapshot_bytes_final" in md

--- a/tests/test_ai_snapshot_v3.py
+++ b/tests/test_ai_snapshot_v3.py
@@ -1,0 +1,410 @@
+"""Snapshot v3 + prompt v3 + mix de modelos (#1547).
+
+Covers the enriched AI snapshot:
+- user tags on transaction samples + ``tags`` aggregations (top by expense/income)
+- tag-linked budgets included with tag name and tag-scoped spent
+- ``pending_commitments``: labelled overdue items + upcoming 7/30d
+- ``month_summary``: savings rate, burn rate, projected end-of-month balance
+- per-period snapshot byte caps (daily 12KiB; weekly/monthly 24KiB)
+- ``_trim_transactions`` handles the real ``sample`` key (was a silent no-op)
+- per-period model mix: daily manual → gpt-4o-mini; weekly/monthly → provider default
+- prompt v3 mandates sections with numbers and references the new snapshot keys
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.extensions.database import db
+from app.models.budget import Budget
+from app.models.tag import Tag
+from app.models.transaction import (
+    Transaction,
+    TransactionStatus,
+    TransactionType,
+)
+from app.models.user import User
+from app.services.financial_insight_context_builder import (
+    FinancialInsightContextBuilder,
+    truncate_snapshot,
+)
+from app.services.llm_provider import LLMResponse
+
+_ANCHOR = date(2026, 7, 10)
+
+
+@pytest.fixture(autouse=True)
+def _bypass_premium_gate():
+    """Raw uuid users; the Premium gate (#1546) has dedicated coverage."""
+    with patch("app.services.ai_advisory_service._ensure_premium_entitlement"):
+        yield
+
+
+def _make_user() -> uuid.UUID:
+    user = User(
+        name="Tag Cliente",
+        email=f"tags-{uuid.uuid4().hex[:8]}@example.com",
+        password="hashed",
+    )
+    db.session.add(user)
+    db.session.commit()
+    return user.id
+
+
+def _make_tag(user_id: uuid.UUID, name: str) -> Tag:
+    tag = Tag(user_id=user_id, name=name)
+    db.session.add(tag)
+    db.session.commit()
+    return tag
+
+
+def _make_tx(
+    user_id: uuid.UUID,
+    *,
+    title: str,
+    amount: str,
+    tx_type: TransactionType = TransactionType.EXPENSE,
+    status: TransactionStatus = TransactionStatus.PAID,
+    due_date: date = _ANCHOR,
+    tag_id: uuid.UUID | None = None,
+) -> Transaction:
+    tx = Transaction(
+        user_id=user_id,
+        title=title,
+        description=title,
+        amount=Decimal(amount),
+        type=tx_type,
+        status=status,
+        due_date=due_date,
+        tag_id=tag_id,
+    )
+    db.session.add(tx)
+    db.session.commit()
+    return tx
+
+
+def _build_daily(user_id: uuid.UUID) -> dict:
+    return FinancialInsightContextBuilder().build_daily(
+        user_id=user_id,
+        anchor_date=_ANCHOR,
+    )
+
+
+class TestTagsInSnapshot:
+    def test_sample_items_carry_tag_name(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            academia = _make_tag(user_id, "Academia")
+            _make_tx(user_id, title="Mensalidade", amount="120.00", tag_id=academia.id)
+
+            snapshot = _build_daily(user_id)
+
+        sample = snapshot["transactions"]["sample"]
+        assert sample[0]["tag"] == "Academia"
+
+    def test_tags_aggregation_top_by_expense_and_income(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            academia = _make_tag(user_id, "Academia")
+            freela = _make_tag(user_id, "Freela")
+            _make_tx(user_id, title="Plano", amount="120.00", tag_id=academia.id)
+            _make_tx(user_id, title="Whey", amount="80.00", tag_id=academia.id)
+            _make_tx(
+                user_id,
+                title="Projeto X",
+                amount="900.00",
+                tx_type=TransactionType.INCOME,
+                tag_id=freela.id,
+            )
+            _make_tx(user_id, title="Sem tag", amount="50.00")
+
+            snapshot = _build_daily(user_id)
+
+        tags = snapshot["tags"]
+        expense_by_tag = {entry["tag"]: entry for entry in tags["top_by_expense"]}
+        assert expense_by_tag["Academia"]["total"] == "200.00"
+        assert expense_by_tag["Academia"]["count"] == 2
+        income_by_tag = {entry["tag"]: entry for entry in tags["top_by_income"]}
+        assert income_by_tag["Freela"]["total"] == "900.00"
+
+    def test_tag_budget_included_with_tag_scoped_spent(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            academia = _make_tag(user_id, "Academia")
+            db.session.add(
+                Budget(
+                    user_id=user_id,
+                    name="Academia mensal",
+                    amount=Decimal("200.00"),
+                    period="monthly",
+                    tag_id=academia.id,
+                    is_active=True,
+                )
+            )
+            db.session.commit()
+            _make_tx(user_id, title="Plano", amount="120.00", tag_id=academia.id)
+            _make_tx(user_id, title="Outros gastos", amount="500.00")
+
+            snapshot = _build_daily(user_id)
+
+        tagged = [b for b in snapshot["budgets"] if b.get("tag") == "Academia"]
+        assert tagged, "tag-linked budget must be present in the snapshot"
+        assert tagged[0]["spent"] == "120.00"  # tag-scoped, not the 500.00
+
+
+class TestPendingCommitments:
+    def test_overdue_items_are_labelled_with_days_overdue(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            _make_tx(
+                user_id,
+                title="Condomínio",
+                amount="1400.00",
+                status=TransactionStatus.PENDING,
+                due_date=date(2026, 7, 6),
+            )
+            _make_tx(
+                user_id,
+                title="Fatura Julho",
+                amount="12055.51",
+                status=TransactionStatus.OVERDUE,
+                due_date=date(2026, 7, 5),
+            )
+
+            snapshot = _build_daily(user_id)
+
+        overdue = snapshot["pending_commitments"]["overdue"]
+        assert overdue["count"] == 2
+        titles = {item["title"]: item for item in overdue["items"]}
+        assert titles["Condomínio"]["days_overdue"] == 4
+        assert titles["Fatura Julho"]["days_overdue"] == 5
+        assert overdue["expense_total"] == "13455.51"
+
+    def test_upcoming_windows_split_7d_and_30d(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            _make_tx(
+                user_id,
+                title="Parcela financiamento",
+                amount="2650.00",
+                status=TransactionStatus.PENDING,
+                due_date=date(2026, 7, 15),  # within 7d
+            )
+            _make_tx(
+                user_id,
+                title="Fatura de agosto",
+                amount="900.00",
+                status=TransactionStatus.PENDING,
+                due_date=date(2026, 8, 5),  # within 30d, beyond 7d
+            )
+            _make_tx(
+                user_id,
+                title="IPVA distante",
+                amount="300.00",
+                status=TransactionStatus.PENDING,
+                due_date=date(2026, 9, 20),  # beyond 30d — excluded
+            )
+
+            snapshot = _build_daily(user_id)
+
+        pending = snapshot["pending_commitments"]
+        titles_7d = [item["title"] for item in pending["upcoming_7d"]["items"]]
+        titles_30d = [item["title"] for item in pending["upcoming_30d"]["items"]]
+        assert titles_7d == ["Parcela financiamento"]
+        assert "Fatura de agosto" in titles_30d
+        assert "IPVA distante" not in titles_30d
+        assert pending["upcoming_30d"]["expense_total"] == "3550.00"
+
+
+class TestMonthSummary:
+    def test_month_summary_fields(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            _make_tx(
+                user_id,
+                title="Salário BRQ",
+                amount="10754.00",
+                tx_type=TransactionType.INCOME,
+                due_date=date(2026, 7, 1),
+            )
+            _make_tx(
+                user_id, title="Aluguel", amount="5000.00", due_date=date(2026, 7, 4)
+            )
+            _make_tx(
+                user_id,
+                title="Parcela",
+                amount="2650.00",
+                status=TransactionStatus.PENDING,
+                due_date=date(2026, 7, 15),
+            )
+
+            snapshot = _build_daily(user_id)
+
+        summary = snapshot["month_summary"]
+        assert summary["month"] == "2026-07"
+        assert summary["income_mtd"] == "10754.00"
+        assert summary["expense_mtd"] == "5000.00"
+        assert summary["balance_mtd"] == "5754.00"
+        assert Decimal(summary["savings_rate_pct"]) > 0
+        assert Decimal(summary["burn_rate_daily"]) > 0
+        # Commitments-based projection: balance minus pending expenses of the
+        # rest of the month.
+        assert summary["projected_eom_balance"] == "3104.00"
+
+
+class TestPerPeriodCapsAndTrim:
+    def test_trim_transactions_handles_sample_key(self) -> None:
+        from app.services.financial_insight_context_builder import _trim_transactions
+
+        sample = [
+            {"type": "expense", "amount": f"{100 + i}.00", "title": f"tx {i}"}
+            for i in range(30)
+        ]
+        snapshot = {"transactions": {"included_count": 30, "sample": sample}}
+        assert _trim_transactions(snapshot) is True
+        assert len(snapshot["transactions"]["sample"]) <= 15
+
+    def test_snapshot_max_bytes_per_period(self, monkeypatch) -> None:
+        from app.services.ai_advisory_service import _snapshot_max_bytes
+
+        monkeypatch.delenv("AI_SNAPSHOT_MAX_BYTES", raising=False)
+        monkeypatch.delenv("AI_SNAPSHOT_MAX_BYTES_LONG", raising=False)
+        assert _snapshot_max_bytes("daily") == 12 * 1024
+        assert _snapshot_max_bytes("weekly") == 24 * 1024
+        assert _snapshot_max_bytes("monthly") == 24 * 1024
+
+    def test_truncate_respects_explicit_cap(self) -> None:
+        sample = [
+            {"type": "expense", "amount": f"{i}.00", "title": "x" * 80}
+            for i in range(200)
+        ]
+        snapshot = {
+            "schema_version": "financial_insight_snapshot.v3",
+            "current_period": {},
+            "comparisons": {},
+            "transactions": {"included_count": 200, "sample": sample},
+        }
+        _, info = truncate_snapshot(snapshot, max_bytes=2048)
+        assert info["truncated"] is True
+        assert "transactions.items" in info["dropped_sections"]
+
+
+class TestPerPeriodModelMix:
+    @staticmethod
+    def _llm_response() -> LLMResponse:
+        item = (
+            '{"type":"saude_financeira","dimension":"general","title":"Item",'
+            '"message":"Os dados foram analisados.",'
+            '"evidence":["current_period.paid.balance"]}'
+        )
+        return LLMResponse(
+            content=f'{{"summary":"Resumo.","items":[{item}]}}',
+            prompt_tokens=100,
+            completion_tokens=40,
+            total_tokens=140,
+            model="gpt-4o-mini",
+            latency_ms=10,
+        )
+
+    def test_daily_manual_generation_uses_mini_model(self, app, monkeypatch) -> None:
+        monkeypatch.delenv("OPENAI_ADVISORY_MODEL_DAILY", raising=False)
+        with app.app_context():
+            from app.services.ai_advisory_service import AIAdvisoryService
+
+            user_id = _make_user()
+            provider = MagicMock()
+            provider.generate_with_usage.return_value = self._llm_response()
+            service = AIAdvisoryService(user_id=user_id, llm_provider=provider)
+            service.generate_financial_insights(
+                period_type="daily", anchor_date=_ANCHOR
+            )
+
+            assert provider.generate_with_usage.call_args.kwargs["model"] == (
+                "gpt-4o-mini"
+            )
+
+    def test_weekly_generation_uses_provider_default_model(self, app) -> None:
+        with app.app_context():
+            from app.services.ai_advisory_service import AIAdvisoryService
+
+            user_id = _make_user()
+            provider = MagicMock()
+            provider.generate_with_usage.return_value = self._llm_response()
+            service = AIAdvisoryService(user_id=user_id, llm_provider=provider)
+            service.generate_financial_insights(
+                period_type="weekly", anchor_date=_ANCHOR
+            )
+
+            assert "model" not in provider.generate_with_usage.call_args.kwargs
+
+    def test_openai_provider_accepts_model_override(self, monkeypatch) -> None:
+        from app.services.llm_provider import OpenAILLMProvider
+
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        provider = OpenAILLMProvider()
+        captured: dict = {}
+
+        class _Resp:
+            def raise_for_status(self) -> None:
+                return None
+
+            @staticmethod
+            def json() -> dict:
+                return {
+                    "choices": [{"message": {"content": "ok"}}],
+                    "usage": {
+                        "prompt_tokens": 1,
+                        "completion_tokens": 1,
+                        "total_tokens": 2,
+                    },
+                    "model": "gpt-4o-mini-2024-07-18",
+                }
+
+        def _fake_post(url, headers=None, json=None, timeout=None):
+            captured["payload"] = json
+            return _Resp()
+
+        with patch("requests.post", _fake_post):
+            provider.generate_with_usage("prompt", model="gpt-4o-mini")
+
+        assert captured["payload"]["model"] == "gpt-4o-mini"
+
+
+class TestPromptV3:
+    def test_prompt_mandates_sections_and_new_keys(self, app) -> None:
+        with app.app_context():
+            from app.services.ai_advisory_service import (
+                _build_financial_insight_prompt,
+            )
+
+            user_id = _make_user()
+            _make_tx(user_id, title="Mercado", amount="100.00")
+            snapshot = _build_daily(user_id)
+            prompt = _build_financial_insight_prompt(
+                snapshot, period_type="daily", forecast=False
+            )
+
+        for required in (
+            "pending_commitments",
+            "month_summary",
+            "tags.top_by_expense",
+            "panorama do período",
+            "pendências e vencimentos",
+            "recomendações acionáveis",
+        ):
+            assert required in prompt, f"prompt v3 must mention: {required}"
+        # Generic advice without numbers is forbidden explicitly.
+        assert "número" in prompt
+
+
+class TestSnapshotVersionBump:
+    def test_schema_version_is_v3(self, app) -> None:
+        with app.app_context():
+            user_id = _make_user()
+            snapshot = _build_daily(user_id)
+        assert snapshot["schema_version"] == "financial_insight_snapshot.v3"

--- a/tests/test_financial_insight_context_builder.py
+++ b/tests/test_financial_insight_context_builder.py
@@ -316,7 +316,7 @@ class TestFinancialInsightContextBuilderDaily:
                 anchor_date=anchor,
             )
 
-        assert snapshot["schema_version"] == "financial_insight_snapshot.v1"
+        assert snapshot["schema_version"] == "financial_insight_snapshot.v3"
         assert snapshot["period_type"] == "daily"
         assert snapshot["period"] == {
             "start": "2026-05-17",


### PR DESCRIPTION
## Summary
Onda "Insights v3" — iniciativa I4 (plano PO 2026-07-10). Empilhada sobre #1550 (snapshot v3) — o diff limpa após o merge dela.

**Corrige o bug "salário de julho" e torna o chat assertivo:**
- **Contexto month-aware** (`build_chat_context`): o chat deixa de enxergar só o dia de HOJE — cobre o mês inteiro da âncora com amostra rotulada de 40 transações (receitas incluídas), `pending_commitments`, `month_summary` e bloco `today` destacado. "Salário BRQ" de 01/07 agora chega ao modelo por nome.
- **Detecção determinística de período pt-BR** (`chat_period_detection.py`): "julho", "maio de 2026", "2026-06", "mês passado", "semana passada", "ontem" ancoram o contexto no período citado (zero custo LLM); `period_label` volta no payload REST+GraphQL para o front exibir o chip "consulta ancorada em julho/2026".
- **Function-calling** (decisão PO): loop de até 3 rodadas com 4 tools read-only escopadas ao usuário — `search_transactions`, `get_period_summary`, `get_wallet_valuation`, `get_pending_overdue`. Kill-switch `AI_CHAT_TOOLS_ENABLED`; qualquer falha do loop degrada graciosamente para a resposta snapshot-grounded. Prompt instrui a USAR tools antes de dizer "não tenho essa informação".
- **System role separado** no `generate_chat` (reduz superfície de prompt injection); resposta até 220 palavras; `AI_CHAT_MAX_TOKENS` 600→900; modelo do chat `OPENAI_CHAT_MODEL` default **gpt-4o-mini** (~US$0,002/msg com tools).
- **Telemetria**: métrica `auraxis_ai_chat_messages_total{tools_used,no_info}` — a taxa de "não tenho essa informação" é o gatilho para aprofundar as tools.

## Validation
- `bash scripts/run_ci_quality_local.sh --local` verde: **2732 passed**, cov ≥85%.
- Suíte nova `tests/test_ai_chat_v2.py` (15 testes): period detection, contexto mensal (caso "Salário BRQ 01/07" coberto por teste de integração), tool loop com provider roteirizado (tokens agregados, resultado da tool chega ao modelo), kill-switch, degradação graciosa, escopo por usuário nas tools, payload REST com period_label.
- Artefatos regenerados: openapi.json, schema.graphql, introspection (campos aditivos `period_label`/`tool_rounds`).

## Residual risk
- Function-calling ativo por default (`AI_CHAT_TOOLS_ENABLED=1`) — desligável por env sem deploy de código.
- Chat com contexto mensal usa o cap longo (24KiB) — custo por mensagem segue ~US$0,002 em mini (conta no ADR platform#859).

## Refs
Closes #1548