### PR TITLE
fix(lgpd): purge-deleted-accounts — corrige path de prod e passa a esperar o resultado do SSM

### DIFF
--- a/.github/workflows/purge-deleted-accounts.yml
+++ b/.github/workflows/purge-deleted-accounts.yml
@@ -78,16 +78,54 @@ jobs:
             DRY_RUN_FLAG="--dry-run"
           fi
 
-          aws ssm send-command \
+          # Stack de prod vive em /opt/auraxis (não /opt/auraxis-api) e o compose
+          # de prod exige -f docker-compose.prod.yml. O container é resolvido por
+          # CID (padrão do fix #1407 — `compose exec web` pode pegar zombie).
+          COMMAND_ID=$(aws ssm send-command \
             --region "${AWS_REGION}" \
             --instance-ids "${PROD_INSTANCE_ID}" \
             --document-name "AWS-RunShellScript" \
+            --comment "purge-deleted-accounts (LGPD) via GH Actions" \
             --parameters "commands=[
-              \"cd /opt/auraxis-api\",
-              \"docker compose exec -T web python scripts/purge_deleted_accounts.py --grace-days ${GRACE_DAYS} ${DRY_RUN_FLAG}\"
+              \"cd /opt/auraxis\",
+              \"WEB_CID=\$(docker compose --env-file .env.prod -f docker-compose.prod.yml ps -q web)\",
+              \"test -n \\\"\$WEB_CID\\\"\",
+              \"docker exec \\\"\$WEB_CID\\\" python scripts/purge_deleted_accounts.py --grace-days ${GRACE_DAYS} ${DRY_RUN_FLAG}\"
             ]" \
             --output text \
-            --query "Command.CommandId"
+            --query "Command.CommandId")
+          echo "SSM CommandId: ${COMMAND_ID}"
+
+          # Espera o resultado real: sem isso o job termina success com o purge
+          # quebrado no host e o alerta de falha abaixo nunca dispara.
+          STATUS="Pending"
+          for _ in $(seq 1 60); do
+            STATUS=$(aws ssm get-command-invocation \
+              --region "${AWS_REGION}" \
+              --command-id "${COMMAND_ID}" \
+              --instance-id "${PROD_INSTANCE_ID}" \
+              --query "Status" --output text 2>/dev/null || echo "Pending")
+            case "${STATUS}" in
+              Success|Failed|Cancelled|TimedOut) break ;;
+            esac
+            sleep 10
+          done
+
+          echo "--- stdout ---"
+          aws ssm get-command-invocation \
+            --region "${AWS_REGION}" \
+            --command-id "${COMMAND_ID}" \
+            --instance-id "${PROD_INSTANCE_ID}" \
+            --query "StandardOutputContent" --output text
+          echo "--- stderr ---"
+          aws ssm get-command-invocation \
+            --region "${AWS_REGION}" \
+            --command-id "${COMMAND_ID}" \
+            --instance-id "${PROD_INSTANCE_ID}" \
+            --query "StandardErrorContent" --output text
+
+          echo "SSM status final: ${STATUS}"
+          [ "${STATUS}" = "Success" ]
 
       - name: Notify failure via GitHub Issue
         if: failure()


### PR DESCRIPTION
## Summary

O cron diário `purge-deleted-accounts.yml` (04:00 UTC) **nunca purgou conta nenhuma** — triagem dos comandos SSM de prod em 2026-07-12 mostrou falha diária silenciosa:

```
sh: 1: cd: can't cd to /opt/auraxis-api
no configuration file provided: not found
failed to run commands: exit status 1
```

Dois bugs compostos, ambos corrigidos:

1. **Path/compose errados** — `cd /opt/auraxis` (não `/opt/auraxis-api`), container resolvido por CID via `docker compose --env-file .env.prod -f docker-compose.prod.yml ps -q web` (iron law do prod-deploy + padrão do fix #1407 contra zombie container), execução via `docker exec "$WEB_CID"`.
2. **Fire-and-forget** — o step só capturava o `CommandId`; o job GH terminava `success` com o comando quebrado no host, então o step `Notify failure via GitHub Issue` (`if: failure()`) nunca disparou. Agora o step espera o estado terminal (`get-command-invocation`, timeout 10min), ecoa stdout/stderr no log e falha o job quando `Status != Success`.

**Impacto LGPD**: contas com deleção solicitada além do grace period (30d) não estavam sendo purgadas — relevante para o gate G2-legal do go-live (épico platform#860).

## Validation

- `yaml.safe_load` OK; mudança restrita ao step "Run purge script via SSM".
- Pós-merge: rodar `workflow_dispatch` com `dry_run=true` para validar ponta a ponta e medir o backlog de contas elegíveis (AC da issue).

## Residual risk

- O primeiro run real pode purgar um backlog acumulado de contas (todas já além do grace period — comportamento correto, mas volume maior que o normal). O `dry_run` pós-merge quantifica antes.

## Refs

Closes #1560
Ref platform#860 (gate G2-legal) · fix #1407 (zombie container)