### PR TITLE
chore(deps): bump opentelemetry group to sdk 1.44.0 / instrumentation 0.65b0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 alembic==1.16.2
 apispec==6.10.0
-opentelemetry-api==1.42.1
-opentelemetry-sdk==1.42.1
-opentelemetry-exporter-otlp-proto-http==1.42.1
-opentelemetry-instrumentation-flask==0.63b1
-opentelemetry-instrumentation-sqlalchemy==0.63b1
+opentelemetry-api==1.44.0
+opentelemetry-sdk==1.44.0
+opentelemetry-exporter-otlp-proto-http==1.44.0
+opentelemetry-instrumentation-flask==0.65b0
+opentelemetry-instrumentation-sqlalchemy==0.65b0
 prometheus-client==0.25.0
 blinker==1.9.0
 click==8.4.2


### PR DESCRIPTION
## Resumo

Consolida a fila do dependabot (grupo opentelemetry) num único PR (decisão PO 2026-07-23).

## Bumps

| Pacote | Antes → Depois | Origem |
|---|---|---|
| opentelemetry-api | 1.42.1 → 1.44.0 | (par do grupo — não tinha PR próprio) |
| opentelemetry-sdk | 1.42.1 → 1.44.0 | #1581 |
| opentelemetry-exporter-otlp-proto-http | 1.42.1 → 1.44.0 | #1580 |
| opentelemetry-instrumentation-flask | 0.63b1 → 0.65b0 | #1583 |
| opentelemetry-instrumentation-sqlalchemy | 0.63b1 → 0.65b0 | #1582 |

O grupo anda junto por design do projeto OpenTelemetry (sdk 1.44.x ↔ instrumentation 0.65bx).

## Validação

- Suíte completa local pré-branch: 91,48% coverage (≥85%).
- `import app` + testes de observability/telemetry verdes com os bumps.
- Pre-push hook (gates completos ruff+mypy+bandit+pytest) verde no push.

Closes #1589

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCQunEjQs5YziwSwFKqJJr
