### PR TITLE
refactor(billing): provider-agnostic webhook parser boundary

### DIFF
--- a/app/controllers/billing_webhook_parsers.py
+++ b/app/controllers/billing_webhook_parsers.py
@@ -1,0 +1,171 @@
+"""Provider-agnostic inbound boundary for billing webhooks (#1564).
+
+``BillingProvider`` (``app.services.billing_adapter``) makes the *outbound* side
+of billing pluggable.  This module is its inbound counterpart: each gateway
+brings its own signature scheme, event vocabulary and payload envelope, and
+normalises them into a single ``BillingSubscriptionSnapshot``.
+
+Adding a gateway means adding a parser and registering it — not editing a
+shared event map.  A flat map shared across gateways is genuinely ambiguous:
+different providers reuse the same event names with different meanings.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Protocol, runtime_checkable
+
+from app.controllers.subscription_webhook_payload import (
+    _ASAAS_WEBHOOK_TOKEN_HEADER,
+    _WEBHOOK_SIGNATURE_HEADER,
+    _extract_subscription_identifiers,
+    _resolve_offer_from_external_reference,
+    _verify_asaas_webhook_token,
+    _verify_webhook_signature,
+)
+from app.models.subscription import SubscriptionStatus
+from app.services.billing_adapter import BillingSubscriptionSnapshot
+
+ASAAS_PROVIDER = "asaas"
+
+
+@runtime_checkable
+class BillingWebhookParser(Protocol):
+    """Structural interface for inbound webhook adapters."""
+
+    @property
+    def provider(self) -> str:
+        """Canonical provider slug, as persisted on ``Subscription.provider``."""
+        ...
+
+    def verify(self, raw_body: bytes, headers: Mapping[str, str]) -> bool:
+        """Return whether the request is authentically from this provider.
+
+        Implementations must be fail-closed: absent configuration rejects.
+        """
+        ...
+
+    def supports_event(self, event_type: str) -> bool:
+        """Return whether this event type maps to a subscription state change."""
+        ...
+
+    def parse(self, payload: dict[str, Any]) -> BillingSubscriptionSnapshot | None:
+        """Normalise a payload, or return ``None`` when it is not actionable."""
+        ...
+
+
+def _build_snapshot(
+    payload: dict[str, Any],
+    *,
+    status: str,
+    provider: str | None,
+) -> BillingSubscriptionSnapshot | None:
+    """Assemble a snapshot from provider-neutral identifier extraction."""
+    (
+        provider_subscription_id,
+        provider_customer_id,
+        external_reference,
+        current_period_start,
+        current_period_end,
+    ) = _extract_subscription_identifiers(payload)
+
+    if not provider_customer_id and not provider_subscription_id:
+        return None
+
+    offer_metadata = _resolve_offer_from_external_reference(external_reference)
+    snapshot: BillingSubscriptionSnapshot = {
+        "status": status,
+        "provider_customer_id": provider_customer_id,
+        "current_period_start": current_period_start,
+        "current_period_end": current_period_end,
+    }
+    if provider:
+        snapshot["provider"] = provider
+    if provider_subscription_id:
+        snapshot["provider_id"] = provider_subscription_id
+    if offer_metadata["plan_code"]:
+        snapshot["plan_code"] = offer_metadata["plan_code"]
+    if offer_metadata["offer_code"]:
+        snapshot["offer_code"] = offer_metadata["offer_code"]
+    if offer_metadata["billing_cycle"]:
+        snapshot["billing_cycle"] = offer_metadata["billing_cycle"]
+    return snapshot
+
+
+class AsaasWebhookParser:
+    """Asaas webhooks, plus the gateway-neutral legacy ``subscription.*`` events.
+
+    The two vocabularies are kept in separate maps on purpose.  Only the
+    Asaas-native events stamp ``provider`` on the snapshot; the legacy generic
+    events are gateway-neutral and must not overwrite ``Subscription.provider``
+    on rows that never came from Asaas.  That distinction was previously an
+    ``event_type.isupper()`` heuristic — correct by accident, and silently
+    wrong the moment a second gateway used uppercase event names.
+    """
+
+    _NATIVE_EVENTS = {
+        "PAYMENT_RECEIVED": SubscriptionStatus.ACTIVE.value,
+        "PAYMENT_CONFIRMED": SubscriptionStatus.ACTIVE.value,
+        "PAYMENT_OVERDUE": SubscriptionStatus.PAST_DUE.value,
+        "SUBSCRIPTION_DELETED": SubscriptionStatus.CANCELED.value,
+    }
+    _LEGACY_EVENTS = {
+        "subscription.activated": SubscriptionStatus.ACTIVE.value,
+        "subscription.canceled": SubscriptionStatus.CANCELED.value,
+        "subscription.past_due": SubscriptionStatus.PAST_DUE.value,
+    }
+
+    @property
+    def provider(self) -> str:
+        return ASAAS_PROVIDER
+
+    def verify(self, raw_body: bytes, headers: Mapping[str, str]) -> bool:
+        signature = headers.get(_WEBHOOK_SIGNATURE_HEADER, "")
+        token = headers.get(_ASAAS_WEBHOOK_TOKEN_HEADER, "")
+        return _verify_webhook_signature(raw_body, signature) or (
+            _verify_asaas_webhook_token(token)
+        )
+
+    def supports_event(self, event_type: str) -> bool:
+        return event_type in self._NATIVE_EVENTS or event_type in self._LEGACY_EVENTS
+
+    def parse(self, payload: dict[str, Any]) -> BillingSubscriptionSnapshot | None:
+        event_type = str(payload.get("event") or "").strip()
+
+        status = self._NATIVE_EVENTS.get(event_type)
+        if status is not None:
+            return _build_snapshot(payload, status=status, provider=ASAAS_PROVIDER)
+
+        legacy_status = self._LEGACY_EVENTS.get(event_type)
+        if legacy_status is not None:
+            return _build_snapshot(payload, status=legacy_status, provider=None)
+
+        return None
+
+
+_PARSERS: dict[str, BillingWebhookParser] = {
+    ASAAS_PROVIDER: AsaasWebhookParser(),
+}
+
+_DEFAULT_PROVIDER = ASAAS_PROVIDER
+
+
+def resolve_webhook_parser(provider: str | None) -> BillingWebhookParser | None:
+    """Return the parser for ``provider``, or ``None`` when unknown.
+
+    An empty provider resolves to the default gateway so the unscoped
+    ``POST /subscriptions/webhook`` route — already registered in the Asaas
+    dashboard in production — keeps working unchanged.
+    """
+    slug = str(provider or "").strip().lower() or _DEFAULT_PROVIDER
+    return _PARSERS.get(slug)
+
+
+def default_webhook_parser() -> BillingWebhookParser:
+    """Parser backing the unscoped legacy ``POST /subscriptions/webhook`` route."""
+    return _PARSERS[_DEFAULT_PROVIDER]
+
+
+def registered_providers() -> tuple[str, ...]:
+    """Provider slugs accepted by the provider-scoped webhook route."""
+    return tuple(sorted(_PARSERS))

--- a/app/controllers/subscription_controller.py
+++ b/app/controllers/subscription_controller.py
@@ -25,6 +25,9 @@ from app.config.billing_plans import (
     list_public_billing_plans,
     resolve_checkout_plan_offer,
 )
+from app.controllers.billing_webhook_parsers import (
+    resolve_webhook_parser as resolve_webhook_parser,  # re-export for CLI
+)
 from app.controllers.response_contract import compat_error_response
 from app.controllers.subscription_webhook_handler import (
     _process_webhook_snapshot as _process_webhook_snapshot,  # noqa: F401  re-export
@@ -34,9 +37,6 @@ from app.controllers.subscription_webhook_handler import (
 )
 from app.controllers.subscription_webhook_payload import (
     _extract_event_id as _extract_event_id,  # re-export for billing_webhooks_cli
-)
-from app.controllers.subscription_webhook_payload import (
-    _extract_provider_snapshot as _extract_provider_snapshot,  # re-export
 )
 from app.extensions.database import db
 from app.models.subscription import Subscription, SubscriptionStatus
@@ -211,8 +211,29 @@ def cancel_my_subscription() -> ResponseReturnValue:
 
 @subscription_bp.post("/webhook")
 def handle_webhook() -> ResponseReturnValue:
-    """Receive provider webhook events (delegated to subscription_webhook_handler)."""
+    """Receive webhook events for the default gateway.
+
+    Kept unscoped for retrocompatibility: this URL is already registered in the
+    Asaas dashboard in production.  New gateways use the scoped route below.
+    """
     return handle_webhook_request()
+
+
+@subscription_bp.post("/webhook/<provider>")
+def handle_provider_webhook(provider: str) -> ResponseReturnValue:
+    """Receive webhook events for an explicitly named gateway.
+
+    Routing by path segment keeps each provider's signature scheme and event
+    vocabulary isolated, instead of guessing the origin from payload shape.
+    """
+    parser = resolve_webhook_parser(provider)
+    if parser is None:
+        return _err(
+            f"Unknown billing provider: {provider}",
+            "NOT_FOUND",
+            404,
+        )
+    return handle_webhook_request(parser)
 
 
 def register_subscription_dependencies(app: Any) -> None:  # noqa: ANN401

--- a/app/controllers/subscription_webhook_handler.py
+++ b/app/controllers/subscription_webhook_handler.py
@@ -11,22 +11,22 @@ Re-exports consumed by ``billing_webhooks_cli`` remain in
 from __future__ import annotations
 
 import logging
-from typing import Any
+from collections.abc import Mapping
+from typing import Any, cast
 
 from flask import request
 from flask.typing import ResponseReturnValue
 
 from app.application.services.billing_email_service import dispatch_billing_email
+from app.controllers.billing_webhook_parsers import (
+    BillingWebhookParser,
+    default_webhook_parser,
+)
 from app.controllers.response_contract import compat_error_response
 from app.controllers.subscription_webhook_payload import (
-    _ASAAS_WEBHOOK_TOKEN_HEADER,
-    _WEBHOOK_SIGNATURE_HEADER,
     _extract_event_id,
-    _extract_provider_snapshot,
     _extract_subscription_identifiers,
     _find_subscription_for_snapshot,
-    _is_supported_webhook_event,
-    _is_webhook_request_authorized,
 )
 from app.extensions.database import db
 from app.http.request_context import current_request_id
@@ -107,28 +107,29 @@ def _process_webhook_snapshot(
     return _ok({"received": True, "processed": True})
 
 
-def handle_webhook_request() -> ResponseReturnValue:
+def handle_webhook_request(
+    parser: BillingWebhookParser | None = None,
+) -> ResponseReturnValue:
     """Process a provider webhook POST.
 
