### PR TITLE
feat(billing): dunning de ciclo de vida (trial D-2/expirado/cancel) + retry de webhooks FAILED com alerta

### DIFF
--- a/.github/workflows/billing-webhooks-retry-job.yml
+++ b/.github/workflows/billing-webhooks-retry-job.yml
@@ -1,0 +1,176 @@
+name: Billing Webhooks Retry Job
+
+on:
+  schedule:
+    # Daily at 05:30 UTC = 02:30 BRT — low-frequency reprocessing of FAILED
+    # billing webhook events (#1556). Recovery normally relies on provider
+    # redelivery; this job is the safety net + backlog alert (Sentry).
+    - cron: "30 5 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry-run only (list eligible FAILED events, reprocess nothing)"
+        type: boolean
+        default: false
+
+concurrency:
+  group: billing-webhooks-retry-job
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+  issues: write
+
+jobs:
+  retry-failed:
+    name: Reprocess FAILED billing webhook events
+    runs-on: ubuntu-latest
+    environment: prod
+
+    steps:
+      - name: Validate required variables
+        run: |
+          [ -n "${AWS_REGION:-}" ] || { echo "Missing var AWS_REGION"; exit 1; }
+          [ -n "${AWS_ROLE_ARN_PROD:-}" ] || { echo "Missing var AWS_ROLE_ARN_PROD"; exit 1; }
+          [ -n "${AURAXIS_PROD_INSTANCE_ID:-}" ] || { echo "Missing var AURAXIS_PROD_INSTANCE_ID"; exit 1; }
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+          AWS_ROLE_ARN_PROD: ${{ vars.AWS_ROLE_ARN_PROD }}
+          AURAXIS_PROD_INSTANCE_ID: ${{ vars.AURAXIS_PROD_INSTANCE_ID }}
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN_PROD }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Retry FAILED webhook events via SSM
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+          PROD_INSTANCE_ID: ${{ vars.AURAXIS_PROD_INSTANCE_ID }}
+          DRY_RUN: ${{ inputs.dry_run == true && '--dry-run' || '' }}
+        run: |
+          FLASK_CMD="flask billing-webhooks retry-failed ${DRY_RUN}"
+          COMMAND_ID=$(aws ssm send-command \
+            --region "${AWS_REGION}" \
+            --instance-ids "${PROD_INSTANCE_ID}" \
+            --document-name "AWS-RunShellScript" \
+            --parameters "commands=[\"cd /opt/auraxis && docker compose exec -T web ${FLASK_CMD}\"]" \
+            --query "Command.CommandId" \
+            --output text)
+
+          echo "SSM Command ID: ${COMMAND_ID}"
+
+          for i in $(seq 1 30); do
+            STATUS=$(aws ssm get-command-invocation \
+              --region "${AWS_REGION}" \
+              --command-id "${COMMAND_ID}" \
+              --instance-id "${PROD_INSTANCE_ID}" \
+              --query "StatusDetails" \
+              --output text 2>/dev/null || echo "Pending")
+
+            echo "Attempt ${i}: ${STATUS}"
+
+            if [ "${STATUS}" = "Success" ]; then
+              echo "Webhook retry run completed successfully."
+              aws ssm get-command-invocation \
+                --region "${AWS_REGION}" \
+                --command-id "${COMMAND_ID}" \
+                --instance-id "${PROD_INSTANCE_ID}" \
+                --query "StandardOutputContent" \
+                --output text 2>/dev/null || true
+              exit 0
+            elif [ "${STATUS}" = "Failed" ] || [ "${STATUS}" = "Cancelled" ] || [ "${STATUS}" = "TimedOut" ]; then
+              echo "Webhook retry run failed with status: ${STATUS}"
+              echo "--- stdout ---"
+              aws ssm get-command-invocation \
+                --region "${AWS_REGION}" \
+                --command-id "${COMMAND_ID}" \
+                --instance-id "${PROD_INSTANCE_ID}" \
+                --query "StandardOutputContent" \
+                --output text 2>/dev/null || true
+              echo "--- stderr ---"
+              aws ssm get-command-invocation \
+                --region "${AWS_REGION}" \
+                --command-id "${COMMAND_ID}" \
+                --instance-id "${PROD_INSTANCE_ID}" \
+                --query "StandardErrorContent" \
+                --output text 2>/dev/null || true
+              exit 1
+            fi
+
+            sleep 10
+          done
+
+          echo "Timed out waiting for SSM command to complete."
+          exit 1
+
+      - name: Notify failure via GitHub Issue
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const now = new Date().toISOString();
+            const title = '🚨 [billing-webhooks] Falha no reprocesso de webhooks FAILED';
+            const issueBody = [
+              '## Billing Webhooks Retry Job falhou',
+              '',
+              `**Última falha:** ${now}`,
+              `**Run:** ${runUrl}`,
+              '',
+              'O job diário de reprocesso de eventos de webhook FAILED falhou via SSM.',
+              '',
+              '### Ações sugeridas',
+              '- Revisar logs da execução no link acima',
+              '- Verificar o estado de `docker compose` e do container `web` na instância PROD',
+              '- Executar `flask billing-webhooks retry-failed --dry-run` no container para validar',
+              '- Conferir o Sentry para alertas de backlog FAILED acumulado',
+              '',
+              '_Issue criada automaticamente pelo GitHub Actions._',
+            ].join('\n');
+            const commentBody = [
+              'Nova falha detectada no billing webhooks retry job.',
+              '',
+              `- Data: ${now}`,
+              `- Run: ${runUrl}`,
+            ].join('\n');
+            const query = [
+              `repo:${context.repo.owner}/${context.repo.repo}`,
+              'is:issue',
+              'in:title',
+              `"${title}"`,
+            ].join(' ');
+            const search = await github.rest.search.issuesAndPullRequests({
+              q: query,
+              per_page: 10,
+            });
+            const matchingIssue = search.data.items.find(
+              (item) => item.title === title,
+            );
+            if (matchingIssue) {
+              if (matchingIssue.state === 'closed') {
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: matchingIssue.number,
+                  state: 'open',
+                });
+              }
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: matchingIssue.number,
+                body: commentBody,
+              });
+              return;
+            }
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body: issueBody,
+              labels: ['bug', 'ops'],
+            });

--- a/.github/workflows/reminder-job.yml
+++ b/.github/workflows/reminder-job.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   dispatch-reminders:
-    name: Dispatch Reminders (due-date + email verification)
+    name: Dispatch Reminders (due-date + email verification + trial ending)
     runs-on: ubuntu-latest
     environment: prod
 
@@ -112,7 +112,7 @@ jobs:
           echo "Timed out waiting for container health check."
           exit 1
 
-      - name: Dispatch reminders via SSM (due-date + email verification)
+      - name: Dispatch reminders via SSM (due-date + email verification + trial ending)
         env:
           AWS_REGION: ${{ vars.AWS_REGION }}
           PROD_INSTANCE_ID: ${{ vars.AURAXIS_PROD_INSTANCE_ID }}
@@ -121,7 +121,7 @@ jobs:
             --region "${AWS_REGION}" \
             --instance-ids "${PROD_INSTANCE_ID}" \
             --document-name "AWS-RunShellScript" \
