### PR TITLE
feat(billing): agendar expire-trials diariamente (trial expirado nunca virava Free)

### DIFF
--- a/.github/workflows/trial-expiry-job.yml
+++ b/.github/workflows/trial-expiry-job.yml
@@ -1,0 +1,219 @@
+name: Trial Expiry Job
+
+# Downgrades TRIALING subscriptions whose trial_ends_at has passed. Without this
+# a subscription the gateway never charges (card removed, webhook lost, or a
+# legacy signup trial with no gateway) would stay Premium for free. See #1586.
+# Complements reminder-job's dispatch-trial-ending, which only warns and never
+# downgrades.
+
+on:
+  schedule:
+    # 08:00 UTC (05:00 BRT) — after reminder-job (07:00 UTC) so warnings go out
+    # before the downgrade runs.
+    - cron: "0 8 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Report which subscriptions would expire, without writing."
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: trial-expiry-job-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+  issues: write
+
+jobs:
+  expire-trials:
+    name: Expire ended trials
+    runs-on: ubuntu-latest
+    environment: prod
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate required variables
+        run: |
+          [ -n "${AWS_REGION:-}" ] || { echo "Missing var AWS_REGION"; exit 1; }
+          [ -n "${AWS_ROLE_ARN_PROD:-}" ] || { echo "Missing var AWS_ROLE_ARN_PROD"; exit 1; }
+          [ -n "${AURAXIS_PROD_INSTANCE_ID:-}" ] || { echo "Missing var AURAXIS_PROD_INSTANCE_ID"; exit 1; }
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+          AWS_ROLE_ARN_PROD: ${{ vars.AWS_ROLE_ARN_PROD }}
+          AURAXIS_PROD_INSTANCE_ID: ${{ vars.AURAXIS_PROD_INSTANCE_ID }}
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN_PROD }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Ensure web container is running
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+          PROD_INSTANCE_ID: ${{ vars.AURAXIS_PROD_INSTANCE_ID }}
+        run: |
+          COMMANDS='["cd /opt/auraxis",
+            "if docker compose exec -T web true 2>/dev/null; then echo web-container-ok; exit 0; fi",
+            "echo web-container-not-running -- attempting restart",
+            "docker compose up -d web",
+            "sleep 20",
+            "if docker compose exec -T web true 2>/dev/null; then echo web-container-recovered; exit 0; fi",
+            "echo FATAL: web container failed to start after restart attempt",
+            "docker compose logs --tail=50 web",
+            "exit 1"
+          ]'
+
+          COMMAND_ID=$(aws ssm send-command \
+            --region "${AWS_REGION}" \
+            --instance-ids "${PROD_INSTANCE_ID}" \
+            --document-name "AWS-RunShellScript" \
+            --parameters "commands=${COMMANDS}" \
+            --query "Command.CommandId" \
+            --output text)
+
+          echo "SSM Command ID: ${COMMAND_ID}"
+
+          for i in $(seq 1 36); do
+            STATUS=$(aws ssm get-command-invocation \
+              --region "${AWS_REGION}" \
+              --command-id "${COMMAND_ID}" \
+              --instance-id "${PROD_INSTANCE_ID}" \
+              --query "StatusDetails" \
+              --output text 2>/dev/null || echo "Pending")
+
+            echo "Attempt ${i}: ${STATUS}"
+
+            if [ "${STATUS}" = "Success" ]; then
+              echo "Container health check passed."
+              exit 0
+            elif [ "${STATUS}" = "Failed" ] || [ "${STATUS}" = "Cancelled" ] || [ "${STATUS}" = "TimedOut" ]; then
+              echo "Container health check/recovery failed with status: ${STATUS}"
+              exit 1
+            fi
+
+            sleep 10
+          done
+
+          echo "Timed out waiting for container health check."
+          exit 1
+
+      - name: Expire ended trials via SSM
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+          PROD_INSTANCE_ID: ${{ vars.AURAXIS_PROD_INSTANCE_ID }}
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+        run: |
+          if [ "${DRY_RUN}" = "true" ]; then
+            FLAG=" --dry-run"
+          else
+            FLAG=""
+          fi
+          COMMAND_ID=$(aws ssm send-command \
+            --region "${AWS_REGION}" \
+            --instance-ids "${PROD_INSTANCE_ID}" \
+            --document-name "AWS-RunShellScript" \
+            --parameters "commands=[\"cd /opt/auraxis && docker compose exec -T web flask billing expire-trials${FLAG}\"]" \
+            --query "Command.CommandId" \
+            --output text)
+
+          echo "SSM Command ID: ${COMMAND_ID}"
+
+          for i in $(seq 1 30); do
+            STATUS=$(aws ssm get-command-invocation \
+              --region "${AWS_REGION}" \
+              --command-id "${COMMAND_ID}" \
+              --instance-id "${PROD_INSTANCE_ID}" \
+              --query "StatusDetails" \
+              --output text 2>/dev/null || echo "Pending")
+
+            echo "Attempt ${i}: ${STATUS}"
+
+            if [ "${STATUS}" = "Success" ]; then
+              echo "Trial expiry completed successfully."
+              aws ssm get-command-invocation \
+                --region "${AWS_REGION}" \
+                --command-id "${COMMAND_ID}" \
+                --instance-id "${PROD_INSTANCE_ID}" \
+                --query "StandardOutputContent" \
+                --output text 2>/dev/null || true
+              exit 0
+            elif [ "${STATUS}" = "Failed" ] || [ "${STATUS}" = "Cancelled" ] || [ "${STATUS}" = "TimedOut" ]; then
+              echo "Trial expiry failed with status: ${STATUS}"
+              echo "--- stdout ---"
+              aws ssm get-command-invocation \
+                --region "${AWS_REGION}" \
+                --command-id "${COMMAND_ID}" \
+                --instance-id "${PROD_INSTANCE_ID}" \
+                --query "StandardOutputContent" \
+                --output text 2>/dev/null || true
+              echo "--- stderr ---"
+              aws ssm get-command-invocation \
+                --region "${AWS_REGION}" \
+                --command-id "${COMMAND_ID}" \
+                --instance-id "${PROD_INSTANCE_ID}" \
+                --query "StandardErrorContent" \
+                --output text 2>/dev/null || true
+              exit 1
+            fi
+
+            sleep 10
+          done
+
+          echo "Timed out waiting for SSM command to complete."
+          exit 1
+
+      - name: Notify failure via GitHub Issue
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const title = '🚨 [trial-expiry-job] Falha ao expirar trials';
+            const body = [
+              '## Trial Expiry Job falhou',
+              '',
+              `**Run:** ${runUrl}`,
+              '',
+              'O job agendado de downgrade de trials expirados falhou via SSM.',
+              'Trials vencidos podem permanecer Premium até a próxima execução bem-sucedida.',
+              '',
+              '### Ações sugeridas',
+              '- Revisar logs da execução no link acima',
+              '- Verificar o container `web` na instância PROD',
+              '- Rodar `flask billing expire-trials --dry-run` manualmente para inspecionar',
+              '',
+              '_Issue criada automaticamente pelo GitHub Actions._',
+            ].join('\n');
+            const query = [
+              `repo:${context.repo.owner}/${context.repo.repo}`,
+              'is:issue',
+              'is:open',
+              'in:title',
+              `"${title}"`,
+            ].join(' ');
+            const search = await github.rest.search.issuesAndPullRequests({ q: query, per_page: 10 });
+            const existing = search.data.items.find((item) => item.title === title);
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body: `Nova falha: ${runUrl}`,
+              });
+              return;
+            }
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+              labels: ['bug', 'ops'],
+            });