-    Validates the signature, persists an audit record, and delegates to
-    ``_process_webhook_snapshot`` for supported event types.
-    Called by ``subscription_controller.handle_webhook``.
+    Verifies the signature, persists an audit record, and delegates to
+    ``_process_webhook_snapshot`` for supported event types.  Called by
+    ``subscription_controller.handle_webhook``.
 
-    Supported events
-    ----------------
-    subscription.activated   — set status to ACTIVE
-    subscription.canceled    — set status to CANCELED
-    subscription.past_due    — set status to PAST_DUE
-    PAYMENT_RECEIVED         — set status to ACTIVE
-    PAYMENT_CONFIRMED        — set status to ACTIVE
-    PAYMENT_OVERDUE          — set status to PAST_DUE
-    SUBSCRIPTION_DELETED     — set status to CANCELED
-    <any other event>        — 200 no-op
+    Signature scheme, event vocabulary and payload shape all come from the
+    ``BillingWebhookParser`` (``app.controllers.billing_webhook_parsers``);
+    unsupported events are a 200 no-op.  ``parser`` defaults to the gateway
+    behind the unscoped legacy route.
     """
+    if parser is None:
+        parser = default_webhook_parser()
+
     raw_body: bytes = request.get_data()
-    signature = request.headers.get(_WEBHOOK_SIGNATURE_HEADER, "")
-    asaas_token = request.headers.get(_ASAAS_WEBHOOK_TOKEN_HEADER, "")
-    sig_verified = _is_webhook_request_authorized(raw_body, signature, asaas_token)
+    # Werkzeug's Headers is not a nominal Mapping, but its ``get`` is
+    # case-insensitive — which is what header lookup needs.  Casting to dict
+    # instead would make ``asaas-access-token`` miss ``Asaas-Access-Token``.
+    headers = cast(Mapping[str, str], request.headers)
+    sig_verified = parser.verify(raw_body, headers)
 
     payload: dict[str, Any] = request.get_json(silent=True) or {}
     event_type: str = payload.get("event", "")
@@ -149,7 +150,7 @@ def handle_webhook_request() -> ResponseReturnValue:
     webhook_ev = WebhookEvent(
         event_id=event_id,
         event_type=event_type or "unknown",
-        provider="asaas",
+        provider=parser.provider,
         provider_subscription_id=provider_subscription_id,
         provider_customer_id=provider_customer_id,
         raw_payload=raw_text,
@@ -173,13 +174,13 @@ def handle_webhook_request() -> ResponseReturnValue:
             details={"request_id": current_request_id()},
         )
 
-    if not _is_supported_webhook_event(event_type):
+    if not parser.supports_event(event_type):
         webhook_ev.mark_skipped(reason=f"unsupported_event:{event_type}")
         db.session.commit()
         logger.info("Unhandled billing webhook event: %s — ignoring", event_type)
         return _ok({"received": True, "processed": False})
 
-    snapshot = _extract_provider_snapshot(payload)
+    snapshot = parser.parse(payload)
     if snapshot is None:
         webhook_ev.mark_skipped(reason="unresolvable_subscription")
         db.session.commit()

--- a/app/controllers/subscription_webhook_payload.py
+++ b/app/controllers/subscription_webhook_payload.py
@@ -16,7 +16,7 @@ from flask import current_app
 from flask.ctx import has_app_context
 
 from app.config.billing_plans import resolve_checkout_plan_offer
-from app.models.subscription import Subscription, SubscriptionStatus
+from app.models.subscription import Subscription
 from app.services.billing_adapter import BillingSubscriptionSnapshot
 
 _WEBHOOK_SIGNATURE_HEADER = "X-Billing-Signature"
@@ -24,15 +24,6 @@ _ASAAS_WEBHOOK_TOKEN_HEADER = "asaas-access-token"
 _WEBHOOK_SECRET_ENV = "BILLING_WEBHOOK_SECRET"
 _WEBHOOK_ALLOW_UNSIGNED_ENV = "BILLING_WEBHOOK_ALLOW_UNSIGNED"
 _ASAAS_WEBHOOK_TOKEN_ENV = "BILLING_ASAAS_WEBHOOK_TOKEN"
-_SUPPORTED_WEBHOOK_EVENTS = {
-    "subscription.activated",
-    "subscription.canceled",
-    "subscription.past_due",
-    "PAYMENT_RECEIVED",
-    "PAYMENT_CONFIRMED",
-    "PAYMENT_OVERDUE",
-    "SUBSCRIPTION_DELETED",
-}
 
 
 def _read_bool_env(name: str, default: bool = False) -> bool:
@@ -90,14 +81,6 @@ def _verify_asaas_webhook_token(header_value: str) -> bool:
     if not header_value.strip():
         return False
     return hmac.compare_digest(expected, header_value.strip())
-
-
-def _is_webhook_request_authorized(
-    payload: bytes, signature: str, asaas_token: str
-) -> bool:
-    return _verify_webhook_signature(payload, signature) or _verify_asaas_webhook_token(
-        asaas_token
-    )
 
 
 def _extract_event_id(payload: dict[str, Any]) -> str | None:
@@ -243,62 +226,6 @@ def _extract_subscription_identifiers(
         _coerce_datetime(current_period_start),
         _coerce_datetime(current_period_end),
     )
-
-
-def _resolve_status(event_type: str) -> str | None:
-    status_map = {
-        "subscription.activated": SubscriptionStatus.ACTIVE.value,
-        "subscription.canceled": SubscriptionStatus.CANCELED.value,
-        "subscription.past_due": SubscriptionStatus.PAST_DUE.value,
-        "PAYMENT_RECEIVED": SubscriptionStatus.ACTIVE.value,
-        "PAYMENT_CONFIRMED": SubscriptionStatus.ACTIVE.value,
-        "PAYMENT_OVERDUE": SubscriptionStatus.PAST_DUE.value,
-        "SUBSCRIPTION_DELETED": SubscriptionStatus.CANCELED.value,
-    }
-    return status_map.get(event_type)
-
-
-def _extract_provider_snapshot(
-    payload: dict[str, Any],
-) -> BillingSubscriptionSnapshot | None:
-    event_type = str(payload.get("event") or "").strip()
-    (
-        provider_subscription_id,
-        provider_customer_id,
-        external_reference,
-        current_period_start,
-        current_period_end,
-    ) = _extract_subscription_identifiers(payload)
-
-    if not provider_customer_id and not provider_subscription_id:
-        return None
-
-    status = _resolve_status(event_type)
-    if status is None:
-        return None
-
-    offer_metadata = _resolve_offer_from_external_reference(external_reference)
-    snapshot: BillingSubscriptionSnapshot = {
-        "status": status,
-        "provider_customer_id": provider_customer_id,
-        "current_period_start": current_period_start,
-        "current_period_end": current_period_end,
-    }
-    if event_type.isupper():
-        snapshot["provider"] = "asaas"
-    if provider_subscription_id:
-        snapshot["provider_id"] = provider_subscription_id
-    if offer_metadata["plan_code"]:
-        snapshot["plan_code"] = offer_metadata["plan_code"]
-    if offer_metadata["offer_code"]:
-        snapshot["offer_code"] = offer_metadata["offer_code"]
-    if offer_metadata["billing_cycle"]:
-        snapshot["billing_cycle"] = offer_metadata["billing_cycle"]
-    return snapshot
-
-
-def _is_supported_webhook_event(event_type: str) -> bool:
-    return event_type in _SUPPORTED_WEBHOOK_EVENTS
 
 
 def _find_subscription_for_snapshot(

--- a/app/extensions/billing_webhooks_cli.py
+++ b/app/extensions/billing_webhooks_cli.py
@@ -17,8 +17,8 @@ def _retry_single_event(event: Any) -> tuple[bool, str | None]:
 
     from app.controllers.subscription_controller import (
         _extract_event_id,
-        _extract_provider_snapshot,
         _process_webhook_snapshot,
+        resolve_webhook_parser,
     )
     from app.extensions.database import db
     from app.utils.datetime_utils import utc_now_naive
@@ -35,7 +35,17 @@ def _retry_single_event(event: Any) -> tuple[bool, str | None]:
         db.session.commit()
         return False, f"payload_parse_error:{exc}"
 
-    snapshot = _extract_provider_snapshot(payload)
+    # Reprocess with the parser of the gateway that originally sent the event,
+    # not whichever provider happens to be active now.
+    parser = resolve_webhook_parser(getattr(event, "provider", None))
+    if parser is None:
+        event.mark_failed(
+            reason=f"unknown_provider:{event.provider}", now=utc_now_naive()
+        )
+        db.session.commit()
+        return False, f"unknown_provider:{event.provider}"
+
+    snapshot = parser.parse(payload)
     if snapshot is None:
         event.mark_failed(
             reason="unresolvable_subscription_on_retry", now=utc_now_naive()

--- a/app/middleware/auth_guard.py
+++ b/app/middleware/auth_guard.py
@@ -34,8 +34,10 @@ def register_auth_guard(app: Flask) -> None:
             "swagger-ui.static",
             "swagger-ui.swagger_json",
             "installment_vs_cash_calculation",
-            # Billing webhook — provider calls this directly without JWT
+            # Billing webhooks — providers call these directly without JWT.
+            # Authenticity is enforced per gateway by BillingWebhookParser.verify.
             "handle_webhook",
+            "handle_provider_webhook",
             # Public billing catalog for checkout surfaces
             "list_subscription_plans",
             # Internal observability export guarded by dedicated header token

--- a/tests/test_billing_webhook_parsers.py
+++ b/tests/test_billing_webhook_parsers.py
@@ -1,0 +1,152 @@
+"""Tests for the provider-agnostic billing webhook parser boundary (#1564).
+
+The parser layer mirrors ``BillingProvider`` on the inbound side: each gateway
+supplies its own signature verification, event vocabulary and payload shape,
+normalised into a single ``BillingSubscriptionSnapshot``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+
+import pytest
+
+from app.controllers.billing_webhook_parsers import (
+    ASAAS_PROVIDER,
+    AsaasWebhookParser,
+    BillingWebhookParser,
+    resolve_webhook_parser,
+)
+
+
+class TestParserRegistry:
+    def test_asaas_parser_satisfies_protocol(self) -> None:
+        assert isinstance(AsaasWebhookParser(), BillingWebhookParser)
+
+    def test_resolves_asaas_by_slug(self) -> None:
+        parser = resolve_webhook_parser(ASAAS_PROVIDER)
+        assert parser is not None
+        assert parser.provider == ASAAS_PROVIDER
+
+    def test_resolution_is_case_insensitive_and_trims(self) -> None:
+        parser = resolve_webhook_parser("  Asaas ")
+        assert parser is not None
+        assert parser.provider == ASAAS_PROVIDER
+
+    def test_defaults_to_asaas_when_unspecified(self) -> None:
+        """The legacy ``/subscriptions/webhook`` route carries no provider."""
+        for empty in (None, "", "   "):
+            parser = resolve_webhook_parser(empty)
+            assert parser is not None
+            assert parser.provider == ASAAS_PROVIDER
+
+    def test_unknown_provider_resolves_to_none(self) -> None:
+        assert resolve_webhook_parser("not-a-gateway") is None
+
+
+class TestAsaasEventVocabulary:
+    @pytest.mark.parametrize(
+        "event",
+        [
+            "PAYMENT_RECEIVED",
+            "PAYMENT_CONFIRMED",
+            "PAYMENT_OVERDUE",
+            "SUBSCRIPTION_DELETED",
+            "subscription.activated",
+            "subscription.canceled",
+            "subscription.past_due",
+        ],
+    )
+    def test_supported_events(self, event: str) -> None:
+        assert AsaasWebhookParser().supports_event(event) is True
+
+    @pytest.mark.parametrize("event", ["", "PAYMENT_UNKNOWN", "subscription.renewed"])
+    def test_unsupported_events(self, event: str) -> None:
+        assert AsaasWebhookParser().supports_event(event) is False
+
+
+class TestAsaasParse:
+    def test_native_event_stamps_provider(self) -> None:
+        snapshot = AsaasWebhookParser().parse(
+            {
+                "event": "PAYMENT_CONFIRMED",
+                "payment": {"subscription": "sub_1", "customer": "cus_1"},
+            }
+        )
+        assert snapshot is not None
+        assert snapshot["provider"] == ASAAS_PROVIDER
+        assert snapshot["status"] == "active"
+        assert snapshot["provider_id"] == "sub_1"
+
+    def test_legacy_generic_event_does_not_stamp_provider(self) -> None:
+        """Legacy ``subscription.*`` events are gateway-neutral.
+
+        Stamping them would overwrite ``Subscription.provider`` on rows that
+        never came from Asaas — the behaviour the ``event_type.isupper()``
+        heuristic preserved by accident.
+        """
+        snapshot = AsaasWebhookParser().parse(
+            {"event": "subscription.activated", "subscription_id": "sub_legacy"}
+        )
+        assert snapshot is not None
+        assert "provider" not in snapshot
+        assert snapshot["status"] == "active"
+
+    def test_unsupported_event_returns_none(self) -> None:
+        assert AsaasWebhookParser().parse({"event": "PAYMENT_UNKNOWN"}) is None
+
+    def test_payload_without_identifiers_returns_none(self) -> None:
+        assert AsaasWebhookParser().parse({"event": "PAYMENT_CONFIRMED"}) is None
+
+
+class TestAsaasVerify:
+    def test_accepts_valid_hmac_signature(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("BILLING_WEBHOOK_SECRET", "s3cr3t")
+        body = json.dumps({"event": "PAYMENT_CONFIRMED"}).encode()
+        signature = hmac.new(b"s3cr3t", body, hashlib.sha256).hexdigest()
+
+        assert AsaasWebhookParser().verify(body, {"X-Billing-Signature": signature})
+
+    def test_rejects_tampered_hmac_signature(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("BILLING_WEBHOOK_SECRET", "s3cr3t")
+        monkeypatch.delenv("BILLING_ASAAS_WEBHOOK_TOKEN", raising=False)
+
+        assert not AsaasWebhookParser().verify(b"{}", {"X-Billing-Signature": "nope"})
+
+    def test_accepts_provider_token_header(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("BILLING_ASAAS_WEBHOOK_TOKEN", "tok_123")
+
+        assert AsaasWebhookParser().verify(b"{}", {"asaas-access-token": "tok_123"})
+
+    def test_rejects_wrong_provider_token(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("BILLING_ASAAS_WEBHOOK_TOKEN", "tok_123")
+        monkeypatch.delenv("BILLING_WEBHOOK_SECRET", raising=False)
+
+        assert not AsaasWebhookParser().verify(b"{}", {"asaas-access-token": "wrong"})
+
+
+class TestProviderScopedRoute:
+    """The provider-scoped route is what makes a second gateway possible."""
+
+    def test_provider_route_accepts_asaas(self, client) -> None:  # noqa: ANN001
+        resp = client.post("/subscriptions/webhook/asaas", json={"event": "noop"})
+        assert resp.status_code in (200, 401)
+
+    def test_unknown_provider_is_rejected(self, client) -> None:  # noqa: ANN001
+        resp = client.post("/subscriptions/webhook/stripe", json={"event": "noop"})
+        assert resp.status_code == 404
+
+    def test_legacy_route_still_served(self, client) -> None:  # noqa: ANN001
+        """Asaas is already configured against the unscoped URL in production."""
+        resp = client.post("/subscriptions/webhook", json={"event": "noop"})
+        assert resp.status_code in (200, 401)

--- a/tests/test_postman_collection_contract.py
+++ b/tests/test_postman_collection_contract.py
@@ -77,6 +77,7 @@ OPENAPI_GAPS: set[tuple[str, str]] = {
     ("POST", "/subscriptions/checkout"),
     ("POST", "/subscriptions/cancel"),
     ("POST", "/subscriptions/webhook"),
+    ("POST", "/subscriptions/webhook/{param}"),
     # Shared entries
     ("POST", "/shared-entries"),
     ("GET", "/shared-entries/by-me"),


### PR DESCRIPTION
## Summary

Pré-requisito da migração de gateway Asaas → AbacatePay (decisão do PO, 2026-07-19).

O lado **outbound** do billing já era plugável (`BillingProvider` Protocol) e o schema do banco já é
provider-neutro. O lado **inbound** não era: `subscription_webhook_payload.py` era um parser único,
hardcoded no formato Asaas. Adicionar um segundo gateway ali significaria reescrever o parser —
e o `_resolve_status` já misturava dois vocabulários num dict plano, que um terceiro tornaria ambíguo.

Este PR converte "reescrever o parser" em "adicionar uma implementação". **Refactor comportamental
neutro para o Asaas** — nenhum contrato externo muda.

### O que muda

- Novo `BillingWebhookParser` Protocol: `verify` + `supports_event` + `parse` → `BillingSubscriptionSnapshot`
- `AsaasWebhookParser` com paridade total; registry + `resolve_webhook_parser()`
- Nova rota `POST /subscriptions/webhook/<provider>`; a rota legada **continua servida** (já está
  cadastrada no dashboard do Asaas em prod)
- `WebhookEvent.provider` passa a vir do parser, não de um literal `"asaas"`
- Retry do CLI reprocessa com o parser do gateway **registrado no evento**, não com o provider
  globalmente ativo — bug latente que só apareceria com dois gateways

### Heurística removida

`_extract_provider_snapshot` decidia se carimbava `provider` via `event_type.isupper()`. Estava
correto por acidente: separava os eventos nativos do Asaas (maiúsculos) dos eventos genéricos legados
`subscription.*`. Ficaria silenciosamente errado no instante em que um segundo gateway usasse nomes
de evento em maiúsculo. Agora são dois mapas explícitos, e só o vocabulário nativo carimba `provider` —
preservando o comportamento de não sobrescrever `Subscription.provider` em linhas que nunca vieram do Asaas.

## Validation

- `bash scripts/run_ci_quality_local.sh --local` → **2781 passed, 2 skipped, cobertura 91,54%** (gate 85%)
- 26 testes novos: registry, vocabulários, verificação de assinatura (HMAC + token) e as três rotas
- Suítes de billing existentes (119 testes) verdes **sem alteração de semântica**

## Residual risk

Baixo. A rota nova entrou na allowlist do `auth_guard` (webhooks não portam JWT — a autenticidade é
garantida pelo `verify` de cada parser) e herda rate limit e skip de idempotência por prefixo de path.
A rota provider-scoped foi adicionada a `OPENAPI_GAPS` no teste de contrato Postman, seguindo o
tratamento já dado a todo o domínio de subscriptions.

## Refs

Closes #1564
Precede #1565 (AbacatePayBillingProvider).