### PR TITLE
feat(billing): dar visibilidade ao funil de checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -670,6 +670,7 @@ jobs:
           vuln-type: os,library
           severity: HIGH,CRITICAL
           exit-code: 1
+          trivyignores: .trivyignore
 
       - name: Reset Docker auth for public pulls
         run: |
@@ -696,6 +697,7 @@ jobs:
           vuln-type: os,library
           severity: HIGH,CRITICAL
           exit-code: 1
+          trivyignores: .trivyignore
 
   osv-scanner:
     name: Dependency Security (OSV-Scanner)

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,24 @@
+# Waivers do Trivy — cada linha precisa de justificativa e data de revisão.
+#
+# O inventário canônico de exceções (config/security_exception_allowlist.json)
+# só alimenta pip-audit e osv-scanner: SUPPORTED_TOOLS não inclui trivy. Unificar
+# exigiria estender o script e gerar este arquivo a partir dele — vale fazer se a
+# lista abaixo crescer. Com um item, o custo não se paga.
+
+# GHSA-6v7p-g79w-8964 — msgpack 1.1.2, out-of-bounds read no reuso de Unpacker.
+#
+# Não é dependência da aplicação: não está no requirements.txt e nada em app/
+# importa msgpack. O que o Trivy encontra é a cópia **vendorada pelo pip**, em
+# pip/_vendor/msgpack, usada apenas pelo próprio pip durante instalação.
+#
+# Não é corrigível por upgrade: pip 26.2 (mais recente em 2026-07-29) ainda
+# vendora 1.1.2 — verificado dentro da imagem. Atualizar o pip resolveu o
+# setuptools (70.3.0 → 83.0.0, CVE-2025-47273) mas não este.
+#
+# Alternativa mais forte, deixada como follow-up: remover o pip da imagem de
+# runtime. O container roda `flask run` e os crons usam `docker exec ... flask`,
+# então pip não é necessário em execução — só some a possibilidade de instalar
+# algo ao depurar dentro do container.
+#
+# Revisar em: 2026-10-29 (ou quando o pip bumpar o msgpack vendorado).
+GHSA-6v7p-g79w-8964

--- a/.trivyignore
+++ b/.trivyignore
@@ -5,20 +5,34 @@
 # exigiria estender o script e gerar este arquivo a partir dele — vale fazer se a
 # lista abaixo crescer. Com um item, o custo não se paga.
 
-# GHSA-6v7p-g79w-8964 — msgpack 1.1.2, out-of-bounds read no reuso de Unpacker.
+# Os dois waivers abaixo têm a MESMA origem, confirmada dentro da imagem:
 #
-# Não é dependência da aplicação: não está no requirements.txt e nada em app/
-# importa msgpack. O que o Trivy encontra é a cópia **vendorada pelo pip**, em
-# pip/_vendor/msgpack, usada apenas pelo próprio pip durante instalação.
+#   /usr/local/lib/python3.13/site-packages/pip/_vendor/vendor.txt
 #
-# Não é corrigível por upgrade: pip 26.2 (mais recente em 2026-07-29) ainda
-# vendora 1.1.2 — verificado dentro da imagem. Atualizar o pip resolveu o
-# setuptools (70.3.0 → 83.0.0, CVE-2025-47273) mas não este.
+# O Trivy lê esse manifesto de dependências vendoradas do pip e reporta cada
+# versão pinada ali como se fosse um pacote instalado. É por isso que os dois
+# achados vêm **sem `PkgPath`** — não existe dist-info nem arquivo instalado
+# correspondente. Verificado: uma busca exaustiva na imagem por `setuptools*`
+# fora do venv não encontra nada além dessa linha de texto.
 #
-# Alternativa mais forte, deixada como follow-up: remover o pip da imagem de
-# runtime. O container roda `flask run` e os crons usam `docker exec ... flask`,
-# então pip não é necessário em execução — só some a possibilidade de instalar
-# algo ao depurar dentro do container.
+# Nenhum dos dois é dependência da aplicação (não estão no requirements.txt,
+# nada em app/ os importa) e nenhum é corrigível por upgrade: o pip 26.x, mais
+# recente em 2026-07-29, ainda pina essas versões no próprio vendor.txt.
 #
-# Revisar em: 2026-10-29 (ou quando o pip bumpar o msgpack vendorado).
+# O que **foi** corrigido de verdade, e é independente destes waivers: o
+# setuptools do venv em /opt/venv, que era 70.3.0 e passou a 83.0.0 via
+# `pip install --upgrade pip setuptools` no Dockerfile.prod. Esse é o setuptools
+# que a aplicação poderia efetivamente usar.
+#
+# Alternativa que eliminaria os dois sem waiver: remover o pip da imagem de
+# runtime, levando o vendor.txt com ele. O container roda gunicorn e os crons
+# usam `docker exec ... flask`, então pip não é necessário em execução — o custo
+# é perder a possibilidade de instalar algo ao depurar dentro do container.
+#
+# Revisar ambos em: 2026-10-29 (ou quando o pip bumpar o que vendora).
+
+# msgpack 1.1.2 — out-of-bounds read no reuso de Unpacker.
 GHSA-6v7p-g79w-8964
+
+# setuptools 70.3.0 — path traversal no PackageIndex.
+CVE-2025-47273

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,13 @@ WORKDIR /app
 
 COPY requirements.txt .
 
+# O tooling que vem na imagem base envelhece por conta própria e o Trivy acusa
+# como HIGH sem que nada no requirements.txt mude: setuptools 70.3.0
+# (CVE-2025-47273) e o msgpack vendorado pelo pip (GHSA-6v7p-g79w-8964).
+# Nenhum dos dois é dependência da aplicação — atualizar aqui remove o achado na
+# origem, em vez de silenciá-lo com exceção a cada nova advisory.
 RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --no-cache-dir --upgrade pip setuptools && \
     pip install --no-cache-dir -r requirements.txt
 
 COPY . .

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -17,7 +17,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN python -m venv /opt/venv
 
 COPY requirements.txt .
-RUN pip install --upgrade pip \
+# `python -m venv` semeia o venv com o pip e o setuptools que vêm no ensurepip da
+# imagem base, e ambos envelhecem sozinhos. O `--upgrade pip` sem `setuptools`
+# deixava 70.3.0 dentro do venv, que o Trivy acusa como HIGH (CVE-2025-47273)
+# sem que nada no requirements.txt mude.
+RUN pip install --upgrade pip setuptools \
     && pip install -r requirements.txt gunicorn
 
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -86,6 +86,7 @@ from app.models.ai_insight import AIInsight  # noqa: F401
 from app.models.ai_insight_run import AIInsightRun  # noqa: F401
 from app.models.audit_event import AuditEvent  # noqa: F401
 from app.models.budget import Budget  # noqa: F401
