### PR TITLE
feat(emails): identidade visual nova + copy + CTAs com deep-link (transação e insight)

### DIFF
--- a/app/application/services/billing_email_service.py
+++ b/app/application/services/billing_email_service.py
@@ -7,6 +7,15 @@ from app.controllers.billing_webhook_parsers import (
     ABACATEPAY_REFUND_EVENTS,
 )
 from app.services.email_provider import EmailMessage
+from app.services.email_templates.base import (
+    render_billing_canceled_email,
+    render_billing_grace_expired_email,
+    render_billing_payment_confirmed_email,
+    render_billing_payment_failed_email,
+    render_billing_refund_email,
+    render_billing_trial_ending_email,
+    render_billing_trial_expired_email,
+)
 
 if TYPE_CHECKING:
     from app.models.subscription import Subscription
@@ -32,69 +41,37 @@ def _plan_label(subscription: Subscription) -> str:
 def dispatch_billing_email(
     *, user: User, subscription: Subscription, event_type: str
 ) -> None:
+    """Route a billing webhook event to its branded transactional email."""
     from app.services.outbound_queue import get_default_outbound_queue
 
     plan_label = _plan_label(subscription)
-    to_email = str(user.email)
 
     if event_type in _PAYMENT_CONFIRMED_EVENTS:
-        get_default_outbound_queue().enqueue_send_email(
-            to_email=to_email,
-            subject="Pagamento confirmado na Auraxis",
-            html=(
-                "<p>Seu pagamento foi confirmado com sucesso.</p>"
-                f"<p>Plano ativo: <strong>{plan_label}</strong></p>"
-            ),
-            text=(
-                f"Seu pagamento foi confirmado com sucesso. Plano ativo: {plan_label}."
-            ),
-            tag="billing_payment_confirmed",
-        )
+        html, text = render_billing_payment_confirmed_email(plan_label=plan_label)
+        tag = "billing_payment_confirmed"
+        subject = "Pagamento confirmado na Auraxis"
+    elif event_type in _PAYMENT_FAILED_EVENTS:
+        html, text = render_billing_payment_failed_email(plan_label=plan_label)
+        tag = "billing_payment_failed"
+        subject = "Pagamento pendente na Auraxis"
+    elif event_type in _REFUND_EVENTS:
+        html, text = render_billing_refund_email(plan_label=plan_label)
+        tag = "billing_refund"
+        subject = "Estorno processado — Auraxis"
+    elif event_type in _CANCELED_EVENTS:
+        html, text = render_billing_canceled_email(plan_label=plan_label)
+        tag = "billing_subscription_canceled"
+        subject = "Assinatura cancelada na Auraxis"
+    else:
         return
 
