### PR TITLE
fix(alerts): persist AlertStatus value not name (unblocks reminder-job + dunning) [#989]

### DIFF
--- a/.github/workflows/reminder-job.yml
+++ b/.github/workflows/reminder-job.yml
@@ -203,7 +203,11 @@ jobs:
           DELIM="DIAG_$(date +%s%N)"
           {
             echo "diagnostics_output<<${DELIM}"
-            echo "${DIAG}" | head -c 3000
+            # head -c can truncate mid-line without a trailing newline, which would
+            # leave the closing delimiter on the same line and break the heredoc
+            # ("Matching delimiter not found") — force a single trailing newline so
+            # the failure comment carries real diagnostics instead of the fallback.
+            printf '%s\n' "$(printf '%s' "${DIAG}" | head -c 3000)"
             echo "${DELIM}"
           } >> "${GITHUB_OUTPUT}"
 

--- a/app/models/alert.py
+++ b/app/models/alert.py
@@ -19,6 +19,16 @@ class AlertStatus(enum.Enum):
     SKIPPED = "skipped"
 
 
+def _enum_values(enum_cls: type[enum.Enum]) -> list[str]:
+    """SQLAlchemy ``values_callable``: persist ``Enum.value`` (lowercase) and not
+    ``Enum.name`` (uppercase). The ``alertstatus`` Postgres enum (migration
+    ``j618``) only declares lowercase labels, so without this every Alert INSERT
+    sends ``"SENT"`` and Postgres raises InvalidTextRepresentation — the root
+    cause of the reminder-job failures (#989).
+    """
+    return [str(member.value) for member in enum_cls]
+
+
 class Alert(db.Model):
     """A single alert dispatch record for a user."""
 
@@ -31,7 +41,9 @@ class Alert(db.Model):
     # Valid values: due_soon | overdue | onboarding_pending | monthly_summary
     category = db.Column(db.String(40), nullable=False)
     status = db.Column(
-        db.Enum(AlertStatus), nullable=False, default=AlertStatus.PENDING
+        db.Enum(AlertStatus, values_callable=_enum_values),
+        nullable=False,
+        default=AlertStatus.PENDING,
     )
     entity_type = db.Column(db.String(40), nullable=True)
     entity_id = db.Column(UUID(as_uuid=True), nullable=True)

--- a/tests/test_j_task_models.py
+++ b/tests/test_j_task_models.py
@@ -11,6 +11,7 @@ from datetime import datetime, timedelta
 from decimal import Decimal
 
 import pytest
+from sqlalchemy import text
 from sqlalchemy.exc import IntegrityError
 
 from app.extensions.database import db
@@ -442,6 +443,33 @@ def test_alert_persists_with_required_fields(app) -> None:
         assert stored.category == "due_soon"
         assert stored.status == AlertStatus.PENDING
         assert stored.sent_at is None
+
+
+def test_alert_status_persists_lowercase_enum_value(app) -> None:
+    """Regression for #989: the ``alertstatus`` Postgres enum only declares
+    lowercase labels, so the ORM must persist ``AlertStatus.value`` ("sent"),
+    not the member name ("SENT"). Without ``values_callable`` the INSERT sent
+    "SENT" and Postgres raised InvalidTextRepresentation — which broke every
+    reminder/dunning dispatch on days with real work. Asserted at the raw
+    column level because SQLite would otherwise round-trip either casing.
+    """
+    with app.app_context():
+        user = _make_user("-al-enum")
+        alert = Alert(
+            user_id=user.id,
+            category="due_soon",
+            triggered_at=datetime.utcnow(),
+            status=AlertStatus.SENT,
+        )
+        db.session.add(alert)
+        db.session.commit()
+
+        raw_status = db.session.execute(text("SELECT status FROM alerts")).scalar()
+        assert raw_status == "sent"
+
+        stored = Alert.query.filter_by(id=alert.id).first()
+        assert stored is not None
+        assert stored.status == AlertStatus.SENT
 
 
 def test_alert_repr(app) -> None:


### PR DESCRIPTION
## Contexto
O cron **reminder-job** (#989) falhava de forma "intermitente" — na verdade determinística. Root cause confirmada:

- `app/models/alert.py` mapeava `status = db.Column(db.Enum(AlertStatus), …)` **sem `values_callable`**, então o SQLAlchemy persiste o **nome** do membro (`"SENT"`, maiúsculo).
- O tipo Postgres `alertstatus` (migration `j618`) só declara labels **minúsculos** (`pending/sent/failed/skipped`).
- Resultado: todo `INSERT` de `Alert` num dia com trabalho real estoura `InvalidTextRepresentation`. Dias "verdes" eram só `scanned=0` (nada a inserir) → falsa sensação de flakiness.

**Impacto:** o mesmo enum atinge `dispatch-trial-ending` (D-2 de trial = **dunning**), item do go-live. Os 8 models irmãos (consent, fiscal, entitlement, subscription…) já usam `values_callable`; o `alert.py` era o único fora do padrão.

## Mudança
- `app/models/alert.py`: adiciona o helper `_enum_values` (mesma convenção dos irmãos) e passa `values_callable=_enum_values` na coluna `status`. **Sem migration, sem backfill** — o tipo PG não muda e nunca houve linha maiúscula gravada (esses inserts sempre falharam).
- `tests/test_j_task_models.py`: regressão que persiste `Alert(status=SENT)` e assere o **valor bruto** gravado = `"sent"` (no SQLite o round-trip esconderia o casing; o assert no raw pega a serialização). **Fail-first verificado**: sem o fix, `assert 'SENT' == 'sent'`.
- `.github/workflows/reminder-job.yml`: conserta o heredoc de diagnóstico (`head -c` truncava sem `\n` final → delimitador na mesma linha → todos os comentários de falha vinham "(diagnostics unavailable)"). Agora futuras falhas trazem os logs reais.

## Validação local
- `pytest` nos 4 arquivos que tocam Alert (test_j_task_models, test_alert_service, test_alert_contract, test_transaction_reminder_service): **56 passed**.
- Fail-first do teste novo confirmado (stash do model → falha; restaura → passa).
- `ruff format/check` ✅ · `mypy app/models/alert.py` ✅ · `actionlint reminder-job.yml` ✅.

## Ativação
⚠️ Requer **deploy em prod** (recreate do container `web` com a imagem nova) para o cron passar a rodar o model corrigido — será feito junto do fix de env do #1596 (`AURAXIS_API_V2_BASE_URL`) num único `auraxis:prod-deploy`.

## Risco residual
Baixo — mudança isolada de serialização de enum, alinhada à convenção já usada em 8 models; reversível. A entregabilidade Resend (#870) é um risco separado, não coberto aqui.

Closes #989