### PR TITLE
fix(auth): align reset/confirm frontend URL paths in env examples [#1603]

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -66,9 +66,9 @@ BILLING_WEBHOOK_ALLOW_UNSIGNED=true
 
 # Email confirmation
 # URL base do frontend para o link de confirmacao de email.
-# Exemplo: https://app.auraxis.com.br/auth/confirm-email
+# Exemplo: https://app.auraxis.com.br/confirm-email
 # Se vazio, o link enviado no email sera "n/a" (usuario nao conseguira confirmar).
-EMAIL_CONFIRMATION_FRONTEND_URL=http://localhost:3000/auth/confirm-email
+EMAIL_CONFIRMATION_FRONTEND_URL=http://localhost:3000/confirm-email
 
 # Sentry error tracking and performance monitoring (opt-in — leave blank to disable)
 #
@@ -159,5 +159,5 @@ EMAIL_PROVIDER=stub
 # EMAIL_PROVIDER=resend
 # RESEND_API_KEY=re_your_key_here
 # EMAIL_FROM=Auraxis <noreply@auraxis.com.br>
-EMAIL_CONFIRMATION_FRONTEND_URL=http://localhost:3000/auth/confirm-email
-PASSWORD_RESET_FRONTEND_URL=http://localhost:3000/auth/reset-password
+EMAIL_CONFIRMATION_FRONTEND_URL=http://localhost:3000/confirm-email
+PASSWORD_RESET_FRONTEND_URL=http://localhost:3000/reset-password

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -69,8 +69,8 @@ EMAIL_PROVIDER=resend
 RESEND_API_KEY=re_replace_with_real_key
 EMAIL_FROM=Auraxis <noreply@auraxis.com.br>
 # Deep-link targets for email CTAs — must match the deployed web app URL.
-EMAIL_CONFIRMATION_FRONTEND_URL=https://app.auraxis.com.br/auth/confirm-email
-PASSWORD_RESET_FRONTEND_URL=https://app.auraxis.com.br/auth/reset-password
+EMAIL_CONFIRMATION_FRONTEND_URL=https://app.auraxis.com.br/confirm-email
+PASSWORD_RESET_FRONTEND_URL=https://app.auraxis.com.br/reset-password
 
 # Sentry error tracking and performance monitoring (opt-in — leave blank to disable)
 SENTRY_DSN=https://replace-with-key@o000000.ingest.us.sentry.io/0000000


### PR DESCRIPTION
## Contexto
O e-mail de recuperação de senha levava a um link morto: em prod `PASSWORD_RESET_FRONTEND_URL` apontava para `/auth/reset-password`, mas a rota real do web é `/reset-password` (`app/pages/reset-password.vue`; `app/pages/auth/` só tem `callback.vue` do OAuth). O usuário via 'n/a' quando o container rodava sem o env carregado (drift), e link morto quando carregado com o path errado.

A fonte do drift são os templates: `.env.prod.example` e `.env.dev.example` documentavam `/auth/reset-password` **e** `/auth/confirm-email` (este último já estava certo em prod, mas errado no template).

## Mudança
Alinha os dois `.env.*.example` aos routes reais — dropa o `/auth` de reset e confirm (preserva `/auth/callback` do OAuth). Docs-only; nenhum código de runtime.

## Prod (já aplicado fora deste PR)
`.env.prod` → `PASSWORD_RESET_FRONTEND_URL=https://app.auraxis.com.br/reset-password` + recreate do `web` (mesma imagem `eee5896`, sem rollback). Verificado: runtime env = `/reset-password`, healthz=200. O link agora abre `/reset-password?token=...`.

## Validação
- `git grep 'auth/(confirm-email|reset-password)'` → 0 ocorrências restantes.
- Pre-commit (sonar-local-check) passou.

## Risco
Nenhum (docs). Entregabilidade do e-mail depende do Resend verificado (platform#870) — ortogonal.

Closes #1603