### PR TITLE
fix(billing): webhook AbacatePay resolve o plano → assinatura paga recebe Premium

### DIFF
--- a/app/controllers/billing_webhook_parsers.py
+++ b/app/controllers/billing_webhook_parsers.py
@@ -236,6 +236,63 @@ def _resolve_abacatepay_customer_id(data: dict[str, Any]) -> str | None:
     return None
 
 
+def _resolve_abacatepay_external_reference(data: dict[str, Any]) -> str | None:
+    """Find the ``auraxis:{user_id}:{offer_slug}`` reference we sent at checkout.
+
+    It surfaces in different sub-objects depending on the event, so probe all
+    three.  Without it the snapshot carries no plan, ``plan_code`` stays Free,
+    and a paid subscription lands active with Free entitlements.
+    """
+    for key in ("checkout", "payment", "subscription"):
+        obj = data.get(key)
+        if isinstance(obj, dict):
+            reference = _clean(obj.get("externalId")) or _clean(
+                obj.get("externalReference")
+            )
+            if reference:
+                return reference
+    return None
+
+
+def _build_abacatepay_snapshot(
+    data: dict[str, Any],
+    subscription_object: dict[str, Any],
+    *,
+    status: str,
+    provider_subscription_id: str | None,
+    provider_customer_id: str | None,
+) -> BillingSubscriptionSnapshot:
+    snapshot: BillingSubscriptionSnapshot = {
+        "status": status,
+        "provider": ABACATEPAY_PROVIDER,
+        "provider_customer_id": provider_customer_id,
+        "current_period_start": _coerce_datetime(subscription_object.get("updatedAt")),
+        "current_period_end": _coerce_datetime(subscription_object.get("nextChargeAt")),
+    }
+
+    offer_metadata = _resolve_offer_from_external_reference(
+        _resolve_abacatepay_external_reference(data)
+    )
+    if offer_metadata["plan_code"]:
+        # Entitlements derive from plan_code — without this a paid sub stays on
+        # Free features despite an active status.
+        snapshot["plan_code"] = offer_metadata["plan_code"]
+    if offer_metadata["offer_code"]:
+        snapshot["offer_code"] = offer_metadata["offer_code"]
+    if offer_metadata["billing_cycle"]:
+        snapshot["billing_cycle"] = offer_metadata["billing_cycle"]
+
+    trial_ends_at = _coerce_datetime(subscription_object.get("trialEndsAt"))
+    if trial_ends_at is not None:
+        # Drives trial_expiry_cli and the D-N ending reminders.
+        snapshot["trial_ends_at"] = trial_ends_at
+
+    if provider_subscription_id:
+        # Promotes the stored bill_… placeholder to the real subs_… id.
+        snapshot["provider_id"] = provider_subscription_id
+    return snapshot
+
+
 class AbacatePayWebhookParser:
     """AbacatePay webhooks (API v2 envelope).
 
@@ -294,27 +351,28 @@ class AbacatePayWebhookParser:
     def supports_event(self, event_type: str) -> bool:
         return event_type in self._EVENTS
 
+    def _devmode_blocks(self, payload: dict[str, Any]) -> bool:
+        """Whether a sandbox payload must be dropped in this runtime."""
+        if not (payload.get("devMode") is True and _is_production_runtime()):
+            return False
+        if not _devmode_allowed_in_production():
+            return True
+        logger.warning(
+            "Accepting AbacatePay devMode webhook in production because "
+            "%s is enabled — turn it off once validation is done",
+            _ABACATEPAY_ALLOW_DEVMODE_ENV,
+        )
+        return False
+
     def parse(self, payload: dict[str, Any]) -> BillingSubscriptionSnapshot | None:
         event_type = str(payload.get("event") or "").strip()
         status = self._EVENTS.get(event_type)
-        if status is None:
+        if status is None or self._devmode_blocks(payload):
             return None
-
-        if payload.get("devMode") is True and _is_production_runtime():
-            # Sandbox traffic must never move real subscriptions, unless the
-            # operator explicitly opted in to validate a sandbox key in place.
-            if not _devmode_allowed_in_production():
-                return None
-            logger.warning(
-                "Accepting AbacatePay devMode webhook in production because "
-                "%s is enabled — turn it off once validation is done",
-                _ABACATEPAY_ALLOW_DEVMODE_ENV,
-            )
 
         data = payload.get("data")
         if not isinstance(data, dict):
             return None
-
         subscription_object = data.get("subscription")
         if not isinstance(subscription_object, dict):
             return None
@@ -324,26 +382,13 @@ class AbacatePayWebhookParser:
         if not provider_subscription_id and not provider_customer_id:
             return None
 
-        snapshot: BillingSubscriptionSnapshot = {
-            "status": status,
-            "provider": ABACATEPAY_PROVIDER,
-            "provider_customer_id": provider_customer_id,
-            "current_period_start": _coerce_datetime(
-                subscription_object.get("updatedAt")
-            ),
-            "current_period_end": _coerce_datetime(
-                subscription_object.get("nextChargeAt")
-            ),
-        }
-        trial_ends_at = _coerce_datetime(subscription_object.get("trialEndsAt"))
-        if trial_ends_at is not None:
-            # Drives trial_expiry_cli and the D-N ending reminders.
-            snapshot["trial_ends_at"] = trial_ends_at
-
-        if provider_subscription_id:
-            # Promotes the stored bill_… placeholder to the real subs_… id.
-            snapshot["provider_id"] = provider_subscription_id
-        return snapshot
+        return _build_abacatepay_snapshot(
+            data,
+            subscription_object,
+            status=status,
+            provider_subscription_id=provider_subscription_id,
+            provider_customer_id=provider_customer_id,
+        )
 
 
 _PARSERS: dict[str, BillingWebhookParser] = {

--- a/tests/test_abacatepay_billing.py
+++ b/tests/test_abacatepay_billing.py
@@ -380,6 +380,33 @@ class TestWebhookParser:
         assert snapshot is not None
         assert "trial_ends_at" not in snapshot
 
+    @pytest.mark.parametrize(
+        "location",
+        ["checkout", "payment", "subscription"],
+    )
+    def test_resolves_plan_from_external_reference(self, location: str) -> None:
+        """Without this, a paid subscription lands active but with Free plan_code,
+        so entitlements stay Free — the user pays and gets no Premium access."""
+        payload = _webhook("subscription.completed")
+        payload["data"][location] = {
+            **payload["data"].get(location, {}),
+            "externalId": "auraxis:user-42:premium_monthly",
+        }
+
+        snapshot = AbacatePayWebhookParser().parse(payload)
+
+        assert snapshot is not None
+        assert snapshot["plan_code"] == "premium"
+        assert snapshot["offer_code"] == "premium_monthly"
+        assert snapshot["billing_cycle"] == "monthly"
+
+    def test_missing_external_reference_omits_plan(self) -> None:
+        """No externalId (e.g. auto-cancel payload) must not fabricate a plan."""
+        snapshot = AbacatePayWebhookParser().parse(_webhook("subscription.cancelled"))
+
+        assert snapshot is not None
+        assert "plan_code" not in snapshot
+
     def test_ignores_unknown_event(self) -> None:
         assert AbacatePayWebhookParser().parse(_webhook("checkout.refunded")) is None
 


### PR DESCRIPTION
## Summary

Bug **encontrado validando o caminho pago em produção** (2026-07-19). É a classe de defeito que só a
validação real pega — nenhum teste unitário anterior cobria a cadeia até os entitlements.

`AbacatePayWebhookParser.parse` promovia `status=active` e o `subs_id`, mas **não resolvia o plano**.
Como os entitlements derivam do `plan_code` (`sync_entitlements_from_subscription`), a assinatura
ficava `active` com `plan_code=free` → **o usuário pagava e continuava sem acesso Premium**.

### Evidência medida em prod

Webhook `subscription.completed` processado → subscription:
- `status=active`, `provider_subscription_id=subs_…`, `trial_ends_at=2026-07-26` ✓
- entitlements: `basic_simulations, wallet_read` ❌ (Free)

## Correção

O parser extrai o `externalReference` (`auraxis:{user_id}:{offer_slug}`, enviado por nós no checkout)
e resolve `plan_code`/`offer_code`/`billing_cycle`, como o parser do Asaas já fazia. Probe em
`checkout` / `payment` / `subscription` porque o AbacatePay move o campo entre eles conforme o evento.

Refatorei `parse` em helpers (`_devmode_blocks`, `_build_abacatepay_snapshot`) para manter a
complexidade dentro do gate.

## Validation

- `bash scripts/run_ci_quality_local.sh --local` → **2823 passed, cobertura 91,50%**
- Teste parametrizado nas 3 posições do externalId; teste de que payload sem referência
  (ex.: auto-cancel) não fabrica plano
- **Revalidação em prod pós-deploy** com webhook real → entitlements Premium (no PR após deploy)

## Refs

Closes #1574