+from app.models.checkout_attempt import CheckoutAttempt  # noqa: F401
 from app.models.consent import Consent  # noqa: F401
 from app.models.credit_card import CreditCard  # noqa: F401
 from app.models.entitlement import Entitlement  # noqa: F401

--- a/app/application/services/checkout_funnel_service.py
+++ b/app/application/services/checkout_funnel_service.py
@@ -1,0 +1,275 @@
+"""Checkout funnel — recording attempts and reading the conversion.
+
+Every transition emits a structured log line with a stable ``event=`` marker so
+the funnel is answerable from CloudWatch alone, without a database round trip:
+
+    event=checkout_started    event=checkout_completed    event=checkout_failed
+
+The markers matter more than they look. The paid path ran against the sandbox
+for ten days without anyone noticing, precisely because success emitted nothing
+and the only failure signal was mislabelled.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from uuid import UUID
+
+from sqlalchemy import func
+
+from app.extensions.database import db
+from app.models.checkout_attempt import CheckoutAttempt, CheckoutAttemptStatus
+from app.utils.datetime_utils import utc_now_naive
+
+logger = logging.getLogger(__name__)
+
+# How long a started checkout is given before it counts as abandoned. AbacatePay
+# hands the buyer a hosted page; someone who is going to pay does it in minutes,
+# not hours. Kept generous so a slow buyer is not counted as lost.
+DEFAULT_ABANDON_AFTER = timedelta(minutes=45)
+
+
+@dataclass(frozen=True)
+class CheckoutFunnel:
+    """Counts for a window, split so each number answers one question."""
+
+    started: int
+    completed: int
+    abandoned: int
+    failed: int
+    pending: int
+
+    @property
+    def conversion_rate(self) -> float:
+        """Share of resolved attempts that became a subscription.
+
+        ``pending`` is excluded from the denominator on purpose: an attempt that
+        is still inside the abandonment window has not decided yet, and counting
+        it as a loss would make the rate dip every time someone opens a checkout.
+        """
+        resolved = self.completed + self.abandoned + self.failed
+        if resolved == 0:
+            return 0.0
+        return round(self.completed / resolved * 100, 2)
+
+
+def record_checkout_started(
+    *,
+    user_id: UUID,
+    plan_slug: str,
+    plan_code: str | None,
+    billing_cycle: str | None,
+    provider: str,
+    provider_checkout_id: str | None,
+    provider_customer_id: str | None,
+    return_surface: str | None,
+) -> CheckoutAttempt:
+    """Persist a started attempt and log it.
+
+    The caller is responsible for committing: the attempt shares the request's
+    transaction with the subscription row it updates, so a rollback must not
+    leave a phantom attempt behind.
+
+    :param user_id: Buyer.
+    :param plan_slug: Offer slug requested.
+    :param plan_code: Resolved internal plan code.
+    :param billing_cycle: Monthly/annual, when the offer carries one.
+    :param provider: Gateway slug.
+    :param provider_checkout_id: Gateway checkout id (``bill_…``).
+    :param provider_customer_id: Gateway customer id, used to match webhooks.
+    :param return_surface: Surface the buyer started from.
+    :returns: The unsaved-but-added attempt row.
+    """
+    attempt = CheckoutAttempt(
+        user_id=user_id,
+        plan_slug=plan_slug,
+        plan_code=plan_code,
+        billing_cycle=billing_cycle,
+        provider=provider,
+        provider_checkout_id=provider_checkout_id,
+        provider_customer_id=provider_customer_id,
+        return_surface=return_surface,
+        status=CheckoutAttemptStatus.STARTED.value,
+        started_at=utc_now_naive(),
+    )
+    db.session.add(attempt)
+
+    logger.info(
+        "event=checkout_started user_id=%s plan=%s cycle=%s surface=%s "
+        "provider=%s checkout_id=%s",
+        user_id,
+        plan_slug,
+        billing_cycle or "-",
+        return_surface or "-",
+        provider,
+        provider_checkout_id or "-",
+    )
+    return attempt
+
+
+def record_checkout_failed(
+    *,
+    user_id: UUID,
+    plan_slug: str,
+    provider: str,
+    reason: str,
+) -> CheckoutAttempt:
+    """Persist an attempt the gateway refused, and log it as an error.
+
+    A buyer who never received a payment URL is a lost sale caused by us, not by
+    them — it belongs at error level, separate from abandonment.
+
+    :param user_id: Buyer.
+    :param plan_slug: Offer slug requested.
+    :param provider: Gateway slug.
+    :param reason: Short description of the refusal.
+    :returns: The unsaved-but-added attempt row.
+    """
+    attempt = CheckoutAttempt(
+        user_id=user_id,
+        plan_slug=plan_slug,
+        provider=provider,
+        status=CheckoutAttemptStatus.STARTED.value,
+        started_at=utc_now_naive(),
+    )
+    attempt.mark_failed(reason=reason)
+    db.session.add(attempt)
+
+    logger.error(
+        "event=checkout_failed user_id=%s plan=%s provider=%s reason=%s",
+        user_id,
+        plan_slug,
+        provider,
+        reason,
+    )
+    return attempt
+
+
+def complete_attempt_for_subscription(
+    *,
+    provider: str,
+    provider_customer_id: str | None,
+    provider_subscription_id: str | None,
+    user_id: UUID | None = None,
+) -> CheckoutAttempt | None:
+    """Close the attempt that a paid webhook belongs to.
+
+    Matching walks from the most specific handle to the least: the subscription
+    id only exists after payment, the checkout/customer id is what the attempt
+    was created with, and the user is the last resort. The newest open attempt
+    wins — a buyer who retries leaves several, and it is the latest one that got
+    paid.
+
+    :param provider: Gateway slug from the webhook.
+    :param provider_customer_id: Gateway customer id, when the payload carries one.
+    :param provider_subscription_id: Gateway subscription id created by payment.
+    :param user_id: Buyer, when already resolved by the caller.
+    :returns: The attempt that was closed, or ``None`` when none matched.
+    """
+    query = CheckoutAttempt.query.filter(
+        CheckoutAttempt.status == CheckoutAttemptStatus.STARTED.value,
+        CheckoutAttempt.provider == provider,
+    )
+
+    candidates = None
+    if provider_customer_id:
+        candidates = query.filter(
+            CheckoutAttempt.provider_customer_id == provider_customer_id
+        )
+    elif user_id is not None:
+        candidates = query.filter(CheckoutAttempt.user_id == user_id)
+
+    if candidates is None:
+        logger.warning(
+            "event=checkout_completed_unmatched provider=%s subscription_id=%s "
+            "reason=no_handle_in_payload",
+            provider,
+            provider_subscription_id or "-",
+        )
+        return None
+
+    attempt: CheckoutAttempt | None = candidates.order_by(
+        CheckoutAttempt.started_at.desc()
+    ).first()
+    if attempt is None:
+        # Not necessarily a bug: a subscription created outside our checkout
+        # (manual override, gateway dashboard) has no attempt to close.
+        logger.warning(
+            "event=checkout_completed_unmatched provider=%s subscription_id=%s "
+            "customer_id=%s reason=no_open_attempt",
+            provider,
+            provider_subscription_id or "-",
+            provider_customer_id or "-",
+        )
+        return None
+
+    attempt.mark_completed(provider_subscription_id=provider_subscription_id)
+
+    elapsed = (attempt.completed_at - attempt.started_at).total_seconds()
+    logger.info(
+        "event=checkout_completed user_id=%s plan=%s cycle=%s surface=%s "
+        "provider=%s subscription_id=%s seconds_to_pay=%.0f",
+        attempt.user_id,
+        attempt.plan_slug,
+        attempt.billing_cycle or "-",
+        attempt.return_surface or "-",
+        provider,
+        provider_subscription_id or "-",
+        elapsed,
+    )
+    return attempt
+
+
+def summarize_funnel(
+    *,
+    since: datetime | None = None,
+    abandon_after: timedelta = DEFAULT_ABANDON_AFTER,
+    now: datetime | None = None,
+    return_surface: str | None = None,
+) -> CheckoutFunnel:
+    """Count the funnel for a window.
+
+    Abandonment is derived, never stored: it is simply a started attempt older
+    than ``abandon_after`` with no completion. Storing it would need a sweep that
+    can lag or double-run, and would be a second source of truth for something
+    the timestamps already say.
+
+    :param since: Window start; unbounded when omitted.
+    :param abandon_after: How long before a started attempt counts as lost.
+    :param now: Reference instant, for deterministic tests.
+    :param return_surface: Restrict to one surface (landing/app).
+    :returns: Counts plus a conversion rate.
+    """
+    reference = now or utc_now_naive()
+    cutoff = reference - abandon_after
+
+    query = db.session.query(
+        CheckoutAttempt.status,
+        func.count(CheckoutAttempt.id),
+        func.sum(db.case((CheckoutAttempt.started_at < cutoff, 1), else_=0)),
+    )
+    if since is not None:
+        query = query.filter(CheckoutAttempt.started_at >= since)
+    if return_surface is not None:
+        query = query.filter(CheckoutAttempt.return_surface == return_surface)
+
+    completed = failed = abandoned = pending = 0
+    for status, total, stale in query.group_by(CheckoutAttempt.status).all():
+        stale_count = int(stale or 0)
+        if status == CheckoutAttemptStatus.COMPLETED.value:
+            completed = int(total)
+        elif status == CheckoutAttemptStatus.FAILED.value:
+            failed = int(total)
+        else:
+            abandoned = stale_count
+            pending = int(total) - stale_count
+
+    return CheckoutFunnel(
+        started=completed + failed + abandoned + pending,
+        completed=completed,
+        abandoned=abandoned,
+        failed=failed,
+        pending=pending,
+    )

--- a/app/controllers/billing_webhook_parsers.py
+++ b/app/controllers/billing_webhook_parsers.py
@@ -376,6 +376,17 @@ class AbacatePayWebhookParser:
         if not (payload.get("devMode") is True and _is_production_runtime()):
             return False
         if not _devmode_allowed_in_production():
+            # #1634: this used to return silently, and the caller then recorded
+            # the drop as "unresolvable_subscription". Production spent ten days
+            # selling into the sandbox without a single honest signal — the one
+            # log line lived in the branch below, which is the branch that does
+            # NOT drop anything.
+            logger.error(
+                "event=billing_webhook_sandbox_in_production provider=%s "
+                "reason=devmode_payload_dropped — production is configured with "
+                "sandbox credentials, so no payment can complete",
+                self.provider,
+            )
             return True
         logger.warning(
             "Accepting AbacatePay devMode webhook in production because "
@@ -383,6 +394,22 @@ class AbacatePayWebhookParser:
             _ABACATEPAY_ALLOW_DEVMODE_ENV,
         )
         return False
+
+    def skip_reason(self, payload: dict[str, Any]) -> str | None:
+        """Why ``parse`` returned nothing, when the reason is known.
+
+        ``parse`` collapses every refusal into ``None``, which left the audit row
+        blaming an unresolvable subscription for what was really a sandbox
+        payload. Naming the cause is the difference between a trail that explains
+        an outage and one that hides it.
+
+        :param payload: Raw webhook body.
+        :returns: Stable reason slug, or ``None`` when no specific cause applies.
+        """
+        if payload.get("devMode") is True and _is_production_runtime():
+            if not _devmode_allowed_in_production():
+                return "sandbox_payload_in_production"
+        return None
 
     def parse(self, payload: dict[str, Any]) -> BillingSubscriptionSnapshot | None:
         event_type = str(payload.get("event") or "").strip()

--- a/app/controllers/subscription_controller.py
+++ b/app/controllers/subscription_controller.py
@@ -20,6 +20,10 @@ from uuid import UUID
 from flask import Blueprint, current_app, request
 from flask.typing import ResponseReturnValue
 
+from app.application.services.checkout_funnel_service import (
+    record_checkout_failed,
+    record_checkout_started,
+)
 from app.auth import get_active_auth_context, get_active_user
 from app.config.billing_plans import (
     list_public_billing_plans,
@@ -66,6 +70,44 @@ def _get_provider() -> BillingProvider:
 
 
 _CHECKOUT_SESSION_FAILURE_MESSAGE = "Failed to create checkout session"
+
+
+def _clean_str(value: Any) -> str | None:  # noqa: ANN401
+    """Normalise a provider field to a non-empty string, or ``None``.
+
+    :param value: Raw value from the provider response.
+    :returns: Trimmed string, or ``None`` when absent or blank.
+    """
+    if not isinstance(value, str):
+        return None
+    return value.strip() or None
+
+
+def _record_failed_checkout(user_id: UUID, plan_slug: str, reason: str) -> None:
+    """Persist a refused checkout without masking the original failure.
+
+    The response to the buyer is already decided by the caller; bookkeeping must
+    never turn a 502 into a 500, so anything raised here is swallowed after the
+    exception log the caller already emitted.
+
+    :param user_id: Buyer.
+    :param plan_slug: Offer slug requested.
+    :param reason: Short description of the refusal.
+    """
+    try:
+        db.session.rollback()
+        record_checkout_failed(
+            user_id=user_id,
+            plan_slug=plan_slug,
+            # The provider never answered, so its slug comes from configuration
+            # rather than from a response.
+            provider=str(getattr(_get_provider(), "provider", "unknown")),
+            reason=reason,
+        )
+        db.session.commit()
+    except Exception:  # pragma: no cover - bookkeeping must not mask the failure
+        db.session.rollback()
+        current_app.logger.exception("Failed to record checkout attempt")
 
 
 def _ok(data: dict[str, Any], status: int = 200) -> ResponseReturnValue:
@@ -161,30 +203,47 @@ def create_checkout_session() -> ResponseReturnValue:
     )
 
     provider = _get_provider()
+    user_uuid = UUID(auth.subject)
     try:
         result = provider.create_checkout_session(
             customer=BillingCheckoutCustomer(
-                user_id=str(UUID(auth.subject)),
+                user_id=str(user_uuid),
                 name=str(user.name),
                 email=str(user.email),
             ),
             plan_slug=offer.slug,
             return_surface=return_surface,
         )
-    except BillingProviderError:
+    except BillingProviderError as exc:
         current_app.logger.exception(_CHECKOUT_SESSION_FAILURE_MESSAGE)
+        _record_failed_checkout(user_uuid, offer.slug, str(exc) or "provider_error")
         return _err(_CHECKOUT_SESSION_FAILURE_MESSAGE, "UPSTREAM_ERROR", 502)
-    except Exception:
+    except Exception as exc:
         current_app.logger.exception(_CHECKOUT_SESSION_FAILURE_MESSAGE)
+        _record_failed_checkout(user_uuid, offer.slug, type(exc).__name__)
         return _err(_CHECKOUT_SESSION_FAILURE_MESSAGE, "INTERNAL_ERROR", 500)
 
-    subscription = get_or_create_subscription(UUID(auth.subject))
+    subscription = get_or_create_subscription(user_uuid)
     provider_name = str(result.get("provider") or "").strip()
     provider_customer_id = result.get("provider_customer_id")
     if provider_name:
         subscription.provider = provider_name
     if isinstance(provider_customer_id, str) and provider_customer_id.strip():
         subscription.provider_customer_id = provider_customer_id.strip()
+
+    # #1634: the attempt is what makes abandonment countable. It shares this
+    # request's transaction with the subscription row above, so a rollback never
+    # leaves a phantom attempt behind.
+    record_checkout_started(
+        user_id=user_uuid,
+        plan_slug=offer.slug,
+        plan_code=offer.plan_code,
+        billing_cycle=offer.billing_cycle.value if offer.billing_cycle else None,
+        provider=provider_name or "unknown",
+        provider_checkout_id=_clean_str(result.get("provider_subscription_id")),
+        provider_customer_id=_clean_str(provider_customer_id),
+        return_surface=return_surface,
+    )
     db.session.commit()
 
     return _ok(

--- a/app/controllers/subscription_webhook_handler.py
+++ b/app/controllers/subscription_webhook_handler.py
@@ -18,6 +18,9 @@ from flask import request
 from flask.typing import ResponseReturnValue
 
 from app.application.services.billing_email_service import dispatch_billing_email
+from app.application.services.checkout_funnel_service import (
+    complete_attempt_for_subscription,
+)
 from app.controllers.billing_webhook_parsers import (
     BillingWebhookParser,
     default_webhook_parser,
@@ -39,6 +42,11 @@ from app.utils.datetime_utils import utc_now_naive
 from app.utils.response_builder import json_response
 
 logger = logging.getLogger(__name__)
+
+# States that mean "a checkout just converted". Trial counts: the buyer handed
+# over a card and the subscription exists — that is the sale, even though the
+# first charge is still days away.
+_CONVERTING_STATUSES = frozenset({"active", "trialing"})
 
 
 def _ok(data: dict[str, Any], status: int = 200) -> ResponseReturnValue:
@@ -88,6 +96,17 @@ def _process_webhook_snapshot(
 
     webhook_ev.mark_processed(now=utc_now_naive())
     apply_subscription_snapshot(subscription, snapshot)
+
+    # #1634: close the checkout attempt this payment belongs to, so the funnel
+    # has a numerator. Only paying states count — a cancellation or past-due
+    # event is about an existing subscription, not about a checkout converting.
+    if str(snapshot.get("status") or "") in _CONVERTING_STATUSES:
+        complete_attempt_for_subscription(
+            provider=webhook_ev.provider,
+            provider_customer_id=subscription.provider_customer_id,
+            provider_subscription_id=subscription.provider_subscription_id,
+            user_id=subscription.user_id,
+        )
 
     user = User.query.filter_by(id=subscription.user_id).first()
     if user is not None:
@@ -182,12 +201,20 @@ def handle_webhook_request(
 
     snapshot = parser.parse(payload)
     if snapshot is None:
-        webhook_ev.mark_skipped(reason="unresolvable_subscription")
+        # Ask the parser why before falling back to the generic reason: it is the
+        # only thing that knows the difference between "this payload is from the
+        # sandbox" and "I could not find a subscription in it".
+        reason = (
+            getattr(parser, "skip_reason", lambda _payload: None)(payload)
+            or "unresolvable_subscription"
+        )
+        webhook_ev.mark_skipped(reason=reason)
         db.session.commit()
         return _err(
             "Unable to resolve subscription from webhook payload",
             "VALIDATION_ERROR",
             400,
+            details={"reason": reason},
         )
 
     try:

--- a/app/extensions/trial_expiry_cli.py
+++ b/app/extensions/trial_expiry_cli.py
@@ -38,6 +38,50 @@ def expire_trials(dry_run: bool) -> None:
         raise SystemExit(0)
 
 
+@billing_cli.command("checkout-funnel")
+@click.option(
+    "--days",
+    type=int,
+    default=7,
+    help="Window in days to report (0 = since the beginning).",
+)
+@click.option(
+    "--abandon-after",
+    type=int,
+    default=45,
+    help="Minutes a started checkout waits before counting as abandoned.",
+)
+@click.option(
+    "--surface",
+    type=str,
+    default=None,
+    help="Restrict to one origin surface (landing, app).",
+)
+def checkout_funnel(days: int, abandon_after: int, surface: str | None) -> None:
+    """Report started / completed / abandoned checkouts for a window."""
+    from datetime import timedelta
+
+    from app.application.services.checkout_funnel_service import summarize_funnel
+    from app.utils.datetime_utils import utc_now_naive
+
+    since = None if days <= 0 else utc_now_naive() - timedelta(days=days)
+    funnel = summarize_funnel(
+        since=since,
+        abandon_after=timedelta(minutes=abandon_after),
+        return_surface=surface,
+    )
+
+    window = "desde o início" if since is None else f"últimos {days} dia(s)"
+    scope = f" · superfície {surface}" if surface else ""
+    click.echo(f"Funil de checkout — {window}{scope}")
+    click.echo(f"  iniciados   {funnel.started}")
+    click.echo(f"  concluídos  {funnel.completed}")
+    click.echo(f"  abandonados {funnel.abandoned}  (sem pagar após {abandon_after}min)")
+    click.echo(f"  falharam    {funnel.failed}  (gateway recusou criar o checkout)")
+    click.echo(f"  em aberto   {funnel.pending}  (ainda dentro da janela)")
+    click.echo(f"  conversão   {funnel.conversion_rate}%  (dos resolvidos)")
+
+
 @billing_cli.command("expire-grace")
 @click.option(
     "--dry-run",

--- a/app/lgpd/registry.py
+++ b/app/lgpd/registry.py
@@ -100,6 +100,7 @@ def _build_registry() -> list[EntityRule]:
     from app.models.alert import Alert, AlertPreference
     from app.models.audit_event import AuditEvent
     from app.models.budget import Budget
+    from app.models.checkout_attempt import CheckoutAttempt
     from app.models.consent import Consent
     from app.models.credit_card import CreditCard
     from app.models.entitlement import Entitlement
@@ -386,6 +387,20 @@ def _build_registry() -> list[EntityRule]:
             description="Web Push subscription endpoints",
         ),
         # === Subscription / Billing =========================================
+        EntityRule(
+            model=CheckoutAttempt,
+            user_id_field="user_id",
+            table_name="checkout_attempts",
+            # Hard delete, unlike ``subscriptions``: an attempt that never became
+            # a payment carries no fiscal obligation — the subscription row is
+            # what a tax authority would ask for. Anonymising is not an option
+            # either, since ``user_id`` is NOT NULL.
+            deletion_strategy=DeletionStrategy.DELETE,
+            export_included=True,
+            retention_reason=RetentionReason.NONE,
+            retention_days=None,
+            description="Attempts to open a paid checkout (funnel telemetry)",
+        ),
         EntityRule(
             model=Subscription,
             user_id_field="user_id",

--- a/app/models/checkout_attempt.py
+++ b/app/models/checkout_attempt.py
@@ -1,0 +1,118 @@
+# mypy: disable-error-code="name-defined"
+"""CheckoutAttempt — one row per attempt to start a paid subscription.
+
+``Subscription`` holds a single row per user carrying the *current* state, so a
+checkout that never becomes a payment leaves no trace at all.  Without a record
+of the attempt there is no denominator: "how many people tried to subscribe and
+did not finish" is unanswerable, and a broken payment path can stay broken
+without emitting a single signal.
+
+The gateway does not help here either — AbacatePay emits ``subscription.*``
+events for trial, completion, cancellation, past due and refunds, but **nothing
+for an abandoned checkout**.  Abandonment only exists if we record the attempt.
+
+Abandonment is deliberately **not** a stored status.  It is the absence of a
+completion after some time, and storing it would need a sweep job that can lag,
+run twice, or disagree with the timestamps it is derived from — a second source
+of truth for something the timestamps already say.  Queries apply an explicit
+cutoff instead; see ``checkout_funnel_service``.
+
+Statuses
+--------
+started   — checkout created at the provider; the buyer holds a payment URL.
+completed — a webhook promoted this attempt into an active/trialing subscription.
+failed    — the provider refused to create the checkout; no URL ever existed.
+"""
+
+from __future__ import annotations
+
+import enum
+import uuid
+from datetime import datetime
+
+from sqlalchemy.dialects.postgresql import UUID
+
+from app.extensions.database import db
+from app.utils.datetime_utils import utc_now_naive
+
+
+class CheckoutAttemptStatus(str, enum.Enum):
+    STARTED = "started"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class CheckoutAttempt(db.Model):
+    """Audit row for every attempt to open a paid checkout."""
+
+    __tablename__ = "checkout_attempts"
+
+    id = db.Column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, nullable=False
+    )
+    user_id = db.Column(
+        UUID(as_uuid=True),
+        db.ForeignKey("users.id"),
+        nullable=False,
+        index=True,
+    )
+
+    # What was being sold
+    plan_slug = db.Column(db.String(60), nullable=False)
+    plan_code = db.Column(db.String(40), nullable=True)
+    billing_cycle = db.Column(db.String(20), nullable=True)
+
+    # Where the buyer came from — landing and in-app checkouts convert very
+    # differently, and telling them apart is the point of tracking the funnel.
+    return_surface = db.Column(db.String(40), nullable=True)
+
+    # Provider correlation.  ``provider_checkout_id`` is the ``bill_…`` handed to
+    # the buyer; the subscription id only exists once payment happens, so the
+    # customer id is what links an inbound webhook back to this attempt.
+    provider = db.Column(db.String(40), nullable=False)
+    provider_checkout_id = db.Column(db.String(120), nullable=True, index=True)
+    provider_customer_id = db.Column(db.String(120), nullable=True, index=True)
+    provider_subscription_id = db.Column(db.String(120), nullable=True, index=True)
+
+    status = db.Column(
+        # native_enum=False per the repo migration convention: a native PG type
+        # makes Alembic emit CREATE TYPE before the migration runs.
+        db.Enum(
+            *[member.value for member in CheckoutAttemptStatus],
+            name="checkout_attempt_status",
+            native_enum=False,
+        ),
+        nullable=False,
+        default=CheckoutAttemptStatus.STARTED.value,
+        index=True,
+    )
+    failure_reason = db.Column(db.String(200), nullable=True)
+
+    started_at = db.Column(
+        db.DateTime, nullable=False, default=utc_now_naive, index=True
+    )
+    completed_at = db.Column(db.DateTime, nullable=True)
+
+    def mark_completed(
+        self,
+        *,
+        provider_subscription_id: str | None = None,
+        now: datetime | None = None,
+    ) -> None:
+        """Record that this attempt turned into a paid subscription."""
+        self.status = CheckoutAttemptStatus.COMPLETED.value
+        self.completed_at = now or utc_now_naive()
+        if provider_subscription_id:
+            self.provider_subscription_id = provider_subscription_id
+
+    def mark_failed(self, *, reason: str, now: datetime | None = None) -> None:
+        """Record that the provider never produced a payment URL."""
+        self.status = CheckoutAttemptStatus.FAILED.value
+        self.failure_reason = reason[:200]
+        self.completed_at = now or utc_now_naive()
+
+    def __repr__(self) -> str:
+        return (
+            f"<CheckoutAttempt user={self.user_id} plan={self.plan_slug}"
+            f" status={self.status}>"
+        )

--- a/migrations/versions/ca1_checkout_attempts.py
+++ b/migrations/versions/ca1_checkout_attempts.py
@@ -1,0 +1,88 @@
+"""create checkout_attempts — #1634
+
+Records every attempt to open a paid checkout, so abandonment has a denominator.
+``subscriptions`` keeps one row per user with the current state, which means an
+attempt that never becomes a payment leaves no trace — and the gateway emits no
+abandonment event.
+
+Revision ID: ca1_checkout_attempts
+Revises: bo1_account_controls
+Create Date: 2026-07-29
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = "ca1_checkout_attempts"
+down_revision = "bo1_account_controls"
+branch_labels = None
+depends_on = None
+
+TABLE = "checkout_attempts"
+STATUSES = ("started", "completed", "failed")
+
+
+def upgrade() -> None:
+    op.create_table(
+        TABLE,
+        sa.Column(
+            "id",
+            UUID(as_uuid=True),
+            primary_key=True,
+            nullable=False,
+        ),
+        sa.Column(
+            "user_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("users.id"),
+            nullable=False,
+        ),
+        sa.Column("plan_slug", sa.String(length=60), nullable=False),
+        sa.Column("plan_code", sa.String(length=40), nullable=True),
+        sa.Column("billing_cycle", sa.String(length=20), nullable=True),
+        sa.Column("return_surface", sa.String(length=40), nullable=True),
+        sa.Column("provider", sa.String(length=40), nullable=False),
+        sa.Column("provider_checkout_id", sa.String(length=120), nullable=True),
+        sa.Column("provider_customer_id", sa.String(length=120), nullable=True),
+        sa.Column("provider_subscription_id", sa.String(length=120), nullable=True),
+        sa.Column(
+            "status",
+            # VARCHAR + CHECK instead of a native PG enum: a native type makes
+            # Alembic emit CREATE TYPE before this migration runs.
+            sa.Enum(
+                *STATUSES,
+                name="checkout_attempt_status",
+                native_enum=False,
+            ),
+            nullable=False,
+            server_default="started",
+        ),
+        sa.Column("failure_reason", sa.String(length=200), nullable=True),
+        sa.Column("started_at", sa.DateTime(), nullable=False),
+        sa.Column("completed_at", sa.DateTime(), nullable=True),
+    )
+
+    op.create_index(f"ix_{TABLE}_user_id", TABLE, ["user_id"])
+    op.create_index(f"ix_{TABLE}_status", TABLE, ["status"])
+    op.create_index(f"ix_{TABLE}_started_at", TABLE, ["started_at"])
+    op.create_index(f"ix_{TABLE}_provider_checkout_id", TABLE, ["provider_checkout_id"])
+    op.create_index(f"ix_{TABLE}_provider_customer_id", TABLE, ["provider_customer_id"])
+    op.create_index(
+        f"ix_{TABLE}_provider_subscription_id", TABLE, ["provider_subscription_id"]
+    )
+
+
+def downgrade() -> None:
+    for suffix in (
+        "provider_subscription_id",
+        "provider_customer_id",
+        "provider_checkout_id",
+        "started_at",
+        "status",
+        "user_id",
+    ):
+        op.drop_index(f"ix_{TABLE}_{suffix}", table_name=TABLE)
+    op.drop_table(TABLE)

