### PR TITLE
feat(billing): job de reconciliação de assinaturas vs gateway (#1600)

### DIFF
--- a/.github/workflows/reconcile-subscriptions-job.yml
+++ b/.github/workflows/reconcile-subscriptions-job.yml
@@ -1,0 +1,165 @@
+name: Reconcile Subscriptions Job
+
+# #1600: polls the payment gateway for every active/trialing/past_due
+# subscription and realigns any that drifted from a lost/never-delivered webhook
+# (paid without premium, or canceled while still premium). Runs after the
+# downgrade jobs (trial/grace at 08:00 UTC) so it observes their result.
+
+on:
+  schedule:
+    - cron: "30 8 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Report drift without writing."
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: reconcile-subscriptions-job-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+  issues: write
+
+jobs:
+  reconcile:
+    name: Reconcile subscriptions vs gateway
+    runs-on: ubuntu-latest
+    environment: prod
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate required variables
+        run: |
+          [ -n "${AWS_REGION:-}" ] || { echo "Missing var AWS_REGION"; exit 1; }
+          [ -n "${AWS_ROLE_ARN_PROD:-}" ] || { echo "Missing var AWS_ROLE_ARN_PROD"; exit 1; }
+          [ -n "${AURAXIS_PROD_INSTANCE_ID:-}" ] || { echo "Missing var AURAXIS_PROD_INSTANCE_ID"; exit 1; }
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+          AWS_ROLE_ARN_PROD: ${{ vars.AWS_ROLE_ARN_PROD }}
+          AURAXIS_PROD_INSTANCE_ID: ${{ vars.AURAXIS_PROD_INSTANCE_ID }}
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN_PROD }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Reconcile subscriptions via SSM
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+          PROD_INSTANCE_ID: ${{ vars.AURAXIS_PROD_INSTANCE_ID }}
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+        run: |
+          if [ "${DRY_RUN}" = "true" ]; then
+            FLAG=" --dry-run"
+          else
+            FLAG=""
+          fi
+          COMMAND_ID=$(aws ssm send-command \
+            --region "${AWS_REGION}" \
+            --instance-ids "${PROD_INSTANCE_ID}" \
+            --document-name "AWS-RunShellScript" \
+            --parameters "commands=[\"cd /opt/auraxis && docker compose exec -T web flask billing reconcile-subscriptions${FLAG}\"]" \
+            --query "Command.CommandId" \
+            --output text)
+
+          echo "SSM Command ID: ${COMMAND_ID}"
+
+          for i in $(seq 1 30); do
+            STATUS=$(aws ssm get-command-invocation \
+              --region "${AWS_REGION}" \
+              --command-id "${COMMAND_ID}" \
+              --instance-id "${PROD_INSTANCE_ID}" \
+              --query "StatusDetails" \
+              --output text 2>/dev/null || echo "Pending")
+
+            echo "Attempt ${i}: ${STATUS}"
+
+            if [ "${STATUS}" = "Success" ]; then
+              echo "Reconciliation completed successfully."
+              aws ssm get-command-invocation \
+                --region "${AWS_REGION}" \
+                --command-id "${COMMAND_ID}" \
+                --instance-id "${PROD_INSTANCE_ID}" \
+                --query "StandardOutputContent" \
+                --output text 2>/dev/null || true
+              exit 0
+            elif [ "${STATUS}" = "Failed" ] || [ "${STATUS}" = "Cancelled" ] || [ "${STATUS}" = "TimedOut" ]; then
+              echo "Reconciliation failed with status: ${STATUS}"
+              echo "--- stdout ---"
+              aws ssm get-command-invocation \
+                --region "${AWS_REGION}" \
+                --command-id "${COMMAND_ID}" \
+                --instance-id "${PROD_INSTANCE_ID}" \
+                --query "StandardOutputContent" \
+                --output text 2>/dev/null || true
+              echo "--- stderr ---"
+              aws ssm get-command-invocation \
+                --region "${AWS_REGION}" \
+                --command-id "${COMMAND_ID}" \
+                --instance-id "${PROD_INSTANCE_ID}" \
+                --query "StandardErrorContent" \
+                --output text 2>/dev/null || true
+              exit 1
+            fi
+
+            sleep 10
+          done
+
+          echo "Timed out waiting for SSM command to complete."
+          exit 1
+
+      - name: Notify failure via GitHub Issue
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const title = '🚨 [reconcile-subscriptions-job] Falha na reconciliação de assinaturas';
+            const body = [
+              '## Reconcile Subscriptions Job falhou',
+              '',
+              `**Run:** ${runUrl}`,
+              '',
+              'O job diário de reconciliação de assinaturas vs gateway falhou via SSM.',
+              'Drift de webhook perdido pode permanecer não corrigido até a próxima execução.',
+              '',
+              '### Ações sugeridas',
+              '- Revisar logs da execução no link acima',
+              '- Rodar `flask billing reconcile-subscriptions --dry-run` manualmente',
+              '',
+              '_Issue criada automaticamente pelo GitHub Actions._',
+            ].join('\n');
+            const query = [
+              `repo:${context.repo.owner}/${context.repo.repo}`,
+              'is:issue',
+              'is:open',
+              'in:title',
+              `"${title}"`,
+            ].join(' ');
+            const search = await github.rest.search.issuesAndPullRequests({ q: query, per_page: 10 });
+            const existing = search.data.items.find((item) => item.title === title);
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body: `Nova falha: ${runUrl}`,
+              });
+              return;
+            }
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+              labels: ['bug', 'ops'],
+            });