### PR DESCRIPTION
## Summary

Gap de produção exposto agora que o billing está no ar. `flask billing expire-trials`
(`trial_expiry_cli.py`) rebaixa assinaturas `TRIALING` cujo `trial_ends_at` passou, mas **nenhum cron
o chamava**. O `reminder-job` só dispara `dispatch-trial-ending` (lembrete D-N) — que **não** rebaixa.

Sem isso, uma assinatura que o gateway nunca cobre (cartão removido, webhook perdido, ou trial legado
do signup antigo sem gateway) fica **Premium grátis indefinidamente**.

## Correção

Workflow `trial-expiry-job.yml`, cron diário às **08:00 UTC** (após o reminder das 07:00, para os
avisos D-N saírem antes do downgrade). Modelado no `reminder-job.yml` já em produção: OIDC prod →
garante o container `web` → `docker compose exec -T web flask billing expire-trials` via SSM →
notifica falha por issue. `workflow_dispatch` aceita `--dry-run`.

## Validation

- YAML parseia; `flask billing expire-trials` e `scripts/process_trial_expirations.py` confirmados
- Reusa o padrão de SSM/OIDC já validado em produção pelo reminder-job
- Pós-merge: `workflow_dispatch` com `dry_run=true` para inspecionar sem escrever

## Residual risk

Baixo — só adiciona um job agendado. A lógica de downgrade já existe e é testada em
`tests/test_billing.py`. Primeira execução recomendada em dry-run.

## Refs

Closes #1586