-            --parameters 'commands=["cd /opt/auraxis && docker compose exec -T web flask reminders dispatch-due-soon && docker compose exec -T web flask reminders dispatch-email-verification"]' \
+            --parameters 'commands=["cd /opt/auraxis && docker compose exec -T web flask reminders dispatch-due-soon && docker compose exec -T web flask reminders dispatch-email-verification && docker compose exec -T web flask reminders dispatch-trial-ending"]' \
             --query "Command.CommandId" \
             --output text)
 

--- a/app/application/services/billing_email_service.py
+++ b/app/application/services/billing_email_service.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from app.services.email_provider import EmailMessage
+
 if TYPE_CHECKING:
     from app.models.subscription import Subscription
     from app.models.user import User
@@ -9,6 +11,9 @@ if TYPE_CHECKING:
 _PAYMENT_CONFIRMED_EVENTS = {"PAYMENT_RECEIVED", "PAYMENT_CONFIRMED"}
 _PAYMENT_FAILED_EVENTS = {"PAYMENT_OVERDUE", "subscription.past_due"}
 _CANCELED_EVENTS = {"subscription.canceled", "SUBSCRIPTION_DELETED"}
+
+_TRIAL_ENDING_TAG_TEMPLATE = "billing_trial_ending_{days}d"
+_TRIAL_EXPIRED_TAG = "billing_trial_expired"
 
 
 def _plan_label(subscription: Subscription) -> str:
@@ -67,3 +72,65 @@ def dispatch_billing_email(
             text=(f"Sua assinatura foi cancelada. Plano anterior: {plan_label}."),
             tag="billing_subscription_canceled",
         )
+
+
+def build_trial_ending_email(
+    *, user: User, subscription: Subscription, days_until_trial_end: int
+) -> EmailMessage:
+    """Build the D-N "trial acabando" dunning email (#1555).
+
+    Content only — scanning, idempotency and delivery live in
+    ``trial_ending_reminder_service``.
+    """
+    days_label = (
+        "1 dia" if days_until_trial_end == 1 else f"{days_until_trial_end} dias"
+    )
+    trial_ends_label = (
+        subscription.trial_ends_at.strftime("%d/%m/%Y")
+        if subscription.trial_ends_at is not None
+        else None
+    )
+    ends_sentence = f" Ele termina em {trial_ends_label}." if trial_ends_label else ""
+    return EmailMessage(
+        to_email=str(user.email),
+        subject=f"Seu período de teste termina em {days_label} — Auraxis",
+        html=(
+            f"<p>Seu período de teste da Auraxis termina em "
+            f"<strong>{days_label}</strong>.{ends_sentence}</p>"
+            "<p>Assine um plano para continuar com acesso aos recursos "
+            "premium — exportação em PDF, simulações avançadas e mais.</p>"
+        ),
+        text=(
+            f"Seu período de teste da Auraxis termina em {days_label}."
+            f"{ends_sentence} "
+            "Assine um plano para continuar com acesso aos recursos premium."
+        ),
+        tag=_TRIAL_ENDING_TAG_TEMPLATE.format(days=days_until_trial_end),
+    )
+
+
+def dispatch_trial_expired_email(*, user: User, subscription: Subscription) -> None:
+    """Notify the user that the trial ended and the downgrade was applied (#1555).
+
+    Called by ``scripts/process_trial_expirations.py`` after the TRIALING →
+    FREE downgrade is committed.
+    """
+    from app.services.outbound_queue import get_default_outbound_queue
+
+    plan_label = _plan_label(subscription)
+    get_default_outbound_queue().enqueue_send_email(
+        to_email=str(user.email),
+        subject="Seu período de teste terminou — Auraxis",
+        html=(
+            "<p>Seu período de teste da Auraxis terminou e sua conta voltou "
+            f"para o plano <strong>{plan_label}</strong>.</p>"
+            "<p>Você pode assinar a qualquer momento para recuperar o acesso "
+            "aos recursos premium.</p>"
+        ),
+        text=(
+            "Seu período de teste da Auraxis terminou e sua conta voltou para "
+            f"o plano {plan_label}. Assine a qualquer momento para recuperar "
+            "o acesso aos recursos premium."
+        ),
+        tag=_TRIAL_EXPIRED_TAG,
+    )