--- a/app/extensions/trial_expiry_cli.py
+++ b/app/extensions/trial_expiry_cli.py
@@ -38,6 +38,25 @@ def expire_trials(dry_run: bool) -> None:
         raise SystemExit(0)
 
 
+@billing_cli.command("reconcile-subscriptions")
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Report drift without writing changes.",
+)
+def reconcile_subscriptions_command(dry_run: bool) -> None:
+    """Realign subscriptions that drifted from the gateway (lost webhook) (#1600)."""
+    from scripts.reconcile_subscriptions import reconcile_subscriptions
+
+    summary = reconcile_subscriptions(dry_run=dry_run)
+    prefix = "[dry-run] " if dry_run else ""
+    click.echo(
+        f"{prefix}checked={summary['checked']} "
+        f"reconciled={summary['reconciled']} errors={summary['errors']}"
+    )
+
+
 def register_trial_expiry_cli(app: Flask) -> None:
     """Register the ``billing`` CLI group on *app*."""
     app.cli.add_command(billing_cli)

--- a/scripts/reconcile_subscriptions.py
+++ b/scripts/reconcile_subscriptions.py
@@ -1,0 +1,188 @@
+"""#1600: Reconcile local subscriptions against the payment gateway.
+
+The subscription sync is lazy (``GET /subscriptions/me``) plus webhooks. A
+webhook that is lost and never redelivered — for a user who does not open the
+app — leaves a **permanent drift**: paid without premium, or canceled while still
+premium. The webhook-retry job only reprocesses events we *received*; it cannot
+cover ones never delivered.
+
+This job polls the gateway for every active/trialing/past_due subscription with a
+real provider id and applies the authoritative snapshot when it diverges from the
+local state. A recurring drift count is a signal the webhook path is broken, so it
+raises a Sentry alert.
+
+Usage
+-----
+    python scripts/reconcile_subscriptions.py [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from flask import Flask
+
+    from app.models.subscription import Subscription
+    from app.services.billing_adapter import BillingSubscriptionSnapshot
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s — %(message)s",
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Reconcile local subscriptions against the payment gateway."
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help="Report drift without writing changes.",
+    )
+    return parser.parse_args()
+
+
+def _snapshot_diverges(
+    sub: Subscription, snapshot: BillingSubscriptionSnapshot
+) -> bool:
+    """Whether the gateway snapshot disagrees with the local subscription.
+
+    Only fields the snapshot actually carries are compared — ``get_subscription``
+    may omit the plan, and a missing field must never be read as "downgrade".
+    """
+    snap_status = str(snapshot.get("status") or "").strip()
+    if snap_status and snap_status != sub.status.value:
+        return True
+    snap_plan = snapshot.get("plan_code")
+    if snap_plan and str(snap_plan) != sub.plan_code:
+        return True
+    return False
+
+
+def _alert_drift(reconciled: int, drifted_ids: list[str]) -> None:
+    """Log + Sentry alert when the gateway corrected local state (#1600).
+
+    Drift means a webhook was lost: loud enough to investigate the webhook path.
+    """
+    logger.error(
+        "reconcile-subscriptions: corrected %d drifted subscription(s) — a lost "
+        "webhook is likely; investigate delivery. ids=%s",
+        reconciled,
+        ",".join(drifted_ids[:50]),
+    )
+    try:
+        import sentry_sdk
+
+        sentry_sdk.capture_message(
+            f"reconcile-subscriptions corrected {reconciled} drifted subscription(s)",
+            level="warning",
+        )
+    except Exception:  # noqa: BLE001 — Sentry is best-effort, never block the job
+        logger.debug("Sentry capture skipped (SDK unavailable).")
+
+
+def reconcile_subscriptions(
+    *, dry_run: bool = False, flask_app: Flask | None = None
+) -> dict[str, Any]:
+    """Poll the gateway and realign every drifted subscription.
+
+    Returns a summary dict: ``{"checked", "reconciled", "errors"}``.
+    """
+    from app import create_app
+    from app.models.subscription import Subscription, SubscriptionStatus
+    from app.services.billing_adapter import get_default_billing_provider
+    from app.services.subscription_service import apply_subscription_snapshot
+
+    app = flask_app or create_app(enable_http_runtime=False)
+
+    checked = 0
+    reconciled = 0
+    errors = 0
+    drifted_ids: list[str] = []
+
+    with app.app_context():
+        provider = get_default_billing_provider()
+        candidates: list[Subscription] = Subscription.query.filter(
+            Subscription.status.in_(
+                [
+                    SubscriptionStatus.ACTIVE,
+                    SubscriptionStatus.TRIALING,
+                    SubscriptionStatus.PAST_DUE,
+                ]
+            ),
+            Subscription.provider_subscription_id.isnot(None),
+        ).all()
+
+        for sub in candidates:
+            provider_id = sub.provider_subscription_id
+            # A ``bill_`` placeholder means the completed webhook never arrived —
+            # there is no real subscription to poll yet, so skip it.
+            if not provider_id or provider_id.startswith("bill_"):
+                continue
+            checked += 1
+            try:
+                snapshot = provider.get_subscription(provider_id)
+            except Exception:  # noqa: BLE001 — one bad poll must not kill the batch
+                errors += 1
+                logger.warning(
+                    "reconcile-subscriptions: get_subscription failed for "
+                    "subscription_id=%s provider_id=%s — skipping",
+                    sub.id,
+                    provider_id,
+                )
+                continue
+
+            if not _snapshot_diverges(sub, snapshot):
+                continue
+
+            reconciled += 1
+            drifted_ids.append(str(sub.id))
+            logger.info(
+                "reconcile-subscriptions: drift on subscription_id=%s user_id=%s "
+                "local_status=%s gateway_status=%s%s",
+                sub.id,
+                sub.user_id,
+                sub.status.value,
+                snapshot.get("status"),
+                " (dry-run)" if dry_run else "",
+            )
+            if not dry_run:
+                apply_subscription_snapshot(sub, snapshot)
+
+        if reconciled and not dry_run:
+            _alert_drift(reconciled, drifted_ids)
+
+    logger.info(
+        "reconcile-subscriptions: checked=%d reconciled=%d errors=%d%s",
+        checked,
+        reconciled,
+        errors,
+        " (dry-run)" if dry_run else "",
+    )
+    return {"checked": checked, "reconciled": reconciled, "errors": errors}
+
+
+def main() -> None:
+    args = _parse_args()
+    summary = reconcile_subscriptions(dry_run=args.dry_run)
+    prefix = "[dry-run] " if args.dry_run else ""
+    print(
+        f"{prefix}checked={summary['checked']} "
+        f"reconciled={summary['reconciled']} errors={summary['errors']}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_billing_reconciliation.py
+++ b/tests/test_billing_reconciliation.py
@@ -1,0 +1,116 @@
+"""#1600 — reconcile local subscriptions against the gateway (lost-webhook drift)."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from app.extensions.database import db
+from app.models.subscription import BillingCycle, Subscription, SubscriptionStatus
+from app.models.user import User
+from scripts.reconcile_subscriptions import reconcile_subscriptions
+
+
+class _FakeProvider:
+    def __init__(
+        self,
+        snapshots: dict[str, dict[str, Any]] | None = None,
+        raise_for: set[str] | None = None,
+    ) -> None:
+        self._snapshots = snapshots or {}
+        self._raise_for = raise_for or set()
+
+    def get_subscription(self, provider_id: str) -> dict[str, Any]:
+        if provider_id in self._raise_for:
+            raise RuntimeError("gateway unavailable")
+        return self._snapshots.get(provider_id, {"status": "active"})
+
+
+def _make_sub(status: SubscriptionStatus, provider_id: str | None) -> Subscription:
+    suffix = uuid.uuid4().hex[:8]
+    user = User(
+        id=uuid.uuid4(),
+        name=f"u-{suffix}",
+        email=f"recon-{suffix}@email.com",
+        password="hash",
+    )
+    db.session.add(user)
+    db.session.commit()
+    sub = Subscription(
+        user_id=user.id,
+        plan_code="premium",
+        status=status,
+        billing_cycle=BillingCycle.MONTHLY,
+        provider="abacatepay",
+        provider_subscription_id=provider_id,
+        provider_customer_id=f"cust_{suffix}",
+    )
+    db.session.add(sub)
+    db.session.commit()
+    return sub
+
+
+def _patch_provider(monkeypatch, provider: _FakeProvider) -> None:
+    monkeypatch.setattr(
+        "app.services.billing_adapter.get_default_billing_provider",
+        lambda: provider,
+    )
+
+
+def test_reconcile_corrects_drift(app, monkeypatch) -> None:
+    with app.app_context():
+        sub = _make_sub(SubscriptionStatus.ACTIVE, "subs_1")
+        _patch_provider(monkeypatch, _FakeProvider({"subs_1": {"status": "canceled"}}))
+
+        summary = reconcile_subscriptions(dry_run=False, flask_app=app)
+
+        assert summary == {"checked": 1, "reconciled": 1, "errors": 0}
+        refreshed = Subscription.query.filter_by(id=sub.id).first()
+        assert refreshed is not None
+        assert refreshed.status == SubscriptionStatus.CANCELED
+
+
+def test_reconcile_noop_when_in_sync(app, monkeypatch) -> None:
+    with app.app_context():
+        sub = _make_sub(SubscriptionStatus.ACTIVE, "subs_1")
+        _patch_provider(monkeypatch, _FakeProvider({"subs_1": {"status": "active"}}))
+
+        summary = reconcile_subscriptions(dry_run=False, flask_app=app)
+
+        assert summary == {"checked": 1, "reconciled": 0, "errors": 0}
+        refreshed = Subscription.query.filter_by(id=sub.id).first()
+        assert refreshed is not None
+        assert refreshed.status == SubscriptionStatus.ACTIVE
+
+
+def test_reconcile_skips_provider_errors(app, monkeypatch) -> None:
+    with app.app_context():
+        _make_sub(SubscriptionStatus.ACTIVE, "subs_1")
+        _patch_provider(monkeypatch, _FakeProvider(raise_for={"subs_1"}))
+
+        summary = reconcile_subscriptions(dry_run=False, flask_app=app)
+
+        assert summary == {"checked": 1, "reconciled": 0, "errors": 1}
+
+
+def test_reconcile_dry_run_detects_but_does_not_apply(app, monkeypatch) -> None:
+    with app.app_context():
+        sub = _make_sub(SubscriptionStatus.ACTIVE, "subs_1")
+        _patch_provider(monkeypatch, _FakeProvider({"subs_1": {"status": "canceled"}}))
+
+        summary = reconcile_subscriptions(dry_run=True, flask_app=app)
+
+        assert summary == {"checked": 1, "reconciled": 1, "errors": 0}
+        refreshed = Subscription.query.filter_by(id=sub.id).first()
+        assert refreshed is not None
+        assert refreshed.status == SubscriptionStatus.ACTIVE
+
+
+def test_reconcile_skips_bill_placeholder(app, monkeypatch) -> None:
+    with app.app_context():
+        _make_sub(SubscriptionStatus.ACTIVE, "bill_not_yet_real")
+        _patch_provider(monkeypatch, _FakeProvider())
+
+        summary = reconcile_subscriptions(dry_run=False, flask_app=app)
+
+        assert summary == {"checked": 0, "reconciled": 0, "errors": 0}


### PR DESCRIPTION
## Contexto

O sync de assinatura é **lazy** (`GET /subscriptions/me`) + webhook. Um webhook **perdido e não-redelivered**, para um usuário que não abre a tela, gera **drift permanente**: pagou sem premium, ou cancelou ainda premium. O `billing-webhooks-retry-job` só reprocessa webhooks **recebidos** (status FAILED) — não cobre os nunca entregues.

## O que muda

- **`flask billing reconcile-subscriptions`** (+ `scripts/reconcile_subscriptions.py`): varre assinaturas `active/trialing/past_due` com `provider_subscription_id` real, faz `get_subscription` no gateway e aplica `apply_subscription_snapshot` **só quando diverge** (compara status/plano; campos ausentes no snapshot nunca são lidos como downgrade). Placeholder `bill_` (webhook de completed nunca chegou) é pulado. Erro de um poll não derruba o batch.
- **Alerta Sentry** quando `reconciled > 0` — drift é sinal de webhook quebrado (log estruturado + `sentry_sdk.capture_message`, best-effort).
- **Workflow agendado** `reconcile-subscriptions-job.yml` — cron diário 08:30 UTC (após os downgrades das 08:00), via OIDC + SSM, com issue automática em caso de falha.

## Validação

- `run_ci_quality_local.sh --local` — **verde**: 2836 passed, coverage **91.47%**, ruff+mypy+bandit+pip-audit OK.
- 5 testes: drift corrigido, no-op quando em sync, erro do provider tratado (não crasha), dry-run detecta sem aplicar, placeholder `bill_` pulado.

## Risco residual
Baixo. Job read-mostly (só escreve em divergência real, via a mesma maquinaria idempotente do webhook). `apply_subscription_snapshot` ignora campos `None`, então um snapshot parcial não zera períodos.

Closes #1600
