### PR TITLE
feat(billing): dunning com carência antes de revogar premium em payment_failed (#1599)

### DIFF
--- a/.github/workflows/trial-expiry-job.yml
+++ b/.github/workflows/trial-expiry-job.yml
@@ -169,6 +169,74 @@ jobs:
           echo "Timed out waiting for SSM command to complete."
           exit 1
 
+      # #1599: same daily cadence downgrades PAST_DUE subscriptions whose dunning
+      # grace window lapsed unpaid (payment_failed → grace → EXPIRED). Reuses the
+      # OIDC creds and container health check already established above.
+      - name: Expire lapsed grace windows via SSM
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+          PROD_INSTANCE_ID: ${{ vars.AURAXIS_PROD_INSTANCE_ID }}
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+        run: |
+          if [ "${DRY_RUN}" = "true" ]; then
+            FLAG=" --dry-run"
+          else
+            FLAG=""
+          fi
+          COMMAND_ID=$(aws ssm send-command \
+            --region "${AWS_REGION}" \
+            --instance-ids "${PROD_INSTANCE_ID}" \
+            --document-name "AWS-RunShellScript" \
+            --parameters "commands=[\"cd /opt/auraxis && docker compose exec -T web flask billing expire-grace${FLAG}\"]" \
+            --query "Command.CommandId" \
+            --output text)
+
+          echo "SSM Command ID: ${COMMAND_ID}"
+
+          for i in $(seq 1 30); do
+            STATUS=$(aws ssm get-command-invocation \
+              --region "${AWS_REGION}" \
+              --command-id "${COMMAND_ID}" \
+              --instance-id "${PROD_INSTANCE_ID}" \
+              --query "StatusDetails" \
+              --output text 2>/dev/null || echo "Pending")
+
+            echo "Attempt ${i}: ${STATUS}"
+
+            if [ "${STATUS}" = "Success" ]; then
+              echo "Grace expiry completed successfully."
+              aws ssm get-command-invocation \
+                --region "${AWS_REGION}" \
+                --command-id "${COMMAND_ID}" \
+                --instance-id "${PROD_INSTANCE_ID}" \
+                --query "StandardOutputContent" \
+                --output text 2>/dev/null || true
+              exit 0
+            elif [ "${STATUS}" = "Failed" ] || [ "${STATUS}" = "Cancelled" ] || [ "${STATUS}" = "TimedOut" ]; then
+              echo "Grace expiry failed with status: ${STATUS}"
+              echo "--- stdout ---"
+              aws ssm get-command-invocation \
+                --region "${AWS_REGION}" \
+                --command-id "${COMMAND_ID}" \
+                --instance-id "${PROD_INSTANCE_ID}" \
+                --query "StandardOutputContent" \
+                --output text 2>/dev/null || true
+              echo "--- stderr ---"
+              aws ssm get-command-invocation \
+                --region "${AWS_REGION}" \
+                --command-id "${COMMAND_ID}" \
+                --instance-id "${PROD_INSTANCE_ID}" \
+                --query "StandardErrorContent" \
+                --output text 2>/dev/null || true
+              exit 1
+            fi
+
+            sleep 10
+          done
+
+          echo "Timed out waiting for SSM command to complete."
+          exit 1
+
       - name: Notify failure via GitHub Issue
         if: failure()
         uses: actions/github-script@v7

--- a/app/application/services/billing_email_service.py
+++ b/app/application/services/billing_email_service.py
@@ -134,3 +134,32 @@ def dispatch_trial_expired_email(*, user: User, subscription: Subscription) -> N
         ),
         tag=_TRIAL_EXPIRED_TAG,
     )