--- a/app/application/services/trial_ending_reminder_service.py
+++ b/app/application/services/trial_ending_reminder_service.py
@@ -1,0 +1,160 @@
+"""Trial-ending reminders — D-2 dunning dispatch service (#1555).
+
+Mirrors the pattern of ``email_verification_reminder_service`` but targets
+``Subscription`` rows in ``TRIALING`` status whose ``trial_ends_at`` falls
+``days_until_trial_end`` days from ``today``.
+
+Idempotency uses the ``Alert`` table with ``entity_type='subscription'`` and
+``entity_id=subscription.id``: once a reminder is recorded for a subscription
+and window, it is never sent again — safe against reruns and boundary drift.
+
+Email content lives in ``billing_email_service.build_trial_ending_email`` so
+all billing dunning copy stays in one module.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from typing import Sequence, cast
+from uuid import UUID
+
+from app.application.services.billing_email_service import build_trial_ending_email
+from app.extensions.database import db
+from app.models.alert import Alert, AlertStatus
+from app.models.subscription import Subscription, SubscriptionStatus
+from app.models.user import User
+from app.services.email_dlq import get_email_dlq
+from app.services.email_provider import (
+    EmailMessage,
+    EmailProviderError,
+    get_default_email_provider,
+)
+from app.utils.datetime_utils import utc_now_naive
+
+_CATEGORY_TEMPLATE = "billing_trial_ending_{days}d"
+_SUBSCRIPTION_ENTITY_TYPE = "subscription"
+
+
+@dataclass(frozen=True)
+class TrialEndingReminderResult:
+    scanned: int
+    sent: int
+    skipped: int
+    queued: int = 0
+
+
+def _start_of_day(day: date) -> datetime:
+    return datetime.combine(day, datetime.min.time())
+
+
+def _end_of_day(day: date) -> datetime:
+    return datetime.combine(day, datetime.max.time())
+
+
+def _existing_alert(
+    *, user_id: UUID, category: str, subscription_id: UUID
+) -> Alert | None:
+    return cast(
+        Alert | None,
+        Alert.query.filter(
+            Alert.user_id == user_id,
+            Alert.category == category,
+            Alert.entity_type == _SUBSCRIPTION_ENTITY_TYPE,
+            Alert.entity_id == subscription_id,
+        ).first(),
+    )
+
+
+def _eligible_subscriptions(*, target_day: date) -> Sequence[tuple[Subscription, User]]:
+    return cast(
+        Sequence[tuple[Subscription, User]],
+        db.session.query(Subscription, User)
+        .join(User, User.id == Subscription.user_id)
+        .filter(
+            Subscription.status == SubscriptionStatus.TRIALING,
+            Subscription.trial_ends_at.isnot(None),
+            Subscription.trial_ends_at >= _start_of_day(target_day),
+            Subscription.trial_ends_at <= _end_of_day(target_day),
+            User.deleted_at.is_(None),
+        )
+        .all(),
+    )
+
+
+def _send_or_queue(message: EmailMessage) -> AlertStatus:
+    try:
+        get_default_email_provider().send(message)
+        return AlertStatus.SENT
+    except EmailProviderError as exc:
+        get_email_dlq().push(message, reason=str(exc))
+        return AlertStatus.PENDING
+
+
+def dispatch_trial_ending_reminders(
+    *, days_until_trial_end: int = 2, today: date | None = None
+) -> TrialEndingReminderResult:
+    """Send "trial acabando" reminders for trials ending in N days.
+
+    Args:
+        days_until_trial_end: countdown window in days (default 2 → D-2).
+        today: Override the reference day for tests.
+
+    Returns:
+        TrialEndingReminderResult with scan/send/skip/queue counters.
+    """
+    if days_until_trial_end < 1:
+        raise ValueError("days_until_trial_end must be >= 1")
+
+    category = _CATEGORY_TEMPLATE.format(days=days_until_trial_end)
+    reference_day = today or date.today()
+    target_day = reference_day + timedelta(days=days_until_trial_end)
+
+    scanned = 0
+    sent = 0
+    skipped = 0
+    queued = 0
+
+    for subscription, user in _eligible_subscriptions(target_day=target_day):
+        scanned += 1
+        if _existing_alert(
+            user_id=user.id, category=category, subscription_id=subscription.id
+        ):
+            skipped += 1
+            continue
+
+        message = build_trial_ending_email(
+            user=user,
+            subscription=subscription,
+            days_until_trial_end=days_until_trial_end,
+        )
+        alert_status = _send_or_queue(message)
+        if alert_status == AlertStatus.SENT:
+            sent += 1
+            sent_at = utc_now_naive()
+        else:
+            queued += 1
+            sent_at = None
+
+        db.session.add(
+            Alert(
+                user_id=user.id,
+                category=category,
+                status=alert_status,
+                entity_type=_SUBSCRIPTION_ENTITY_TYPE,
+                entity_id=subscription.id,
+                triggered_at=_start_of_day(reference_day),
+                sent_at=sent_at,
+            )
+        )
+
+    db.session.commit()
+    return TrialEndingReminderResult(
+        scanned=scanned, sent=sent, skipped=skipped, queued=queued
+    )
+
+
+__all__ = [
+    "TrialEndingReminderResult",
+    "dispatch_trial_ending_reminders",
+]

--- a/app/extensions/billing_webhooks_cli.py
+++ b/app/extensions/billing_webhooks_cli.py
@@ -59,6 +59,54 @@ def _retry_single_event(event: Any) -> tuple[bool, str | None]:
         return False, str(exc)
 
 
+def _alert_failed_backlog(threshold: int) -> int:
+    """Alert (log + Sentry) when FAILED webhook events accumulate (#1556).
+
+    Counts every event still in FAILED status — including those that
+    exhausted ``--max-retries`` and need manual intervention.  Returns the
+    backlog size so callers can report it.
+    """
+    from sqlalchemy import func
+
+    from app.extensions.database import db
+    from app.models.webhook_event import WebhookEvent, WebhookEventStatus
+
+    backlog = (
+        db.session.query(func.count(WebhookEvent.id))
+        .filter(WebhookEvent.status == WebhookEventStatus.FAILED.value)
+        .scalar()
+        or 0
+    )
+    if backlog < threshold:
+        return int(backlog)
+
+    oldest = (
+        db.session.query(func.min(WebhookEvent.received_at))
+        .filter(WebhookEvent.status == WebhookEventStatus.FAILED.value)
+        .scalar()
+    )
+    logger.error(
+        "billing-webhooks: %d webhook event(s) stuck in FAILED status "
+        "(threshold=%d oldest_received_at=%s) — manual review required",
+        backlog,
+        threshold,
+        oldest,
+    )
+    try:
+        import sentry_sdk
+
+        sentry_sdk.capture_message(
+            f"billing-webhooks: {backlog} webhook event(s) stuck in FAILED "
+            f"status (threshold={threshold}, oldest_received_at={oldest})",
+            level="error",
+        )
+    except Exception:
+        logger.debug(
+            "Sentry unavailable for billing-webhooks backlog alert", exc_info=True
+        )
+    return int(backlog)
+
+
 def register_billing_webhooks_commands(app: Flask) -> None:
     @app.cli.group("billing-webhooks")
     def billing_webhooks_group() -> None:
@@ -85,13 +133,27 @@ def register_billing_webhooks_commands(app: Flask) -> None:
         default=False,
         help="Log eligible events without reprocessing them.",
     )
-    def retry_failed(max_events: int, max_retries: int, dry_run: bool) -> None:
+    @click.option(
+        "--alert-threshold",
+        default=1,
+        show_default=True,
+        type=int,
+        help=(
+            "Emit a Sentry/log alert when at least this many events remain "
+            "in FAILED status after the run."
+        ),
+    )
+    def retry_failed(
+        max_events: int, max_retries: int, dry_run: bool, alert_threshold: int
+    ) -> None:
         """Retry webhook events that failed during processing.
 
         Reprocesses up to ``--max-events`` events whose status is ``failed``
         and whose ``retry_count`` is below ``--max-retries``.  Each successful
         retry updates the event status to ``processed``; each new failure
-        increments ``retry_count`` and keeps status ``failed``.
+        increments ``retry_count`` and keeps status ``failed``.  After the
+        run, any remaining FAILED backlog above ``--alert-threshold`` is
+        reported via log + Sentry (#1556).
         """
         from app.extensions.database import db
         from app.models.webhook_event import WebhookEvent, WebhookEventStatus
@@ -109,6 +171,11 @@ def register_billing_webhooks_commands(app: Flask) -> None:
 
         if not eligible:
             click.echo("billing-webhooks retry-failed: no eligible events found.")
+            backlog = _alert_failed_backlog(alert_threshold)
+            click.echo(
+                f"billing-webhooks retry-failed: backlog={backlog} "
+                "FAILED event(s) remaining."
+            )
             return
 
         click.echo(
@@ -138,4 +205,9 @@ def register_billing_webhooks_commands(app: Flask) -> None:
             f"billing-webhooks retry-failed: done — "
             f"processed={processed_count} failed={failed_count} "
             f"skipped_dry_run={len(eligible) if dry_run else 0}"
+        )
+        backlog = _alert_failed_backlog(alert_threshold)
+        click.echo(
+            f"billing-webhooks retry-failed: backlog={backlog} "
+            "FAILED event(s) remaining."
         )

--- a/app/extensions/reminders_cli.py
+++ b/app/extensions/reminders_cli.py
@@ -1,13 +1,15 @@
-"""Flask CLI commands — transaction and email-verification reminders.
+"""Flask CLI commands — transaction, email-verification and trial reminders.
 
 Dispatches email reminders:
 
     flask reminders dispatch-due-soon [--dry-run]
     flask reminders dispatch-email-verification [--dry-run]
+    flask reminders dispatch-trial-ending [--dry-run] [--days N]
 
 Business logic lives in
-``app.application.services.transaction_reminder_service`` and
-``app.application.services.email_verification_reminder_service``.
+``app.application.services.transaction_reminder_service``,
+``app.application.services.email_verification_reminder_service`` and
+``app.application.services.trial_ending_reminder_service``.
 """
 
 from __future__ import annotations
@@ -95,6 +97,53 @@ def dispatch_email_verification(ctx: click.Context, dry_run: bool) -> None:
                 err=True,
             )
             exit_code = 1
+
+    sys.exit(exit_code)
+
+
+@reminders_cli.command("dispatch-trial-ending")
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Print what would be sent without dispatching emails.",
+)
+@click.option(
+    "--days",
+    default=2,
+    show_default=True,
+    type=int,
+    help="Countdown window in days before trial_ends_at.",
+)
+@click.pass_context
+def dispatch_trial_ending(ctx: click.Context, dry_run: bool, days: int) -> None:
+    """Send D-N reminders for TRIALING subscriptions about to end (#1555)."""
+    import sys
+
+    if dry_run:
+        click.echo(
+            f"[dry-run] Would dispatch trial-ending reminders for the D-{days} window."
+        )
+        return
+
+    from app.application.services.trial_ending_reminder_service import (
+        dispatch_trial_ending_reminders,
+    )
+
+    exit_code = 0
+    try:
+        result = dispatch_trial_ending_reminders(days_until_trial_end=days)
+        click.echo(
+            f"D-{days} trial-ending reminders: "
+            f"scanned={result.scanned} sent={result.sent} "
+            f"skipped={result.skipped} queued={result.queued}"
+        )
+    except Exception as exc:  # noqa: BLE001
+        click.echo(
+            f"ERROR D-{days} trial-ending reminders: unexpected failure — {exc}",
+            err=True,
+        )
+        exit_code = 1
 
     sys.exit(exit_code)
 