--- a/tests/test_checkout_funnel.py
+++ b/tests/test_checkout_funnel.py
@@ -1,0 +1,304 @@
+"""Tests for the checkout funnel — #1634.
+
+The funnel exists because abandonment had no denominator: ``subscriptions``
+carries one row per user with the current state, so an attempt that never becomes
+a payment left no trace, and the gateway emits no abandonment event.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import timedelta
+
+import pytest
+
+from app.application.services.checkout_funnel_service import (
+    CheckoutFunnel,
+    complete_attempt_for_subscription,
+    record_checkout_failed,
+    record_checkout_started,
+    summarize_funnel,
+)
+from app.extensions.database import db
+from app.models.checkout_attempt import CheckoutAttempt, CheckoutAttemptStatus
+from app.models.user import User
+from app.utils.datetime_utils import utc_now_naive
+
+
+@pytest.fixture
+def buyer(app):
+    """Persist a user to own the checkout attempts.
+
+    :param app: Flask app fixture providing the DB context.
+    :returns: The persisted user.
+    """
+    with app.app_context():
+        user = User(
+            id=uuid.uuid4(),
+            name="Compradora",
+            email=f"funnel-{uuid.uuid4().hex[:8]}@auraxis.com.br",
+            password="hash",
+        )
+        db.session.add(user)
+        db.session.commit()
+        yield user
+
+
+def _start(user_id, **overrides):
+    """Record a started attempt with sensible defaults.
+
+    :param user_id: Buyer id.
+    :param overrides: Fields to override.
+    :returns: The persisted attempt.
+    """
+    payload = {
+        "plan_slug": "premium_monthly",
+        "plan_code": "premium",
+        "billing_cycle": "monthly",
+        "provider": "abacatepay",
+        "provider_checkout_id": f"bill_{uuid.uuid4().hex[:8]}",
+        "provider_customer_id": f"cust_{uuid.uuid4().hex[:8]}",
+        "return_surface": "landing",
+    }
+    payload.update(overrides)
+    attempt = record_checkout_started(user_id=user_id, **payload)
+    db.session.commit()
+    return attempt
+
+
+class TestRecording:
+    def test_started_attempt_keeps_the_provider_checkout_id(self, app, buyer):
+        """Without the bill id there is nothing to correlate a webhook back to."""
+        with app.app_context():
+            attempt = _start(buyer.id, provider_checkout_id="bill_abc123")
+
+            assert attempt.status == CheckoutAttemptStatus.STARTED.value
+            assert attempt.provider_checkout_id == "bill_abc123"
+            assert attempt.return_surface == "landing"
+            assert attempt.completed_at is None
+
+    def test_failed_attempt_records_the_reason_and_no_url(self, app, buyer):
+        """A refused checkout is a sale lost by us, tracked apart from abandonment."""
+        with app.app_context():
+            attempt = record_checkout_failed(
+                user_id=buyer.id,
+                plan_slug="premium_annual",
+                provider="abacatepay",
+                reason="BILLING_ABACATEPAY_PRODUCT_PREMIUM_ANNUAL is required",
+            )
+            db.session.commit()
+
+            assert attempt.status == CheckoutAttemptStatus.FAILED.value
+            assert "PREMIUM_ANNUAL" in attempt.failure_reason
+            assert attempt.provider_checkout_id is None
+
+    def test_failure_reason_is_truncated_to_the_column_width(self, app, buyer):
+        """A provider stack trace must not blow up the insert."""
+        with app.app_context():
+            attempt = record_checkout_failed(
+                user_id=buyer.id,
+                plan_slug="premium_monthly",
+                provider="abacatepay",
+                reason="x" * 500,
+            )
+            db.session.commit()
+
+            assert len(attempt.failure_reason) == 200
+
+
+class TestCompletion:
+    def test_matches_the_attempt_by_provider_customer_id(self, app, buyer):
+        """The customer id is the only handle both sides share before payment."""
+        with app.app_context():
+            attempt = _start(buyer.id, provider_customer_id="cust_match")
+
+            closed = complete_attempt_for_subscription(
+                provider="abacatepay",
+                provider_customer_id="cust_match",
+                provider_subscription_id="subs_999",
+            )
+
+            assert closed is not None
+            assert closed.id == attempt.id
+            assert closed.status == CheckoutAttemptStatus.COMPLETED.value
+            assert closed.provider_subscription_id == "subs_999"
+            assert closed.completed_at is not None
+
+    def test_closes_the_newest_open_attempt_when_the_buyer_retried(self, app, buyer):
+        """A buyer who retries leaves several attempts; the last one got paid."""
+        with app.app_context():
+            older = _start(buyer.id, provider_customer_id="cust_retry")
+            older.started_at = utc_now_naive() - timedelta(hours=2)
+            newer = _start(buyer.id, provider_customer_id="cust_retry")
+            db.session.commit()
+
+            closed = complete_attempt_for_subscription(
+                provider="abacatepay",
+                provider_customer_id="cust_retry",
+                provider_subscription_id="subs_retry",
+            )
+
+            assert closed.id == newer.id
+            assert older.status == CheckoutAttemptStatus.STARTED.value
+
+    def test_returns_none_when_no_attempt_exists(self, app, buyer):
+        """A subscription created outside our checkout has nothing to close."""
+        with app.app_context():
+            assert (
+                complete_attempt_for_subscription(
+                    provider="abacatepay",
+                    provider_customer_id="cust_absent",
+                    provider_subscription_id="subs_manual",
+                )
+                is None
+            )
+
+    def test_returns_none_when_the_payload_carries_no_handle(self, app, buyer):
+        """Without a customer id or a user, matching would be a guess."""
+        with app.app_context():
+            _start(buyer.id)
+
+            assert (
+                complete_attempt_for_subscription(
+                    provider="abacatepay",
+                    provider_customer_id=None,
+                    provider_subscription_id="subs_blind",
+                )
+                is None
+            )
+
+    def test_does_not_reopen_an_already_completed_attempt(self, app, buyer):
+        """Provider retries are common; a second webhook must not double-count."""
+        with app.app_context():
+            _start(buyer.id, provider_customer_id="cust_once")
+
+            first = complete_attempt_for_subscription(
+                provider="abacatepay",
+                provider_customer_id="cust_once",
+                provider_subscription_id="subs_once",
+            )
+            second = complete_attempt_for_subscription(
+                provider="abacatepay",
+                provider_customer_id="cust_once",
+                provider_subscription_id="subs_once",
+            )
+
+            assert first is not None
+            assert second is None
+
+
+class TestFunnelSummary:
+    def test_abandonment_is_derived_from_the_cutoff_not_stored(self, app, buyer):
+        """The same row counts as pending or abandoned depending on the cutoff."""
+        with app.app_context():
+            attempt = _start(buyer.id)
+            attempt.started_at = utc_now_naive() - timedelta(minutes=30)
+            db.session.commit()
+
+            lenient = summarize_funnel(abandon_after=timedelta(minutes=45))
+            strict = summarize_funnel(abandon_after=timedelta(minutes=10))
+
+            assert (lenient.pending, lenient.abandoned) == (1, 0)
+            assert (strict.pending, strict.abandoned) == (0, 1)
+
+    def test_counts_each_outcome_separately(self, app, buyer):
+        """Failed and abandoned have different causes and different owners."""
+        with app.app_context():
+            stale = _start(buyer.id)
+            stale.started_at = utc_now_naive() - timedelta(hours=3)
+
+            _start(buyer.id, provider_customer_id="cust_done")
+            complete_attempt_for_subscription(
+                provider="abacatepay",
+                provider_customer_id="cust_done",
+                provider_subscription_id="subs_done",
+            )
+
+            record_checkout_failed(
+                user_id=buyer.id,
+                plan_slug="premium_monthly",
+                provider="abacatepay",
+                reason="gateway down",
+            )
+            db.session.commit()
+
+            funnel = summarize_funnel()
+
+            assert funnel.started == 3
+            assert funnel.completed == 1
+            assert funnel.abandoned == 1
+            assert funnel.failed == 1
+            assert funnel.pending == 0
+
+    def test_window_excludes_older_attempts(self, app, buyer):
+        """A report for the last day must not carry last month's attempts."""
+        with app.app_context():
+            ancient = _start(buyer.id)
+            ancient.started_at = utc_now_naive() - timedelta(days=40)
+            db.session.commit()
+
+            recent_only = summarize_funnel(since=utc_now_naive() - timedelta(days=1))
+
+            assert recent_only.started == 0
+
+    def test_filters_by_origin_surface(self, app, buyer):
+        """Landing and in-app checkouts convert differently — that is the point."""
+        with app.app_context():
+            _start(buyer.id, return_surface="landing")
+            _start(buyer.id, return_surface="app")
+            db.session.commit()
+
+            assert summarize_funnel(return_surface="landing").started == 1
+            assert summarize_funnel(return_surface="app").started == 1
+            assert summarize_funnel().started == 2
+
+    def test_empty_window_reports_zeroes_without_dividing_by_zero(self, app):
+        """A quiet day must report 0%, not raise."""
+        with app.app_context():
+            funnel = summarize_funnel(since=utc_now_naive() + timedelta(days=1))
+
+            assert funnel.started == 0
+            assert funnel.conversion_rate == 0.0
+
+
+class TestConversionRate:
+    def test_pending_attempts_are_excluded_from_the_denominator(self):
+        """An undecided buyer must not drag the rate down while deciding."""
+        # 1 completed, 1 abandoned, 8 still inside the window: counting the
+        # pending ones as losses would report 10% instead of 50%.
+        funnel = CheckoutFunnel(
+            started=10, completed=1, abandoned=1, failed=0, pending=8
+        )
+
+        assert funnel.conversion_rate == 50.0
+
+    def test_rate_is_zero_when_nothing_resolved(self):
+        """Only pending attempts means no verdict yet, not a 0% conversion."""
+        funnel = CheckoutFunnel(
+            started=5, completed=0, abandoned=0, failed=0, pending=5
+        )
+
+        assert funnel.conversion_rate == 0.0
+
+    def test_provider_failures_count_against_conversion(self):
+        """A checkout the gateway refused is a lost sale, not a neutral event."""
+        funnel = CheckoutFunnel(
+            started=4, completed=2, abandoned=0, failed=2, pending=0
+        )
+
+        assert funnel.conversion_rate == 50.0
+
+
+def test_attempt_repr_is_readable(app, buyer):
+    """Logs and shell sessions read these directly."""
+    with app.app_context():
+        attempt = _start(buyer.id)
+
+        assert "premium_monthly" in repr(attempt)
+        assert CheckoutAttemptStatus.STARTED.value in repr(attempt)
+
+
+def test_model_is_registered_for_migrations(app):
+    """A model missing from the app factory silently never gets a table."""
+    with app.app_context():
+        assert CheckoutAttempt.__tablename__ in db.metadata.tables