+
+
+def dispatch_billing_grace_expired_email(
+    *, user: User, subscription: Subscription
+) -> None:
+    """Notify that the dunning grace window lapsed unpaid and premium ended (#1599).
+
+    Called by ``scripts/process_grace_expirations.py`` after the PAST_DUE →
+    EXPIRED downgrade is committed.
+    """
+    from app.services.outbound_queue import get_default_outbound_queue
+
+    plan_label = _plan_label(subscription)
+    get_default_outbound_queue().enqueue_send_email(
+        to_email=str(user.email),
+        subject="Assinatura encerrada por falta de pagamento — Auraxis",
+        html=(
+            "<p>Não conseguimos confirmar o pagamento da sua assinatura dentro "
+            "do período de tolerância, então o acesso premium foi encerrado.</p>"
+            f"<p>Plano encerrado: <strong>{plan_label}</strong></p>"
+            "<p>Regularize o pagamento para reativar quando quiser.</p>"
+        ),
+        text=(
+            "Não conseguimos confirmar o pagamento da sua assinatura dentro do "
+            "período de tolerância, então o acesso premium foi encerrado. "
+            f"Plano encerrado: {plan_label}. Regularize o pagamento para reativar."
+        ),
+        tag="billing_grace_expired",
+    )

--- a/app/extensions/trial_expiry_cli.py
+++ b/app/extensions/trial_expiry_cli.py
@@ -38,6 +38,24 @@ def expire_trials(dry_run: bool) -> None:
         raise SystemExit(0)
 
 
+@billing_cli.command("expire-grace")
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Print which subscriptions would be downgraded without writing to DB.",
+)
+def expire_grace(dry_run: bool) -> None:
+    """Downgrade PAST_DUE subscriptions whose dunning grace window lapsed (#1599)."""
+    from scripts.process_grace_expirations import process_grace_expirations
+
+    count = process_grace_expirations(dry_run=dry_run)
+    if dry_run:
+        click.echo(f"[dry-run] {count} subscription(s) would be downgraded.")
+    else:
+        click.echo(f"{count} subscription(s) downgraded.")
+
+
 def register_trial_expiry_cli(app: Flask) -> None:
     """Register the ``billing`` CLI group on *app*."""
     app.cli.add_command(billing_cli)

--- a/app/services/entitlement_service.py
+++ b/app/services/entitlement_service.py
@@ -232,7 +232,32 @@ _DEGRADED_STATUSES = {
 }
 
 
-def _resolve_effective_plan(plan_slug: str, status: SubscriptionStatus | None) -> str:
+def _subscription_in_grace(
+    subscription: Subscription, *, now: datetime | None = None
+) -> bool:
+    """#1599: a PAST_DUE subscription still inside its dunning grace window.
+
+    Only PAST_DUE with an explicit ``grace_period_ends_at`` in the future counts —
+    a legacy PAST_DUE without a grace date keeps the old immediate-revoke
+    behaviour, so this change never silently re-grants premium.
+    """
+    if subscription.status != SubscriptionStatus.PAST_DUE:
+        return False
+    grace_end = subscription.grace_period_ends_at
+    if grace_end is None:
+        return False
+    return bool((now or utc_now_naive()) <= grace_end)
+
+
+def _resolve_effective_plan(
+    plan_slug: str,
+    status: SubscriptionStatus | None,
+    *,
+    in_grace: bool = False,
+) -> str:
+    # #1599: keep premium while a payment retry is still within the grace window.
+    if status == SubscriptionStatus.PAST_DUE and in_grace:
+        return plan_slug if plan_slug in PLAN_FEATURES else "free"
     if status in _DEGRADED_STATUSES:
         return "free"
     return plan_slug if plan_slug in PLAN_FEATURES else "free"
