### PR TITLE
fix(auth): manter a sessão quando o navegador é fechado

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from datetime import timedelta
 
 
 def _read_bool_env(name: str, default: bool) -> bool:
@@ -7,6 +8,25 @@ def _read_bool_env(name: str, default: bool) -> bool:
     if raw is None:
         return default
     return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _read_int_env(name: str, default: int) -> int:
+    """Read a positive integer env var, falling back on anything unusable.
+
+    A malformed value must not take the service down at import time — the
+    default is the documented behaviour, so we log and move on.
+    """
+    raw = os.getenv(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        value = int(raw.strip())
+    except ValueError:
+        logging.getLogger(__name__).warning(
+            "Invalid %s=%r — falling back to %d", name, raw, default
+        )
+        return default
+    return value if value > 0 else default
 
 
 def _is_secret_weak(secret: str) -> bool:
@@ -116,6 +136,19 @@ class Config:
         and not _read_bool_env("FLASK_TESTING", False),
     )
     JWT_COOKIE_SAMESITE = os.getenv("JWT_COOKIE_SAMESITE", "Lax")
+    # Refresh cookie must OUTLIVE the browser window. flask-jwt-extended
+    # defaults JWT_SESSION_COOKIE to True, which emits the cookie without
+    # Max-Age/Expires — the browser then drops it on close and the user is back
+    # at /login on the next visit, even though the refresh token itself is still
+    # valid for days. That silently cancelled the whole "stay signed in" design
+    # (#1628 — same symptom as #1528 and #1436, different cause).
+    JWT_SESSION_COOKIE = False
+    # Explicit instead of inheriting the library default (30 days): the cookie
+    # Max-Age is derived from this, so the value is now a deliberate product
+    # decision rather than a hidden default.
+    JWT_REFRESH_TOKEN_EXPIRES = timedelta(
+        days=_read_int_env("JWT_REFRESH_TOKEN_EXPIRES_DAYS", 30)
+    )
     # SEC-AUD-03 — Double-submit CSRF token for the refresh cookie.
     # Gated behind AURAXIS_CSRF_ENFORCE so web/app clients can migrate first:
     # while OFF, the CSRF cookie is NOT set and refresh works without the header

--- a/tests/test_auth_refresh_cookie.py
+++ b/tests/test_auth_refresh_cookie.py
@@ -11,6 +11,7 @@ Covers:
 
 from __future__ import annotations
 
+import re
 import uuid
 from typing import Any
 
@@ -86,6 +87,52 @@ class TestLoginEmitsRefreshCookie:
         assert "Path=/auth/refresh" in raw, (
             "refresh cookie must be scoped to /auth/refresh"
         )
