### PR TITLE
chore(ai): reduz cron do radar de gastos de diário para semanal (sábados)

### DIFF
--- a/.github/workflows/spending-patterns-job.yml
+++ b/.github/workflows/spending-patterns-job.yml
@@ -2,8 +2,10 @@ name: Spending Patterns Job
 
 on:
   schedule:
-    # Every day at 06:00 UTC = 03:00 BRT
-    - cron: "0 6 * * *"
+    # Weekly on Saturdays at 06:00 UTC = 03:00 BRT (issue #1553 — PO 2026-07-10:
+    # automatic insights are weekly/monthly only; the daily run created a new
+    # AIInsight per user every night, perceived as "new insight on every login")
+    - cron: "0 6 * * 6"
   workflow_dispatch:
     inputs:
       dry_run:


### PR DESCRIPTION
## Summary

Muda o schedule do `spending-patterns-job.yml` de diário (`0 6 * * *`) para **semanal aos sábados** (`0 6 * * 6`, 06:00 UTC = 03:00 BRT), alinhado ao ciclo do insight semanal.

Contexto (diagnóstico da Onda IA v3 no LLMAuditLog, 2026-07-11): o cron diário criava um `AIInsight` novo por usuário toda madrugada — a fonte do "insight novo a cada login" percebido pelo PO. Regra de produto (PO 2026-07-10): insights automáticos são apenas semanais e mensais.

- `workflow_dispatch` preservado para geração manual (com `dry_run`).
- Mudança workflow-only — zero impacto em código de runtime.

## Validation

- `yaml.safe_load` OK.
- Diff restrito ao bloco `on.schedule` + comentário.

## Residual risk

Nenhum relevante — o radar continua acessível manualmente via dispatch; próxima execução automática passa a ser sábado.

## Refs

Closes #1553