-    if event_type in _PAYMENT_FAILED_EVENTS:
-        get_default_outbound_queue().enqueue_send_email(
-            to_email=to_email,
-            subject="Pagamento pendente na Auraxis",
-            html=(
-                "<p>Identificamos uma pendencia no pagamento da sua assinatura.</p>"
-                f"<p>Plano impactado: <strong>{plan_label}</strong></p>"
-            ),
-            text=(
-                "Identificamos uma pendencia no pagamento da sua assinatura. "
-                f"Plano impactado: {plan_label}."
-            ),
-            tag="billing_payment_failed",
-        )
-        return
-
-    if event_type in _REFUND_EVENTS:
-        get_default_outbound_queue().enqueue_send_email(
-            to_email=to_email,
-            subject="Estorno processado — Auraxis",
-            html=(
-                "<p>Um estorno foi processado e o acesso premium foi encerrado.</p>"
-                f"<p>Plano encerrado: <strong>{plan_label}</strong></p>"
-            ),
-            text=(
-                "Um estorno foi processado e o acesso premium foi encerrado. "
-                f"Plano encerrado: {plan_label}."
-            ),
-            tag="billing_refund",
-        )
-        return
-
-    if event_type in _CANCELED_EVENTS:
-        get_default_outbound_queue().enqueue_send_email(
-            to_email=to_email,
-            subject="Assinatura cancelada na Auraxis",
-            html=(
-                "<p>Sua assinatura foi cancelada.</p>"
-                f"<p>Plano anterior: <strong>{plan_label}</strong></p>"
-            ),
-            text=(f"Sua assinatura foi cancelada. Plano anterior: {plan_label}."),
-            tag="billing_subscription_canceled",
-        )
+    get_default_outbound_queue().enqueue_send_email(
+        to_email=str(user.email),
+        subject=subject,
+        html=html,
+        text=text,
+        tag=tag,
+    )
 
 
 def build_trial_ending_email(
@@ -113,21 +90,14 @@ def build_trial_ending_email(
         if subscription.trial_ends_at is not None
         else None
     )
-    ends_sentence = f" Ele termina em {trial_ends_label}." if trial_ends_label else ""
+    html, text = render_billing_trial_ending_email(
+        days_label=days_label, trial_ends_label=trial_ends_label
+    )
     return EmailMessage(
         to_email=str(user.email),
         subject=f"Seu período de teste termina em {days_label} — Auraxis",
-        html=(
-            f"<p>Seu período de teste da Auraxis termina em "
-            f"<strong>{days_label}</strong>.{ends_sentence}</p>"
-            "<p>Assine um plano para continuar com acesso aos recursos "
-            "premium — exportação em PDF, simulações avançadas e mais.</p>"
-        ),
-        text=(
-            f"Seu período de teste da Auraxis termina em {days_label}."
-            f"{ends_sentence} "
-            "Assine um plano para continuar com acesso aos recursos premium."
-        ),
+        html=html,
+        text=text,
         tag=_TRIAL_ENDING_TAG_TEMPLATE.format(days=days_until_trial_end),
     )
 
@@ -140,21 +110,14 @@ def dispatch_trial_expired_email(*, user: User, subscription: Subscription) -> N
     """
     from app.services.outbound_queue import get_default_outbound_queue
 
-    plan_label = _plan_label(subscription)
+    html, text = render_billing_trial_expired_email(
+        plan_label=_plan_label(subscription)
+    )
     get_default_outbound_queue().enqueue_send_email(
         to_email=str(user.email),
         subject="Seu período de teste terminou — Auraxis",
-        html=(
-            "<p>Seu período de teste da Auraxis terminou e sua conta voltou "
-            f"para o plano <strong>{plan_label}</strong>.</p>"
-            "<p>Você pode assinar a qualquer momento para recuperar o acesso "
-            "aos recursos premium.</p>"
-        ),
-        text=(
-            "Seu período de teste da Auraxis terminou e sua conta voltou para "
-            f"o plano {plan_label}. Assine a qualquer momento para recuperar "
-            "o acesso aos recursos premium."
-        ),
+        html=html,
+        text=text,
         tag=_TRIAL_EXPIRED_TAG,
     )
 
@@ -169,20 +132,13 @@ def dispatch_billing_grace_expired_email(
     """
     from app.services.outbound_queue import get_default_outbound_queue
 
-    plan_label = _plan_label(subscription)
+    html, text = render_billing_grace_expired_email(
+        plan_label=_plan_label(subscription)
+    )
     get_default_outbound_queue().enqueue_send_email(
         to_email=str(user.email),
         subject="Assinatura encerrada por falta de pagamento — Auraxis",
-        html=(
-            "<p>Não conseguimos confirmar o pagamento da sua assinatura dentro "
-            "do período de tolerância, então o acesso premium foi encerrado.</p>"
-            f"<p>Plano encerrado: <strong>{plan_label}</strong></p>"
-            "<p>Regularize o pagamento para reativar quando quiser.</p>"
-        ),
-        text=(
-            "Não conseguimos confirmar o pagamento da sua assinatura dentro do "
-            "período de tolerância, então o acesso premium foi encerrado. "
-            f"Plano encerrado: {plan_label}. Regularize o pagamento para reativar."
-        ),
+        html=html,
+        text=text,
         tag="billing_grace_expired",
     )

--- a/app/application/services/transaction_reminder_service.py
+++ b/app/application/services/transaction_reminder_service.py
@@ -17,7 +17,7 @@ from app.services.email_provider import (
     EmailProviderError,
     get_default_email_provider,
 )
-from app.services.email_templates.base import render_due_soon_email
+from app.services.email_templates.base import render_due_soon_email, web_base_url
 from app.services.entitlement_service import has_entitlement
 from app.utils.datetime_utils import utc_now_naive
 
@@ -139,10 +139,19 @@ def dispatch_due_transaction_reminders(
             continue
 
         amount_str = _serialize_amount(transaction.amount)
+        # #emails: deep-link the CTA straight to the expiring transaction.
+        transaction_url = f"{web_base_url()}/transactions?open={transaction.id}"
+        due_date_label = (
+            transaction.due_date.strftime("%d/%m/%Y")
+            if transaction.due_date is not None
+            else ""
+        )
         email_html, email_text = render_due_soon_email(
             title=transaction.title,
             amount_formatted=amount_str,
             days_before_due=days_before_due,
+            due_date_label=due_date_label,
+            transaction_url=transaction_url,
         )
         subject = _build_subject(
             days_before_due=days_before_due,

--- a/app/cli/ai_insights_cli.py
+++ b/app/cli/ai_insights_cli.py
@@ -240,6 +240,7 @@ def _run_batch(
                     dispatch_analysis_ready_notification(
                         user_id=user_id,
                         summary_preview=_notification_preview(result),
+                        insight_id=result.get("id"),
                     )
                 except Exception as exc:  # noqa: BLE001
                     click.echo(

--- a/app/services/analysis_ready_notification_service.py
+++ b/app/services/analysis_ready_notification_service.py
@@ -28,7 +28,10 @@ from app.extensions.database import db
 from app.models.push_subscription import PushSubscription, PushTransport
 from app.models.user import User
 from app.services.email_provider import EmailMessage, get_default_email_provider
-from app.services.email_templates.base import render_analysis_ready_email
+from app.services.email_templates.base import (
+    render_analysis_ready_email,
+    web_base_url,
+)
 from app.services.entitlement_service import has_entitlement
 
 log = logging.getLogger(__name__)
@@ -52,6 +55,7 @@ def dispatch_analysis_ready_notification(
     *,
     user_id: UUID,
     summary_preview: str = _DEFAULT_SUMMARY,
+    insight_id: UUID | str | None = None,
 ) -> AnalysisNotificationResult:
     """Send 'analysis ready' notification to a premium user.
 
@@ -89,10 +93,16 @@ def dispatch_analysis_ready_notification(
         )
 
     first_name = _extract_first_name(user)
+    insight_url = (
+        f"{web_base_url()}/insights?open={insight_id}"
+        if insight_id
+        else f"{web_base_url()}/insights"
+    )
     email_sent = _send_email(
         to_email=str(user.email),
         first_name=first_name,
         summary_preview=summary_preview,
+        insight_url=insight_url,
     )
     push_sent = _send_expo_push(
         user_id=user_id,
@@ -116,12 +126,14 @@ def _send_email(
     to_email: str,
     first_name: str,
     summary_preview: str,
+    insight_url: str | None = None,
 ) -> bool:
     """Send the analysis-ready email. Returns True on success, False on failure."""
     try:
         html, text = render_analysis_ready_email(
             first_name=first_name,
             summary_preview=summary_preview,
+            insight_url=insight_url,
         )
         provider = get_default_email_provider()
         provider.send(

--- a/app/services/email_templates/__init__.py
+++ b/app/services/email_templates/__init__.py
@@ -2,14 +2,36 @@
 
 from .base import (
     render_account_deletion_email,
+    render_analysis_ready_email,
+    render_billing_canceled_email,
+    render_billing_grace_expired_email,
+    render_billing_payment_confirmed_email,
+    render_billing_payment_failed_email,
+    render_billing_refund_email,
+    render_billing_trial_ending_email,
+    render_billing_trial_expired_email,
     render_confirmation_email,
     render_due_soon_email,
+    render_email_verification_reminder_email,
+    render_monthly_analysis_ready_email,
     render_password_reset_email,
+    web_base_url,
 )
 
 __all__ = [
     "render_account_deletion_email",
+    "render_analysis_ready_email",
+    "render_billing_canceled_email",
+    "render_billing_grace_expired_email",
+    "render_billing_payment_confirmed_email",
+    "render_billing_payment_failed_email",
+    "render_billing_refund_email",
+    "render_billing_trial_ending_email",
+    "render_billing_trial_expired_email",
     "render_confirmation_email",
     "render_due_soon_email",
+    "render_email_verification_reminder_email",
+    "render_monthly_analysis_ready_email",
     "render_password_reset_email",
+    "web_base_url",
 ]

--- a/app/services/email_templates/base.py
+++ b/app/services/email_templates/base.py
@@ -1,10 +1,10 @@
 """Auraxis transactional email template system.
 
-All emails are rendered from a shared base layout that enforces brand
-consistency with the v3 "Market Pulse" design system: navy background,
-cyan brand colour, Inter sans-serif throughout — mirrored from the
-auraxis-web design tokens (dark variant, since emails are always rendered
-against a dark canvas).
+A single, component-based **light** layout that matches the auraxis-web brand
+(teal ``#087fa7`` → green ``#087f5b`` gradient, navy ink, purple accent),
+replacing the previous dark "Market Pulse" shell. Every transactional email —
+auth, reminders, billing and AI insights — renders through ``_base_layout`` so
+the identity, spacing and CTA style stay consistent.
 
 Usage::
 
@@ -15,29 +15,151 @@ Usage::
 
 from __future__ import annotations
 
+import os
+
 # ---------------------------------------------------------------------------
-# Brand tokens (mirrored from auraxis-web design system)
+# Brand tokens (light — mirrored from auraxis-web app/assets/css/main.css)
 # ---------------------------------------------------------------------------
 
-# v3 "Market Pulse" tokens — mirrors auraxis-web design system (dark variant).
-# Emails are always rendered against a dark navy background regardless of the
-# recipient's client preference, so we lock to the dark-mode palette here.
-_COLOR_BG_BASE = "#05070d"
-_COLOR_BG_SURFACE = "#121a2a"
-_COLOR_BG_ELEVATED = "#0e1523"
-_COLOR_BRAND = "#44d4ff"
-_COLOR_BRAND_HOVER = "#7eddff"
-_COLOR_BRAND_DARK = "#087FA7"
-_COLOR_TEXT_PRIMARY = "#f1f5ff"
-_COLOR_TEXT_SECONDARY = "#c5cee0"
-_COLOR_TEXT_MUTED = "#8b95b1"
-_COLOR_BORDER = "rgba(30, 41, 59, 0.8)"
+_COLOR_BG = "#eef3f7"  # page canvas
+_COLOR_CARD = "#ffffff"  # email card
+_COLOR_BRAND = "#087fa7"  # brand teal (--color-brand-500)
+_COLOR_BRAND_DARK = "#066985"  # --color-brand-600
+_COLOR_GREEN = "#087f5b"  # --color-positive
+_COLOR_ON_BRAND = "#ffffff"
+_COLOR_INK = "#0a1628"  # --color-text-primary
+_COLOR_INK_SOFT = "#263a56"  # --color-text-secondary
+_COLOR_MUTED = "#5d6f89"  # --color-text-muted
+_COLOR_SUBTLE = "#7a8ba3"  # --color-text-subtle
+_COLOR_BORDER = "#e6edf3"
+_COLOR_SURFACE = "#f4f8fb"  # --color-neutral-100
+_COLOR_POSITIVE = "#087f5b"
+_COLOR_NEGATIVE = "#c2414d"  # --color-negative
+_COLOR_WARNING_BG = "rgba(183, 121, 31, 0.14)"
+_COLOR_WARNING_TEXT = "#8e5e13"  # --color-warning-dark
+_COLOR_ACCENT_BG = "rgba(111, 98, 226, 0.14)"
+_COLOR_ACCENT_TEXT = "#5a4fd0"
 
-_FONT_HEADING = "'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif"
-_FONT_BODY = "'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif"
+_FONT = (
+    "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, "
+    "'Helvetica Neue', Arial, sans-serif"
+)
 
-_LOGO_URL = "https://app.auraxis.com.br/logo.png"
-_APP_URL = "https://app.auraxis.com.br"
+_DEFAULT_WEB_URL = "https://app.auraxis.com.br"
+
+
+def web_base_url() -> str:
+    """Frontend base URL for deep links, env-driven (staging vs prod).
+
+    Reads ``AURAXIS_WEB_BASE_URL`` then ``AURAXIS_APP_URL``; falls back to the
+    canonical prod URL. Trailing slash stripped so callers can append paths.
+    """
+    for var in ("AURAXIS_WEB_BASE_URL", "AURAXIS_APP_URL"):
+        value = os.getenv(var, "").strip()
+        if value:
+            return value.rstrip("/")
+    return _DEFAULT_WEB_URL
+
+
+# ---------------------------------------------------------------------------
+# Reusable components (inline-styled for email-client compatibility)
+# ---------------------------------------------------------------------------
+
+
+def _button(url: str, label: str) -> str:
+    """A branded CTA button with an Outlook (MSO) fallback."""
+    return f"""
+      <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin: 24px 0 8px;">
+        <tr>
+          <td align="left" style="border-radius: 10px; background-color: {_COLOR_BRAND};">
+            <!--[if mso]>
+            <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word"
+              href="{url}" style="height:46px;v-text-anchor:middle;width:240px;" arcsize="20%"
+              strokecolor="{_COLOR_BRAND_DARK}" fillcolor="{_COLOR_BRAND}">
+              <w:anchorlock/>
+              <center style="color:{_COLOR_ON_BRAND};font-family:{_FONT};font-size:15px;font-weight:600;">{label}</center>
+            </v:roundrect>
+            <![endif]-->
+            <!--[if !mso]><!-->
+            <a href="{url}" style="display: inline-block; padding: 13px 28px; font-family: {_FONT};
+               font-size: 15px; font-weight: 600; color: {_COLOR_ON_BRAND}; text-decoration: none;
+               border-radius: 10px;">{label}</a>
+            <!--<![endif]-->
+          </td>
+        </tr>
+      </table>
+    """
+
+
+_BADGE_VARIANTS = {
+    "warning": (_COLOR_WARNING_BG, _COLOR_WARNING_TEXT),
+    "accent": (_COLOR_ACCENT_BG, _COLOR_ACCENT_TEXT),
+    "positive": ("rgba(8, 127, 91, 0.12)", _COLOR_POSITIVE),
+    "danger": ("rgba(194, 65, 77, 0.12)", _COLOR_NEGATIVE),
+}
+
+
+def _badge(text: str, variant: str = "accent") -> str:
+    bg, fg = _BADGE_VARIANTS.get(variant, _BADGE_VARIANTS["accent"])
+    return (
+        f'<div style="display:inline-block;background:{bg};color:{fg};font-family:{_FONT};'
+        f'font-size:12px;font-weight:600;padding:5px 12px;border-radius:999px;">{text}</div>'
+    )
+
+
+def _heading(text: str) -> str:
+    return (
+        f'<h1 style="font-family:{_FONT};font-size:23px;line-height:1.3;font-weight:700;'
+        f'color:{_COLOR_INK};margin:16px 0 10px;">{text}</h1>'
+    )
+
+
+def _para(text: str) -> str:
+    return (
+        f'<p style="font-family:{_FONT};font-size:15px;line-height:1.65;'
+        f'color:{_COLOR_INK_SOFT};margin:0 0 16px;">{text}</p>'
+    )
+
+
+def _hint(text: str) -> str:
+    return (
+        f'<p style="font-family:{_FONT};font-size:13px;line-height:1.6;'
+        f'color:{_COLOR_SUBTLE};margin:6px 0 0;">{text}</p>'
+    )
+
+
+def _detail_card(rows: list[tuple[str, str, str]]) -> str:
+    """A light bordered card of label/value rows.
+
+    Each row is ``(label, value, value_color)`` — value_color is a hex string
+    (use the semantic colours for amounts) or empty for the default ink.
+    """
+    cells = []
+    for index, (label, value, value_color) in enumerate(rows):
+        top = f"border-top:1px solid {_COLOR_BORDER};" if index else ""
+        color = value_color or _COLOR_INK
+        cells.append(
+            f'<tr><td style="font-family:{_FONT};font-size:14px;color:{_COLOR_INK_SOFT};'
+            f'padding:9px 0;{top}">{label}</td>'
+            f'<td align="right" style="font-family:{_FONT};font-size:14px;font-weight:600;'
+            f'color:{color};padding:9px 0;{top}white-space:nowrap;">{value}</td></tr>'
+        )
+    return (
+        f'<table role="presentation" width="100%" cellpadding="0" cellspacing="0" '
+        f'style="background:{_COLOR_SURFACE};border-radius:12px;">'
+        f'<tr><td style="padding:6px 20px;">'
+        f'<table role="presentation" width="100%">{"".join(cells)}</table>'
+        f"</td></tr></table>"
+    )
+
+
+def _fallback_link(url: str) -> str:
+    return (
+        f'<div style="border-top:1px solid {_COLOR_BORDER};margin:24px 0 0;padding:16px 0 0;">'
+        f'<p style="font-family:{_FONT};font-size:12px;line-height:1.6;color:{_COLOR_SUBTLE};margin:0;">'
+        f"Se o botão não funcionar, copie e cole este link no navegador:<br/>"
+        f'<a href="{url}" style="color:{_COLOR_BRAND};word-break:break-all;">{url}</a></p></div>'
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -45,12 +167,20 @@ _APP_URL = "https://app.auraxis.com.br"
 # ---------------------------------------------------------------------------
 
 
-def _base_layout(*, title: str, preview_text: str, body_html: str) -> str:
-    """Wrap email body in the Auraxis branded shell.
+def _base_layout(
+    *, title: str, preview_text: str, body_html: str, eyebrow: str = ""
+) -> str:
+    """Wrap the email body in the Auraxis branded (light) shell.
 
-    The layout is intentionally table-based for maximum email-client
-    compatibility (Gmail, Outlook, Apple Mail, mobile).
+    Table-based for maximum client compatibility. The header is a teal→green
+    brand gradient with the Auraxis wordmark and an optional ``eyebrow``.
     """
+    eyebrow_html = (
+        f'<td align="right" style="font-family:{_FONT};font-size:12px;'
+        f'color:rgba(255,255,255,0.82);">{eyebrow}</td>'
+        if eyebrow
+        else ""
+    )
     return f"""<!DOCTYPE html>
 <html lang="pt-BR">
 <head>
@@ -59,69 +189,53 @@ def _base_layout(*, title: str, preview_text: str, body_html: str) -> str:
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <title>{title}</title>
   <!--[if mso]>
-  <noscript>
-    <xml><o:OfficeDocumentSettings><o:PixelsPerInch>96</o:PixelsPerInch></o:OfficeDocumentSettings></xml>
-  </noscript>
+  <noscript><xml><o:OfficeDocumentSettings><o:PixelsPerInch>96</o:PixelsPerInch></o:OfficeDocumentSettings></xml></noscript>
   <![endif]-->
   <style>
-    @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap');
     body, table, td, a {{ -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; }}
     table, td {{ mso-table-lspace: 0pt; mso-table-rspace: 0pt; }}
     img {{ -ms-interpolation-mode: bicubic; border: 0; height: auto; line-height: 100%; outline: none; text-decoration: none; }}
-    body {{ margin: 0; padding: 0; background-color: {_COLOR_BG_BASE}; }}
-    .email-wrapper {{ background-color: {_COLOR_BG_BASE}; width: 100%; }}
+    body {{ margin: 0; padding: 0; background-color: {_COLOR_BG}; }}
     .email-container {{ max-width: 600px; margin: 0 auto; }}
-    .btn {{ display: inline-block; background-color: {_COLOR_BRAND}; color: {_COLOR_BG_BASE} !important; font-family: {_FONT_BODY}; font-size: 15px; font-weight: 600; text-decoration: none; padding: 14px 32px; border-radius: 8px; mso-padding-alt: 0; }}
-    .btn-wrapper {{ padding: 8px 0; }}
     @media only screen and (max-width: 600px) {{
       .email-container {{ width: 100% !important; }}
-      .email-body {{ padding: 24px 20px !important; }}
+      .email-body {{ padding: 28px 22px !important; }}
     }}
   </style>
 </head>
 <body>
-  <!-- Preview text (hidden) -->
   <div style="display:none;font-size:1px;line-height:1px;max-height:0;max-width:0;opacity:0;overflow:hidden;mso-hide:all;">{preview_text}&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;</div>
-
-  <table role="presentation" class="email-wrapper" cellpadding="0" cellspacing="0" border="0" width="100%">
+  <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:{_COLOR_BG};">
     <tr>
-      <td align="center" style="padding: 32px 16px;">
-
-        <!-- Container -->
-        <table role="presentation" class="email-container" cellpadding="0" cellspacing="0" border="0" width="600">
-
-          <!-- Header / Logo -->
+      <td align="center" style="padding: 28px 14px;">
+        <table role="presentation" class="email-container" cellpadding="0" cellspacing="0" border="0" width="600"
+               style="background-color:{_COLOR_CARD};border-radius:16px;overflow:hidden;box-shadow:0 6px 24px rgba(10,22,40,0.08);">
+          <!-- Header -->
           <tr>
-            <td align="center" style="padding: 32px 0 24px;">
-              <a href="{_APP_URL}" style="text-decoration: none;">
-                <span style="font-family: {_FONT_HEADING}; font-size: 28px; font-weight: 700; color: {_COLOR_BRAND}; letter-spacing: -0.5px;">Auraxis</span>
-              </a>
+            <td style="background:linear-gradient(135deg,{_COLOR_BRAND},{_COLOR_GREEN});padding:22px 32px;">
+              <table role="presentation" width="100%"><tr>
+                <td style="font-family:{_FONT};font-size:20px;font-weight:700;letter-spacing:-0.02em;color:#ffffff;">Auraxis</td>
+                {eyebrow_html}
+              </tr></table>
             </td>
           </tr>
-
-          <!-- Card body -->
+          <!-- Body -->
           <tr>
-            <td class="email-body" style="background-color: {_COLOR_BG_SURFACE}; border-radius: 16px; border: 1px solid {_COLOR_BG_ELEVATED}; padding: 40px 48px;">
+            <td class="email-body" style="padding: 32px 32px 8px;">
               {body_html}
             </td>
           </tr>
-
           <!-- Footer -->
           <tr>
-            <td align="center" style="padding: 28px 0 0;">
-              <p style="font-family: {_FONT_BODY}; font-size: 12px; color: {_COLOR_TEXT_MUTED}; margin: 0 0 8px;">
-                Este é um email automático — por favor não responda.
-              </p>
-              <p style="font-family: {_FONT_BODY}; font-size: 12px; color: {_COLOR_TEXT_MUTED}; margin: 0;">
+            <td style="padding: 24px 32px; border-top: 1px solid {_COLOR_SURFACE};">
+              <p style="font-family:{_FONT};font-size:12px;line-height:1.6;color:{_COLOR_SUBTLE};margin:0;">
+                Email automático da Auraxis — por favor não responda.
                 &copy; 2026 Auraxis &bull;
-                <a href="{_APP_URL}" style="color: {_COLOR_TEXT_MUTED}; text-decoration: underline;">app.auraxis.com.br</a>
+                <a href="{web_base_url()}" style="color:{_COLOR_SUBTLE};text-decoration:underline;">app.auraxis.com.br</a>
               </p>
             </td>
           </tr>
-
         </table>
-        <!-- /Container -->
-
       </td>
     </tr>
   </table>
@@ -130,243 +244,123 @@ def _base_layout(*, title: str, preview_text: str, body_html: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Email templates
+# Signature helper
+# ---------------------------------------------------------------------------
+
+_SIGNATURE = "— Equipe Auraxis\nhttps://app.auraxis.com.br\n"
+
+
+# ---------------------------------------------------------------------------
+# Auth emails
 # ---------------------------------------------------------------------------
 
 
 def render_confirmation_email(*, confirmation_url: str) -> tuple[str, str]:
-    """Render the account confirmation email.
-
-    Returns:
-        (html, text) tuple ready to pass to EmailMessage.
-    """
-    body_html = f"""
-      <!-- Heading -->
-      <h1 style="font-family: {_FONT_HEADING}; font-size: 26px; font-weight: 700;
-                 color: {_COLOR_TEXT_PRIMARY}; margin: 0 0 8px; line-height: 1.2;">
-        Confirme sua conta
-      </h1>
-      <p style="font-family: {_FONT_BODY}; font-size: 13px; font-weight: 600;
-                color: {_COLOR_BRAND}; margin: 0 0 24px; text-transform: uppercase;
-                letter-spacing: 1px;">
-        Auraxis &mdash; Finanças pessoais
-      </p>
-
-      <!-- Divider -->
-      <div style="border-top: 1px solid {_COLOR_BG_ELEVATED}; margin: 0 0 28px;"></div>
-
-      <!-- Body -->
-      <p style="font-family: {_FONT_BODY}; font-size: 15px; color: {_COLOR_TEXT_SECONDARY};
-                line-height: 1.65; margin: 0 0 16px;">
-        Olá! Você está a um passo de ter controle total das suas finanças.
-        Clique no botão abaixo para confirmar seu endereço de email e ativar sua conta.
-      </p>
-
-      <!-- CTA -->
-      <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin: 32px 0;">
-        <tr>
-          <td class="btn-wrapper" align="left"
-              style="border-radius: 8px; background-color: {_COLOR_BRAND};">
-            <!--[if mso]>
-            <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word"
-              href="{confirmation_url}" style="height:48px;v-text-anchor:middle;width:220px;" arcsize="17%"
-              strokecolor="{_COLOR_BRAND_DARK}" fillcolor="{_COLOR_BRAND}">
-              <w:anchorlock/>
-              <center style="color:{_COLOR_BG_BASE};font-family:{_FONT_BODY};font-size:15px;font-weight:600;">
-                Confirmar email
-              </center>
-            </v:roundrect>
-            <![endif]-->
-            <!--[if !mso]><!-->
-            <a href="{confirmation_url}" class="btn"
-               style="background-color: {_COLOR_BRAND}; color: {_COLOR_BG_BASE};
-                      font-family: {_FONT_BODY}; font-size: 15px; font-weight: 600;
-                      text-decoration: none; display: inline-block;
-                      padding: 14px 32px; border-radius: 8px;">
-              Confirmar email
-            </a>
-            <!--<![endif]-->
-          </td>
-        </tr>
-      </table>
-
-      <!-- Expiry notice -->
-      <p style="font-family: {_FONT_BODY}; font-size: 13px; color: {_COLOR_TEXT_MUTED};
-                line-height: 1.6; margin: 0 0 24px;">
-        Este link expira em <strong style="color: {_COLOR_TEXT_SECONDARY};">24 horas</strong>.
-        Se você não criou uma conta na Auraxis, pode ignorar este email com segurança.
-      </p>
-
-      <!-- Divider -->
-      <div style="border-top: 1px solid {_COLOR_BG_ELEVATED}; margin: 0 0 20px;"></div>
-
-      <!-- Fallback URL -->
-      <p style="font-family: {_FONT_BODY}; font-size: 12px; color: {_COLOR_TEXT_MUTED};
-                line-height: 1.6; margin: 0;">
-        Se o botão não funcionar, copie e cole este link no seu navegador:<br/>
-        <a href="{confirmation_url}"
-           style="color: {_COLOR_BRAND}; word-break: break-all; font-size: 12px;">
-          {confirmation_url}
-        </a>
-      </p>
-    """
-
+    """Render the account confirmation email."""
+    body_html = (
+        _badge("Bem-vindo à Auraxis", "positive")
+        + _heading("Confirme seu email para começar")
+        + _para(
+            "Olá! Falta só um passo para você assumir o controle das suas "
+            "finanças. Confirme seu email no botão abaixo e sua conta é ativada "
+            "na hora."
+        )
+        + _button(confirmation_url, "Confirmar meu email →")
+        + _hint("O botão ativa sua conta. O link vale por 24 horas.")
+        + _para(
+            "Se você não criou uma conta na Auraxis, é só ignorar este email — "
+            "nada acontece."
+        )
+        + _fallback_link(confirmation_url)
+    )
     html = _base_layout(
         title="Confirme sua conta Auraxis",
         preview_text="Confirme seu email para ativar sua conta Auraxis.",
         body_html=body_html,
+        eyebrow="Ativação de conta",
     )
-
     text = (
-        "Confirme sua conta Auraxis\n"
-        "==========================\n\n"
-        "Olá! Você está a um passo de ter controle total das suas finanças.\n\n"
-        "Clique no link abaixo para confirmar seu email e ativar sua conta:\n\n"
+        "Confirme seu email para começar\n\n"
+        "Falta só um passo para assumir o controle das suas finanças. Confirme "
+        "seu email no link abaixo e sua conta é ativada na hora:\n\n"
         f"{confirmation_url}\n\n"
-        "Este link expira em 24 horas.\n\n"
-        "Se você não criou uma conta na Auraxis, ignore este email.\n\n"
-        "— Equipe Auraxis\n"
-        "https://app.auraxis.com.br\n"
+        "O link vale por 24 horas. Se você não criou uma conta na Auraxis, "
+        "ignore este email.\n\n" + _SIGNATURE
     )
-
     return html, text
 
 
 def render_password_reset_email(*, reset_url: str) -> tuple[str, str]:
     """Render the password reset email."""
-    body_html = f"""
-      <h1 style="font-family: {_FONT_HEADING}; font-size: 26px; font-weight: 700;
-                 color: {_COLOR_TEXT_PRIMARY}; margin: 0 0 8px; line-height: 1.2;">
-        Redefinir senha
-      </h1>
-      <p style="font-family: {_FONT_BODY}; font-size: 13px; font-weight: 600;
-                color: {_COLOR_BRAND}; margin: 0 0 24px; text-transform: uppercase;
-                letter-spacing: 1px;">
-        Auraxis &mdash; Finanças pessoais
-      </p>
-
-      <div style="border-top: 1px solid {_COLOR_BG_ELEVATED}; margin: 0 0 28px;"></div>
-
-      <p style="font-family: {_FONT_BODY}; font-size: 15px; color: {_COLOR_TEXT_SECONDARY};
-                line-height: 1.65; margin: 0 0 16px;">
-        Recebemos uma solicitação para redefinir a senha da sua conta.
-        Clique no botão abaixo para criar uma nova senha.
-      </p>
-
-      <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin: 32px 0;">
-        <tr>
-          <td align="left" style="border-radius: 8px; background-color: {_COLOR_BRAND};">
-            <a href="{reset_url}" class="btn"
-               style="background-color: {_COLOR_BRAND}; color: {_COLOR_BG_BASE};
-                      font-family: {_FONT_BODY}; font-size: 15px; font-weight: 600;
-                      text-decoration: none; display: inline-block;
-                      padding: 14px 32px; border-radius: 8px;">
-              Redefinir senha
-            </a>
-          </td>
-        </tr>
-      </table>
-
-      <p style="font-family: {_FONT_BODY}; font-size: 13px; color: {_COLOR_TEXT_MUTED};
-                line-height: 1.6; margin: 0 0 24px;">
-        Este link expira em <strong style="color: {_COLOR_TEXT_SECONDARY};">1 hora</strong>.
-        Se você não solicitou a redefinição de senha, ignore este email — sua conta está segura.
-      </p>
-
-      <div style="border-top: 1px solid {_COLOR_BG_ELEVATED}; margin: 0 0 20px;"></div>
-
-      <p style="font-family: {_FONT_BODY}; font-size: 12px; color: {_COLOR_TEXT_MUTED};
-                line-height: 1.6; margin: 0;">
-        Se o botão não funcionar, copie e cole este link no seu navegador:<br/>
-        <a href="{reset_url}"
-           style="color: {_COLOR_BRAND}; word-break: break-all; font-size: 12px;">
-          {reset_url}
-        </a>
-      </p>
-    """
-
+    body_html = (
+        _badge("Segurança", "accent")
+        + _heading("Vamos redefinir sua senha")
+        + _para(
+            "Recebemos um pedido para redefinir a senha da sua conta. Clique no "
+            "botão abaixo para criar uma nova — leva menos de um minuto."
+        )
+        + _button(reset_url, "Criar nova senha →")
+        + _hint("O link vale por 1 hora, por segurança.")
+        + _para(
+            "Não foi você? Pode ignorar este email com tranquilidade — sua senha "
+            "atual continua valendo e sua conta segue protegida."
+        )
+        + _fallback_link(reset_url)
+    )
     html = _base_layout(
         title="Redefinir senha — Auraxis",
-        preview_text="Solicitação de redefinição de senha para sua conta Auraxis.",
+        preview_text="Pedido de redefinição de senha da sua conta Auraxis.",
         body_html=body_html,
+        eyebrow="Redefinição de senha",
     )
-
     text = (
-        "Redefinir senha — Auraxis\n"
-        "=========================\n\n"
-        "Recebemos uma solicitação para redefinir a senha da sua conta.\n\n"
-        "Acesse o link abaixo para criar uma nova senha:\n\n"
+        "Vamos redefinir sua senha\n\n"
+        "Recebemos um pedido para redefinir a senha da sua conta. Use o link "
+        "abaixo para criar uma nova (vale por 1 hora):\n\n"
         f"{reset_url}\n\n"
-        "Este link expira em 1 hora.\n\n"
-        "Se você não solicitou a redefinição, ignore este email.\n\n"
-        "— Equipe Auraxis\n"
-        "https://app.auraxis.com.br\n"
+        "Não foi você? Ignore este email — sua senha atual continua valendo.\n\n"
+        + _SIGNATURE
     )
-
     return html, text
 
 
 def render_account_deletion_email() -> tuple[str, str]:
-    """Render the LGPD account deletion confirmation email.
-
-    Returns:
-        (html, text) tuple ready to pass to EmailMessage.
-    """
-    body_html = f"""
-      <h1 style="font-family: {_FONT_HEADING}; font-size: 26px; font-weight: 700;
-                 color: {_COLOR_TEXT_PRIMARY}; margin: 0 0 8px; line-height: 1.2;">
-        Sua conta foi excluída
-      </h1>
-      <p style="font-family: {_FONT_BODY}; font-size: 13px; font-weight: 600;
-                color: {_COLOR_BRAND}; margin: 0 0 24px; text-transform: uppercase;
-                letter-spacing: 1px;">
-        Auraxis &mdash; Finanças pessoais
-      </p>
-
-      <div style="border-top: 1px solid {_COLOR_BG_ELEVATED}; margin: 0 0 28px;"></div>
-
-      <p style="font-family: {_FONT_BODY}; font-size: 15px; color: {_COLOR_TEXT_SECONDARY};
-                line-height: 1.65; margin: 0 0 16px;">
-        Confirmamos que sua conta Auraxis foi excluída com sucesso.
-        Todos os seus dados pessoais foram anonimizados em conformidade com a
-        <strong style="color: {_COLOR_TEXT_PRIMARY};">Lei Geral de Proteção de Dados (LGPD)</strong>.
-      </p>
-
-      <p style="font-family: {_FONT_BODY}; font-size: 15px; color: {_COLOR_TEXT_SECONDARY};
-                line-height: 1.65; margin: 0 0 24px;">
-        Se você não solicitou a exclusão da sua conta ou acredita que isso ocorreu
-        por engano, entre em contato com nossa equipe de suporte imediatamente.
-      </p>
-
-      <div style="border-top: 1px solid {_COLOR_BG_ELEVATED}; margin: 0 0 20px;"></div>
-
-      <p style="font-family: {_FONT_BODY}; font-size: 13px; color: {_COLOR_TEXT_MUTED};
-                line-height: 1.6; margin: 0;">
-        Obrigado por ter utilizado a Auraxis. Esperamos ter contribuído positivamente
-        para o seu gerenciamento financeiro.
-      </p>
-    """
-
+    """Render the LGPD account deletion confirmation email."""
+    body_html = (
+        _heading("Sua conta foi excluída")
+        + _para(
+            "Confirmamos que sua conta Auraxis foi excluída. Todos os seus dados "
+            "pessoais foram anonimizados conforme a "
+            "<strong>Lei Geral de Proteção de Dados (LGPD)</strong>."
+        )
+        + _para(
+            "Não foi você que pediu a exclusão, ou acha que houve engano? Fale "
+            "com o nosso suporte o quanto antes."
+        )
+        + _hint(
+            "Obrigado por ter usado a Auraxis. Torcemos para ter ajudado a "
+            "cuidar melhor do seu dinheiro."
+        )
+    )
     html = _base_layout(
         title="Conta excluída — Auraxis",
-        preview_text="Sua conta Auraxis foi excluída com sucesso (LGPD).",
+        preview_text="Sua conta Auraxis foi excluída (LGPD).",
         body_html=body_html,
+        eyebrow="Privacidade",
     )
-
     text = (
-        "Conta excluída — Auraxis\n"
-        "========================\n\n"
-        "Confirmamos que sua conta Auraxis foi excluída com sucesso.\n\n"
-        "Todos os seus dados pessoais foram anonimizados em conformidade com a\n"
-        "Lei Geral de Proteção de Dados (LGPD).\n\n"
-        "Se você não solicitou a exclusão da sua conta ou acredita que isso ocorreu\n"
-        "por engano, entre em contato com nossa equipe de suporte imediatamente.\n\n"
-        "Obrigado por ter utilizado a Auraxis.\n\n"
-        "— Equipe Auraxis\n"
-        "https://app.auraxis.com.br\n"
+        "Sua conta foi excluída\n\n"
+        "Confirmamos que sua conta Auraxis foi excluída. Todos os seus dados "
+        "pessoais foram anonimizados conforme a LGPD.\n\n"
+        "Não foi você, ou acha que houve engano? Fale com o suporte o quanto "
+        "antes.\n\nObrigado por ter usado a Auraxis.\n\n" + _SIGNATURE
     )
-
     return html, text
+
+
+# ---------------------------------------------------------------------------
+# Transaction reminder
+# ---------------------------------------------------------------------------
 
 
 def render_due_soon_email(
@@ -374,202 +368,129 @@ def render_due_soon_email(
     title: str,
     amount_formatted: str,
     days_before_due: int,
+    due_date_label: str = "",
+    transaction_url: str | None = None,
 ) -> tuple[str, str]:
-    """Render the transaction due-soon reminder email (D-7 or D-1).
+    """Render the transaction due-soon reminder (D-7 or D-1).
 
-    Args:
-        title: Transaction title (e.g., "Aluguel").
-        amount_formatted: Pre-formatted amount string (e.g., "1500.00").
-        days_before_due: 7 or 1.
-
-    Returns:
-        (html, text) tuple ready to pass to EmailMessage.
+    When ``transaction_url`` is provided the CTA deep-links straight to that
+    transaction; otherwise it falls back to the transactions list.
     """
+    link = transaction_url or f"{web_base_url()}/transactions"
     if days_before_due == 1:
-        email_title = "Amanhã vence uma pendência"
-        preview = f"Amanhã vence R$ {amount_formatted} — {title}."
-        heading = "Amanhã vence uma pendência"
-        intro = (
-            f'Sua transação <strong style="color: {_COLOR_TEXT_PRIMARY};">{title}</strong> '
-            f'vence <strong style="color: {_COLOR_BRAND};">amanhã</strong> no valor de '
-            f'<strong style="color: {_COLOR_TEXT_PRIMARY};">R$ {amount_formatted}</strong>.'
-        )
+        when = "amanhã"
+        badge = _badge("⏳ Vence amanhã", "warning")
+        heading = "Uma conta sua está quase vencendo"
     else:
-        email_title = "Pendência vencendo em breve"
-        preview = f"Você tem R$ {amount_formatted} vencendo em {days_before_due} dias — {title}."
-        heading = "Pendência vencendo em breve"
-        intro = (
-            f'Sua transação <strong style="color: {_COLOR_TEXT_PRIMARY};">{title}</strong> '
-            f'vence em <strong style="color: {_COLOR_BRAND};">{days_before_due} dias</strong> '
-            f'no valor de <strong style="color: {_COLOR_TEXT_PRIMARY};">R$ {amount_formatted}</strong>.'
+        when = f"em {days_before_due} dias"
+        badge = _badge(f"⏳ Vence em {days_before_due} dias", "warning")
+        heading = "Uma conta sua está chegando no vencimento"
+
+    due_suffix = f" ({due_date_label})" if due_date_label else ""
+    rows = [
+        (title, f"R$ {amount_formatted}", _COLOR_NEGATIVE),
+        ("Vencimento", (due_date_label or when).capitalize(), ""),
+    ]
+    body_html = (
+        badge
+        + _heading(heading)
+        + _para(
+            f"Passando só para lembrar de um pagamento que vence <strong>{when}"
+            f"{due_suffix}</strong>. Dá para resolver em segundos."
         )
-
-    body_html = f"""
-      <h1 style="font-family: {_FONT_HEADING}; font-size: 26px; font-weight: 700;
-                 color: {_COLOR_TEXT_PRIMARY}; margin: 0 0 8px; line-height: 1.2;">
-        {heading}
-      </h1>
-      <p style="font-family: {_FONT_BODY}; font-size: 13px; font-weight: 600;
-                color: {_COLOR_BRAND}; margin: 0 0 24px; text-transform: uppercase;
-                letter-spacing: 1px;">
-        Auraxis &mdash; Finanças pessoais
-      </p>
-
-      <div style="border-top: 1px solid {_COLOR_BG_ELEVATED}; margin: 0 0 28px;"></div>
-
-      <p style="font-family: {_FONT_BODY}; font-size: 15px; color: {_COLOR_TEXT_SECONDARY};
-                line-height: 1.65; margin: 0 0 24px;">
-        {intro}
-      </p>
-
-      <!-- CTA -->
-      <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin: 8px 0 32px;">
-        <tr>
-          <td align="left" style="border-radius: 8px; background-color: {_COLOR_BRAND};">
-            <!--[if mso]>
-            <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word"
-              href="{_APP_URL}" style="height:48px;v-text-anchor:middle;width:200px;" arcsize="17%"
-              strokecolor="{_COLOR_BRAND_DARK}" fillcolor="{_COLOR_BRAND}">
-              <w:anchorlock/>
-              <center style="color:{_COLOR_BG_BASE};font-family:{_FONT_BODY};font-size:15px;font-weight:600;">
-                Ver no Auraxis
-              </center>
-            </v:roundrect>
-            <![endif]-->
-            <!--[if !mso]><!-->
-            <a href="{_APP_URL}"
-               style="background-color: {_COLOR_BRAND}; color: {_COLOR_BG_BASE};
-                      font-family: {_FONT_BODY}; font-size: 15px; font-weight: 600;
-                      text-decoration: none; display: inline-block;
-                      padding: 14px 32px; border-radius: 8px;">
-              Ver no Auraxis
-            </a>
-            <!--<![endif]-->
-          </td>
-        </tr>
-      </table>
-
-      <div style="border-top: 1px solid {_COLOR_BG_ELEVATED}; margin: 0 0 20px;"></div>
-
-      <p style="font-family: {_FONT_BODY}; font-size: 12px; color: {_COLOR_TEXT_MUTED};
-                line-height: 1.6; margin: 0;">
-        Para gerenciar suas preferências de notificação, acesse as configurações no aplicativo.
-      </p>
-    """
-
+        + _detail_card(rows)
+        + _button(link, "Ver transação →")
+        + _hint("O botão abre exatamente essa transação no seu Auraxis.")
+    )
+    email_title = (
+        "Amanhã vence uma conta sua"
+        if days_before_due == 1
+        else f"Uma conta vence em {days_before_due} dias"
+    )
     html = _base_layout(
         title=email_title,
-        preview_text=preview,
+        preview_text=f"{title} — R$ {amount_formatted}, vence {when}.",
         body_html=body_html,
+        eyebrow="Lembrete de vencimento",
     )
-
-    if days_before_due == 1:
-        text = (
-            f"Amanhã vence uma pendência — Auraxis\n"
-            f"=====================================\n\n"
-            f"Sua transação '{title}' vence amanhã no valor de R$ {amount_formatted}.\n\n"
-            f"Acesse o Auraxis para gerenciar suas finanças:\n"
-            f"{_APP_URL}\n\n"
-            f"Para gerenciar preferências de notificação, acesse as configurações no app.\n\n"
-            f"— Equipe Auraxis\n"
-        )
-    else:
-        text = (
-            f"Pendência vencendo em breve — Auraxis\n"
-            f"======================================\n\n"
-            f"Sua transação '{title}' vence em {days_before_due} dias "
-            f"no valor de R$ {amount_formatted}.\n\n"
-            f"Acesse o Auraxis para gerenciar suas finanças:\n"
-            f"{_APP_URL}\n\n"
-            f"Para gerenciar preferências de notificação, acesse as configurações no app.\n\n"
-            f"— Equipe Auraxis\n"
-        )
-
+    text = (
+        f"{heading}\n\n"
+        f"'{title}' vence {when}{due_suffix}, no valor de R$ {amount_formatted}.\n\n"
+        f"Ver a transação: {link}\n\n"
+        "Você recebe este lembrete porque ativou avisos de vencimento — ajuste "
+        "quando quiser nas configurações.\n\n" + _SIGNATURE
+    )
     return html, text
+
+
+# ---------------------------------------------------------------------------
+# AI insight emails
+# ---------------------------------------------------------------------------
+
+
+def _insight_body(
+    *,
+    eyebrow_badge: str,
+    heading: str,
+    intro: str,
+    detail_rows: list[tuple[str, str, str]] | None,
+    suggestion: str,
+    cta_url: str,
+    cta_label: str,
+    cta_hint: str,
+) -> str:
+    parts = [_badge(eyebrow_badge, "accent"), _heading(heading), _para(intro)]
+    if detail_rows:
+        parts.append(_detail_card(detail_rows))
+    if suggestion:
+        parts.append(
+            f'<p style="font-family:{_FONT};font-size:14px;line-height:1.6;'
+            f'color:{_COLOR_INK_SOFT};margin:16px 0 0;">'
+            f'<strong style="color:{_COLOR_GREEN};">Sugestão:</strong> {suggestion}</p>'
+        )
+    parts.append(_button(cta_url, cta_label))
+    parts.append(_hint(cta_hint))
+    return "".join(parts)
 
 
 def render_analysis_ready_email(
     *,
     first_name: str,
     summary_preview: str,
+    insight_url: str | None = None,
+    detail_rows: list[tuple[str, str, str]] | None = None,
+    suggestion: str = "",
 ) -> tuple[str, str]:
-    """Render the 'AI analysis ready' notification email.
+    """Render the weekly 'AI analysis ready' email.
 
-    Args:
-        first_name: User's first name for personalisation.
-        summary_preview: Short 1-2 sentence AI-generated preview to include.
-
-    Returns:
-        (html, text) tuple ready to pass to EmailMessage.
+    When ``insight_url`` is given the CTA deep-links to that insight; when
+    ``detail_rows`` is given the full insight is embedded in the email.
     """
-    email_title = f"Sua análise financeira está pronta, {first_name}!"
-    preview = "Novos insights sobre suas finanças estão disponíveis no Auraxis."
-    dashboard_url = f"{_APP_URL}/dashboard"
-
-    body_html = f"""
-      <h1 style="font-family: {_FONT_HEADING}; font-size: 26px; font-weight: 700;
-                 color: {_COLOR_TEXT_PRIMARY}; margin: 0 0 8px; line-height: 1.2;">
-        Sua análise financeira está pronta
-      </h1>
-      <p style="font-family: {_FONT_BODY}; font-size: 13px; font-weight: 600;
-                color: {_COLOR_BRAND}; margin: 0 0 24px; text-transform: uppercase;
-                letter-spacing: 1px;">
-        Auraxis &mdash; Inteligência Financeira
-      </p>
-
-      <div style="border-top: 1px solid {_COLOR_BG_ELEVATED}; margin: 0 0 28px;"></div>
-
-      <p style="font-family: {_FONT_BODY}; font-size: 15px; color: {_COLOR_TEXT_SECONDARY};
-                line-height: 1.65; margin: 0 0 16px;">
-        Olá, <strong style="color: {_COLOR_TEXT_PRIMARY};">{first_name}</strong>!
-        Geramos uma nova análise das suas finanças com inteligência artificial.
-      </p>
-
-      <div style="background: {_COLOR_BG_SURFACE}; border-left: 3px solid {_COLOR_BRAND};
-                  border-radius: 4px; padding: 16px 20px; margin: 0 0 28px;">
-        <p style="font-family: {_FONT_BODY}; font-size: 14px; color: {_COLOR_TEXT_SECONDARY};
-                  line-height: 1.6; margin: 0; font-style: italic;">
-          {summary_preview}
-        </p>
-      </div>
-
-      <!-- CTA -->
-      <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin: 8px 0 32px;">
-        <tr>
-          <td align="left" style="border-radius: 8px; background-color: {_COLOR_BRAND};">
-            <a href="{dashboard_url}"
-               style="display: inline-block; padding: 14px 28px; font-family: {_FONT_BODY};
-                      font-size: 15px; font-weight: 700; color: #0b0909; text-decoration: none;
-                      border-radius: 8px; letter-spacing: 0.3px;">
-              Ver análise completa
-            </a>
-          </td>
-        </tr>
-      </table>
-
-      <p style="font-family: {_FONT_BODY}; font-size: 12px; color: {_COLOR_TEXT_MUTED};
-                line-height: 1.6; margin: 0;">
-        Para gerenciar suas preferências de notificação, acesse as configurações no aplicativo.
-      </p>
-    """
-
+    cta_url = insight_url or f"{web_base_url()}/insights"
+    body_html = _insight_body(
+        eyebrow_badge="✨ Insight de gastos",
+        heading=f"{first_name}, seu insight da semana está pronto",
+        intro=summary_preview,
+        detail_rows=detail_rows,
+        suggestion=suggestion,
+        cta_url=cta_url,
+        cta_label="Abrir no Auraxis →",
+        cta_hint="O botão leva para /insights com este insight já aberto.",
+    )
     html = _base_layout(
-        title=email_title,
-        preview_text=preview,
+        title=f"Seu insight da semana, {first_name}",
+        preview_text="Seu insight financeiro da semana já está no Auraxis.",
         body_html=body_html,
+        eyebrow="Seu insight da semana",
     )
-
     text = (
-        f"Sua análise financeira está pronta — Auraxis\n"
-        f"=============================================\n\n"
-        f"Olá, {first_name}!\n\n"
+        f"{first_name}, seu insight da semana está pronto\n\n"
         f"{summary_preview}\n\n"
-        f"Acesse o Auraxis para ver a análise completa:\n"
-        f"{dashboard_url}\n\n"
-        f"Para gerenciar preferências de notificação, acesse as configurações no app.\n\n"
-        f"— Equipe Auraxis\n"
+        + (f"Sugestão: {suggestion}\n\n" if suggestion else "")
+        + f"Abrir no Auraxis: {cta_url}\n\n"
+        + "Gerado pela IA da Auraxis a partir das suas transações — sem "
+        "julgamentos, só clareza.\n\n" + _SIGNATURE
     )
-
     return html, text
 
 
@@ -578,201 +499,296 @@ def render_monthly_analysis_ready_email(
     first_name: str,
     summary_preview: str,
     insight_url: str,
+    detail_rows: list[tuple[str, str, str]] | None = None,
+    suggestion: str = "",
 ) -> tuple[str, str]:
-    """Render the monthly AI report ready email with a deep link."""
-    email_title = f"Seu relatório mensal está pronto, {first_name}!"
-    preview = "Seu consolidado mensal de finanças já está disponível no Auraxis."
-
-    body_html = f"""
-      <h1 style="font-family: {_FONT_HEADING}; font-size: 26px; font-weight: 700;
-                 color: {_COLOR_TEXT_PRIMARY}; margin: 0 0 8px; line-height: 1.2;">
-        Seu relatório mensal está pronto
-      </h1>
-      <p style="font-family: {_FONT_BODY}; font-size: 13px; font-weight: 600;
-                color: {_COLOR_BRAND}; margin: 0 0 24px; text-transform: uppercase;
-                letter-spacing: 1px;">
-        Auraxis &mdash; Inteligência Financeira
-      </p>
-
-      <div style="border-top: 1px solid {_COLOR_BG_ELEVATED}; margin: 0 0 28px;"></div>
-
-      <p style="font-family: {_FONT_BODY}; font-size: 15px; color: {_COLOR_TEXT_SECONDARY};
-                line-height: 1.65; margin: 0 0 16px;">
-        Olá, <strong style="color: {_COLOR_TEXT_PRIMARY};">{first_name}</strong>!
-        Consolidamos os seus insights diários, movimentos do mês e histórico
-        recente para montar um relatório mensal completo.
-      </p>
-
-      <div style="background: {_COLOR_BG_SURFACE}; border-left: 3px solid {_COLOR_BRAND};
-                  border-radius: 4px; padding: 16px 20px; margin: 0 0 28px;">
-        <p style="font-family: {_FONT_BODY}; font-size: 14px; color: {_COLOR_TEXT_SECONDARY};
-                  line-height: 1.6; margin: 0; font-style: italic;">
-          {summary_preview}
-        </p>
-      </div>
-
-      <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin: 8px 0 32px;">
-        <tr>
-          <td align="left" style="border-radius: 8px; background-color: {_COLOR_BRAND};">
-            <a href="{insight_url}"
-               style="display: inline-block; padding: 14px 28px; font-family: {_FONT_BODY};
-                      font-size: 15px; font-weight: 700; color: #0b0909; text-decoration: none;
-                      border-radius: 8px; letter-spacing: 0.3px;">
-              Abrir relatório mensal
-            </a>
-          </td>
-        </tr>
-      </table>
-
-      <p style="font-family: {_FONT_BODY}; font-size: 12px; color: {_COLOR_TEXT_MUTED};
-                line-height: 1.6; margin: 0;">
-        Se o botão não funcionar, copie e cole este link no navegador:<br/>
-        <a href="{insight_url}"
-           style="color: {_COLOR_BRAND}; word-break: break-all; font-size: 12px;">
-          {insight_url}
-        </a>
-      </p>
-    """
-
+    """Render the monthly AI report email with a deep link + embedded insight."""
+    body_html = _insight_body(
+        eyebrow_badge="📊 Relatório mensal",
+        heading=f"{first_name}, seu resumo do mês chegou",
+        intro=summary_preview,
+        detail_rows=detail_rows,
+        suggestion=suggestion,
+        cta_url=insight_url,
+        cta_label="Abrir relatório completo →",
+        cta_hint="O botão leva para /insights com o relatório do mês já aberto.",
+    )
     html = _base_layout(
-        title=email_title,
-        preview_text=preview,
-        body_html=body_html,
+        title=f"Seu resumo do mês, {first_name}",
+        preview_text="Seu consolidado mensal de finanças já está no Auraxis.",
+        body_html=body_html + _fallback_link(insight_url),
+        eyebrow="Resumo do mês",
     )
-
     text = (
-        "Seu relatório mensal está pronto — Auraxis\n"
-        "===========================================\n\n"
-        f"Olá, {first_name}!\n\n"
+        f"{first_name}, seu resumo do mês chegou\n\n"
         f"{summary_preview}\n\n"
-        "Acesse o relatório completo pelo link abaixo:\n"
-        f"{insight_url}\n\n"
-        "— Equipe Auraxis\n"
+        + (f"Sugestão: {suggestion}\n\n" if suggestion else "")
+        + f"Abrir relatório completo: {insight_url}\n\n"
+        + _SIGNATURE
     )
-
     return html, text
+
+
+# ---------------------------------------------------------------------------
+# Email verification reminder
+# ---------------------------------------------------------------------------
 
 
 def render_email_verification_reminder_email(
     *, days_until_deadline: int
 ) -> tuple[str, str]:
-    """Render the D-7 / D-1 verification reminder email.
-
-    Args:
-        days_until_deadline: 7 (mild urgency) or 1 (high urgency).
-
-    Returns:
-        (html, text) tuple ready to pass to EmailMessage.
-    """
-    resend_url = f"{_APP_URL}/resend-confirmation"
-
+    """Render the D-7 / D-1 verification reminder email."""
+    resend_url = f"{web_base_url()}/resend-confirmation"
     if days_until_deadline == 1:
         email_title = "Último dia para confirmar seu email"
-        preview = (
-            "Amanhã sua conta entra em modo somente-leitura. "
-            "Confirme seu email para manter o acesso total."
-        )
+        preview = "Amanhã sua conta fica só-leitura. Confirme para manter o acesso."
         heading = "Último dia para confirmar seu email"
-        urgency_copy = (
-            f"Sua conta foi criada há quase 14 dias. "
-            f'Se você não confirmar seu email <strong style="color: {_COLOR_BRAND};">'
-            f"até amanhã</strong>, ela entrará em modo somente-leitura — "
-            f"você ainda poderá ver seus dados, mas não criar ou editar nada."
+        intro = (
+            "Sua conta foi criada há quase 14 dias. Se o email não for confirmado "
+            "<strong>até amanhã</strong>, ela entra em modo só-leitura: você ainda "
+            "vê seus dados, mas não consegue criar ou editar nada."
         )
-        cta_label = "Confirmar agora"
+        cta_label = "Confirmar agora →"
     else:
-        email_title = "Faltam 7 dias para confirmar seu email"
+        email_title = f"Faltam {days_until_deadline} dias para confirmar seu email"
         preview = (
-            "Confirme seu email no Auraxis dentro de 7 dias para evitar bloqueio "
-            "de novas transações."
+            f"Confirme seu email em {days_until_deadline} dias para não perder "
+            "acesso a novas transações."
         )
         heading = f"Faltam {days_until_deadline} dias para confirmar seu email"
-        urgency_copy = (
-            f"Você criou sua conta no Auraxis recentemente, mas ainda não "
-            f'confirmou seu email. Em <strong style="color: {_COLOR_BRAND};">'
-            f"{days_until_deadline} dias</strong> sua conta entrará em modo "
-            f"somente-leitura caso o email não seja confirmado."
+        intro = (
+            "Você criou sua conta na Auraxis há pouco, mas ainda não confirmou o "
+            f"email. Em <strong>{days_until_deadline} dias</strong> ela entra em "
+            "modo só-leitura se o email não for confirmado."
         )
-        cta_label = "Confirmar email"
+        cta_label = "Confirmar email →"
 
-    body_html = f"""
-      <h1 style="font-family: {_FONT_HEADING}; font-size: 26px; font-weight: 700;
-                 color: {_COLOR_TEXT_PRIMARY}; margin: 0 0 8px; line-height: 1.2;">
-        {heading}
-      </h1>
-      <p style="font-family: {_FONT_BODY}; font-size: 13px; font-weight: 600;
-                color: {_COLOR_BRAND}; margin: 0 0 24px; text-transform: uppercase;
-                letter-spacing: 1px;">
-        Auraxis &mdash; Finanças pessoais
-      </p>
-
-      <div style="border-top: 1px solid {_COLOR_BG_ELEVATED}; margin: 0 0 28px;"></div>
-
-      <p style="font-family: {_FONT_BODY}; font-size: 15px; color: {_COLOR_TEXT_SECONDARY};
-                line-height: 1.65; margin: 0 0 24px;">
-        {urgency_copy}
-      </p>
-
-      <!-- CTA -->
-      <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin: 8px 0 32px;">
-        <tr>
-          <td align="left" style="border-radius: 8px; background-color: {_COLOR_BRAND};">
-            <a href="{resend_url}" class="btn"
-               style="background-color: {_COLOR_BRAND}; color: {_COLOR_BG_BASE};
-                      font-family: {_FONT_BODY}; font-size: 15px; font-weight: 600;
-                      text-decoration: none; display: inline-block;
-                      padding: 14px 32px; border-radius: 8px;">
-              {cta_label}
-            </a>
-          </td>
-        </tr>
-      </table>
-
-      <div style="border-top: 1px solid {_COLOR_BG_ELEVATED}; margin: 0 0 20px;"></div>
-
-      <p style="font-family: {_FONT_BODY}; font-size: 12px; color: {_COLOR_TEXT_MUTED};
-                line-height: 1.6; margin: 0;">
-        Não recebeu o email de confirmação original? Acesse
-        <a href="{resend_url}" style="color: {_COLOR_BRAND};">{resend_url}</a>
-        para reenviar.
-      </p>
-    """
-
+    body_html = (
+        _badge("Confirmação pendente", "warning")
+        + _heading(heading)
+        + _para(intro)
+        + _button(resend_url, cta_label)
+        + _hint("O botão reenvia seu email de confirmação em segundos.")
+    )
     html = _base_layout(
         title=email_title,
         preview_text=preview,
         body_html=body_html,
+        eyebrow="Confirmação de email",
     )
+    text = (
+        f"{heading}\n\n"
+        + intro.replace("<strong>", "").replace("</strong>", "")
+        + f"\n\nConfirmar agora: {resend_url}\n\n"
+        + _SIGNATURE
+    )
+    return html, text
 
-    if days_until_deadline == 1:
-        text = (
-            "Último dia para confirmar seu email — Auraxis\n"
-            "=============================================\n\n"
-            "Sua conta foi criada há quase 14 dias. Se você não confirmar seu "
-            "email até amanhã, ela entrará em modo somente-leitura.\n\n"
-            f"Confirme agora: {resend_url}\n\n"
-            "— Equipe Auraxis\n"
-        )
-    else:
-        text = (
-            f"Faltam {days_until_deadline} dias para confirmar seu email — Auraxis\n"
-            "========================================================\n\n"
-            f"Você criou sua conta no Auraxis recentemente. Em "
-            f"{days_until_deadline} dias sua conta entrará em modo "
-            "somente-leitura se o email não for confirmado.\n\n"
-            f"Confirme agora: {resend_url}\n\n"
-            "— Equipe Auraxis\n"
-        )
 
+# ---------------------------------------------------------------------------
+# Billing emails (migrated into the shared layout — #emails redesign)
+# ---------------------------------------------------------------------------
+
+
+def render_billing_payment_confirmed_email(*, plan_label: str) -> tuple[str, str]:
+    body_html = (
+        _badge("Pagamento confirmado", "positive")
+        + _heading("Tudo certo com seu pagamento")
+        + _para(
+            "Seu pagamento foi confirmado e o acesso premium está ativo. "
+            f"Plano ativo: <strong>{plan_label}</strong>."
+        )
+        + _button(f"{web_base_url()}/dashboard", "Ir para o Auraxis →")
+    )
+    html = _base_layout(
+        title="Pagamento confirmado na Auraxis",
+        preview_text="Seu pagamento foi confirmado e o premium está ativo.",
+        body_html=body_html,
+        eyebrow="Cobrança",
+    )
+    text = (
+        "Tudo certo com seu pagamento\n\n"
+        f"Seu pagamento foi confirmado e o acesso premium está ativo. Plano "
+        f"ativo: {plan_label}.\n\n" + _SIGNATURE
+    )
+    return html, text
+
+
+def render_billing_payment_failed_email(*, plan_label: str) -> tuple[str, str]:
+    body_html = (
+        _badge("Pagamento pendente", "warning")
+        + _heading("Não conseguimos confirmar seu pagamento")
+        + _para(
+            "Houve uma pendência na cobrança da sua assinatura. Sem stress: você "
+            "tem alguns dias de tolerância antes de qualquer mudança, e o "
+            f"premium continua ativo enquanto isso. Plano: <strong>{plan_label}</strong>."
+        )
+        + _button(f"{web_base_url()}/dashboard", "Revisar assinatura →")
+    )
+    html = _base_layout(
+        title="Pagamento pendente na Auraxis",
+        preview_text="Houve uma pendência no pagamento da sua assinatura.",
+        body_html=body_html,
+        eyebrow="Cobrança",
+    )
+    text = (
+        "Não conseguimos confirmar seu pagamento\n\n"
+        "Houve uma pendência na cobrança da sua assinatura. Você tem alguns dias "
+        "de tolerância antes de qualquer mudança, e o premium continua ativo "
+        f"enquanto isso. Plano: {plan_label}.\n\n" + _SIGNATURE
+    )
+    return html, text
+
+
+def render_billing_refund_email(*, plan_label: str) -> tuple[str, str]:
+    body_html = (
+        _badge("Estorno processado", "danger")
+        + _heading("Seu estorno foi processado")
+        + _para(
+            "Um estorno foi processado e, com ele, o acesso premium foi "
+            f"encerrado. Plano encerrado: <strong>{plan_label}</strong>."
+        )
+        + _para("Quando quiser voltar, é só assinar de novo — leva um minuto.")
+        + _button(f"{web_base_url()}/dashboard", "Ver planos →")
+    )
+    html = _base_layout(
+        title="Estorno processado — Auraxis",
+        preview_text="Um estorno foi processado e o premium foi encerrado.",
+        body_html=body_html,
+        eyebrow="Cobrança",
+    )
+    text = (
+        "Seu estorno foi processado\n\n"
+        "Um estorno foi processado e o acesso premium foi encerrado. Plano "
+        f"encerrado: {plan_label}. Quando quiser voltar, é só assinar de "
+        "novo.\n\n" + _SIGNATURE
+    )
+    return html, text
+
+
+def render_billing_canceled_email(*, plan_label: str) -> tuple[str, str]:
+    body_html = (
+        _badge("Assinatura cancelada", "accent")
+        + _heading("Sua assinatura foi cancelada")
+        + _para(
+            "Confirmamos o cancelamento da sua assinatura. Plano anterior: "
+            f"<strong>{plan_label}</strong>. Você continua com a conta e os seus "
+            "dados — só sem os recursos premium."
+        )
+        + _para("Mudou de ideia? Dá para reativar quando quiser.")
+        + _button(f"{web_base_url()}/dashboard", "Reativar premium →")
+    )
+    html = _base_layout(
+        title="Assinatura cancelada na Auraxis",
+        preview_text="Sua assinatura foi cancelada.",
+        body_html=body_html,
+        eyebrow="Cobrança",
+    )
+    text = (
+        "Sua assinatura foi cancelada\n\n"
+        f"Confirmamos o cancelamento. Plano anterior: {plan_label}. Você continua "
+        "com a conta e os seus dados — só sem os recursos premium. Dá para "
+        "reativar quando quiser.\n\n" + _SIGNATURE
+    )
+    return html, text
+
+
+def render_billing_trial_ending_email(
+    *, days_label: str, trial_ends_label: str | None
+) -> tuple[str, str]:
+    ends = f" Ele termina em {trial_ends_label}." if trial_ends_label else ""
+    body_html = (
+        _badge("Seu teste está acabando", "warning")
+        + _heading(f"Seu período de teste termina em {days_label}")
+        + _para(
+            f"Seu teste gratuito da Auraxis termina em <strong>{days_label}</strong>."
+            f"{ends} Assine para continuar com os recursos premium — exportação em "
+            "PDF, simulações avançadas e mais."
+        )
+        + _button(f"{web_base_url()}/dashboard", "Assinar e continuar →")
+    )
+    html = _base_layout(
+        title=f"Seu teste termina em {days_label} — Auraxis",
+        preview_text=f"Seu teste gratuito termina em {days_label}.",
+        body_html=body_html,
+        eyebrow="Período de teste",
+    )
+    text = (
+        f"Seu período de teste termina em {days_label}\n\n"
+        f"Seu teste gratuito da Auraxis termina em {days_label}.{ends} Assine para "
+        "continuar com os recursos premium.\n\n" + _SIGNATURE
+    )
+    return html, text
+
+
+def render_billing_trial_expired_email(*, plan_label: str) -> tuple[str, str]:
+    body_html = (
+        _badge("Teste encerrado", "accent")
+        + _heading("Seu período de teste terminou")
+        + _para(
+            "Seu teste gratuito acabou e sua conta voltou para o plano "
+            f"<strong>{plan_label}</strong>. Você continua com todos os seus "
+            "dados salvos."
+        )
+        + _para("Quando quiser recuperar o premium, é só assinar.")
+        + _button(f"{web_base_url()}/dashboard", "Recuperar premium →")
+    )
+    html = _base_layout(
+        title="Seu período de teste terminou — Auraxis",
+        preview_text="Seu teste terminou e sua conta voltou ao plano gratuito.",
+        body_html=body_html,
+        eyebrow="Período de teste",
+    )
+    text = (
+        "Seu período de teste terminou\n\n"
+        f"Seu teste gratuito acabou e sua conta voltou para o plano {plan_label}. "
+        "Seus dados continuam salvos. Quando quiser recuperar o premium, é só "
+        "assinar.\n\n" + _SIGNATURE
+    )
+    return html, text
+
+
+def render_billing_grace_expired_email(*, plan_label: str) -> tuple[str, str]:
+    body_html = (
+        _badge("Assinatura encerrada", "danger")
+        + _heading("Não recebemos o pagamento a tempo")
+        + _para(
+            "Não conseguimos confirmar o pagamento dentro do período de "
+            "tolerância, então o acesso premium foi encerrado. Plano encerrado: "
+            f"<strong>{plan_label}</strong>."
+        )
+        + _para("Regularize o pagamento para reativar quando quiser.")
+        + _button(f"{web_base_url()}/dashboard", "Regularizar e reativar →")
+    )
+    html = _base_layout(
+        title="Assinatura encerrada por falta de pagamento — Auraxis",
+        preview_text="O período de tolerância acabou e o premium foi encerrado.",
+        body_html=body_html,
+        eyebrow="Cobrança",
+    )
+    text = (
+        "Não recebemos o pagamento a tempo\n\n"
+        "Não conseguimos confirmar o pagamento dentro do período de tolerância, "
+        f"então o acesso premium foi encerrado. Plano encerrado: {plan_label}. "
+        "Regularize o pagamento para reativar quando quiser.\n\n" + _SIGNATURE
+    )
     return html, text
 
 
 __all__ = [
     "render_account_deletion_email",
     "render_analysis_ready_email",
+    "render_billing_canceled_email",
+    "render_billing_grace_expired_email",
+    "render_billing_payment_confirmed_email",
+    "render_billing_payment_failed_email",
+    "render_billing_refund_email",
+    "render_billing_trial_ending_email",
+    "render_billing_trial_expired_email",
     "render_confirmation_email",
     "render_due_soon_email",
     "render_email_verification_reminder_email",
     "render_monthly_analysis_ready_email",
     "render_password_reset_email",
+    "web_base_url",
 ]

--- a/tests/test_ai_weekly_insights_cli.py
+++ b/tests/test_ai_weekly_insights_cli.py
@@ -78,10 +78,14 @@ def _create_user(app) -> uuid.UUID:
 def _log_weekly_summary_today(app, user_id: uuid.UUID) -> None:
     """Simulate that a weekly summary was already generated today."""
     with app.app_context():
+        from app.cli.ai_insights_cli import _brt_today
         from app.extensions.database import db
         from app.models.ai_insight import AIInsight, InsightType
 
-        today = date.today()
+        # Use the same BRT "today" the CLI anchors on — a bare date.today()
+        # (UTC in CI) drifts a day across the 00:00–03:00 UTC window and made the
+        # ISO-week period_label mismatch, so the idempotency skip flaked.
+        today = _brt_today()
         iso = today.isocalendar()
         insight = AIInsight(
             user_id=user_id,

--- a/tests/test_email_templates.py
+++ b/tests/test_email_templates.py
@@ -1,178 +1,186 @@
-"""Tests for Auraxis branded email templates.
+"""Tests for Auraxis branded email templates (light identity redesign).
 
-Covers:
-- HTML structure: doctype, viewport, brand colours, fonts
-- CTA link is present and uses the provided URL
-- Plain-text fallback contains the URL
-- Password reset template follows the same contract
+Covers the shared shell (doctype, brand colour, wordmark), every renderer's
+(html, text) contract, the deep-link CTAs (transaction + insight) and the
+env-driven base URL.
 """
 
 from __future__ import annotations
 
 from app.services.email_templates import (
+    render_account_deletion_email,
+    render_analysis_ready_email,
+    render_billing_canceled_email,
+    render_billing_grace_expired_email,
+    render_billing_payment_confirmed_email,
+    render_billing_payment_failed_email,
+    render_billing_refund_email,
+    render_billing_trial_ending_email,
+    render_billing_trial_expired_email,
     render_confirmation_email,
     render_due_soon_email,
+    render_email_verification_reminder_email,
+    render_monthly_analysis_ready_email,
     render_password_reset_email,
+    web_base_url,
 )
 
 CONFIRM_URL = "https://app.auraxis.com.br/confirm-email?token=abc123"
 RESET_URL = "https://app.auraxis.com.br/reset-password?token=xyz456"
+_BRAND = "#087fa7"  # brand teal (light identity)
 
 
-class TestRenderConfirmationEmail:
-    def test_returns_html_and_text_tuple(self) -> None:
-        result = render_confirmation_email(confirmation_url=CONFIRM_URL)
-        assert isinstance(result, tuple)
-        assert len(result) == 2
+def _is_email(result: tuple[str, str]) -> None:
+    html, text = result
+    assert html.strip().startswith("<!DOCTYPE html>")
+    assert _BRAND in html  # every email carries the brand identity
+    assert "Auraxis" in html
+    assert "<" not in text  # plain-text fallback
 
-    def test_html_is_valid_doctype(self) -> None:
-        html, _ = render_confirmation_email(confirmation_url=CONFIRM_URL)
-        assert html.strip().startswith("<!DOCTYPE html>")
 
-    def test_html_contains_confirmation_url(self) -> None:
-        html, _ = render_confirmation_email(confirmation_url=CONFIRM_URL)
+class TestConfirmationEmail:
+    def test_contract_and_identity(self) -> None:
+        _is_email(render_confirmation_email(confirmation_url=CONFIRM_URL))
+
+    def test_cta_and_url(self) -> None:
+        html, text = render_confirmation_email(confirmation_url=CONFIRM_URL)
         assert CONFIRM_URL in html
-
-    def test_html_contains_brand_colour(self) -> None:
-        html, _ = render_confirmation_email(confirmation_url=CONFIRM_URL)
-        # Primary brand cyan (v3 Market Pulse)
-        assert "#44d4ff" in html
-
-    def test_html_contains_brand_name(self) -> None:
-        html, _ = render_confirmation_email(confirmation_url=CONFIRM_URL)
-        assert "Auraxis" in html
-
-    def test_html_contains_inter_font(self) -> None:
-        # v3 Market Pulse uses Inter as a single sans-serif for headings and body.
-        html, _ = render_confirmation_email(confirmation_url=CONFIRM_URL)
-        assert "Inter" in html
-
-    def test_html_contains_cta_button(self) -> None:
-        html, _ = render_confirmation_email(confirmation_url=CONFIRM_URL)
-        assert "Confirmar email" in html
-
-    def test_html_contains_expiry_notice(self) -> None:
-        html, _ = render_confirmation_email(confirmation_url=CONFIRM_URL)
+        assert CONFIRM_URL in text
+        assert "Confirmar meu email" in html
         assert "24 horas" in html
 
-    def test_html_has_preview_text(self) -> None:
-        html, _ = render_confirmation_email(confirmation_url=CONFIRM_URL)
-        assert "Confirme seu email" in html
 
-    def test_text_contains_url(self) -> None:
-        _, text = render_confirmation_email(confirmation_url=CONFIRM_URL)
-        assert CONFIRM_URL in text
+class TestPasswordResetEmail:
+    def test_contract_and_identity(self) -> None:
+        _is_email(render_password_reset_email(reset_url=RESET_URL))
 
-    def test_text_is_plain_string(self) -> None:
-        _, text = render_confirmation_email(confirmation_url=CONFIRM_URL)
-        assert "<" not in text
-
-
-class TestRenderPasswordResetEmail:
-    def test_returns_html_and_text_tuple(self) -> None:
-        result = render_password_reset_email(reset_url=RESET_URL)
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-
-    def test_html_contains_reset_url(self) -> None:
-        html, _ = render_password_reset_email(reset_url=RESET_URL)
+    def test_cta_and_url(self) -> None:
+        html, text = render_password_reset_email(reset_url=RESET_URL)
         assert RESET_URL in html
-
-    def test_html_contains_cta_button(self) -> None:
-        html, _ = render_password_reset_email(reset_url=RESET_URL)
-        assert "Redefinir senha" in html
-
-    def test_html_contains_expiry_notice(self) -> None:
-        html, _ = render_password_reset_email(reset_url=RESET_URL)
+        assert RESET_URL in text
+        assert "Criar nova senha" in html
         assert "1 hora" in html
 
-    def test_text_contains_url(self) -> None:
-        _, text = render_password_reset_email(reset_url=RESET_URL)
-        assert RESET_URL in text
 
-    def test_text_is_plain_string(self) -> None:
-        _, text = render_password_reset_email(reset_url=RESET_URL)
-        assert "<" not in text
-
-    def test_html_contains_brand_colour(self) -> None:
-        html, _ = render_password_reset_email(reset_url=RESET_URL)
-        assert "#44d4ff" in html
+class TestAccountDeletionEmail:
+    def test_contract_and_lgpd(self) -> None:
+        html, text = render_account_deletion_email()
+        _is_email((html, text))
+        assert "LGPD" in html
 
 
-class TestRenderDueSoonEmail:
-    def test_returns_html_and_text_tuple(self) -> None:
-        result = render_due_soon_email(
-            title="Aluguel", amount_formatted="1500.00", days_before_due=7
+class TestDueSoonEmail:
+    def test_contract(self) -> None:
+        _is_email(
+            render_due_soon_email(
+                title="Aluguel", amount_formatted="1500.00", days_before_due=7
+            )
         )
-        assert isinstance(result, tuple)
-        assert len(result) == 2
 
-    def test_html_is_valid_doctype(self) -> None:
+    def test_deep_link_cta(self) -> None:
+        url = "https://app.auraxis.com.br/transactions?open=tx-42"
+        html, text = render_due_soon_email(
+            title="Aluguel",
+            amount_formatted="1500.00",
+            days_before_due=1,
+            due_date_label="27/07/2026",
+            transaction_url=url,
+        )
+        assert "Ver transação" in html
+        assert url in html  # CTA deep-links to the exact transaction
+        assert url in text
+        assert "Aluguel" in html and "1500.00" in html
+        assert "Vence amanhã" in html
+
+    def test_d7_badge_and_content(self) -> None:
+        html, _ = render_due_soon_email(
+            title="Cartão", amount_formatted="320.50", days_before_due=7
+        )
+        assert "Vence em 7 dias" in html
+        assert "Cartão" in html and "320.50" in html
+
+    def test_falls_back_to_transactions_list_without_url(self) -> None:
         html, _ = render_due_soon_email(
             title="Aluguel", amount_formatted="1500.00", days_before_due=7
         )
-        assert html.strip().startswith("<!DOCTYPE html>")
+        assert "/transactions" in html
 
-    def test_html_contains_brand_colour(self) -> None:
-        html, _ = render_due_soon_email(
-            title="Aluguel", amount_formatted="1500.00", days_before_due=7
-        )
-        assert "#44d4ff" in html
 
-    def test_html_contains_brand_name(self) -> None:
-        html, _ = render_due_soon_email(
-            title="Aluguel", amount_formatted="1500.00", days_before_due=7
+class TestInsightEmails:
+    def test_weekly_deep_links_to_insight(self) -> None:
+        url = "https://app.auraxis.com.br/insights?open=ins-7"
+        html, text = render_analysis_ready_email(
+            first_name="Italo",
+            summary_preview="Seus gastos com delivery subiram 34%.",
+            insight_url=url,
+            detail_rows=[("Delivery", "R$ 620", "#c2414d")],
+            suggestion="definir um teto mensal de R$ 480.",
         )
-        assert "Auraxis" in html
+        _is_email((html, text))
+        assert "Abrir no Auraxis" in html
+        assert url in html
+        assert "Delivery" in html and "620" in html  # full insight embedded
+        assert "Sugestão" in html
 
-    def test_html_contains_cta_button(self) -> None:
-        html, _ = render_due_soon_email(
-            title="Aluguel", amount_formatted="1500.00", days_before_due=7
+    def test_weekly_without_insight_id_falls_back(self) -> None:
+        html, _ = render_analysis_ready_email(
+            first_name="Italo", summary_preview="Resumo."
         )
-        assert "Ver no Auraxis" in html
+        assert "/insights" in html
 
-    def test_d7_html_contains_title_and_amount(self) -> None:
-        html, _ = render_due_soon_email(
-            title="Aluguel", amount_formatted="1500.00", days_before_due=7
+    def test_monthly_deep_links(self) -> None:
+        url = "https://app.auraxis.com.br/insights?open=month-3"
+        html, text = render_monthly_analysis_ready_email(
+            first_name="Italo",
+            summary_preview="Consolidado do mês.",
+            insight_url=url,
         )
-        assert "Aluguel" in html
-        assert "1500.00" in html
-        assert "Pendência vencendo em breve" in html
+        _is_email((html, text))
+        assert url in html
+        assert "Abrir relatório" in html
 
-    def test_d1_html_heading_is_tomorrow(self) -> None:
-        html, _ = render_due_soon_email(
-            title="Aluguel", amount_formatted="750.00", days_before_due=1
-        )
-        assert "Amanhã vence uma pendência" in html
-        assert "amanhã" in html
 
-    def test_d1_html_contains_title_and_amount(self) -> None:
-        html, _ = render_due_soon_email(
-            title="Cartão Nubank", amount_formatted="320.50", days_before_due=1
-        )
-        assert "Cartão Nubank" in html
-        assert "320.50" in html
+class TestVerificationReminderEmail:
+    def test_d1_and_d7(self) -> None:
+        html1, _ = render_email_verification_reminder_email(days_until_deadline=1)
+        _is_email((html1, _))
+        assert "Último dia" in html1
+        html7, _ = render_email_verification_reminder_email(days_until_deadline=7)
+        assert "7 dias" in html7
 
-    def test_text_is_plain_string(self) -> None:
-        _, text = render_due_soon_email(
-            title="Aluguel", amount_formatted="1500.00", days_before_due=7
-        )
-        assert "<" not in text
 
-    def test_text_contains_app_url(self) -> None:
-        _, text = render_due_soon_email(
-            title="Aluguel", amount_formatted="1500.00", days_before_due=7
-        )
-        assert "app.auraxis.com.br" in text
+class TestBillingEmails:
+    def test_all_billing_renderers_carry_identity_and_plan(self) -> None:
+        plan = "premium annual"
+        renderers = [
+            render_billing_payment_confirmed_email,
+            render_billing_payment_failed_email,
+            render_billing_refund_email,
+            render_billing_canceled_email,
+            render_billing_trial_expired_email,
+            render_billing_grace_expired_email,
+        ]
+        for renderer in renderers:
+            html, text = renderer(plan_label=plan)
+            _is_email((html, text))
+            assert plan in html
+            assert plan in text
 
-    def test_d7_text_mentions_days(self) -> None:
-        _, text = render_due_soon_email(
-            title="Aluguel", amount_formatted="1500.00", days_before_due=7
+    def test_trial_ending_email(self) -> None:
+        html, text = render_billing_trial_ending_email(
+            days_label="2 dias", trial_ends_label="27/07/2026"
         )
-        assert "7 dias" in text
+        _is_email((html, text))
+        assert "2 dias" in html
+        assert "27/07/2026" in html
 
-    def test_d1_text_mentions_amanha(self) -> None:
-        _, text = render_due_soon_email(
-            title="Aluguel", amount_formatted="1500.00", days_before_due=1
-        )
-        assert "amanhã" in text
+
+class TestWebBaseUrl:
+    def test_env_override(self, monkeypatch) -> None:
+        monkeypatch.setenv("AURAXIS_WEB_BASE_URL", "https://staging.auraxis.com.br/")
+        assert web_base_url() == "https://staging.auraxis.com.br"
+
+    def test_default(self, monkeypatch) -> None:
+        monkeypatch.delenv("AURAXIS_WEB_BASE_URL", raising=False)
+        monkeypatch.delenv("AURAXIS_APP_URL", raising=False)
+        assert web_base_url() == "https://app.auraxis.com.br"


### PR DESCRIPTION
## Contexto

Os emails transacionais estavam no shell dark v3 (navy + cyan `#44d4ff`) — o "preto e azul" que o PO pediu para trocar — e os 6 emails de billing nem usavam o template (HTML cru, sem marca).

## O que muda

### Identidade nova (clara, alinhada à marca web)
`_base_layout` reescrito: header com gradiente **teal `#087fa7` → verde `#087f5b`** + wordmark, corpo navy sobre claro, cartão com sombra suave, botão CTA branded, footer discreto. Componentes reutilizáveis: `_button`, `_badge`, `_detail_card`, `_heading`, `_para`, `_hint` — DRY e consistente. Fonte system-stack (deliverability).

### Copy reescrita (todos os ~14 emails)
Mais leve e humana, sempre dizendo o que o botão faz. Ex.: confirmação, reset de senha, exclusão LGPD, verificação, billing (confirmado/pendente/estorno/cancelado/trial-acabando/trial-expirado/carência-vencida), reminders e insights.

### CTAs com deep-link (pedido do PO)
- **Transação expirando** (`render_due_soon_email`): badge de aviso + **card da conta** (título, valor em vermelho, vencimento) + botão **"Ver transação"** que deep-linka em `/transactions?open={id}` (o `transaction.id` já estava em escopo no `transaction_reminder_service`, só não era passado). Requer o suporte web (`?open=`) — PR separado no auraxis-web.
- **Insight** (semanal + mensal): botão **"Abrir no Auraxis"** → `/insights?open={id}` (deep-link já suportado no web). O semanal agora threada o `insight.id` (via `result["id"]` no `ai_insights_cli`). Os renderers aceitam `detail_rows` + `suggestion` para embutir o insight completo (tabela de números + sugestão).

### Migração + centralização
- Os 6 emails de billing migrados para o template (novos `render_billing_*`).
- Base URL **env-driven** (`web_base_url()`: `AURAXIS_WEB_BASE_URL` → `AURAXIS_APP_URL` → prod) em vez do `_APP_URL` hardcoded.

## Validação
- `run_ci_quality_local.sh --local` — **verde** (coverage ~91%, ruff+mypy+bandit).
- `test_email_templates.py` reescrito (17 testes): identidade (`#087fa7` em todo email), CTAs, deep-links (transação + insight), renderers de billing, `web_base_url` com env. +100 testes de email/billing/reminder sem regressão.

## Risco residual
Baixo. Mudança de apresentação; assinaturas preservadas (params novos são opcionais com fallback). O deep-link de transação só "abre" após o merge do suporte web — até lá cai graciosamente na lista `/transactions`.

Closes #870-adjacent (email identity) — refina os emails de todas as frentes.