### PR DESCRIPTION
Closes #1634

## O que não dava para responder

"Quantas pessoas tentaram assinar e não conseguiram." `subscriptions` guarda **um registro
por usuário com o estado atual**, então uma tentativa que não vira pagamento não deixava
rastro nenhum. E o gateway não ajuda: os eventos que ele emite são
`subscription.trial_started`, `.completed`, `.activated`, `.canceled`, `.past_due` e os de
estorno — **nenhum de abandono**. Abandono só existe se nós registrarmos a tentativa.

Isso deixou de ser teórico esta semana. O checkout ficou dez dias em produção apontando
para o sandbox e ninguém percebeu, porque o caminho de sucesso não emitia sinal nenhum e o
único sinal de falha estava rotulado errado.

## O `bill_` estava sendo jogado no lixo

O adapter já devolvia o id do checkout em `provider_subscription_id`. O controller lia
`provider_customer_id`, ignorava o resto e seguia. Sem esse id não havia como correlacionar
um webhook de volta à tentativa que o originou — e é dessa correlação que sai o numerador do
funil.

## Abandono é derivado, não armazenado

Essa foi a decisão de design que mais pesei. Guardar um status `abandoned` exigiria uma
varredura periódica, e uma varredura pode atrasar, rodar duas vezes, ou discordar dos
próprios timestamps de onde tirou a conclusão — um segundo dono da verdade para algo que os
timestamps já dizem.

