### PR TITLE
feat(billing): revogar entitlements em refund/chargeback do AbacatePay (#1598)

### DIFF
--- a/app/application/services/billing_email_service.py
+++ b/app/application/services/billing_email_service.py
@@ -2,6 +2,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from app.controllers.billing_webhook_parsers import (
+    ABACATEPAY_CHARGEBACK_EVENTS,
+    ABACATEPAY_REFUND_EVENTS,
+)
 from app.services.email_provider import EmailMessage
 
 if TYPE_CHECKING:
@@ -11,6 +15,9 @@ if TYPE_CHECKING:
 _PAYMENT_CONFIRMED_EVENTS = {"PAYMENT_RECEIVED", "PAYMENT_CONFIRMED"}
 _PAYMENT_FAILED_EVENTS = {"PAYMENT_OVERDUE", "subscription.past_due"}
 _CANCELED_EVENTS = {"subscription.canceled", "SUBSCRIPTION_DELETED"}
+# #1598 — refund/chargeback notice; event strings owned by
+# billing_webhook_parsers (single source of truth, guarded by a parity test).
+_REFUND_EVENTS = ABACATEPAY_REFUND_EVENTS | ABACATEPAY_CHARGEBACK_EVENTS
 
 _TRIAL_ENDING_TAG_TEMPLATE = "billing_trial_ending_{days}d"
 _TRIAL_EXPIRED_TAG = "billing_trial_expired"
@@ -58,6 +65,22 @@ def dispatch_billing_email(
                 f"Plano impactado: {plan_label}."
             ),
             tag="billing_payment_failed",
+        )
+        return
+
+    if event_type in _REFUND_EVENTS:
+        get_default_outbound_queue().enqueue_send_email(
+            to_email=to_email,
+            subject="Estorno processado — Auraxis",
+            html=(
+                "<p>Um estorno foi processado e o acesso premium foi encerrado.</p>"
+                f"<p>Plano encerrado: <strong>{plan_label}</strong></p>"
+            ),
+            text=(
+                "Um estorno foi processado e o acesso premium foi encerrado. "
+                f"Plano encerrado: {plan_label}."
+            ),
+            tag="billing_refund",
         )
         return
 

