### PR TITLE
fix(radar): mint token_use=service for the internal v2 call [#1606]

### DIFF
--- a/app/services/ai_spending_patterns_service.py
+++ b/app/services/ai_spending_patterns_service.py
@@ -153,7 +153,14 @@ def generate_and_persist_spending_patterns(
     start = anchor_date - timedelta(days=_PERIOD_DAYS)
     transactions = _build_expense_payload(user_id=user_id, start=start, end=end)
 
-    auth_header = f"Bearer {create_access_token(str(user_id))}"
+    # Server-to-server token for the internal v2 call. The token_use=service
+    # claim tells v2 to skip its per-user session (active_jti) revocation — this
+    # cron token has no user session — while signature and account-block checks
+    # still apply on the v2 side. See auraxis-api-v2#97.
+    service_token = create_access_token(
+        str(user_id), additional_claims={"token_use": "service"}
+    )
+    auth_header = f"Bearer {service_token}"
     status_code, body = call_v2_spending_patterns(
         transactions=transactions,
         period_days=_PERIOD_DAYS,

--- a/tests/test_ai_spending_patterns_latest.py
+++ b/tests/test_ai_spending_patterns_latest.py
@@ -205,6 +205,32 @@ def _patch_v2(monkeypatch, *, status: int, body: dict) -> None:
     monkeypatch.setattr(sps_service, "call_v2_spending_patterns", _fake_call)
 
 
+def test_generate_mints_service_token(app, client, monkeypatch) -> None:
+    """The cron mints a token_use=service token so v2 skips per-user session
+    (active_jti) revocation for the internal call. Regression for #1596."""
+    from flask_jwt_extended import decode_token
+
+    token = _register_and_login(client)
+    user_id = _grant_premium(app, token)
+
+    captured: dict[str, str] = {}
+
+    def _capture(*, transactions, period_days, auth_header):  # noqa: ANN001
+        captured["auth_header"] = auth_header
+        return 200, {"patterns": []}
+
+    monkeypatch.setattr(sps_service, "call_v2_spending_patterns", _capture)
+
+    with app.app_context():
+        sps_service.generate_and_persist_spending_patterns(
+            user_id, anchor_date=date(2026, 6, 5)
+        )
+        service_token = captured["auth_header"].removeprefix("Bearer ")
+        decoded = decode_token(service_token)
+        assert decoded["token_use"] == "service"
+        assert decoded["sub"] == str(user_id)
+
+
 def test_generate_persists_insight(app, client, monkeypatch) -> None:
     token = _register_and_login(client)
     user_id = _grant_premium(app, token)


### PR DESCRIPTION
## Contexto
Camada 2 do fix de #1596. O cron semanal do radar (`generate_and_persist_spending_patterns`) mintava um access token server-to-server comum; a revogação de sessão única da v2 rejeitava com **401 `Token revoked`** porque o `jti` aleatório nunca casa com o `active_jti` da sessão do usuário.

## Mudança
Adiciona o claim `token_use=service` ao token da chamada interna:
```python
create_access_token(str(user_id), additional_claims={"token_use": "service"})
```
A v2 (par api-v2#97/#98) pula a revogação de sessão para esse claim; assinatura + bloqueio de conta continuam valendo. O **proxy on-demand não é afetado** — ele repassa o token de sessão do próprio usuário.

## Validação
- `pytest` spending-patterns → **18 passed** (1 novo: assere `token_use=service` + `sub` no token mintado).
- **Fail-first**: sem o claim, o teste falha com `KeyError: 'token_use'`.
- `ruff format/check` ✅ · `mypy` ✅.

## Deploy
⚠️ **DEPOIS da v2 (#98)**. Ordem: v2 aceita o claim → v1 passa a mandá-lo → re-disparar `spending-patterns-job` e confirmar `processed>0 failures=0`. Fecha #1596 após deploy + verificação.

Closes #1606