+
+    def test_refresh_cookie_survives_browser_close(self, app, client):
+        """Cookie must carry Max-Age — without it the browser drops it on close.
+
+        flask-jwt-extended defaults JWT_SESSION_COOKIE to True, which emits a
+        session cookie: the refresh token stays valid for days but the user is
+        sent back to /login as soon as the browser is reopened (#1628).
+        """
+        _create_user(app)
+        resp = _login(client)
+        raw = _find_set_cookie(resp, REFRESH_COOKIE_NAME) or ""
+        assert "Max-Age=" in raw, (
+            "refresh cookie must be persistent (Max-Age), not a session cookie"
+        )
+
+    def test_refresh_cookie_max_age_outlives_the_token(self, app, client):
+        """Max-Age must comfortably outlive the refresh token itself.
+
+        flask-jwt-extended writes a fixed one-year Max-Age for non-session
+        cookies, so the effective session length is governed by
+        JWT_REFRESH_TOKEN_EXPIRES: the cookie survives restarts and the token
+        inside it decides when the user really has to sign in again.
+        """
+        _create_user(app)
+        resp = _login(client)
+        raw = _find_set_cookie(resp, REFRESH_COOKIE_NAME) or ""
+        match = re.search(r"Max-Age=(\d+)", raw)
+        assert match is not None, raw
+        token_lifetime = int(app.config["JWT_REFRESH_TOKEN_EXPIRES"].total_seconds())
+        assert int(match.group(1)) >= token_lifetime
+
+    def test_rotated_cookie_is_also_persistent(self, app, client):
+        """The cookie re-emitted by /auth/refresh must persist too.
+
+        Otherwise the session would survive the first browser restart and die
+        on the next one, right after any refresh.
+        """
+        _create_user(app)
+        # The Flask test client keeps cookies between requests, so the login
+        # above already leaves the refresh cookie in place.
+        _login(client)
+
+        resp = client.post("/auth/refresh", headers={"X-API-Contract": "v2"})
+        assert resp.status_code == 200, resp.get_json()
+        raw = _find_set_cookie(resp, REFRESH_COOKIE_NAME) or ""
+        assert "Max-Age=" in raw, "rotated refresh cookie must be persistent too"
 
     def test_login_body_still_contains_refresh_token_for_legacy_clients(
         self, app, client


### PR DESCRIPTION
## O que estava quebrado

Usuário loga, fecha o navegador, reabre — está deslogado. É o sintoma que web#1179 registrava como "F5 desloga".

Testei os três cenários em produção, com conta real:

| Cenário | Resultado |
|---|---|
| F5 numa rota privada | **mantém** — `POST /auth/refresh → 200` |
| F5 simultâneo em duas abas (rotação concorrente) | **mantém as duas** — três refresh, todos 200 |
| Fechar e reabrir o navegador | **desloga** — dois `refresh → 401` → `/login` |

Ou seja, o F5 nunca foi o gatilho.

## Causa

O `Set-Cookie` do login sai sem `Max-Age` e sem `Expires`:

```
set-cookie: auraxis_refresh=…; Domain=auraxis.com.br; Secure; HttpOnly;
            Path=/auth/refresh; SameSite=Lax
```

Sem eles o cookie é **de sessão**, e o navegador o descarta ao fechar. Isolei exatamente esse comportamento: dos três cookies do app, `auraxis_refresh` e `auraxis_csrf_refresh` somem ao fechar; só `i18n_redirected` persiste. Recriando o contexto do browser apenas com o que sobrevive, o boot cai em `/login`.

Vem do default `JWT_SESSION_COOKIE=True` do flask-jwt-extended, que o projeto nunca sobrescreveu. O efeito prático é que o refresh token era emitido com **30 dias** de validade e o cookie que o carrega não passava do fechamento da janela — o "continuar logado" nunca funcionou.

## O que mudou

```python
JWT_SESSION_COOKIE = False
JWT_REFRESH_TOKEN_EXPIRES = timedelta(
    days=_read_int_env("JWT_REFRESH_TOKEN_EXPIRES_DAYS", 30)
)
```

O segundo não é cosmético: com o cookie persistente, é o TTL do token que passa a governar quando o usuário precisa logar de novo. Deixar isso como default silencioso da biblioteca seria esconder a decisão de produto. O helper `_read_int_env` cai no default diante de valor inválido em vez de derrubar o serviço no import.

## Validação

`bash scripts/run_ci_quality_local.sh --local` verde — **2897 passed**, cobertura **91,45%**.

Três testes novos em `test_auth_refresh_cookie.py`:

- `test_refresh_cookie_survives_browser_close` — exige `Max-Age` no login;
- `test_refresh_cookie_max_age_outlives_the_token` — a relação correta entre cookie e token;
- `test_rotated_cookie_is_also_persistent` — o cookie reemitido pelo `/auth/refresh` também persiste (senão a sessão sobreviveria ao primeiro restart e morreria no seguinte).

Uma correção de rota que vale registrar: meu primeiro teste assumia `Max-Age == TTL do token`. Não é — a biblioteca grava **um ano fixo** para cookies não-sessão, e quem decide a duração real é o token. O teste foi ajustado para verificar a relação, não um número inventado.

## Trade-off de segurança

Cookie persistente amplia a janela de exposição em máquina compartilhada. As proteções existentes seguem valendo e são as usuais de "manter conectado": `HttpOnly`, `Secure`, `SameSite=Lax`, `Path=/auth/refresh`, rotação a cada uso e detecção de reuso.

## Risco residual

- **Sessões atuais não mudam sozinhas.** Quem já está logado só recebe o cookie persistente no próximo login ou refresh.
- Precisa de deploy em produção para a correção valer — e a validação real é fechar e reabrir o navegador depois disso.
- Mesmo sintoma já teve outras duas causas (#1528 `JWT_COOKIE_DOMAIN`, #1436 CORS/`X-CSRF-TOKEN`), ambas corrigidas. Se reaparecer, não assumir que é esta.

Closes #1628