### PR TITLE
feat(nginx): vhost v2.auraxis.com.br para o control plane api-v2

### DIFF
--- a/deploy/nginx/v2.conf
+++ b/deploy/nginx/v2.conf
@@ -1,0 +1,109 @@
+# v2.conf — v2.auraxis.com.br → auraxis-api-v2 (FastAPI control plane).
+#
+# Mounted into the compose `reverse-proxy` service as conf.d/v2.conf. The
+# upstream is the api-v2 container reached through the shared Docker network
+# (service alias `auraxis-v2`, port 8001) — NOT 127.0.0.1, which inside the
+# nginx container is nginx itself.
+#
+# The upstream address is resolved lazily via the Docker embedded DNS
+# (`resolver 127.0.0.11`) and a variable proxy_pass: nginx starts and reloads
+# cleanly even when the v2 container is down, so a v2 outage can never take
+# the v1 API down with it.
+#
+# Bootstrap note: this server block references the Let's Encrypt certificate
+# for v2.auraxis.com.br. Until that cert exists, apply `v2.http.conf` instead
+# (ACME-only) — see the header of that file. Issue #1592.
+
+# Per-IP rate limiting for the v2 /graphql endpoint — same policy as the v1
+# zones in default.conf, but with dedicated zone names: `limit_req_zone` names
+# are global across conf.d files, so reusing graphql_auth/graphql_anon here
+# would fail the config load with "zone already exists".
+limit_req_zone $binary_remote_addr zone=v2_graphql_auth:10m rate=100r/m;
+limit_req_zone $binary_remote_addr zone=v2_graphql_anon:10m rate=30r/m;
+
+server {
+    listen 80;
+    server_name v2.auraxis.com.br;
+
+    server_tokens off;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl;
+    http2 on;
+    server_name v2.auraxis.com.br;
+
+    ssl_certificate /etc/letsencrypt/live/v2.auraxis.com.br/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/v2.auraxis.com.br/privkey.pem;
+
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers off;
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_timeout 1d;
+
+    client_max_body_size 10m;
+
+    # Hide server identity — strip upstream (uvicorn) Server header so clients
+    # never see backend technology info, and suppress nginx version from error pages.
+    server_tokens off;
+    proxy_hide_header Server;
+    proxy_hide_header X-Powered-By;
+
+    # Consolidate HSTS in one place: nginx is the canonical source (see
+    # default.tls.conf for the rationale — ZAP finding [10035]).
+    proxy_hide_header Strict-Transport-Security;
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
+
+    # SEC-AUD-10 — Unified security-header baseline, same values as the other
+    # nginx variants (default.conf, default.tls.conf, default.alb_dual.conf).
+    add_header X-Frame-Options "DENY" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "geolocation=(), microphone=(), camera=(), payment=(), usb=(), accelerometer=()" always;
+    add_header Content-Security-Policy "default-src 'none'; frame-ancestors 'none'" always;
+
+    # Docker embedded DNS — lazy upstream resolution (see file header).
+    resolver 127.0.0.11 valid=30s;
+
+    location /graphql {
+        limit_req zone=v2_graphql_anon burst=10 nodelay;
+        limit_req zone=v2_graphql_auth burst=20 nodelay;
+        limit_req_status 429;
+
+        set $v2_upstream http://auraxis-v2:8001;
+        proxy_pass $v2_upstream;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Request-ID $request_id;
+        proxy_set_header Connection "";
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 30s;
+    }
+
+    location / {
+        set $v2_upstream http://auraxis-v2:8001;
+        proxy_pass $v2_upstream;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Request-ID $request_id;
+        proxy_set_header Connection "";
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 30s;
+    }
+}

--- a/deploy/nginx/v2.http.conf
+++ b/deploy/nginx/v2.http.conf
@@ -1,0 +1,27 @@
+# v2.http.conf — BOOTSTRAP variant for v2.auraxis.com.br (auraxis-api-v2).
+#
+# Apply this file as conf.d/v2.conf on the prod reverse-proxy ONLY while the
+# Let's Encrypt certificate for v2.auraxis.com.br does not exist yet:
+# it serves the ACME webroot challenge over HTTP and nothing else, so
+# `nginx -t` never references a missing certificate.
+#
+# Once the cert is issued (`certbot certonly --webroot -w /var/www/certbot
+# -d v2.auraxis.com.br` via the compose `certbot` service), replace this file
+# with `v2.conf` (the full HTTP→HTTPS + TLS proxy variant) and reload.
+#
+# Issue #1592 — backoffice control plane exposure.
+
+server {
+    listen 80;
+    server_name v2.auraxis.com.br;
+
+    server_tokens off;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -115,6 +115,10 @@ services:
       - "443:443"
     volumes:
       - ./deploy/nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+      # v2.auraxis.com.br → auraxis-api-v2 control plane (#1592). During cert
+      # bootstrap the host applies v2.http.conf in place of v2.conf — see the
+      # headers of both files under deploy/nginx/.
+      - ./deploy/nginx/v2.conf:/etc/nginx/conf.d/v2.conf:ro
       - certbot_challenge:/var/www/certbot
       - letsencrypt:/etc/letsencrypt
 


### PR DESCRIPTION
## Resumo

- Novo `deploy/nginx/v2.conf` (final: 80→443 + TLS proxy) e `deploy/nginx/v2.http.conf` (bootstrap ACME-only, aplicado enquanto o cert Let's Encrypt de `v2.auraxis.com.br` não existe) — mesmo padrão das variantes `default.http.conf`/`default.tls.conf`.
- Upstream = container do api-v2 na network Docker compartilhada (`auraxis-v2:8001`), com `resolver 127.0.0.11` + `proxy_pass` via variável: o nginx sobe/recarrega mesmo com o v2 fora do ar — indisponibilidade do v2 nunca derruba o v1.
- Zonas `limit_req` dedicadas `v2_graphql_*` (nomes de zona são globais entre arquivos conf.d — reusar os do v1 falharia o load).
- Headers de segurança na baseline SEC-AUD-10; `http2 on` (diretiva moderna, sem o warning de deprecação do `listen ... http2`).
- Mount novo no `docker-compose.prod.yml` do serviço `reverse-proxy`.

## Validação

- `nginx -t` verde nas duas variantes dentro de `nginx:1.27-alpine` (v2.conf testado com cert dummy nos paths letsencrypt).
- Reload sem o container v2 no ar: validado pelo design (resolução tardia), sem bloco `upstream` estático.

## Risco residual

- O `default.conf` de prod tem drift load-bearing conhecido (HTTPS custom fora do git) — este PR **não toca** no default.conf; a aplicação no host será cirúrgica (copiar `v2.http.conf` → emitir cert → trocar por `v2.conf`), documentada no runbook do provisionamento (platform#908).
- Aplicar em prod só junto do provisionamento do v2 (ordem no plano da frente backoffice).

Closes #1592