--- a/app/services/subscription_service.py
+++ b/app/services/subscription_service.py
@@ -6,6 +6,7 @@ keeping controllers thin and provider-agnostic.
 
 from __future__ import annotations
 
+import logging
 import os
 from datetime import datetime
 from typing import cast
@@ -21,6 +22,8 @@ from app.models.user import User
 from app.services.billing_adapter import BillingProvider, BillingSubscriptionSnapshot
 from app.services.entitlement_service import sync_entitlements_from_subscription
 from app.utils.datetime_utils import utc_now_naive
+
+logger = logging.getLogger(__name__)
 
 _FREE_PLAN_CODE = "free"
 _PREMIUM_OVERRIDE_USER_IDS_CONFIG_KEY = "AURAXIS_PREMIUM_OVERRIDE_USER_IDS"
@@ -337,4 +340,32 @@ def cancel_subscription(
         entity_id=str(snapshot.id),
         actor_id=str(snapshot.user_id),
     )
+    if not snapshot.provider_subscription_id:
+        _dispatch_local_cancellation_email(snapshot)
     return snapshot
+
+
+def _dispatch_local_cancellation_email(subscription: Subscription) -> None:
+    """Send the cancellation confirmation for local-only cancels (#1555).
+
+    Provider-backed subscriptions get their confirmation via the
+    ``SUBSCRIPTION_DELETED`` webhook; local-only subscriptions (no
+    ``provider_subscription_id``) never receive a webhook, so the email is
+    dispatched here. Failures are logged but never block the cancel flow.
+    """
+    from app.application.services.billing_email_service import dispatch_billing_email
+
+    user = cast(User | None, db.session.get(User, subscription.user_id))
+    if user is None:
+        return
+    try:
+        dispatch_billing_email(
+            user=user,
+            subscription=subscription,
+            event_type="subscription.canceled",
+        )
+    except Exception:
+        logger.exception(
+            "Failed to dispatch cancellation email for subscription_id=%s",
+            str(subscription.id),
+        )

--- a/scripts/process_trial_expirations.py
+++ b/scripts/process_trial_expirations.py
@@ -23,6 +23,12 @@ import argparse
 import logging
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from flask import Flask
+
+    from app.models.subscription import Subscription
 
 # ---------------------------------------------------------------------------
 # Bootstrap: ensure the project root is on sys.path
@@ -52,8 +58,38 @@ def _parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def process_trial_expirations(*, dry_run: bool = False) -> int:
+def _notify_trial_expired(sub: Subscription) -> None:
+    """Send the "downgrade efetivado" email for an expired trial (#1555).
+
+    Email failures are logged and never block the downgrade batch.
+    """
+    from app.application.services.billing_email_service import (
+        dispatch_trial_expired_email,
+    )
+    from app.extensions.database import db
+    from app.models.user import User
+
+    user = db.session.get(User, sub.user_id)
+    if user is None:
+        return
+    try:
+        dispatch_trial_expired_email(user=user, subscription=sub)
+    except Exception:
+        logger.exception(
+            "Failed to dispatch trial-expired email for user_id=%s",
+            sub.user_id,
+        )
+
+
+def process_trial_expirations(
+    *, dry_run: bool = False, flask_app: Flask | None = None
+) -> int:
     """Downgrade all expired TRIALING subscriptions to FREE.
+
+    Args:
+        dry_run: Print candidates without committing changes.
+        flask_app: Optional pre-built Flask app (tests). When omitted, a
+            minimal app is bootstrapped via ``create_app``.
 
     Returns the count of processed subscriptions.
     """
@@ -63,7 +99,7 @@ def process_trial_expirations(*, dry_run: bool = False) -> int:
     from app.services.entitlement_service import deactivate_premium
     from app.utils.datetime_utils import utc_now_naive
 
-    app = create_app(enable_http_runtime=False)
+    app = flask_app or create_app(enable_http_runtime=False)
 
     processed = 0
     with app.app_context():
@@ -101,6 +137,8 @@ def process_trial_expirations(*, dry_run: bool = False) -> int:
         if not dry_run:
             db.session.commit()
             logger.info("Downgraded %d expired trial subscription(s).", processed)
