### PR TITLE
feat(billing): retorno do checkout na superfície de origem (landing ou app)

### DIFF
--- a/app/controllers/subscription_controller.py
+++ b/app/controllers/subscription_controller.py
@@ -153,6 +153,13 @@ def create_checkout_session() -> ResponseReturnValue:
     if offer is None:
         return _err("Unsupported plan_slug", "VALIDATION_ERROR", 400)
 
+    # #1620: the buyer returns to the surface the checkout started from. This
+    # is a key into an allowlist of configured URLs — a URL sent here is
+    # ignored, so it can never become an open redirect.
+    return_surface: str | None = (
+        str(body.get("return_surface") or "").strip().lower() or None
+    )
+
     provider = _get_provider()
     try:
         result = provider.create_checkout_session(
@@ -162,6 +169,7 @@ def create_checkout_session() -> ResponseReturnValue:
                 email=str(user.email),
             ),
             plan_slug=offer.slug,
+            return_surface=return_surface,
         )
     except BillingProviderError:
         current_app.logger.exception(_CHECKOUT_SESSION_FAILURE_MESSAGE)

--- a/app/graphql/mutations/subscription.py
+++ b/app/graphql/mutations/subscription.py
@@ -43,6 +43,9 @@ class CreateCheckoutSessionMutation(graphene.Mutation):
     class Arguments:
         plan_slug = graphene.String(required=True)
         billing_cycle = SubscriptionBillingCycleEnum()
+        # #1620: which configured return URLs the buyer comes back to. A key
+        # into an allowlist — never a URL, so it cannot become a redirect.
+        return_surface = graphene.String()
 
     message = graphene.String(required=True)
     checkout = graphene.Field(CheckoutSessionType, required=True)
@@ -52,6 +55,7 @@ class CreateCheckoutSessionMutation(graphene.Mutation):
         info: graphene.ResolveInfo,
         plan_slug: str,
         billing_cycle: object | None = None,
+        return_surface: str | None = None,
     ) -> "CreateCheckoutSessionMutation":
         user = get_current_user_required()
         billing_cycle_value = coerce_enum_value(billing_cycle)
@@ -82,6 +86,7 @@ class CreateCheckoutSessionMutation(graphene.Mutation):
                     email=str(user.email),
                 ),
                 plan_slug=offer.slug,
