### PR TITLE
fix(lgpd): criar migration faltante de sharing_audit_events (DELETE /user/me quebrado em prod)

### DIFF
--- a/migrations/versions/sae1_sharing_audit_events.py
+++ b/migrations/versions/sae1_sharing_audit_events.py
@@ -1,0 +1,71 @@
+"""create sharing_audit_events — #1577
+
+The ``SharingAuditEvent`` model (J13) shipped without an Alembic migration, so
+the table only ever existed in dev/test via ``create_all()``.  In production it
+was never created, which made ``DELETE /user/me`` (LGPD account deletion) fail
+with ``UndefinedTable`` — the anonymisation pass walks every registered entity,
+this one included.
+
+Idempotent: tolerate prod/dev drift where the table already exists from a
+metadata ``create_all()``.
+
+Revision ID: sae1_sharing_audit_events
+Revises: as1_transaction_auto_settle
+Create Date: 2026-07-19
+
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = "sae1_sharing_audit_events"
+down_revision = "as1_transaction_auto_settle"
+branch_labels = None
+depends_on = None
+
+TABLE = "sharing_audit_events"
+
+
+def _has_table(table: str) -> bool:
+    inspector = sa.inspect(op.get_context().connection)
+    return inspector.has_table(table)
+
+
+def upgrade() -> None:
+    if _has_table(TABLE):
+        return
+
+    op.create_table(
+        TABLE,
+        sa.Column("id", UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("user_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("action", sa.String(length=64), nullable=False),
+        sa.Column("resource_type", sa.String(length=64), nullable=False),
+        sa.Column("resource_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("event_metadata", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+    )
+    op.create_index(
+        "ix_sharing_audit_events_user_id", TABLE, ["user_id"], unique=False
+    )
+    op.create_index(
+        "ix_sharing_audit_events_resource",
+        TABLE,
+        ["resource_type", "resource_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_sharing_audit_events_created_at", TABLE, ["created_at"], unique=False
+    )
+
+
+def downgrade() -> None:
+    if not _has_table(TABLE):
+        return
+    op.drop_index("ix_sharing_audit_events_created_at", table_name=TABLE)
+    op.drop_index("ix_sharing_audit_events_resource", table_name=TABLE)
+    op.drop_index("ix_sharing_audit_events_user_id", table_name=TABLE)
+    op.drop_table(TABLE)


### PR DESCRIPTION
## Summary

Bug **crítico de LGPD encontrado em produção** ao exercitar o fluxo de exclusão de conta durante a
validação do AbacatePay. **Independente da migração de gateway** — é um defeito pré-existente.

`DELETE /user/me` retornava **500 para qualquer usuário** em prod:

```
psycopg2.errors.UndefinedTable: relation "sharing_audit_events" does not exist
  lgpd_deletion_service.py:144 → _anonymize_entity
```

Ou seja: **o direito à exclusão não funcionava em produção** — violação ativa de LGPD e bloqueio do
gate G2-legal do go-live.

## Causa raiz

O modelo `SharingAuditEvent` (J13) foi mergeado **sem migration Alembic**
(`grep -rl sharing_audit migrations/` → vazio). Em dev/test a tabela nasce do `create_all()`, o que
mascarou a ausência por completo. Em prod, que só aplica migrations, a tabela nunca existiu. Prod
estava no head `as1_transaction_auto_settle` sem pendências — não era migration atrasada, era
migration **inexistente**.

Por que só apareceu agora: nenhum teste automatizado exercitava `DELETE /user/me` contra Postgres —
o teste existente roda em SQLite com a tabela criada por metadata.

## Correção

Migration `sae1_sharing_audit_events` cria a tabela + os 3 índices conforme o modelo. Idempotente
(tolera a tabela já existente de um `create_all`) e reversível.

## Validation

- `bash scripts/test_migrations_local.sh` → **upgrade ✓ head único ✓ downgrade ✓** (Postgres efêmero)
- `bash scripts/run_ci_quality_local.sh --local` → **2823 passed, cobertura 91,50%**
- **Revalidação pós-deploy**: `DELETE /user/me` volta a funcionar em prod (confirmo no PR)

## Refs

Closes #1577