--- a/app/controllers/billing_webhook_parsers.py
+++ b/app/controllers/billing_webhook_parsers.py
@@ -293,6 +293,19 @@ def _build_abacatepay_snapshot(
     return snapshot
 
 
+# #1598 — refund/chargeback events. AbacatePay's exact event strings for these
+# are not yet documented (pending support confirmation tracked in platform#891);
+# we map the plausible variants. Every one revokes access, so over-inclusion is
+# safe: an unexpected-but-refund-shaped event simply degrades the subscription.
+ABACATEPAY_REFUND_EVENTS = frozenset(
+    {"subscription.refunded", "checkout.refunded", "payment.refunded"}
+)
+ABACATEPAY_CHARGEBACK_EVENTS = frozenset(
+    {"subscription.chargeback", "payment.chargeback", "chargeback.created"}
+)
+ABACATEPAY_REVOCATION_EVENTS = ABACATEPAY_REFUND_EVENTS | ABACATEPAY_CHARGEBACK_EVENTS
+
+
 class AbacatePayWebhookParser:
     """AbacatePay webhooks (API v2 envelope).
 
@@ -316,6 +329,13 @@ class AbacatePayWebhookParser:
         "subscription.renewed": SubscriptionStatus.ACTIVE.value,
         "subscription.cancelled": SubscriptionStatus.CANCELED.value,
         "subscription.payment_failed": SubscriptionStatus.PAST_DUE.value,
+        # #1598: refund/chargeback degrade to CANCELED, so the existing
+        # _DEGRADED_STATUSES machinery revokes premium entitlements with no
+        # further wiring. Without this a refund in the gateway dashboard leaves
+        # premium active — a revenue leak.
+        **dict.fromkeys(
+            ABACATEPAY_REVOCATION_EVENTS, SubscriptionStatus.CANCELED.value
+        ),
     }
 
     @property
@@ -375,7 +395,13 @@ class AbacatePayWebhookParser:
             return None
         subscription_object = data.get("subscription")
         if not isinstance(subscription_object, dict):
-            return None
+            # #1598: refund/chargeback payloads may omit the subscription block
+            # (they reference the checkout/customer instead). Those events still
+            # need to revoke, so resolve them via the customer id below. Every
+            # other event keeps requiring an explicit subscription object.
+            if event_type not in ABACATEPAY_REVOCATION_EVENTS:
+                return None
+            subscription_object = {}
 
         provider_subscription_id = _clean(subscription_object.get("id"))
         provider_customer_id = _resolve_abacatepay_customer_id(data)

--- a/tests/test_abacatepay_billing.py
+++ b/tests/test_abacatepay_billing.py
@@ -16,6 +16,7 @@ import pytest
 
 from app.controllers.billing_webhook_parsers import (
     ABACATEPAY_PROVIDER,
+    ABACATEPAY_REVOCATION_EVENTS,
     AbacatePayWebhookParser,
     BillingWebhookParser,
     resolve_webhook_parser,
@@ -408,7 +409,38 @@ class TestWebhookParser:
         assert "plan_code" not in snapshot
 
     def test_ignores_unknown_event(self) -> None:
-        assert AbacatePayWebhookParser().parse(_webhook("checkout.refunded")) is None
+        assert (
+            AbacatePayWebhookParser().parse(_webhook("subscription.frobnicated"))
+            is None
+        )
+
+    @pytest.mark.parametrize("event", sorted(ABACATEPAY_REVOCATION_EVENTS))
+    def test_refund_and_chargeback_events_revoke(self, event: str) -> None:
+        """#1598: a refund/chargeback degrades to CANCELED, which the
+        _DEGRADED_STATUSES machinery turns into an entitlement revocation."""
+        snapshot = AbacatePayWebhookParser().parse(_webhook(event))
+        assert snapshot is not None
+        assert snapshot["status"] == "canceled"
+
+    def test_refund_without_subscription_block_resolves_via_customer(self) -> None:
+        """Refund payloads may omit the subscription object (they reference the
+        checkout/customer). The event must still resolve so premium is revoked."""
+        payload = _webhook("checkout.refunded")
+        del payload["data"]["subscription"]
+
+        snapshot = AbacatePayWebhookParser().parse(payload)
+
+        assert snapshot is not None
+        assert snapshot["status"] == "canceled"
+        assert snapshot["provider_customer_id"] == "cust_def456"
+
+    def test_non_revocation_event_still_requires_subscription_block(self) -> None:
+        """The relaxed subscription-object rule is scoped to revocation events;
+        a completed event without a subscription block must still be rejected."""
+        payload = _webhook("subscription.completed")
+        del payload["data"]["subscription"]
+
+        assert AbacatePayWebhookParser().parse(payload) is None
 
     def test_sandbox_traffic_rejected_in_production(
         self, monkeypatch: pytest.MonkeyPatch
@@ -515,3 +547,104 @@ class TestWebhookVerification:
         assert not parser.verify(
             body, {"X-Webhook-Signature": "bogus"}, {"webhookSecret": "s3cr3t"}
         )
+
+
+class TestRefundWebhookFlow:
+    """End-to-end: a refund webhook revokes premium and is idempotent (#1598)."""
+
+    def _make_active_premium_sub(self, app: Any, client: Any) -> tuple[str, str]:
+        import uuid
+
+        from app.extensions.database import db
+        from app.models.subscription import (
+            BillingCycle,
+            Subscription,
+            SubscriptionStatus,
+        )
+        from app.models.user import User
+        from app.services.entitlement_service import (
+            sync_entitlements_from_subscription,
+        )
+
+        suffix = uuid.uuid4().hex[:8]
+        email = f"refund-{suffix}@email.com"
+        resp = client.post(
+            "/auth/register",
+            json={
+                "name": f"u-{suffix}",
+                "email": email,
+                "password": "StrongPass@123",
+            },
+        )
+        assert resp.status_code == 201
+
+        with app.app_context():
+            user = User.query.filter_by(email=email).first()
+            assert user is not None
+            sub = Subscription.query.filter_by(user_id=user.id).first()
+            if sub is None:
+                sub = Subscription(
+                    user_id=user.id,
+                    plan_code="premium",
+                    status=SubscriptionStatus.FREE,
+                )
+                db.session.add(sub)
+            sub.status = SubscriptionStatus.ACTIVE
+            sub.plan_code = "premium"
+            sub.billing_cycle = BillingCycle.MONTHLY
+            sub.provider = "abacatepay"
+            sub.provider_customer_id = "cust_def456"
+            db.session.commit()
+            sync_entitlements_from_subscription(sub)
+            db.session.commit()
+            return str(user.id), str(sub.id)
+
+    def test_refund_webhook_revokes_and_is_idempotent(
+        self, app: Any, client: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import uuid
+
+        from app.config.plan_features import PREMIUM_FEATURES
+        from app.models.entitlement import Entitlement
+        from app.models.subscription import Subscription, SubscriptionStatus
+
+        monkeypatch.setenv("BILLING_ABACATEPAY_WEBHOOK_SECRET", "s3cr3t")
+        monkeypatch.delenv("BILLING_ABACATEPAY_SIGNING_KEY", raising=False)
+
+        user_id, sub_id = self._make_active_premium_sub(app, client)
+        premium_feature = next(iter(PREMIUM_FEATURES))
+
+        with app.app_context():
+            assert (
+                Entitlement.query.filter_by(
+                    user_id=uuid.UUID(user_id), feature_key=premium_feature
+                ).first()
+                is not None
+            )
+
+        payload = _webhook("subscription.refunded")
+        resp = client.post(
+            "/subscriptions/webhook/abacatepay?webhookSecret=s3cr3t", json=payload
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["data"]["processed"] is True
+
+        with app.app_context():
+            sub = Subscription.query.filter_by(id=uuid.UUID(sub_id)).first()
+            assert sub is not None
+            assert sub.status == SubscriptionStatus.CANCELED
+            assert (
+                Entitlement.query.filter_by(
+                    user_id=uuid.UUID(user_id), feature_key=premium_feature
+                ).first()
+                is None
+            )
+
+        # Replaying the same event id must be a deduped no-op.
+        resp2 = client.post(
+            "/subscriptions/webhook/abacatepay?webhookSecret=s3cr3t", json=payload
+        )
+        assert resp2.status_code == 200
+        body2 = resp2.get_json()["data"]
+        assert body2["processed"] is False
+        assert body2.get("reason") == "duplicate"

--- a/tests/test_billing_email_service.py
+++ b/tests/test_billing_email_service.py
@@ -2,11 +2,15 @@ from __future__ import annotations
 
 import uuid
 
+import pytest
+
 from app.application.services.billing_email_service import (
+    _REFUND_EVENTS,
     build_trial_ending_email,
     dispatch_billing_email,
     dispatch_trial_expired_email,
 )
+from app.controllers.billing_webhook_parsers import ABACATEPAY_REVOCATION_EVENTS
 from app.models.subscription import BillingCycle, Subscription, SubscriptionStatus
 from app.models.user import User
 from app.services.email_provider import EmailMessage, get_email_outbox
@@ -89,6 +93,40 @@ def test_billing_email_service_sends_subscription_canceled_email(app) -> None:
         outbox = get_email_outbox()
         assert len(outbox) == 1
         assert outbox[0]["tag"] == "billing_subscription_canceled"
+
+
+@pytest.mark.parametrize("event_type", sorted(ABACATEPAY_REVOCATION_EVENTS))
+def test_billing_email_service_sends_refund_email(app, event_type: str) -> None:
+    """#1598: a refund/chargeback dispatches a distinct 'estorno' notice."""
+    with app.app_context():
+        user = User(
+            id=uuid.uuid4(),
+            name="Auraxis User",
+            email="billing@email.com",
+            password="hash",
+        )
+        subscription = Subscription(
+            user_id=user.id,
+            plan_code="premium",
+            status=SubscriptionStatus.CANCELED,
+            billing_cycle=BillingCycle.MONTHLY,
+        )
+
+        dispatch_billing_email(
+            user=user,
+            subscription=subscription,
+            event_type=event_type,
+        )
+
+        outbox = get_email_outbox()
+        assert len(outbox) == 1
+        assert outbox[0]["tag"] == "billing_refund"
+
+
+def test_refund_email_events_match_parser_revocation_events() -> None:
+    """Drift guard: the email set must equal the parser's revocation set so a
+    new refund event can never revoke access without also notifying the user."""
+    assert _REFUND_EVENTS == ABACATEPAY_REVOCATION_EVENTS
 
 
 def test_build_trial_ending_email_returns_ready_message(app) -> None:


### PR DESCRIPTION
## Contexto

Um reembolso/chargeback feito no dashboard do AbacatePay **não revogava entitlements**: `AbacatePayWebhookParser._EVENTS` mapeava só 5 eventos (trial_started, completed, renewed, cancelled, payment_failed), nenhum de estorno. `REFUNDED→canceled` existia apenas no `_ABACATEPAY_STATUS_MAP` do polling, não no webhook — vazamento de receita/abuso.

## O que muda

- **Parser** (`billing_webhook_parsers.py`): eventos de refund/chargeback passam a mapear para `CANCELED`. Como `CANCELED` já está em `_DEGRADED_STATUSES`, a maquinaria existente (`apply_subscription_snapshot` → `sync_entitlements_from_subscription`) **revoga premium automaticamente**, sem fiação nova.
- **`parse()` generalizado**: payloads de estorno podem vir **sem o bloco `subscription`** (referenciam checkout/customer). Só para eventos de revogação, a resolução cai para o `provider_customer_id`. Eventos normais continuam exigindo o bloco `subscription`.
- **E-mail transacional de estorno** (`billing_email_service.py`): branch distinto (`billing_refund`) para o usuário saber do encerramento.
- **Drift-guard**: teste garante que o set de eventos do e-mail == o set do parser (evita repetir o bug histórico `cancelled` vs `canceled`).

### ⚠️ Nomes de evento pendentes de confirmação
Os event-strings exatos de refund/chargeback do AbacatePay **não estão documentados** (item de "confirmar com o suporte" da platform#891). Mapeei o conjunto plausível (`subscription.refunded`/`checkout.refunded`/`payment.refunded`/`subscription.chargeback`/`payment.chargeback`/`chargeback.created`). Como **todos** levam à mesma revogação, a sobre-inclusão é segura; ajustar o set quando o suporte confirmar é trivial (uma constante).

## Validação

- `run_ci_quality_local.sh --local` — **verde**: 2846 passed, coverage **91.50%** (≥85%), ruff+mypy+bandit+pip-audit OK.
- **E2E**: `test_refund_webhook_revokes_and_is_idempotent` — refund via rota revoga o entitlement premium **e** o replay do mesmo `event_id` é deduplicado (no-op).
- Parser: refund/chargeback → `canceled` (com e sem bloco `subscription`); evento não-revogação sem `subscription` continua rejeitado.

## Risco residual
Baixo. Mudança aditiva; não altera os 5 eventos existentes. A idempotência reusa o dedupe por `provider_event_id` (inalterado). Único ponto aberto: os nomes de evento (acima) — mas o comportamento de revogação é correto para qualquer variante.

Closes #1598