+                return_surface=str(return_surface or "").strip().lower() or None,
             )
         except BillingProviderError as exc:
             raise build_public_graphql_error(

--- a/app/services/billing_adapter.py
+++ b/app/services/billing_adapter.py
@@ -120,11 +120,16 @@ class BillingProvider(Protocol):
         ...
 
     def create_checkout_session(
-        self, customer: BillingCheckoutCustomer, plan_slug: str
+        self,
+        customer: BillingCheckoutCustomer,
+        plan_slug: str,
+        return_surface: str | None = None,
     ) -> BillingCheckoutSession:
         """Create a hosted checkout session for the given plan.
 
-        Returns a dict with at least a ``checkout_url`` key.
+        ``return_surface`` selects which configured return URLs the provider
+        sends the buyer back to (#1620). Returns a dict with at least a
+        ``checkout_url`` key.
         """
         ...
 
@@ -156,7 +161,10 @@ class StubBillingProvider:
         }
 
     def create_checkout_session(
-        self, customer: BillingCheckoutCustomer, plan_slug: str
+        self,
+        customer: BillingCheckoutCustomer,
+        plan_slug: str,
+        return_surface: str | None = None,
     ) -> BillingCheckoutSession:
         return {
             "checkout_url": (
@@ -169,6 +177,43 @@ class StubBillingProvider:
 
 def _env(name: str, default: str = "") -> str:
     return str(os.getenv(name, default)).strip()
+
+
+# Surfaces a checkout can start from, mapped to the env vars holding their
+# return URLs. This is an allowlist on purpose: the caller picks a *key*, never
+# a URL, so a client can never turn the completion URL into an open redirect.
+_CHECKOUT_RETURN_ENVS: dict[str, tuple[str, str]] = {
+    "app": ("BILLING_CHECKOUT_SUCCESS_URL", "BILLING_CHECKOUT_CANCEL_URL"),
+    "landing": (
+        "BILLING_CHECKOUT_LANDING_SUCCESS_URL",
+        "BILLING_CHECKOUT_LANDING_CANCEL_URL",
+    ),
+}
+
+_DEFAULT_CHECKOUT_SURFACE = "app"
+
+
+def resolve_checkout_return_urls(surface: str | None) -> tuple[str, str]:
+    """Resolve the ``(success_url, cancel_url)`` pair for a checkout surface.
+
+    Buyers coming from the landing have no session on the app domain, so they
+    must return to the landing after paying (#1620).
+
+    Unknown surfaces — including anything that looks like a client-supplied
+    URL — fall back to the app pair, as does a surface whose own URLs are not
+    fully configured. Callers are responsible for rejecting an empty pair.
+
+    :param surface: Surface key (``app`` or ``landing``); case-insensitive.
+    :returns: The success and cancel URLs, possibly empty when unconfigured.
+    """
+    normalized = str(surface or "").strip().lower()
+    default = tuple(_env(name) for name in _CHECKOUT_RETURN_ENVS["app"])
+    if normalized in _CHECKOUT_RETURN_ENVS and normalized != _DEFAULT_CHECKOUT_SURFACE:
+        success_env, cancel_env = _CHECKOUT_RETURN_ENVS[normalized]
+        success, cancel = _env(success_env), _env(cancel_env)
+        if success and cancel:
+            return success, cancel
+    return default[0], default[1]
 
 
 def _parse_datetime(value: object) -> datetime | None:
@@ -278,9 +323,10 @@ class AsaasBillingProvider:
             raise BillingProviderError("Asaas customer response did not include an id")
         return customer_id
 
-    def _checkout_callback_payload(self) -> dict[str, str]:
-        success_url = _env("BILLING_CHECKOUT_SUCCESS_URL")
-        cancel_url = _env("BILLING_CHECKOUT_CANCEL_URL")
+    def _checkout_callback_payload(
+        self, return_surface: str | None = None
+    ) -> dict[str, str]:
+        success_url, cancel_url = resolve_checkout_return_urls(return_surface)
         expired_url = _env("BILLING_CHECKOUT_EXPIRED_URL", cancel_url)
         callback: dict[str, str] = {}
         if success_url:
@@ -292,10 +338,14 @@ class AsaasBillingProvider:
         return callback
 
     def _checkout_payload(
-        self, offer: BillingPlanOffer, customer_id: str, user_id: str
+        self,
+        offer: BillingPlanOffer,
+        customer_id: str,
+        user_id: str,
+        return_surface: str | None = None,
     ) -> dict[str, object]:
         cycle = "YEARLY" if offer.billing_cycle == BillingCycle.ANNUAL else "MONTHLY"
-        callback = self._checkout_callback_payload()
+        callback = self._checkout_callback_payload(return_surface)
         if not callback:
             raise BillingProviderError(
                 "BILLING_CHECKOUT_SUCCESS_URL and "
@@ -353,7 +403,10 @@ class AsaasBillingProvider:
         }
 
     def create_checkout_session(
-        self, customer: BillingCheckoutCustomer, plan_slug: str
+        self,
+        customer: BillingCheckoutCustomer,
+        plan_slug: str,
+        return_surface: str | None = None,
     ) -> BillingCheckoutSession:
         offer = resolve_checkout_plan_offer(plan_slug)
         if offer is None:
@@ -362,7 +415,9 @@ class AsaasBillingProvider:
         payload = self._request(
             "POST",
             "/checkouts",
-            json_payload=self._checkout_payload(offer, customer_id, customer.user_id),
+            json_payload=self._checkout_payload(
+                offer, customer_id, customer.user_id, return_surface
+            ),
         )
         checkout_id = str(payload.get("id") or "").strip()
         if not checkout_id:
@@ -511,14 +566,16 @@ class AbacatePayBillingProvider:
         }
 
     def create_checkout_session(
-        self, customer: BillingCheckoutCustomer, plan_slug: str
+        self,
+        customer: BillingCheckoutCustomer,
+        plan_slug: str,
+        return_surface: str | None = None,
     ) -> BillingCheckoutSession:
         offer = resolve_checkout_plan_offer(plan_slug)
         if offer is None:
             raise BillingProviderError(f"Unsupported plan slug: {plan_slug}")
 
-        success_url = _env("BILLING_CHECKOUT_SUCCESS_URL")
-        cancel_url = _env("BILLING_CHECKOUT_CANCEL_URL")
+        success_url, cancel_url = resolve_checkout_return_urls(return_surface)
         if not success_url or not cancel_url:
             raise BillingProviderError(
                 "BILLING_CHECKOUT_SUCCESS_URL and "

--- a/graphql.introspection.json
+++ b/graphql.introspection.json
@@ -13558,6 +13558,18 @@
                       "ofType": null
                     }
                   }