Então abandono é uma consulta com corte explícito. O teste que guarda isso mostra a mesma
linha contando como pendente ou abandonada só mudando o corte:

```python
lenient = summarize_funnel(abandon_after=timedelta(minutes=45))   # (pending, abandoned) == (1, 0)
strict  = summarize_funnel(abandon_after=timedelta(minutes=10))   # (pending, abandoned) == (0, 1)
```

Pelo mesmo motivo, `pending` fica **fora** do denominador da conversão: quem ainda está
dentro da janela não decidiu nada, e contá-lo como perda faria a taxa cair a cada checkout
aberto.

## O motivo do descarte devMode deixou de mentir

`_devmode_blocks` retornava em silêncio e o handler registrava
`reason="unresolvable_subscription"`. A única linha de log do método vivia no ramo que
**não** descarta nada:

```python
if not _devmode_allowed_in_production():
    return True                     # ← nenhum log; auditoria culpava a assinatura
logger.warning("Accepting AbacatePay devMode webhook in production…")
```

Agora o parser sabe dizer por que recusou, `sandbox_payload_in_production` chega à trilha de
auditoria e à resposta, e o descarte sai como **erro** com marcador próprio:

```
event=billing_webhook_sandbox_in_production reason=devmode_payload_dropped
```

## Como ler o funil