@@ -266,7 +291,9 @@ def sync_entitlements_from_subscription(
     plan_slug = subscription.plan_code or "free"
     status = subscription.status
 
-    effective_plan = _resolve_effective_plan(plan_slug, status)
+    effective_plan = _resolve_effective_plan(
+        plan_slug, status, in_grace=_subscription_in_grace(subscription)
+    )
     desired_features: set[str] = set(PLAN_FEATURES[effective_plan])
     source = _resolve_entitlement_source(effective_plan, status)
 

--- a/app/services/subscription_service.py
+++ b/app/services/subscription_service.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import logging
 import os
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import cast
 from uuid import UUID
 
@@ -21,6 +21,7 @@ from app.models.subscription import BillingCycle, Subscription, SubscriptionStat
 from app.models.user import User
 from app.services.billing_adapter import BillingProvider, BillingSubscriptionSnapshot
 from app.services.entitlement_service import sync_entitlements_from_subscription
+from app.utils.datetime_utils import utc_now_naive
 
 logger = logging.getLogger(__name__)
 
@@ -167,6 +168,37 @@ def _set_nullable_datetime_if_changed(
     return next_value, True
 
 
+def _grace_period_days() -> int:
+    """Dunning grace window (#1599). Configurable; defaults to 5 days."""
+    default = 5
+    if has_app_context():
+        return int(current_app.config.get("BILLING_GRACE_PERIOD_DAYS", default))
+    return int(os.getenv("BILLING_GRACE_PERIOD_DAYS", str(default)))
+
+
+def _apply_grace_transition(
+    subscription: Subscription,
+    *,
+    status_changed: bool,
+    next_status: SubscriptionStatus | None,
+) -> None:
+    """#1599: manage the dunning grace window on status transitions.
+
+    Entering PAST_DUE opens a grace window so premium stays on during payment
+    retries; entering ACTIVE clears it (a renewal keeps premium continuous). A
+    repeated payment_failed does not extend an already-open window.
+    """
+    if not status_changed or next_status is None:
+        return
+    if next_status == SubscriptionStatus.PAST_DUE:
+        if subscription.grace_period_ends_at is None:
+            subscription.grace_period_ends_at = utc_now_naive() + timedelta(
+                days=_grace_period_days()
+            )
+    elif next_status == SubscriptionStatus.ACTIVE:
+        subscription.grace_period_ends_at = None
+
+
 def apply_subscription_snapshot(
     subscription: Subscription,
     snapshot: BillingSubscriptionSnapshot,
@@ -180,8 +212,10 @@ def apply_subscription_snapshot(
         next_status = SubscriptionStatus(str(raw_status))
     except ValueError:
         next_status = None
-    subscription.status, did_change = _set_if_changed(subscription.status, next_status)
-    changed = changed or did_change
+    subscription.status, status_changed = _set_if_changed(
+        subscription.status, next_status
+    )
+    changed = changed or status_changed
 
     normalized_plan = _normalize_plan_snapshot(
         raw_plan_code=snapshot.get("plan_code"),
@@ -237,6 +271,9 @@ def apply_subscription_snapshot(
         )
         changed = changed or did_change
 
+    _apply_grace_transition(
+        subscription, status_changed=status_changed, next_status=next_status
+    )
     _sync_access_if_needed(subscription, changed=changed)
     db.session.commit()
     return subscription

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -147,6 +147,9 @@ class Config:
         os.getenv("EMAIL_VERIFICATION_GRACE_PERIOD_DAYS", "14")
     )
     EMAIL_VERIFICATION_ENFORCE = _read_bool_env("EMAIL_VERIFICATION_ENFORCE", True)
+    # Billing dunning grace window (#1599) — on payment_failed, premium stays on
+    # until now + N days; a daily job downgrades once the window lapses unpaid.
+    BILLING_GRACE_PERIOD_DAYS = int(os.getenv("BILLING_GRACE_PERIOD_DAYS", "5"))
     # URL base do frontend para o link de confirmação de email. Consumido por
     # email_confirmation_service. Quando vazio, o serviço faz fallback para
     # a URL canônica de prod com warning de log (PR #1335).

--- a/scripts/process_grace_expirations.py
+++ b/scripts/process_grace_expirations.py
@@ -1,0 +1,151 @@
+"""#1599: Process billing grace-period expirations.
+
+Downgrade PAST_DUE subscriptions whose dunning grace window lapsed without a
+successful payment retry: PAST_DUE → EXPIRED, which revokes premium entitlements
+through the normal ``apply_subscription_snapshot`` machinery.
+
+Run this on a daily cron (via ``flask billing expire-grace`` or this script).
+
+Usage
+-----
+    python scripts/process_grace_expirations.py [--dry-run]
+
+Environment
+-----------
+``DATABASE_URL`` must be set (or the application ``.env`` loaded). The script
+bootstraps a minimal Flask application context so all ORM models are available.
+``BILLING_GRACE_PERIOD_DAYS`` controls the window length (default 5) and is
+applied when the grace window is *opened* (on ``payment_failed``), not here.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from flask import Flask
+
+    from app.models.subscription import Subscription
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s — %(message)s",
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Downgrade subscriptions whose dunning grace window lapsed unpaid."
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help="Print candidates without committing changes.",
+    )
+    return parser.parse_args()
+
+
+def _notify_grace_expired(sub: Subscription) -> None:
+    """Send the "downgrade por falta de pagamento" email (#1599).
+
+    Email failures are logged and never block the downgrade batch.
+    """
+    from app.application.services.billing_email_service import (
+        dispatch_billing_grace_expired_email,
+    )
+    from app.extensions.database import db
+    from app.models.user import User
+
+    user = db.session.get(User, sub.user_id)
+    if user is None:
+        return
+    try:
+        dispatch_billing_grace_expired_email(user=user, subscription=sub)
+    except Exception:
+        logger.exception(
+            "Failed to dispatch grace-expired email for user_id=%s",
+            sub.user_id,
+        )
+
+
+def process_grace_expirations(
+    *, dry_run: bool = False, flask_app: Flask | None = None
+) -> int:
+    """Downgrade PAST_DUE subscriptions whose grace window lapsed unpaid.
+
+    Args:
+        dry_run: Print candidates without committing changes.
+        flask_app: Optional pre-built Flask app (tests). When omitted, a
+            minimal app is bootstrapped via ``create_app``.
+
+    Returns the count of processed subscriptions.
+    """
+    from app import create_app
+    from app.models.subscription import Subscription, SubscriptionStatus
+    from app.services.billing_adapter import BillingSubscriptionSnapshot
+    from app.services.subscription_service import apply_subscription_snapshot
+    from app.utils.datetime_utils import utc_now_naive
+
+    app = flask_app or create_app(enable_http_runtime=False)
+
+    processed = 0
+    with app.app_context():
+        now = utc_now_naive()
+        lapsed: list[Subscription] = Subscription.query.filter(
+            Subscription.status == SubscriptionStatus.PAST_DUE,
+            Subscription.grace_period_ends_at.isnot(None),
+            Subscription.grace_period_ends_at < now,
+        ).all()
+
+        if not lapsed:
+            logger.info("No lapsed grace-period subscriptions found.")
+            return 0
+
+        downgraded: list[Subscription] = []
+        for sub in lapsed:
+            logger.info(
+                "Grace lapsed: subscription_id=%s user_id=%s grace_period_ends_at=%s",
+                sub.id,
+                sub.user_id,
+                sub.grace_period_ends_at,
+            )
+            processed += 1
+            if dry_run:
+                continue
+            expired_snapshot: BillingSubscriptionSnapshot = {
+                "status": SubscriptionStatus.EXPIRED.value
+            }
+            apply_subscription_snapshot(sub, expired_snapshot)
+            downgraded.append(sub)
+
+        if dry_run:
+            logger.info(
+                "[dry-run] Would downgrade %d lapsed grace subscription(s).", processed
+            )
+        else:
+            logger.info("Downgraded %d lapsed grace subscription(s).", processed)
+            for sub in downgraded:
+                _notify_grace_expired(sub)
+
+    return processed
+
+
+def main() -> None:
+    args = _parse_args()
+    count = process_grace_expirations(dry_run=args.dry_run)
+    prefix = "[dry-run] " if args.dry_run else ""
+    print(f"{prefix}{count} subscription(s) downgraded.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_billing_grace_dunning.py
+++ b/tests/test_billing_grace_dunning.py
@@ -1,0 +1,149 @@
+"""#1599 — dunning grace window before revoking premium on payment_failed.
+
+Covers the three acceptance paths (isolated payment_failed keeps premium,
+retry keeps continuity, lapsed grace downgrades + emails) plus the safe legacy
+default (a PAST_DUE without a grace date still revokes immediately).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import timedelta
+
+from app.config.plan_features import PREMIUM_FEATURES
+from app.extensions.database import db
+from app.models.entitlement import Entitlement
+from app.models.subscription import BillingCycle, Subscription, SubscriptionStatus
+from app.models.user import User
+from app.services.entitlement_service import sync_entitlements_from_subscription
+from app.services.subscription_service import apply_subscription_snapshot
+from app.utils.datetime_utils import utc_now_naive
+
+_PREMIUM_FEATURE = next(iter(PREMIUM_FEATURES))
+
+
+def _make_active_premium_user_and_sub() -> tuple[User, Subscription]:
+    suffix = uuid.uuid4().hex[:8]
+    user = User(
+        id=uuid.uuid4(),
+        name=f"u-{suffix}",
+        email=f"grace-{suffix}@email.com",
+        password="hash",
+    )
+    db.session.add(user)
+    db.session.commit()
+    sub = Subscription(
+        user_id=user.id,
+        plan_code="premium",
+        status=SubscriptionStatus.ACTIVE,
+        billing_cycle=BillingCycle.MONTHLY,
+        provider="abacatepay",
+        provider_customer_id=f"cust_{suffix}",
+    )
+    db.session.add(sub)
+    db.session.commit()
+    sync_entitlements_from_subscription(sub)
+    db.session.commit()
+    return user, sub
+
+
+def _has_premium(user_id: uuid.UUID) -> bool:
+    return (
+        Entitlement.query.filter_by(
+            user_id=user_id, feature_key=_PREMIUM_FEATURE
+        ).first()
+        is not None
+    )
+
+
+def test_payment_failed_opens_grace_and_keeps_premium(app) -> None:
+    with app.app_context():
+        user, sub = _make_active_premium_user_and_sub()
+        assert _has_premium(user.id) is True
+
+        apply_subscription_snapshot(sub, {"status": SubscriptionStatus.PAST_DUE.value})
+
+        assert sub.status == SubscriptionStatus.PAST_DUE
+        assert sub.grace_period_ends_at is not None
+        expected = utc_now_naive() + timedelta(days=5)
+        assert abs((sub.grace_period_ends_at - expected).total_seconds()) < 120
+        # Premium must survive the grace window (no instant downgrade).
+        assert _has_premium(user.id) is True
+
+
+def test_repeated_payment_failed_does_not_extend_grace(app) -> None:
+    with app.app_context():
+        _user, sub = _make_active_premium_user_and_sub()
+        apply_subscription_snapshot(sub, {"status": SubscriptionStatus.PAST_DUE.value})
+        first_grace = sub.grace_period_ends_at
+
+        # A second payment_failed while already PAST_DUE must not reset the clock.
+        apply_subscription_snapshot(sub, {"status": SubscriptionStatus.PAST_DUE.value})
+
+        assert sub.grace_period_ends_at == first_grace
+
+
+def test_renewed_during_grace_clears_it_and_keeps_premium(app) -> None:
+    with app.app_context():
+        user, sub = _make_active_premium_user_and_sub()
+        apply_subscription_snapshot(sub, {"status": SubscriptionStatus.PAST_DUE.value})
+        assert sub.grace_period_ends_at is not None
+
+        apply_subscription_snapshot(sub, {"status": SubscriptionStatus.ACTIVE.value})
+
+        assert sub.status == SubscriptionStatus.ACTIVE
+        assert sub.grace_period_ends_at is None
+        # Continuous premium — no flicker.
+        assert _has_premium(user.id) is True
+
+
+def test_past_due_without_grace_date_still_revokes(app) -> None:
+    """Safety: a legacy PAST_DUE (no grace date) keeps the old immediate revoke."""
+    with app.app_context():
+        user, sub = _make_active_premium_user_and_sub()
+        sub.status = SubscriptionStatus.PAST_DUE
+        sub.grace_period_ends_at = None
+        db.session.commit()
+
+        sync_entitlements_from_subscription(sub)
+        db.session.commit()
+
+        assert _has_premium(user.id) is False
+
+
+def test_lapsed_grace_downgrades_and_emails(app) -> None:
+    from app.services.email_provider import get_email_outbox
+    from scripts.process_grace_expirations import process_grace_expirations
+
+    with app.app_context():
+        user, sub = _make_active_premium_user_and_sub()
+        # Force a PAST_DUE whose grace already lapsed.
+        sub.status = SubscriptionStatus.PAST_DUE
+        sub.grace_period_ends_at = utc_now_naive() - timedelta(days=1)
+        db.session.commit()
+
+        count = process_grace_expirations(dry_run=False, flask_app=app)
+
+        assert count == 1
+        refreshed = Subscription.query.filter_by(id=sub.id).first()
+        assert refreshed is not None
+        assert refreshed.status == SubscriptionStatus.EXPIRED
+        assert _has_premium(user.id) is False
+        assert any(m["tag"] == "billing_grace_expired" for m in get_email_outbox())
+
+
+def test_lapsed_grace_dry_run_makes_no_change(app) -> None:
+    from scripts.process_grace_expirations import process_grace_expirations
+
+    with app.app_context():
+        _user, sub = _make_active_premium_user_and_sub()
+        sub.status = SubscriptionStatus.PAST_DUE
+        sub.grace_period_ends_at = utc_now_naive() - timedelta(days=1)
+        db.session.commit()
+
+        count = process_grace_expirations(dry_run=True, flask_app=app)
+
+        assert count == 1
+        refreshed = Subscription.query.filter_by(id=sub.id).first()
+        assert refreshed is not None
+        assert refreshed.status == SubscriptionStatus.PAST_DUE


### PR DESCRIPTION
## Contexto

A coluna `Subscription.grace_period_ends_at` existia mas **nunca era usada**. Um único webhook `subscription.payment_failed` → PAST_DUE, e `entitlement_service` revogava premium **no mesmo instante** (PAST_DUE ∈ `_DEGRADED_STATUSES`). Se o retry do gateway pagasse depois (`renewed`), o premium ligava/desligava — flicker de entitlement e UX imprevisível.

## O que muda

- **Carência ao falhar o pagamento**: entrar em PAST_DUE abre uma janela `grace_period_ends_at = now + N dias` (`BILLING_GRACE_PERIOD_DAYS`, default **5**) em `apply_subscription_snapshot`. Um `payment_failed` repetido **não estende** a janela.
- **Premium contínuo durante a carência**: `_resolve_effective_plan` fica *grace-aware* — PAST_DUE **dentro** da janela mantém o plano; PAST_DUE **fora** (ou sem data) → free.
- **Retry limpa a carência**: entrar em ACTIVE (`renewed`/`completed`) zera `grace_period_ends_at` → premium sem flicker.
- **Downgrade quando a carência vence**: novo `flask billing expire-grace` (+ `scripts/process_grace_expirations.py`) varre PAST_DUE com janela vencida → **EXPIRED** (revoga premium via a maquinaria normal) + **e-mail** `billing_grace_expired`. Agendado no cron diário existente (`trial-expiry-job.yml`, mesma cadência de downgrade).

### Segurança da mudança
Um PAST_DUE **legado sem `grace_period_ends_at`** mantém o comportamento antigo (revoga na hora) — a nova regra só preserva premium quando há uma janela explícita e futura. Zero risco de re-conceder premium silenciosamente.

## Validação

- `run_ci_quality_local.sh --local` — **verde**: 2837 passed, coverage **91.48%**, ruff+mypy+bandit+pip-audit OK.
- 6 testes cobrindo os 3 caminhos do aceite + o default legado + dry-run:
  - payment_failed isolado abre carência e **mantém** premium
  - payment_failed repetido não estende a janela
  - `renewed` na carência limpa e mantém premium contínuo
  - carência vencida → EXPIRED + premium revogado + e-mail
  - PAST_DUE sem data de carência → revoga (comportamento antigo)

## Risco residual
Baixo. O único ponto operacional é o job diário; se falhar, o próprio `_resolve_effective_plan` grace-aware já revoga na próxima sincronização (webhook/lazy read) após a janela — fail-safe.

Closes #1599