+                },
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "returnSurface",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
                 }
               ],
               "deprecationReason": "ADR-0004: use POST /subscription/checkout",

--- a/schema.graphql
+++ b/schema.graphql
@@ -889,7 +889,7 @@ type Mutation {
   createBudget(amount: String!, endDate: String, isActive: Boolean, name: String!, period: String!, startDate: String, tagId: String): CreateBudgetMutation @deprecated(reason: "ADR-0002: use POST /budgets")
   updateBudget(amount: String, budgetId: UUID!, endDate: String, isActive: Boolean, name: String, period: String, startDate: String, tagId: String): UpdateBudgetMutation @deprecated(reason: "ADR-0002: use PATCH /budgets/{id}")
   deleteBudget(budgetId: UUID!): DeleteBudgetMutation @deprecated(reason: "ADR-0002: use DELETE /budgets/{id}")
-  createCheckoutSession(billingCycle: BillingCycle, planSlug: String!): CreateCheckoutSessionMutation @deprecated(reason: "ADR-0004: use POST /subscription/checkout")
+  createCheckoutSession(billingCycle: BillingCycle, planSlug: String!, returnSurface: String): CreateCheckoutSessionMutation @deprecated(reason: "ADR-0004: use POST /subscription/checkout")
   cancelSubscription: CancelSubscriptionMutation @deprecated(reason: "ADR-0004: use POST /subscription/cancel")
 
   """Swap plan without double-charging (#1597); mirrors REST /change-plan."""

--- a/tests/test_billing_plan_change.py
+++ b/tests/test_billing_plan_change.py
@@ -44,7 +44,11 @@ class _FakeProvider:
         return {"status": "canceled"}
 
     def create_checkout_session(
-        self, *, customer: BillingCheckoutCustomer, plan_slug: str
+        self,
+        *,
+        customer: BillingCheckoutCustomer,
+        plan_slug: str,
+        return_surface: str | None = None,
     ) -> dict[str, Any]:
         self.calls.append(("checkout", plan_slug))
         return self._checkout

--- a/tests/test_checkout_return_surface.py
+++ b/tests/test_checkout_return_surface.py
@@ -1,0 +1,256 @@
+"""Tests for per-surface checkout return URLs (#1620).
+
+The subscription checkout can start either on the product app or on the public
+landing (auraxis.com.br). Whoever buys from the landing has no session on the
+app domain, so sending them back there after paying would drop them on a login
+screen. The provider payload therefore has to carry the return URLs of the
+surface the purchase started from.
+
+The surface is a **key into an allowlist of configured URLs** — never a URL
+supplied by the client, which would be an open redirect.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+from app.services.billing_adapter import (
+    BillingCheckoutCustomer,
+    resolve_checkout_return_urls,
+)
+
+APP_SUCCESS = "https://app.auraxis.com.br/checkout/success"
+APP_CANCEL = "https://app.auraxis.com.br/checkout/cancel"
+LANDING_SUCCESS = "https://auraxis.com.br/checkout/sucesso"
+LANDING_CANCEL = "https://auraxis.com.br/checkout/cancelado"
+
+
+@pytest.fixture
+def _app_envs(monkeypatch) -> None:
+    monkeypatch.setenv("BILLING_CHECKOUT_SUCCESS_URL", APP_SUCCESS)
+    monkeypatch.setenv("BILLING_CHECKOUT_CANCEL_URL", APP_CANCEL)
+    monkeypatch.delenv("BILLING_CHECKOUT_LANDING_SUCCESS_URL", raising=False)
+    monkeypatch.delenv("BILLING_CHECKOUT_LANDING_CANCEL_URL", raising=False)
+
+
+@pytest.fixture
+def _all_envs(_app_envs, monkeypatch) -> None:
+    monkeypatch.setenv("BILLING_CHECKOUT_LANDING_SUCCESS_URL", LANDING_SUCCESS)
+    monkeypatch.setenv("BILLING_CHECKOUT_LANDING_CANCEL_URL", LANDING_CANCEL)
+
+
+class TestResolveReturnUrls:
+    def test_defaults_to_the_app_surface(self, _all_envs) -> None:
+        assert resolve_checkout_return_urls(None) == (APP_SUCCESS, APP_CANCEL)
+
+    def test_app_surface_is_explicit_too(self, _all_envs) -> None:
+        assert resolve_checkout_return_urls("app") == (APP_SUCCESS, APP_CANCEL)
+
+    def test_landing_surface_uses_landing_urls(self, _all_envs) -> None:
+        assert resolve_checkout_return_urls("landing") == (
+            LANDING_SUCCESS,
+            LANDING_CANCEL,
+        )
+
+    def test_surface_is_case_and_space_insensitive(self, _all_envs) -> None:
+        assert resolve_checkout_return_urls("  LANDING  ") == (
+            LANDING_SUCCESS,
+            LANDING_CANCEL,
+        )
+
+    def test_unknown_surface_falls_back_to_app(self, _all_envs) -> None:
+        assert resolve_checkout_return_urls("marketing") == (APP_SUCCESS, APP_CANCEL)
+
+    def test_landing_without_envs_falls_back_to_app(self, _app_envs) -> None:
+        """Missing landing config degrades to the app URLs instead of breaking."""
+        assert resolve_checkout_return_urls("landing") == (APP_SUCCESS, APP_CANCEL)
+
+    def test_partial_landing_config_falls_back_to_app(
+        self, _app_envs, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("BILLING_CHECKOUT_LANDING_SUCCESS_URL", LANDING_SUCCESS)
+        assert resolve_checkout_return_urls("landing") == (APP_SUCCESS, APP_CANCEL)
+
+    def test_client_supplied_url_is_never_used(self, _all_envs) -> None:
+        """A URL where a surface key is expected must not become a redirect."""
+        success, cancel = resolve_checkout_return_urls("https://evil.example/steal")
+        assert success == APP_SUCCESS
+        assert cancel == APP_CANCEL
+
+    def test_missing_app_config_returns_empty(self, monkeypatch) -> None:
+        """Callers raise on empty URLs; the resolver just reports them."""
+        monkeypatch.delenv("BILLING_CHECKOUT_SUCCESS_URL", raising=False)
+        monkeypatch.delenv("BILLING_CHECKOUT_CANCEL_URL", raising=False)
+        assert resolve_checkout_return_urls("app") == ("", "")
+
+
+class TestAbacatePayUsesTheSurface:
+    def _provider(self):
+        from app.services.billing_adapter import AbacatePayBillingProvider
+
+        return AbacatePayBillingProvider()
+
+    def _customer(self) -> BillingCheckoutCustomer:
+        return BillingCheckoutCustomer(
+            user_id=str(uuid.uuid4()), name="QA", email="qa@test.com"
+        )
+
+    def test_landing_surface_reaches_the_provider_payload(
+        self, app, _all_envs, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("BILLING_ABACATEPAY_API_KEY", "test-key")
+        monkeypatch.setenv("BILLING_ABACATEPAY_PRODUCT_PREMIUM_MONTHLY", "prod_test")
+        with app.app_context():
+            provider = self._provider()
+            with (
+                patch.object(provider, "_ensure_customer", return_value="cust_1"),
+                patch.object(
+                    provider,
+                    "_request",
+                    return_value={"url": "https://abacate/pay", "id": "bill_1"},
+                ) as mock_request,
+            ):
+                provider.create_checkout_session(
+                    customer=self._customer(),
+                    plan_slug="premium_monthly",
+                    return_surface="landing",
+                )
+
+            body = mock_request.call_args.kwargs["json_payload"]
+            assert body["completionUrl"] == LANDING_SUCCESS
+            assert body["returnUrl"] == LANDING_CANCEL
+
+    def test_default_keeps_the_app_urls(self, app, _all_envs, monkeypatch) -> None:
+        monkeypatch.setenv("BILLING_ABACATEPAY_API_KEY", "test-key")
+        monkeypatch.setenv("BILLING_ABACATEPAY_PRODUCT_PREMIUM_MONTHLY", "prod_test")
+        with app.app_context():
+            provider = self._provider()
+            with (
+                patch.object(provider, "_ensure_customer", return_value="cust_1"),
+                patch.object(
+                    provider,
+                    "_request",
+                    return_value={"url": "https://abacate/pay", "id": "bill_1"},
+                ) as mock_request,
+            ):
+                provider.create_checkout_session(
+                    customer=self._customer(), plan_slug="premium_monthly"
+                )
+
+            body = mock_request.call_args.kwargs["json_payload"]
+            assert body["completionUrl"] == APP_SUCCESS
+            assert body["returnUrl"] == APP_CANCEL
+
+
+class TestRestContract:
+    """The REST endpoint forwards the surface and never trusts a URL."""
+
+    def _login(self, client) -> dict[str, str]:
+        suffix = uuid.uuid4().hex[:8]
+        email = f"surface-{suffix}@test.com"
+        reg = client.post(
+            "/auth/register",
+            json={
+                "name": f"Surface {suffix}",
+                "email": email,
+                "password": "StrongPass@123",
+            },
+        )
+        assert reg.status_code == 201
+        login = client.post(
+            "/auth/login", json={"email": email, "password": "StrongPass@123"}
+        )
+        assert login.status_code == 200
+        return {"Authorization": f"Bearer {login.get_json()['token']}"}
+
+    def test_surface_reaches_the_provider(self, client) -> None:
+        headers = self._login(client)
+        with patch(
+            "app.controllers.subscription_controller._get_provider"
+        ) as mock_provider:
+            mock_provider.return_value.create_checkout_session.return_value = {
+                "checkout_url": "https://pay/x",
+                "provider": "stub",
+            }
+            response = client.post(
+                "/subscriptions/checkout",
+                json={"plan_slug": "premium_monthly", "return_surface": "landing"},
+                headers=headers,
+            )
+        assert response.status_code in (200, 201)
+        kwargs = mock_provider.return_value.create_checkout_session.call_args.kwargs
+        assert kwargs["return_surface"] == "landing"
+
+    def test_absent_surface_is_none(self, client) -> None:
+        headers = self._login(client)
+        with patch(
+            "app.controllers.subscription_controller._get_provider"
+        ) as mock_provider:
+            mock_provider.return_value.create_checkout_session.return_value = {
+                "checkout_url": "https://pay/x",
+                "provider": "stub",
+            }
+            client.post(
+                "/subscriptions/checkout",
+                json={"plan_slug": "premium_monthly"},
+                headers=headers,
+            )
+        kwargs = mock_provider.return_value.create_checkout_session.call_args.kwargs
+        assert kwargs["return_surface"] is None
+
+    def test_url_in_the_surface_field_is_neutralised(self, client) -> None:
+        """The resolver drops it, so the app URLs are used — no open redirect."""
+        headers = self._login(client)
+        with patch(
+            "app.controllers.subscription_controller._get_provider"
+        ) as mock_provider:
+            mock_provider.return_value.create_checkout_session.return_value = {
+                "checkout_url": "https://pay/x",
+                "provider": "stub",
+            }
+            client.post(
+                "/subscriptions/checkout",
+                json={
+                    "plan_slug": "premium_monthly",
+                    "return_surface": "https://evil.example/steal",
+                },
+                headers=headers,
+            )
+        kwargs = mock_provider.return_value.create_checkout_session.call_args.kwargs
+        assert resolve_checkout_return_urls(kwargs["return_surface"]) == (_env_pair())
+
+
+def _env_pair() -> tuple[str, str]:
+    import os
+
+    return (
+        os.getenv("BILLING_CHECKOUT_SUCCESS_URL", ""),
+        os.getenv("BILLING_CHECKOUT_CANCEL_URL", ""),
+    )
+
+
+class TestGraphqlParity:
+    """REST and GraphQL must expose the same capability (repo rule)."""
+
+    def test_mutation_accepts_the_surface_argument(self) -> None:
+        from app.graphql.mutations.subscription import CreateCheckoutSessionMutation
+
+        arguments = CreateCheckoutSessionMutation.Arguments
+        assert hasattr(arguments, "return_surface")
+
+
+class TestStubProviderAcceptsTheSurface:
+    def test_stub_signature_matches_the_protocol(self) -> None:
+        from app.services.billing_adapter import StubBillingProvider
+
+        session = StubBillingProvider().create_checkout_session(
+            customer=BillingCheckoutCustomer(
+                user_id="u1", name="QA", email="qa@test.com"
+            ),
+            plan_slug="premium_monthly",
+            return_surface="landing",
+        )
+        assert session["checkout_url"]

--- a/tests/test_j9_billing_subscriptions.py
+++ b/tests/test_j9_billing_subscriptions.py
@@ -513,7 +513,10 @@ class TestCreateCheckoutSession:
 
         class _FakeProvider:
             def create_checkout_session(
-                self, customer: BillingCheckoutCustomer, plan_slug: str
+                self,
+                customer: BillingCheckoutCustomer,
+                plan_slug: str,
+                return_surface: str | None = None,
             ) -> dict[str, str]:
                 assert customer.email.endswith("@email.com")
                 assert plan_slug == "premium_monthly"


### PR DESCRIPTION
## Contexto

A landing (`auraxis.com.br`) vai passar a ter checkout próprio (web#1187). Hoje as URLs de retorno do provider são globais e apontam sempre para o app:

```
BILLING_CHECKOUT_SUCCESS_URL=https://app.auraxis.com.br/checkout/success
BILLING_CHECKOUT_CANCEL_URL=https://app.auraxis.com.br/checkout/cancel
```

Quem comprasse pela landing voltaria para o app **sem sessão** — a conta foi criada no domínio da landing — e cairia numa tela de login logo depois de pagar.

## O que muda

`resolve_checkout_return_urls(surface)` resolve o par `(sucesso, cancelamento)` a partir de uma **allowlist de envs**. `POST /subscriptions/checkout` e a mutation equivalente aceitam `return_surface`.

O ponto de segurança: a superfície é uma **chave** (`app` / `landing`), nunca uma URL. Um cliente que mandar `https://evil.example/…` no campo é ignorado e cai no par do app — sem open redirect. Há teste cobrindo exatamente isso.

Degradação: superfície desconhecida, ausente, ou configurada pela metade → par do app, sem erro. Sem as envs novas, o comportamento é idêntico ao de hoje.

## Compatibilidade

O `Protocol` ganhou um parâmetro com default; as três implementações (Stub, Asaas, AbacatePay) e os fakes de teste foram atualizados juntos. `subscription_service.change_subscription_plan` segue no default (troca de plano acontece dentro do app).

## Validação

- `scripts/run_ci_quality_local.sh --local` — **verde**: 2894 passed, 2 skipped, coverage **91.45%**, ruff + mypy + bandit + pip-audit ok.
- 16 testes novos: resolução por superfície (default, case/espaços, desconhecida, sem env, meia config), payload real do AbacatePay, contrato REST, paridade GraphQL e a neutralização de URL no campo.
- `schema.graphql` + `graphql.introspection.json` regenerados via `scripts/export_graphql_docs.py`.

⚠️ **O `schema.graphql` mudou** → o `graphql.ts` do auraxis-web fica stale e qualquer PR de lá quebra no `codegen:check` até rodar `pnpm codegen`. Já está previsto no PR do checkout da landing.

## Deploy

As envs novas são opcionais. Para ligar a jornada de compra na landing, adicionar ao `.env.prod` (backup antes + `--force-recreate`, conforme `auraxis:prod-deploy`):

```
BILLING_CHECKOUT_LANDING_SUCCESS_URL=https://auraxis.com.br/checkout/sucesso
BILLING_CHECKOUT_LANDING_CANCEL_URL=https://auraxis.com.br/checkout/cancelado
```

Documentado no runbook `PAY-AbacatePay-Setup.md` (PR separado no platform, que é onde a wiki vive).

## Risco residual

Baixo. Caminho novo é opt-in por env; sem elas nada muda. O caminho de erro (URL arbitrária) está coberto por teste.

## Refs

Closes #1620