+            for sub in expired_subs:
+                _notify_trial_expired(sub)
         else:
             logger.info(
                 "[dry-run] Would downgrade %d expired trial subscription(s).", processed

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -539,3 +539,157 @@ class TestBillingCheckoutEndpoint:
         assert resp.status_code == 400
         body = resp.get_json()
         assert body["error"]["code"] == "VALIDATION_ERROR"
+
+
+# ---------------------------------------------------------------------------
+# Dunning emails — trial expiration + local cancellation (#1555)
+# ---------------------------------------------------------------------------
+
+
+class TestTrialExpirationEmail:
+    def test_process_trial_expirations_sends_trial_expired_email(self, app) -> None:
+        """The expiry job must email the downgraded user (downgrade efetivado)."""
+        from scripts.process_trial_expirations import process_trial_expirations
+
+        with app.app_context():
+            user = User(
+                id=uuid.uuid4(),
+                name="Expired Trial User",
+                email="expired-trial@test.com",
+                password="hash",
+            )
+            db.session.add(user)
+            db.session.flush()
+            sub = Subscription(
+                user_id=user.id,
+                plan_code="trial",
+                status=SubscriptionStatus.TRIALING,
+                trial_ends_at=datetime.utcnow() - timedelta(hours=1),
+            )
+            db.session.add(sub)
+            db.session.commit()
+            sub_id = sub.id
+
+        count = process_trial_expirations(dry_run=False, flask_app=app)
+
+        assert count == 1
+        with app.app_context():
+            from app.services.email_provider import get_email_outbox
+
+            downgraded = Subscription.query.filter_by(id=sub_id).first()
+            assert downgraded is not None
+            assert downgraded.status == SubscriptionStatus.FREE
+
+            outbox = get_email_outbox()
+            tags = [entry["tag"] for entry in outbox]
+            assert "billing_trial_expired" in tags
+            emails = [entry["email"] for entry in outbox]
+            assert "expired-trial@test.com" in emails
+            outbox.clear()
+
+    def test_process_trial_expirations_dry_run_sends_no_email(self, app) -> None:
+        from scripts.process_trial_expirations import process_trial_expirations
+
+        with app.app_context():
+            user = User(
+                id=uuid.uuid4(),
+                name="Dry Run Trial User",
+                email="dry-trial@test.com",
+                password="hash",
+            )
+            db.session.add(user)
+            db.session.flush()
+            db.session.add(
+                Subscription(
+                    user_id=user.id,
+                    plan_code="trial",
+                    status=SubscriptionStatus.TRIALING,
+                    trial_ends_at=datetime.utcnow() - timedelta(hours=1),
+                )
+            )
+            db.session.commit()
+
+        count = process_trial_expirations(dry_run=True, flask_app=app)
+
+        assert count == 1
+        with app.app_context():
+            from app.services.email_provider import get_email_outbox
+
+            assert len(get_email_outbox()) == 0
+
+
+class TestCancelSubscriptionEmail:
+    class _UnusedProvider:
+        """cancel_subscription must not call the provider for local-only subs."""
+
+        def cancel_subscription(self, provider_subscription_id: str) -> None:
+            raise AssertionError("provider must not be called for local cancel")
+
+    class _RecordingProvider:
+        def __init__(self) -> None:
+            self.canceled: list[str] = []
+
+        def cancel_subscription(self, provider_subscription_id: str) -> None:
+            self.canceled.append(provider_subscription_id)
+
+    def test_local_cancel_sends_confirmation_email(self, app) -> None:
+        """Cancel without provider_subscription_id has no webhook — email here."""
+        from app.services.email_provider import get_email_outbox
+        from app.services.subscription_service import cancel_subscription
+
+        with app.app_context():
+            user = User(
+                id=uuid.uuid4(),
+                name="Local Cancel User",
+                email="local-cancel@test.com",
+                password="hash",
+            )
+            db.session.add(user)
+            db.session.flush()
+            sub = Subscription(
+                user_id=user.id,
+                plan_code="premium",
+                status=SubscriptionStatus.ACTIVE,
+            )
+            db.session.add(sub)
+            db.session.commit()
+
+            result = cancel_subscription(sub, self._UnusedProvider())
+
+            assert result.status == SubscriptionStatus.CANCELED
+            outbox = get_email_outbox()
+            assert len(outbox) == 1
+            assert outbox[0]["tag"] == "billing_subscription_canceled"
+            assert outbox[0]["email"] == "local-cancel@test.com"
+            outbox.clear()
+
+    def test_provider_backed_cancel_relies_on_webhook_email(self, app) -> None:
+        """Provider-backed cancel gets SUBSCRIPTION_DELETED webhook — no dupe."""
+        from app.services.email_provider import get_email_outbox
+        from app.services.subscription_service import cancel_subscription
+
+        with app.app_context():
+            user = User(
+                id=uuid.uuid4(),
+                name="Provider Cancel User",
+                email="provider-cancel@test.com",
+                password="hash",
+            )
+            db.session.add(user)
+            db.session.flush()
+            sub = Subscription(
+                user_id=user.id,
+                plan_code="premium",
+                status=SubscriptionStatus.ACTIVE,
+                provider="asaas",
+                provider_subscription_id="sub_prov_1",
+            )
+            db.session.add(sub)
+            db.session.commit()
+
+            provider = self._RecordingProvider()
+            result = cancel_subscription(sub, provider)
+
+            assert result.status == SubscriptionStatus.CANCELED
+            assert provider.canceled == ["sub_prov_1"]
+            assert len(get_email_outbox()) == 0

--- a/tests/test_billing_email_service.py
+++ b/tests/test_billing_email_service.py
@@ -2,10 +2,14 @@ from __future__ import annotations
 
 import uuid
 
-from app.application.services.billing_email_service import dispatch_billing_email
+from app.application.services.billing_email_service import (
+    build_trial_ending_email,
+    dispatch_billing_email,
+    dispatch_trial_expired_email,
+)
 from app.models.subscription import BillingCycle, Subscription, SubscriptionStatus
 from app.models.user import User
-from app.services.email_provider import get_email_outbox
+from app.services.email_provider import EmailMessage, get_email_outbox
 
 
 def test_billing_email_service_sends_payment_confirmed_email(app) -> None:
@@ -59,3 +63,78 @@ def test_billing_email_service_sends_payment_failed_email(app) -> None:
         outbox = get_email_outbox()
         assert len(outbox) == 1
         assert outbox[0]["tag"] == "billing_payment_failed"
+
+
+def test_billing_email_service_sends_subscription_canceled_email(app) -> None:
+    with app.app_context():
+        user = User(
+            id=uuid.uuid4(),
+            name="Auraxis User",
+            email="billing@email.com",
+            password="hash",
+        )
+        subscription = Subscription(
+            user_id=user.id,
+            plan_code="premium",
+            status=SubscriptionStatus.CANCELED,
+            billing_cycle=BillingCycle.MONTHLY,
+        )
+
+        dispatch_billing_email(
+            user=user,
+            subscription=subscription,
+            event_type="SUBSCRIPTION_DELETED",
+        )
+
+        outbox = get_email_outbox()
+        assert len(outbox) == 1
+        assert outbox[0]["tag"] == "billing_subscription_canceled"
+
+
+def test_build_trial_ending_email_returns_ready_message(app) -> None:
+    with app.app_context():
+        user = User(
+            id=uuid.uuid4(),
+            name="Auraxis User",
+            email="trial@email.com",
+            password="hash",
+        )
+        subscription = Subscription(
+            user_id=user.id,
+            plan_code="trial",
+            status=SubscriptionStatus.TRIALING,
+        )
+
+        message = build_trial_ending_email(
+            user=user,
+            subscription=subscription,
+            days_until_trial_end=2,
+        )
+
+        assert isinstance(message, EmailMessage)
+        assert message.to_email == "trial@email.com"
+        assert message.tag == "billing_trial_ending_2d"
+        assert "2 dias" in message.subject
+        assert "2 dias" in message.text
+
+
+def test_dispatch_trial_expired_email_sends_downgrade_notice(app) -> None:
+    with app.app_context():
+        user = User(
+            id=uuid.uuid4(),
+            name="Auraxis User",
+            email="expired@email.com",
+            password="hash",
+        )
+        subscription = Subscription(
+            user_id=user.id,
+            plan_code="free",
+            status=SubscriptionStatus.FREE,
+        )
+
+        dispatch_trial_expired_email(user=user, subscription=subscription)
+
+        outbox = get_email_outbox()
+        assert len(outbox) == 1
+        assert outbox[0]["email"] == "expired@email.com"
+        assert outbox[0]["tag"] == "billing_trial_expired"

--- a/tests/test_billing_webhooks_cli.py
+++ b/tests/test_billing_webhooks_cli.py
@@ -1,0 +1,269 @@
+"""Tests for the ``flask billing-webhooks retry-failed`` CLI (#1556).
+
+Covers:
+- Reprocessing a FAILED event back to PROCESSED (with billing email dispatch)
+- Idempotency: duplicate provider_event_id is skipped on retry
+- max-retries cap keeps exhausted events out of the eligible set
+- Backlog alert: logger.error + Sentry capture when FAILED events accumulate
+- No alert when the backlog is below the threshold
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import timedelta
+
+from app.extensions.database import db
+from app.models.subscription import Subscription, SubscriptionStatus
+from app.models.user import User
+from app.models.webhook_event import WebhookEvent, WebhookEventStatus
+from app.services.email_provider import get_email_outbox
+from app.utils.datetime_utils import utc_now_naive
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_user_with_subscription(
+    *, customer_id: str, provider_subscription_id: str | None = None
+) -> Subscription:
+    suffix = uuid.uuid4().hex[:8]
+    user = User(
+        id=uuid.uuid4(),
+        name=f"Webhook {suffix}",
+        email=f"webhook-{suffix}@test.com",
+        password="hash",
+    )
+    db.session.add(user)
+    db.session.flush()
+    subscription = Subscription(
+        user_id=user.id,
+        plan_code="premium",
+        status=SubscriptionStatus.PAST_DUE,
+        provider="asaas",
+        provider_customer_id=customer_id,
+        provider_subscription_id=provider_subscription_id,
+    )
+    db.session.add(subscription)
+    db.session.commit()
+    return subscription
+
+
+def _make_failed_event(
+    *,
+    event_id: str,
+    customer_id: str,
+    raw_payload: str | None = None,
+    retry_count: int = 0,
+    event_type: str = "PAYMENT_CONFIRMED",
+) -> WebhookEvent:
+    payload = raw_payload
+    if payload is None:
+        payload = json.dumps(
+            {
+                "event": event_type,
+                "id": event_id,
+                "payment": {"customer": customer_id, "dueDate": "2030-01-01"},
+            }
+        )
+    event = WebhookEvent(
+        event_id=event_id,
+        event_type=event_type,
+        provider="asaas",
+        provider_customer_id=customer_id,
+        raw_payload=payload,
+        signature_verified=True,
+        status=WebhookEventStatus.FAILED.value,
+        failure_reason="boom",
+        retry_count=retry_count,
+        received_at=utc_now_naive() - timedelta(hours=1),
+    )
+    db.session.add(event)
+    db.session.commit()
+    return event
+
+
+# ---------------------------------------------------------------------------
+# Reprocessing
+# ---------------------------------------------------------------------------
+
+
+def test_retry_failed_reprocesses_event_to_processed(app) -> None:
+    with app.app_context():
+        subscription = _make_user_with_subscription(customer_id="cus_retry_1")
+        event = _make_failed_event(event_id="evt_retry_1", customer_id="cus_retry_1")
+        event_pk = event.id
+        subscription_pk = subscription.id
+
+        runner = app.test_cli_runner()
+        result = runner.invoke(args=["billing-webhooks", "retry-failed"])
+
+        assert result.exit_code == 0
+        assert "processed=1" in result.output
+
+        refreshed = db.session.get(WebhookEvent, event_pk)
+        assert refreshed is not None
+        assert refreshed.status == WebhookEventStatus.PROCESSED.value
+
+        sub = db.session.get(Subscription, subscription_pk)
+        assert sub is not None
+        assert sub.status == SubscriptionStatus.ACTIVE
+        assert sub.provider_event_id == "evt_retry_1"
+
+        outbox = get_email_outbox()
+        assert any(entry["tag"] == "billing_payment_confirmed" for entry in outbox)
+        outbox.clear()
+
+
+def test_retry_failed_skips_duplicate_provider_event_id(app) -> None:
+    """Events whose provider_event_id was already applied must be skipped."""
+    with app.app_context():
+        subscription = _make_user_with_subscription(customer_id="cus_dup_1")
+        subscription.provider_event_id = "evt_dup_1"
+        db.session.commit()
+        event = _make_failed_event(event_id="evt_dup_1", customer_id="cus_dup_1")
+        event_pk = event.id
+
+        runner = app.test_cli_runner()
+        result = runner.invoke(args=["billing-webhooks", "retry-failed"])
+
+        assert result.exit_code == 0
+        refreshed = db.session.get(WebhookEvent, event_pk)
+        assert refreshed is not None
+        assert refreshed.status == WebhookEventStatus.SKIPPED.value
+        assert len(get_email_outbox()) == 0
+
+
+def test_retry_failed_respects_max_retries(app) -> None:
+    with app.app_context():
+        _make_user_with_subscription(customer_id="cus_max_1")
+        event = _make_failed_event(
+            event_id="evt_max_1", customer_id="cus_max_1", retry_count=3
+        )
+        event_pk = event.id
+
+        runner = app.test_cli_runner()
+        result = runner.invoke(args=["billing-webhooks", "retry-failed"])
+
+        assert result.exit_code == 0
+        assert "no eligible events" in result.output
+        refreshed = db.session.get(WebhookEvent, event_pk)
+        assert refreshed is not None
+        assert refreshed.status == WebhookEventStatus.FAILED.value
+
+
+# ---------------------------------------------------------------------------
+# Backlog alerting
+# ---------------------------------------------------------------------------
+
+
+def test_retry_failed_alerts_on_accumulated_backlog(app, monkeypatch) -> None:
+    """FAILED events left after the run must trigger a Sentry alert."""
+    import sentry_sdk
+
+    captured: list[tuple[str, str | None]] = []
+
+    def _fake_capture_message(message: str, level: str | None = None, **_: object):
+        captured.append((message, level))
+        return None
+
+    monkeypatch.setattr(sentry_sdk, "capture_message", _fake_capture_message)
+
+    with app.app_context():
+        _make_user_with_subscription(customer_id="cus_alert_1")
+        # Exhausted event: stays FAILED and is not eligible for retry.
+        _make_failed_event(
+            event_id="evt_alert_1", customer_id="cus_alert_1", retry_count=3
+        )
+
+        runner = app.test_cli_runner()
+        result = runner.invoke(args=["billing-webhooks", "retry-failed"])
+
+        assert result.exit_code == 0
+        assert "backlog=1" in result.output
+        assert len(captured) == 1
+        message, level = captured[0]
+        assert "FAILED" in message
+        assert "1" in message
+        assert level == "error"
+
+
+def test_retry_failed_alert_counts_events_failing_again(app, monkeypatch) -> None:
+    """An event that fails again during retry still counts toward the backlog."""
+    import sentry_sdk
+
+    captured: list[str] = []
+    monkeypatch.setattr(
+        sentry_sdk,
+        "capture_message",
+        lambda message, level=None, **_: captured.append(message),
+    )
+
+    with app.app_context():
+        _make_failed_event(
+            event_id="evt_bad_1",
+            customer_id="cus_bad_1",
+            raw_payload="not-json{{",
+        )
+
+        runner = app.test_cli_runner()
+        result = runner.invoke(args=["billing-webhooks", "retry-failed"])
+
+        assert result.exit_code == 0
+        assert "failed=1" in result.output
+        assert "backlog=1" in result.output
+        assert len(captured) == 1
+
+
+def test_retry_failed_no_alert_below_threshold(app, monkeypatch) -> None:
+    import sentry_sdk
+
+    captured: list[str] = []
+    monkeypatch.setattr(
+        sentry_sdk,
+        "capture_message",
+        lambda message, level=None, **_: captured.append(message),
+    )
+
+    with app.app_context():
+        subscription = _make_user_with_subscription(customer_id="cus_clean_1")
+        _make_failed_event(event_id="evt_clean_1", customer_id="cus_clean_1")
+        assert subscription is not None
+
+        runner = app.test_cli_runner()
+        result = runner.invoke(args=["billing-webhooks", "retry-failed"])
+
+        assert result.exit_code == 0
+        assert "processed=1" in result.output
+        # Everything was reprocessed — no backlog, no alert.
+        assert captured == []
+        get_email_outbox().clear()
+
+
+def test_retry_failed_alert_threshold_option_raises_bar(app, monkeypatch) -> None:
+    import sentry_sdk
+
+    captured: list[str] = []
+    monkeypatch.setattr(
+        sentry_sdk,
+        "capture_message",
+        lambda message, level=None, **_: captured.append(message),
+    )
+
+    with app.app_context():
+        _make_failed_event(
+            event_id="evt_thresh_1",
+            customer_id="cus_thresh_1",
+            retry_count=3,
+        )
+
+        runner = app.test_cli_runner()
+        result = runner.invoke(
+            args=["billing-webhooks", "retry-failed", "--alert-threshold", "5"]
+        )
+
+        assert result.exit_code == 0
+        # Backlog (1) below threshold (5): no Sentry alert.
+        assert captured == []

--- a/tests/test_reminders_cli.py
+++ b/tests/test_reminders_cli.py
@@ -144,3 +144,65 @@ def test_dispatch_due_soon_dry_run_does_not_send(app) -> None:
 
     outbox = get_email_outbox()
     assert len(outbox) == 0
+
+
+def test_dispatch_trial_ending_cli_sends_reminder(app) -> None:
+    from datetime import datetime, time
+
+    from app.models.subscription import Subscription, SubscriptionStatus
+
+    with app.app_context():
+        user = User(
+            id=uuid.uuid4(),
+            name="Trial CLI User",
+            email="trial-cli@email.com",
+            password="hash",
+        )
+        db.session.add(user)
+        db.session.flush()
+        db.session.add(
+            Subscription(
+                user_id=user.id,
+                plan_code="trial",
+                status=SubscriptionStatus.TRIALING,
+                trial_ends_at=datetime.combine(
+                    date.today() + timedelta(days=2), time(hour=12)
+                ),
+            )
+        )
+        db.session.commit()
+
+        runner = app.test_cli_runner()
+        result = runner.invoke(args=["reminders", "dispatch-trial-ending"])
+
+        assert result.exit_code == 0
+        assert "trial-ending reminders:" in result.output
+        assert "sent=1" in result.output
+        outbox = get_email_outbox()
+        assert len(outbox) == 1
+        assert outbox[0]["tag"] == "billing_trial_ending_2d"
+        outbox.clear()
+
+
+def test_dispatch_trial_ending_cli_dry_run_does_not_send(app) -> None:
+    runner = app.test_cli_runner()
+    result = runner.invoke(args=["reminders", "dispatch-trial-ending", "--dry-run"])
+
+    assert result.exit_code == 0
+    assert "[dry-run]" in result.output
+    assert len(get_email_outbox()) == 0
+
+
+def test_dispatch_trial_ending_cli_unexpected_error_exits_nonzero(app) -> None:
+    import unittest.mock as mock
+
+    with app.app_context():
+        runner = app.test_cli_runner()
+        with mock.patch(
+            "app.application.services.trial_ending_reminder_service.dispatch_trial_ending_reminders",
+            side_effect=RuntimeError("DB connection lost"),
+        ):
+            result = runner.invoke(args=["reminders", "dispatch-trial-ending"])
+
+    assert result.exit_code == 1
+    assert "ERROR" in result.output

--- a/tests/test_trial_ending_reminder_service.py
+++ b/tests/test_trial_ending_reminder_service.py
@@ -1,0 +1,172 @@
+"""Tests for trial_ending_reminder_service (#1555 — dunning D-2).
+
+Covers:
+- Happy path D-2 dispatch for TRIALING subscription ending in 2 days
+- Idempotency: running twice does not duplicate emails (Alert dedupe)
+- Skip non-TRIALING subscriptions inside the window
+- Skip subscriptions outside the target window
+- Skip soft-deleted users
+- Invalid window raises ValueError
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime, timedelta
+
+import pytest
+
+from app.application.services.trial_ending_reminder_service import (
+    TrialEndingReminderResult,
+    dispatch_trial_ending_reminders,
+)
+from app.extensions.database import db
+from app.models.alert import Alert
+from app.models.subscription import Subscription, SubscriptionStatus
+from app.models.user import User
+from app.services.email_provider import get_email_outbox
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_user_with_trial(
+    *,
+    trial_ends_at: datetime | None,
+    status: SubscriptionStatus = SubscriptionStatus.TRIALING,
+    deleted_at: datetime | None = None,
+) -> tuple[User, Subscription]:
+    suffix = uuid.uuid4().hex[:8]
+    user = User(
+        id=uuid.uuid4(),
+        name=f"Trial {suffix}",
+        email=f"trial-{suffix}@test.com",
+        password="hash",
+        deleted_at=deleted_at,
+    )
+    db.session.add(user)
+    db.session.flush()
+    subscription = Subscription(
+        user_id=user.id,
+        plan_code="trial",
+        status=status,
+        trial_ends_at=trial_ends_at,
+    )
+    db.session.add(subscription)
+    db.session.commit()
+    return user, subscription
+
+
+def _drain_outbox() -> None:
+    get_email_outbox().clear()
+
+
+def _at_hour(day: date, hour: int) -> datetime:
+    return datetime.combine(day, datetime.min.time()) + timedelta(hours=hour)
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_dispatches_d2_reminder_for_trial_ending_in_two_days(app) -> None:
+    today = date(2030, 6, 15)
+    with app.app_context():
+        user, subscription = _make_user_with_trial(
+            trial_ends_at=_at_hour(today + timedelta(days=2), 10),
+        )
+        result = dispatch_trial_ending_reminders(days_until_trial_end=2, today=today)
+
+        assert isinstance(result, TrialEndingReminderResult)
+        assert result.scanned == 1
+        assert result.sent == 1
+        outbox = get_email_outbox()
+        assert len(outbox) == 1
+        assert outbox[0]["email"] == str(user.email)
+        assert outbox[0]["tag"] == "billing_trial_ending_2d"
+
+        alert = Alert.query.filter_by(
+            user_id=user.id, category="billing_trial_ending_2d"
+        ).first()
+        assert alert is not None
+        assert alert.entity_type == "subscription"
+        assert alert.entity_id == subscription.id
+        _drain_outbox()
+
+
+# ---------------------------------------------------------------------------
+# Idempotency
+# ---------------------------------------------------------------------------
+
+
+def test_is_idempotent_across_runs(app) -> None:
+    today = date(2030, 6, 15)
+    with app.app_context():
+        _make_user_with_trial(
+            trial_ends_at=_at_hour(today + timedelta(days=2), 10),
+        )
+        first = dispatch_trial_ending_reminders(days_until_trial_end=2, today=today)
+        second = dispatch_trial_ending_reminders(days_until_trial_end=2, today=today)
+
+        assert first.sent == 1
+        assert second.sent == 0
+        assert second.skipped == 1
+        assert len(get_email_outbox()) == 1
+        _drain_outbox()
+
+
+# ---------------------------------------------------------------------------
+# Skip cases
+# ---------------------------------------------------------------------------
+
+
+def test_skips_non_trialing_subscription(app) -> None:
+    today = date(2030, 6, 15)
+    with app.app_context():
+        _make_user_with_trial(
+            trial_ends_at=_at_hour(today + timedelta(days=2), 10),
+            status=SubscriptionStatus.ACTIVE,
+        )
+        result = dispatch_trial_ending_reminders(days_until_trial_end=2, today=today)
+
+        assert result.scanned == 0
+        assert result.sent == 0
+        assert len(get_email_outbox()) == 0
+
+
+def test_skips_trial_outside_target_window(app) -> None:
+    today = date(2030, 6, 15)
+    with app.app_context():
+        _make_user_with_trial(
+            trial_ends_at=_at_hour(today + timedelta(days=5), 10),
+        )
+        result = dispatch_trial_ending_reminders(days_until_trial_end=2, today=today)
+
+        assert result.scanned == 0
+        assert result.sent == 0
+
+
+def test_skips_soft_deleted_user(app) -> None:
+    today = date(2030, 6, 15)
+    with app.app_context():
+        _make_user_with_trial(
+            trial_ends_at=_at_hour(today + timedelta(days=2), 10),
+            deleted_at=_at_hour(today - timedelta(days=1), 8),
+        )
+        result = dispatch_trial_ending_reminders(days_until_trial_end=2, today=today)
+
+        assert result.scanned == 0
+        assert result.sent == 0
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_window_raises_value_error(app) -> None:
+    with app.app_context():
+        with pytest.raises(ValueError):
+            dispatch_trial_ending_reminders(days_until_trial_end=0)


### PR DESCRIPTION
## O que muda

### Dunning / emails de ciclo de vida de billing (#1555)

Auditoria da cobertura atual de `dispatch_billing_email`:

| Estado do ciclo | Antes | Depois |
|---|---|---|
| Pagamento confirmado (`PAYMENT_RECEIVED`/`PAYMENT_CONFIRMED`) | ✅ coberto | ✅ inalterado |
| Pagamento falhou (`PAYMENT_OVERDUE`/`subscription.past_due` → PAST_DUE) | ✅ coberto | ✅ inalterado |
| Cancelamento via webhook (`subscription.canceled`/`SUBSCRIPTION_DELETED`) | ✅ coberto | ✅ + teste de regressão novo |
| **Trial acabando (D-2)** | ❌ inexistente | ✅ novo job event-driven por cron |
| **Trial expirado (downgrade efetivado TRIALING→FREE)** | ❌ inexistente | ✅ email no `process_trial_expirations` |
| **Cancelamento local (sem `provider_subscription_id`)** | ❌ nenhum email jamais | ✅ confirmação no `cancel_subscription` |

- **Novo `trial_ending_reminder_service`**: varre `Subscription` TRIALING com `trial_ends_at` na janela D-N (default 2), idempotente via tabela `Alert` (`entity_type='subscription'`, sem migration), envio Resend com fallback para o email DLQ — espelho fiel do `email_verification_reminder_service`.
- **`flask reminders dispatch-trial-ending [--dry-run] [--days N]`** no grupo `reminders`; o cron diário existente (`reminder-job.yml`, 07:00 UTC) passa a despachá-lo junto com os demais reminders.
- **`build_trial_ending_email` / `dispatch_trial_expired_email`** centralizam o copy de dunning em `billing_email_service.py`.
- **Cancel local**: `cancel_subscription` dispara `billing_subscription_canceled` **apenas** quando não há `provider_subscription_id` (provider-backed continua recebendo via webhook `SUBSCRIPTION_DELETED` — sem email duplicado).

### Reprocesso de WebhookEvent FAILED + alerta (#1556)

O comando `flask billing-webhooks retry-failed` (idempotente via dedupe de `provider_event_id`) já existia; o que faltava e foi entregue:

- **Alerta de backlog acumulado**: nova opção `--alert-threshold` (default 1). Após a execução, eventos que permanecem `FAILED` (incluindo os que esgotaram `--max-retries`) geram `logger.error` + `sentry_sdk.capture_message(level="error")` com contagem e `received_at` mais antigo. Saída do CLI reporta `backlog=N`.
- **Cron de baixa frequência**: novo workflow `billing-webhooks-retry-job.yml` (diário 05:30 UTC) via SSM na instância prod, espelhando `reminder-job.yml`/`spending-patterns-job.yml`, com `workflow_dispatch` (`dry_run`) e issue automática em caso de falha.
- **Cobertura nova do CLI** (não havia nenhum teste): reprocesso FAILED→PROCESSED com email de billing, dedupe por `provider_event_id`, cap de `--max-retries`, e todos os cenários de alerta.

Sem migrations, sem endpoint REST novo (CLI-only), sem mudança de contrato REST/GraphQL.

## Como testar

```bash
# suíte dirigida
scripts/repo_bin.sh pytest tests/test_trial_ending_reminder_service.py \
  tests/test_billing_email_service.py tests/test_billing_webhooks_cli.py \
  tests/test_reminders_cli.py tests/test_billing.py -v

# manual (container prod ou local)
flask reminders dispatch-trial-ending --dry-run
flask billing-webhooks retry-failed --dry-run
```

## Quality gates

- `bash scripts/run_ci_quality_local.sh --local` → **verde** (ruff format+check, mypy, bandit, pip-audit, pytest)
- **2755 passed, 2 skipped** — coverage total **91,53%** (gate ≥85%)
- TDD: testes escritos primeiro e confirmados falhando antes da implementação

## Risco

- 🟢 **Baixo.** Todos os fluxos novos de email são try/except-guarded — falha de email nunca bloqueia webhook, cancel ou downgrade.
- Idempotência de reminder por `Alert` (subscription+categoria): reexecução do cron não duplica email.
- O cron novo de retry só reexecuta eventos `FAILED` com `retry_count < 3`; duplicatas são descartadas pelo dedupe existente de `provider_event_id`.
- Risco residual: `flask billing expire-trials` (TRIALING→FREE) segue **sem scheduler** — sem ele o email de trial expirado só sai quando o job for rodado; registrado como lacuna na #1555 (decisão de produto/ops).

Closes #1555
Closes #1556