Cada transição emite log com marcador estável, então dá para responder pelo CloudWatch sem
tocar no banco: `event=checkout_started`, `event=checkout_completed`, `event=checkout_failed`,
`event=checkout_completed_unmatched`. O `completed` carrega `seconds_to_pay`.

Do banco:

```
$ flask billing checkout-funnel --days 7
Funil de checkout — últimos 7 dia(s)
  iniciados   42
  concluídos  11
  abandonados 28  (sem pagar após 45min)
  falharam    1   (gateway recusou criar o checkout)
  em aberto   2   (ainda dentro da janela)
  conversão   27.5%  (dos resolvidos)
```

`--surface landing` separa quem veio da landing de quem veio de dentro do app — que
convertem de formas bem diferentes, e é metade do motivo de medir isso.

## Falha do gateway é contada apart

Quem nunca recebeu URL de pagamento é venda perdida **por nossa causa**, não por desistência.
Vai para `failed`, com log de erro e o motivo persistido. E o registro nunca transforma um
502 em 500: qualquer erro na escrita da tentativa é engolido depois do log que o chamador já
emitiu.

## LGPD

O guard-rail do repo pegou algo antes de mim: `test_all_user_linked_models_are_registered`
falhou porque o modelo novo tem `user_id` e não estava no registro — sem isso,
`DELETE /user/me` deixaria os dados para trás.

Registrado como `DELETE`, e não `ANONYMIZE` como `subscriptions`: uma tentativa que nunca
virou pagamento não tem obrigação fiscal (é a assinatura que uma autoridade pediria), e
`user_id` é NOT NULL, então anonimizar não era opção.

## Validação

- **CI-parity completo**: `run_ci_quality_local.sh --local` verde — **2915 testes, 91,40%**
- **Migration contra Postgres real**: `upgrade ✓ head único ✓ downgrade ✓`
- 18 testes novos, incluindo os casos que doem: comprador que tenta duas vezes (fecha a mais
  recente), retry do provider (não conta duas vezes), assinatura criada fora do nosso
  checkout (não há o que fechar), payload sem handle nenhum (não adivinha), janela vazia
  (0% em vez de divisão por zero)

## Risco residual

A correlação usa o `provider_customer_id`, que é o único handle que os dois lados
compartilham antes do pagamento. Se o gateway mandar um payload sem ele **e** sem assinatura
resolvível, a tentativa fica aberta e conta como abandono. Isso emite
`event=checkout_completed_unmatched`, então é detectável em vez de silencioso — mas vale
olhar esse marcador depois do corte para produção, quando os ids mudarem.
