### PR TITLE
feat(billing): troca de plano (upgrade/downgrade) sem cobrança dupla — REST + GraphQL (#1597)

### DIFF
--- a/app/controllers/subscription_controller.py
+++ b/app/controllers/subscription_controller.py
@@ -50,6 +50,7 @@ from app.services.billing_adapter import (
 from app.services.premium_override_service import has_active_premium_override
 from app.services.subscription_service import (
     cancel_subscription,
+    change_subscription_plan,
     get_or_create_subscription,
     sync_subscription_from_provider,
 )
@@ -214,6 +215,75 @@ def cancel_my_subscription() -> ResponseReturnValue:
         return _err("Failed to cancel subscription", "INTERNAL_ERROR", 500)
 
     return _ok({"subscription": serialize_subscription(sub)})
+
+
+# ---------------------------------------------------------------------------
+# POST /subscriptions/change-plan
+# ---------------------------------------------------------------------------
+
+
+@subscription_bp.post("/change-plan")
+def change_my_plan() -> ResponseReturnValue:
+    """Swap the authenticated user's plan without double-charging (#1597).
+
+    Cancels the current gateway subscription before issuing the new checkout, so
+    a monthly↔annual switch never leaves two active subscriptions billing.
+    """
+    auth, user = get_active_user()
+
+    body: dict[str, Any] = request.get_json(silent=True) or {}
+    plan_slug: str | None = body.get("plan_slug")
+    if not plan_slug:
+        return _err("plan_slug is required", "VALIDATION_ERROR", 400)
+
+    billing_cycle_raw: str | None = (
+        str(body.get("billing_cycle") or "").strip().lower() or None
+    )
+    if billing_cycle_raw:
+        offer = resolve_checkout_plan_offer(
+            f"{plan_slug}_{billing_cycle_raw}"
+        ) or resolve_checkout_plan_offer(plan_slug)
+    else:
+        offer = resolve_checkout_plan_offer(plan_slug)
+
+    if offer is None:
+        return _err("Unsupported plan_slug", "VALIDATION_ERROR", 400)
+
+    sub = get_or_create_subscription(UUID(auth.subject))
+    if sub.plan_code == offer.plan_code and sub.billing_cycle == offer.billing_cycle:
+        return _err("Already on this plan", "ALREADY_ON_PLAN", 409)
+
+    provider = _get_provider()
+    try:
+        result = change_subscription_plan(
+            sub,
+            provider,
+            offer,
+            BillingCheckoutCustomer(
+                user_id=str(UUID(auth.subject)),
+                name=str(user.name),
+                email=str(user.email),
+            ),
+        )
+    except BillingProviderError:
+        current_app.logger.exception("Failed to change plan")
+        return _err("Failed to change plan", "UPSTREAM_ERROR", 502)
+    except Exception:
+        current_app.logger.exception("Failed to change plan")
+        return _err("Failed to change plan", "INTERNAL_ERROR", 500)
+
+    return _ok(
+        {
+            "plan_slug": offer.slug,
+            "plan_code": offer.plan_code,
+            "billing_cycle": (
+                offer.billing_cycle.value if offer.billing_cycle else None
+            ),
+            "checkout_url": result.get("checkout_url"),
+            "provider": result.get("provider"),
+        },
+        201,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/app/extensions/audit_trail.py
+++ b/app/extensions/audit_trail.py
@@ -161,6 +161,44 @@ def record_entity_delete(
         )
 
 
+def record_entity_change(
+    *,
+    entity_type: str,
+    entity_id: str,
+    actor_id: str | None,
+    action: str,
+    extra: str | None = None,
+) -> None:
+    """Persist a state-change audit event for a domain entity.
+
+    Sibling of :func:`record_entity_delete` for non-delete mutations (e.g. a
+    billing plan change), so the audit trail records the real ``action`` instead
+    of mislabelling it as a delete.
+    """
+    if not _is_audit_persistence_enabled():
+        return
+    try:
+        event = AuditEvent(
+            method="SYSTEM",
+            path="",
+            status=0,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            action=action,
+            actor_id=actor_id,
+            extra=extra,
+        )
+        db.session.add(event)
+        db.session.flush()
+    except Exception:
+        current_app.logger.exception(
+            "audit_entity_change_failed entity_type=%s entity_id=%s action=%s",
+            entity_type,
+            _safe_log_id(entity_id),
+            action,
+        )
+
+
 def register_audit_trail(app: Flask) -> None:
     if not _is_audit_trail_enabled():
         return

--- a/app/graphql/docs_catalog.py
+++ b/app/graphql/docs_catalog.py
@@ -614,6 +614,15 @@ GRAPHQL_OPERATION_CATALOG: tuple[GraphQLOperationDoc, ...] = (
         summary="Cancela a assinatura ativa do usuário autenticado.",
         source_module=MUTATION_SUBSCRIPTION_MODULE,
     ),
+    GraphQLOperationDoc(
+        name="changeSubscriptionPlan",
+        operation_type="mutation",
+        domain="billing",
+        access="auth_required",
+        summary="Troca o plano da assinatura sem cobrança dupla (cancela o atual "
+        "antes de criar o novo checkout).",
+        source_module=MUTATION_SUBSCRIPTION_MODULE,
+    ),
     # Notification preferences
     GraphQLOperationDoc(
         name="notificationPreferences",

--- a/app/graphql/mutations/__init__.py
+++ b/app/graphql/mutations/__init__.py
@@ -60,6 +60,7 @@ from app.graphql.mutations.simulation import (
 )
 from app.graphql.mutations.subscription import (
     CancelSubscriptionMutation,
+    ChangeSubscriptionPlanMutation,
     CreateCheckoutSessionMutation,
 )
 from app.graphql.mutations.tag import (
@@ -170,6 +171,9 @@ class Mutation(graphene.ObjectType):
     )
     cancel_subscription = CancelSubscriptionMutation.Field(
         deprecation_reason="ADR-0004: use POST /subscription/cancel"
+    )
+    change_subscription_plan = ChangeSubscriptionPlanMutation.Field(
+        deprecation_reason="ADR-0004: use POST /subscription/change-plan"
     )
     update_notification_preferences = UpdateNotificationPreferencesMutation.Field()
     revoke_session = RevokeSessionMutation.Field()

--- a/app/graphql/mutations/subscription.py
+++ b/app/graphql/mutations/subscription.py
@@ -34,6 +34,7 @@ from app.services.billing_adapter import (
 )
 from app.services.subscription_service import (
     cancel_subscription,
+    change_subscription_plan,
     get_or_create_subscription,
 )
 
@@ -138,4 +139,78 @@ class CancelSubscriptionMutation(graphene.Mutation):
             ok=True,
             message="Assinatura cancelada com sucesso",
             subscription=_to_subscription_type(_serialize_subscription(sub)),
+        )
+
+
+class ChangeSubscriptionPlanMutation(graphene.Mutation):
+    """Swap plan without double-charging (#1597); mirrors REST /change-plan."""
+
+    class Arguments:
+        plan_slug = graphene.String(required=True)
+        billing_cycle = SubscriptionBillingCycleEnum()
+
+    message = graphene.String(required=True)
+    checkout = graphene.Field(CheckoutSessionType, required=True)
+
+    @log_graphql_resolver("changeSubscriptionPlan")
+    def mutate(
+        self,
+        info: graphene.ResolveInfo,
+        plan_slug: str,
+        billing_cycle: object | None = None,
+    ) -> "ChangeSubscriptionPlanMutation":
+        user = get_current_user_required()
+        billing_cycle_value = coerce_enum_value(billing_cycle)
+        billing_cycle = (
+            str(billing_cycle_value) if billing_cycle_value is not None else None
+        )
+
+        if billing_cycle:
+            composed = f"{plan_slug}_{billing_cycle.strip().lower()}"
+            offer = resolve_checkout_plan_offer(
+                composed
+            ) or resolve_checkout_plan_offer(plan_slug)
+        else:
+            offer = resolve_checkout_plan_offer(plan_slug)
+
+        if offer is None:
+            raise build_public_graphql_error(
+                "plan_slug inválido", code=GRAPHQL_ERROR_CODE_VALIDATION
+            )
+
+        sub = get_or_create_subscription(UUID(str(user.id)))
+        if (
+            sub.plan_code == offer.plan_code
+            and sub.billing_cycle == offer.billing_cycle
+        ):
+            raise build_public_graphql_error(
+                "Você já está neste plano", code=GRAPHQL_ERROR_CODE_CONFLICT
+            )
+
+        provider = get_default_billing_provider()
+        try:
+            result = change_subscription_plan(
+                sub,
+                provider,
+                offer,
+                BillingCheckoutCustomer(
+                    user_id=str(UUID(str(user.id))),
+                    name=str(user.name),
+                    email=str(user.email),
+                ),
+            )
+        except BillingProviderError as exc:
+            raise build_public_graphql_error(
+                str(exc) or "Erro ao trocar de plano",
+                code=GRAPHQL_ERROR_CODE_VALIDATION,
+            ) from exc
+
+        return ChangeSubscriptionPlanMutation(
+            message="Troca de plano iniciada com sucesso",
+            checkout=CheckoutSessionType(
+                checkout_url=result.get("checkout_url") or "",
+                provider=result.get("provider") or "",
+                provider_customer_id=result.get("provider_customer_id"),
+                provider_subscription_id=result.get("provider_subscription_id"),
+            ),
         )

--- a/app/services/subscription_service.py
+++ b/app/services/subscription_service.py
@@ -14,12 +14,21 @@ from uuid import UUID
 
 from flask import current_app, has_app_context
 
-from app.config.billing_plans import parse_billing_cycle, resolve_checkout_plan_offer
+from app.config.billing_plans import (
+    BillingPlanOffer,
+    parse_billing_cycle,
+    resolve_checkout_plan_offer,
+)
 from app.config.plan_features import PLAN_FEATURES
 from app.extensions.database import db
 from app.models.subscription import BillingCycle, Subscription, SubscriptionStatus
 from app.models.user import User
-from app.services.billing_adapter import BillingProvider, BillingSubscriptionSnapshot
+from app.services.billing_adapter import (
+    BillingCheckoutCustomer,
+    BillingCheckoutSession,
+    BillingProvider,
+    BillingSubscriptionSnapshot,
+)
 from app.services.entitlement_service import sync_entitlements_from_subscription
 from app.utils.datetime_utils import utc_now_naive
 
@@ -344,6 +353,68 @@ def cancel_subscription(
     if not snapshot.provider_subscription_id:
         _dispatch_local_cancellation_email(snapshot)
     return snapshot
+
+
+def change_subscription_plan(
+    subscription: Subscription,
+    provider: BillingProvider,
+    new_offer: BillingPlanOffer,
+    customer: BillingCheckoutCustomer,
+) -> BillingCheckoutSession:
+    """Swap the active plan without ever double-charging (#1597).
+
+    Ordering is the safety guarantee: the current subscription is canceled at the
+    gateway **before** the new checkout is created, so there are never two active
+    subscriptions billing in parallel. If the cancel raises, the new checkout is
+    never created — no double charge.
+
+    Entitlements stay continuous: local ``status``, ``plan_code`` and
+    ``current_period_end`` are left untouched, so the user keeps premium on the
+    period they already paid for; the new plan lands when the gateway delivers the
+    ``subscription.completed`` webhook. The local record is pointed at the new
+    ``bill_`` placeholder so the reconciliation job (#1600) skips it until then.
+    If the user abandons the new checkout, entitlements simply expire at the old
+    period end — no indefinite free premium.
+
+    Returns the new checkout session (hosted URL for the user to pay).
+    """
+    from app.extensions.audit_trail import record_entity_change
+
+    old_provider_id = subscription.provider_subscription_id
+    # 1. Cancel the current subscription at the gateway FIRST. Only a real
+    #    ``subs_`` id has active billing — a ``bill_`` placeholder (an earlier
+    #    unpaid swap/checkout) has nothing to cancel.
+    if old_provider_id and not old_provider_id.startswith("bill_"):
+        provider.cancel_subscription(old_provider_id)
+
+    # 2. Only now create the new checkout. A failure here leaves the user on their
+    #    already-paid period (premium intact) and never double-charged.
+    result = provider.create_checkout_session(
+        customer=customer, plan_slug=new_offer.slug
+    )
+
+    # 3. Point the local record at the new bill_ placeholder; leave status/plan/
+    #    period untouched so premium is continuous and reconciliation skips it
+    #    until the completed webhook promotes the real subscription id + plan.
+    new_provider_id = result.get("provider_subscription_id")
+    if isinstance(new_provider_id, str) and new_provider_id.strip():
+        subscription.provider_subscription_id = new_provider_id.strip()
+    provider_name = str(result.get("provider") or "").strip()
+    if provider_name:
+        subscription.provider = provider_name
+    provider_customer_id = result.get("provider_customer_id")
+    if isinstance(provider_customer_id, str) and provider_customer_id.strip():
+        subscription.provider_customer_id = provider_customer_id.strip()
+    db.session.commit()
+
+    record_entity_change(
+        entity_type="subscription",
+        entity_id=str(subscription.id),
+        actor_id=str(subscription.user_id),
+        action="plan_change",
+        extra=f"to={new_offer.slug}",
+    )
+    return result
 
 
 def _dispatch_local_cancellation_email(subscription: Subscription) -> None:

--- a/graphql.introspection.json
+++ b/graphql.introspection.json
@@ -13589,6 +13589,47 @@
                   "deprecationReason": null,
                   "description": null,
                   "isDeprecated": false,
+                  "name": "billingCycle",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "BillingCycle",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "planSlug",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": "ADR-0004: use POST /subscription/change-plan",
+              "description": "Swap plan without double-charging (#1597); mirrors REST /change-plan.",
+              "isDeprecated": true,
+              "name": "changeSubscriptionPlan",
+              "type": {
+                "kind": "OBJECT",
+                "name": "ChangeSubscriptionPlanMutation",
+                "ofType": null
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
                   "name": "preferences",
                   "type": {
                     "kind": "NON_NULL",
@@ -16194,6 +16235,50 @@
           "interfaces": [],
           "kind": "OBJECT",
           "name": "CancelSubscriptionMutation",
+          "possibleTypes": null,
+          "specifiedByURL": null
+        },
+        {
+          "description": "Swap plan without double-charging (#1597); mirrors REST /change-plan.",
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "message",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "checkout",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CheckoutSessionType",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "ChangeSubscriptionPlanMutation",
           "possibleTypes": null,
           "specifiedByURL": null
         },

--- a/graphql.operations.manifest.json
+++ b/graphql.operations.manifest.json
@@ -520,6 +520,14 @@
   },
   {
     "access": "auth_required",
+    "domain": "billing",
+    "name": "changeSubscriptionPlan",
+    "operation_type": "mutation",
+    "source_module": "app.graphql.mutations.subscription",
+    "summary": "Troca o plano da assinatura sem cobrança dupla (cancela o atual antes de criar o novo checkout)."
+  },
+  {
+    "access": "auth_required",
     "domain": "notifications",
     "name": "notificationPreferences",
     "operation_type": "query",

--- a/schema.graphql
+++ b/schema.graphql
@@ -891,6 +891,9 @@ type Mutation {
   deleteBudget(budgetId: UUID!): DeleteBudgetMutation @deprecated(reason: "ADR-0002: use DELETE /budgets/{id}")
   createCheckoutSession(billingCycle: BillingCycle, planSlug: String!): CreateCheckoutSessionMutation @deprecated(reason: "ADR-0004: use POST /subscription/checkout")
   cancelSubscription: CancelSubscriptionMutation @deprecated(reason: "ADR-0004: use POST /subscription/cancel")
+
+  """Swap plan without double-charging (#1597); mirrors REST /change-plan."""
+  changeSubscriptionPlan(billingCycle: BillingCycle, planSlug: String!): ChangeSubscriptionPlanMutation @deprecated(reason: "ADR-0004: use POST /subscription/change-plan")
   updateNotificationPreferences(preferences: [PreferenceInput!]!): UpdateNotificationPreferencesPayload
 
   """Revoke a specific session by ID (multi-device, #1028)."""
@@ -1266,6 +1269,12 @@ type CancelSubscriptionMutation {
   ok: Boolean!
   message: String!
   subscription: SubscriptionType!
+}
+
+"""Swap plan without double-charging (#1597); mirrors REST /change-plan."""
+type ChangeSubscriptionPlanMutation {
+  message: String!
+  checkout: CheckoutSessionType!
 }
 
 """Canonical payload for updateNotificationPreferences mutation."""

--- a/tests/test_billing_plan_change.py
+++ b/tests/test_billing_plan_change.py
@@ -1,0 +1,225 @@
+"""#1597 — plan upgrade/downgrade without double-charging.
+
+The safety invariant: the current subscription is canceled at the gateway BEFORE
+the new checkout is created, so a monthly↔annual switch never leaves two active
+subscriptions billing in parallel. Entitlements stay continuous (local state is
+untouched; the new plan lands via the completed webhook).
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import pytest
+
+from app.config.billing_plans import resolve_checkout_plan_offer
+from app.extensions.database import db
+from app.models.audit_event import AuditEvent
+from app.models.subscription import BillingCycle, Subscription, SubscriptionStatus
+from app.models.user import User
+from app.services.billing_adapter import BillingCheckoutCustomer, BillingProviderError
+from app.services.subscription_service import change_subscription_plan
+
+_ANNUAL = resolve_checkout_plan_offer("premium_annual")
+
+
+class _FakeProvider:
+    def __init__(
+        self, *, cancel_raises: bool = False, checkout: dict[str, Any] | None = None
+    ) -> None:
+        self.calls: list[tuple[str, str]] = []
+        self._cancel_raises = cancel_raises
+        self._checkout = checkout or {
+            "checkout_url": "https://pay.test/bill_new",
+            "provider": "abacatepay",
+            "provider_customer_id": "cust_new",
+            "provider_subscription_id": "bill_new",
+        }
+
+    def cancel_subscription(self, provider_id: str) -> dict[str, Any]:
+        self.calls.append(("cancel", provider_id))
+        if self._cancel_raises:
+            raise BillingProviderError("cancel failed")
+        return {"status": "canceled"}
+
+    def create_checkout_session(
+        self, *, customer: BillingCheckoutCustomer, plan_slug: str
+    ) -> dict[str, Any]:
+        self.calls.append(("checkout", plan_slug))
+        return self._checkout
+
+    def get_subscription(self, provider_id: str) -> dict[str, Any]:
+        return {"status": "active"}
+
+
+def _make_active_sub(provider_sub_id: str) -> tuple[User, Subscription]:
+    suffix = uuid.uuid4().hex[:8]
+    user = User(
+        id=uuid.uuid4(),
+        name=f"u-{suffix}",
+        email=f"pc-{suffix}@email.com",
+        password="hash",
+    )
+    db.session.add(user)
+    db.session.commit()
+    sub = Subscription(
+        user_id=user.id,
+        plan_code="premium",
+        status=SubscriptionStatus.ACTIVE,
+        billing_cycle=BillingCycle.MONTHLY,
+        provider="abacatepay",
+        provider_subscription_id=provider_sub_id,
+        provider_customer_id=f"cust_{suffix}",
+    )
+    db.session.add(sub)
+    db.session.commit()
+    return user, sub
+
+
+def _customer(user: User) -> BillingCheckoutCustomer:
+    return BillingCheckoutCustomer(
+        user_id=str(user.id), name=str(user.name), email=str(user.email)
+    )
+
+
+def test_change_plan_cancels_old_before_new_checkout(app) -> None:
+    with app.app_context():
+        user, sub = _make_active_sub("subs_old")
+        fake = _FakeProvider()
+
+        result = change_subscription_plan(sub, fake, _ANNUAL, _customer(user))
+
+        # Cancel must precede checkout — never two active subscriptions.
+        assert [c[0] for c in fake.calls] == ["cancel", "checkout"]
+        assert fake.calls[0][1] == "subs_old"
+        assert fake.calls[1][1] == "premium_annual"
+        assert result["checkout_url"] == "https://pay.test/bill_new"
+        # Continuity: local state untouched; pointed at the new placeholder.
+        assert sub.status == SubscriptionStatus.ACTIVE
+        assert sub.plan_code == "premium"
+        assert sub.billing_cycle == BillingCycle.MONTHLY
+        assert sub.provider_subscription_id == "bill_new"
+
+
+def test_change_plan_skips_cancel_for_bill_placeholder(app) -> None:
+    with app.app_context():
+        user, sub = _make_active_sub("bill_pending")
+        fake = _FakeProvider()
+
+        change_subscription_plan(sub, fake, _ANNUAL, _customer(user))
+
+        # A bill_ placeholder has no active billing to cancel.
+        assert [c[0] for c in fake.calls] == ["checkout"]
+
+
+def test_change_plan_aborts_when_cancel_fails(app) -> None:
+    with app.app_context():
+        user, sub = _make_active_sub("subs_old")
+        fake = _FakeProvider(cancel_raises=True)
+
+        with pytest.raises(BillingProviderError):
+            change_subscription_plan(sub, fake, _ANNUAL, _customer(user))
+
+        # New checkout was never created → no double charge; state untouched.
+        assert [c[0] for c in fake.calls] == ["cancel"]
+        assert sub.provider_subscription_id == "subs_old"
+
+
+def test_change_plan_records_audit(app, monkeypatch) -> None:
+    monkeypatch.setenv("AUDIT_PERSISTENCE_ENABLED", "true")
+    with app.app_context():
+        user, sub = _make_active_sub("subs_old")
+        fake = _FakeProvider()
+
+        change_subscription_plan(sub, fake, _ANNUAL, _customer(user))
+
+        events = AuditEvent.query.filter_by(
+            entity_id=str(sub.id), action="plan_change"
+        ).all()
+        assert len(events) == 1
+        assert events[0].extra == "to=premium_annual"
+
+
+# ── REST surface ────────────────────────────────────────────────────────────
+
+
+def _register_active_premium(app, client) -> str:
+    suffix = uuid.uuid4().hex[:8]
+    email = f"rest-pc-{suffix}@email.com"
+    resp = client.post(
+        "/auth/register",
+        json={"name": f"u-{suffix}", "email": email, "password": "StrongPass@123"},
+    )
+    assert resp.status_code == 201
+    login = client.post(
+        "/auth/login", json={"email": email, "password": "StrongPass@123"}
+    )
+    token = login.get_json()["token"]
+    with app.app_context():
+        user = User.query.filter_by(email=email).first()
+        sub = Subscription.query.filter_by(user_id=user.id).first()
+        if sub is None:
+            sub = Subscription(
+                user_id=user.id, plan_code="free", status=SubscriptionStatus.FREE
+            )
+            db.session.add(sub)
+        sub.status = SubscriptionStatus.ACTIVE
+        sub.plan_code = "premium"
+        sub.billing_cycle = BillingCycle.MONTHLY
+        sub.provider = "abacatepay"
+        sub.provider_subscription_id = "subs_rest_old"
+        db.session.commit()
+    return token
+
+
+def test_rest_change_plan_happy_path(app, client, monkeypatch) -> None:
+    fake = _FakeProvider()
+    monkeypatch.setattr(
+        "app.controllers.subscription_controller.get_default_billing_provider",
+        lambda: fake,
+    )
+    token = _register_active_premium(app, client)
+
+    resp = client.post(
+        "/subscriptions/change-plan",
+        json={"plan_slug": "premium", "billing_cycle": "annual"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert resp.status_code == 201
+    data = resp.get_json()["data"]
+    assert data["billing_cycle"] == "annual"
+    assert data["checkout_url"] == "https://pay.test/bill_new"
+    assert [c[0] for c in fake.calls] == ["cancel", "checkout"]
+
+
+def test_rest_change_plan_same_plan_conflicts(app, client, monkeypatch) -> None:
+    fake = _FakeProvider()
+    monkeypatch.setattr(
+        "app.controllers.subscription_controller.get_default_billing_provider",
+        lambda: fake,
+    )
+    token = _register_active_premium(app, client)
+
+    resp = client.post(
+        "/subscriptions/change-plan",
+        json={"plan_slug": "premium", "billing_cycle": "monthly"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert resp.status_code == 409
+    # Guarded before touching the gateway.
+    assert fake.calls == []
+
+
+def test_rest_change_plan_invalid_plan(app, client, monkeypatch) -> None:
+    token = _register_active_premium(app, client)
+
+    resp = client.post(
+        "/subscriptions/change-plan",
+        json={"plan_slug": "does_not_exist"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert resp.status_code == 400

--- a/tests/test_postman_collection_contract.py
+++ b/tests/test_postman_collection_contract.py
@@ -76,6 +76,7 @@ OPENAPI_GAPS: set[tuple[str, str]] = {
     ("GET", "/subscriptions/me"),
     ("POST", "/subscriptions/checkout"),
     ("POST", "/subscriptions/cancel"),
+    ("POST", "/subscriptions/change-plan"),
     ("POST", "/subscriptions/webhook"),
     ("POST", "/subscriptions/webhook/{param}"),
     # Shared entries


### PR DESCRIPTION
## Contexto

Existiam só checkout novo (`POST /subscriptions/checkout`) e cancel — **não havia troca de plano**. Trocar mensal↔anual disparava um **novo checkout**, que no AbacatePay cria uma **segunda assinatura paralela** → risco de **cobrança dupla**.

## O que muda

Novo `change_subscription_plan` (serviço) + endpoint **REST** `POST /subscriptions/change-plan` e **mutation GraphQL** `changeSubscriptionPlan` (paridade; deprecated→REST no mesmo padrão dos demais, ADR-0004).

### Invariante de segurança (nunca cobra duas vezes)
A ordem é a garantia: **cancela a assinatura atual no gateway ANTES de criar o novo checkout**. Se o cancel falhar → o novo checkout **nunca** é criado (aborta) → sem cobrança dupla. Nunca há duas assinaturas ativas faturando.

### Continuidade de entitlements (sem flicker)
`status`, `plan_code` e `current_period_end` locais ficam **intocados** — o usuário mantém premium no período que já pagou; o **novo plano entra pelo webhook `subscription.completed`**. O registro local aponta para o novo placeholder `bill_`, então o **job de reconciliação (#1600) o ignora** até a promoção. Se o usuário abandonar o novo checkout, os entitlements simplesmente **expiram no fim do período** (via `expires_at`) — sem premium grátis indefinido.

### Decisão de proration (registrada)
**Sem crédito de proration.** O AbacatePay não expõe proration nem troca agendada (só create-checkout + cancel), então o modelo correto é cancelar o atual e emitir um checkout novo para o plano novo; o novo plano fatura na conclusão. Documentado no docstring do serviço.

### Auditoria
`record_entity_change(action="plan_change", extra="to=<offer>")` — novo helper de auditoria (irmão do `record_entity_delete`) para não mislabelar a troca como delete.

## Validação

- `run_ci_quality_local.sh --local` — **verde** (coverage ~91%, ruff+mypy+bandit+pip-audit + hooks de arquitetura GraphQL).
- 7 testes: ordem cancel→checkout (nunca 2 ativas); placeholder `bill_` pula o cancel; **falha no cancel aborta sem criar checkout**; continuidade (status/plano intocados); auditoria registrada; REST happy-path (201) + já-no-plano (409) + plano inválido (400).
- `test_graphql_auth_everywhere` verde → a nova mutation exige auth.

## Risco residual
Médio-baixo. Mexe em cobrança real, mas a ordem cancel-antes-de-checkout elimina o double-charge e a continuidade via `expires_at` evita leak. **Edge documentado como follow-up**: se o usuário trocar e abandonar o novo checkout, fica um `bill_` placeholder no registro (premium expira no período; sem cobrança) — o reconcile poderia futuramente expirar placeholders `bill_` velhos. Nomes de evento/estado do gateway seguem pendentes de confirmação (platform#891).

Closes #1597
