### PR TITLE
fix(deploy): atribuir cada erro do Sentry ao commit implantado

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -73,11 +73,17 @@ EMAIL_CONFIRMATION_FRONTEND_URL=https://app.auraxis.com.br/confirm-email
 PASSWORD_RESET_FRONTEND_URL=https://app.auraxis.com.br/reset-password
 
 # Sentry error tracking and performance monitoring (opt-in — leave blank to disable)
+# The rates below mirror what production actually runs (enabled 2026-04-03).
+# Keeping them at 0.0 here made an environment rebuild ship with tracing off
+# without anyone noticing — canonical values live in .context/09_infra_map.md
+# of auraxis-platform.
 SENTRY_DSN=https://replace-with-key@o000000.ingest.us.sentry.io/0000000
 SENTRY_ENVIRONMENT=production
-SENTRY_TRACES_RATE=0.0
-SENTRY_PROFILES_RATE=0.0
+SENTRY_TRACES_RATE=0.1
+SENTRY_PROFILES_RATE=0.05
 SENTRY_ERROR_RATE=1.0
+# SENTRY_RELEASE is written automatically by scripts/aws_deploy_i6.py on every
+# deploy and rollback (value = the deployed commit SHA). Do not set it by hand.
 # SENTRY_RELEASE=
 
 # Domain / TLS
@@ -89,9 +95,12 @@ CERTBOT_EMAIL=you@example.com
 EDGE_TLS_MODE=instance_tls
 
 # Startup strategy
-# Use migrations on startup and keep bootstrap fallback disabled by default.
+# Production does NOT migrate on boot: the deploy job applies `flask db upgrade`
+# pinned to the web container and then gates on drift (current == heads). Leaving
+# this at true means every gunicorn worker races the same migration on restart —
+# the 2026-05-31 incident. Keep the bootstrap fallback disabled.
 AUTO_CREATE_DB=false
-MIGRATE_ON_START=true
+MIGRATE_ON_START=false
 ALLOW_SCHEMA_BOOTSTRAP_WITHOUT_MIGRATIONS=false
 DB_WAIT_TIMEOUT=90
 

--- a/scripts/aws_deploy_i6.py
+++ b/scripts/aws_deploy_i6.py
@@ -1025,6 +1025,22 @@ else
 fi
 echo "[i6] WEB_IMAGE=$WEB_IMAGE written to $ENV_FILE"
 
+# Write SENTRY_RELEASE so every event in Sentry is attributable to the exact
+# deployed commit (without it, sentry_sdk.init(release=None) and Release Health
+# is unavailable — see auraxis-api#1637). Derived from the image tag, which is
+# always the commit SHA; $GIT_REF is only a fallback because it may be a branch
+# name such as "master".
+SENTRY_RELEASE_VALUE="$(echo "$WEB_IMAGE" | sed -n 's/.*://p')"
+case "$SENTRY_RELEASE_VALUE" in
+  ""|*/*) SENTRY_RELEASE_VALUE="$GIT_REF" ;;
+esac
+if grep -q "^SENTRY_RELEASE=" "$ENV_FILE"; then
+  sed -i "s|^SENTRY_RELEASE=.*|SENTRY_RELEASE=$SENTRY_RELEASE_VALUE|" "$ENV_FILE"
+else
+  echo "SENTRY_RELEASE=$SENTRY_RELEASE_VALUE" >> "$ENV_FILE"
+fi
+echo "[i6] SENTRY_RELEASE=$SENTRY_RELEASE_VALUE written to $ENV_FILE"
+
 # Phase 4: Swap web container only.
 # --no-deps: do not touch db or redis.
 # --force-recreate: ensure the new image is used even if compose thinks nothing changed.

--- a/tests/test_aws_deploy_i6.py
+++ b/tests/test_aws_deploy_i6.py
@@ -144,6 +144,54 @@ def test_build_script_writes_schema_version_to_deploy_state() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Sentry release attribution (#1637)
+# ---------------------------------------------------------------------------
+
+
+def test_build_script_writes_sentry_release_before_recreating_web() -> None:
+    """SENTRY_RELEASE must land in the env file BEFORE the container swap.
+
+    Written after the swap it would only take effect on the *next* deploy, so
+    every error in Sentry would be attributed to the previous commit — worse
+    than having no release at all.
+    """
+    script = aws_deploy_i6._build_script(
+        env_name="prod",
+        aws_region="us-east-1",
+        git_ref="origin/master",
+        mode="deploy",
+        web_image="ghcr.io/italofelipe/auraxis-api:deadbeef",
+    )
+
+    write_idx = script.find("SENTRY_RELEASE=$SENTRY_RELEASE_VALUE")
+    swap_idx = script.find("swapping web container")
+
+    assert write_idx != -1, "expected SENTRY_RELEASE to be written to the env file"
+    assert swap_idx != -1, "expected web container swap section"
+    assert write_idx < swap_idx, (
+        "SENTRY_RELEASE must be written before the web container is recreated"
+    )
+
+
+def test_build_script_derives_sentry_release_from_image_tag() -> None:
+    """The release value comes from the image tag, with $GIT_REF as fallback.
+
+    The image tag is always the commit SHA; git_ref may be a branch name such
+    as 'origin/master', which would make every deploy share one release.
+    """
+    script = aws_deploy_i6._build_script(
+        env_name="prod",
+        aws_region="us-east-1",
+        git_ref="origin/master",
+        mode="deploy",
+        web_image="ghcr.io/italofelipe/auraxis-api:deadbeef",
+    )
+
+    assert 'SENTRY_RELEASE_VALUE="$(echo "$WEB_IMAGE" | sed -n \'s/.*://p\')"' in script
+    assert 'SENTRY_RELEASE_VALUE="$GIT_REF"' in script
+
+
+# ---------------------------------------------------------------------------
 # Migration step on deploy (#1252)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -148,6 +148,36 @@ def test_sentry_init_traces_sample_rate_from_env(
         assert kwargs.get("traces_sample_rate") == pytest.approx(0.25)
 
 
+def test_sentry_init_release_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """release must carry SENTRY_RELEASE so events map to the deployed commit."""
+    monkeypatch.setenv("SENTRY_DSN", "https://public@sentry.example.io/56")
+    monkeypatch.setenv("SENTRY_RELEASE", "e623e673a2fb94f5371a896889c9eb0e5bdac77a")
+
+    with patch("sentry_sdk.init") as mock_init:
+        mod = _reload_sentry()
+        mod.init_sentry()
+        _, kwargs = mock_init.call_args
+        assert kwargs.get("release") == "e623e673a2fb94f5371a896889c9eb0e5bdac77a"
+
+
+def test_sentry_init_release_is_none_when_env_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An absent SENTRY_RELEASE must become None, never the empty string.
+
+    Sentry treats "" as a release literally named empty, which silently splits
+    the issue stream instead of leaving events unversioned.
+    """
+    monkeypatch.setenv("SENTRY_DSN", "https://public@sentry.example.io/57")
+    monkeypatch.delenv("SENTRY_RELEASE", raising=False)
+
+    with patch("sentry_sdk.init") as mock_init:
+        mod = _reload_sentry()
+        mod.init_sentry()
+        _, kwargs = mock_init.call_args
+        assert kwargs.get("release") is None
+
+
 def test_sentry_init_registers_before_send(monkeypatch: pytest.MonkeyPatch) -> None:
     """before_send must be passed to sentry_sdk.init for quota protection."""
     monkeypatch.setenv("SENTRY_DSN", "https://public@sentry.example.io/11")


### PR DESCRIPTION
## Resumo

Auditoria de prontidão do go-live fez um inventário read-only do `.env.prod`. A notícia boa primeiro:
**o Sentry está ativo e enviando eventos em produção** — DSN presente no arquivo e no container,
`environment=production`, e os logs de 24h de `auraxis-web-1` trazem `Sentry is attempting to send 1
pending events`, mensagem de flush que só existe com cliente inicializado e fila de eventos.

Duas coisas estavam erradas.

### 1. `SENTRY_RELEASE` vazio — nenhum erro apontava para um deploy

`SENTRY_RELEASE` não existia em lugar nenhum do plumbing, então `sentry_sdk.init(release=None)`
(`app/extensions/sentry.py:100,111`). Ao abrir um erro no painel não havia como saber **qual deploy
o introduziu**, e Release Health ficava indisponível.

O deploy agora escreve `SENTRY_RELEASE` no `.env.prod` **no mesmo bloco que já escreve `WEB_IMAGE`**
(`scripts/aws_deploy_i6.py`), reusando o mecanismo existente — o compose carrega o arquivo inteiro
via `env_file`, então não precisou tocar no `docker-compose.prod.yml`.

Duas decisões que importam:

- **Antes do `--force-recreate`**, não depois. Escrito depois, o valor só valeria no deploy seguinte
  e **todo erro seria atribuído ao commit anterior** — pior que não ter release. Há teste de posição
  para isso.
- **Valor derivado da tag da imagem**, não de `$GIT_REF`. A tag é sempre o SHA; `git_ref` pode ser
  `origin/master`, o que faria todos os deploys compartilharem um único "release". `$GIT_REF` fica
  como fallback.

Vale para **rollback** também: o modo rollback atribui `WEB_IMAGE="$STATE_PREVIOUS"` e passa pelas
mesmas fases, então o release acompanha a imagem que voltou.

### 2. `.env.prod.example` mentia sobre produção

O template é o que se copia ao reconstruir o ambiente (runbook Env-Reconstruction), e divergia em dois
pontos — o segundo perigoso:

| Chave | Template dizia | Prod roda |
|---|---|---|
| `SENTRY_TRACES_RATE` | `0.0` | `0.1` |
| `SENTRY_PROFILES_RATE` | `0.0` | `0.05` |
| `MIGRATE_ON_START` | `true` | **`false`** |

`MIGRATE_ON_START=true` faz cada worker do gunicorn disputar a mesma migration no restart — o
incidente de 2026-05-31 (500 em massa). Produção usa `false` e aplica a migration no passo do deploy,
pinada no container, com gate de drift depois.

## Validação

- `bash scripts/run_ci_quality_local.sh --local` → **verde**: 2919 passed, 2 skipped, cobertura
  **91,40%** (mínimo 85%).
- 4 testes novos: `release` vindo de `SENTRY_RELEASE`; `release=None` quando a env falta (não `""`,
  que o Sentry trataria como um release literalmente vazio e dividiria o stream de issues); posição
  da escrita antes do recreate; derivação a partir da tag da imagem.
- O script gerado foi **renderizado e passado por `sh -n`, `bash -n` e `dash -n`** nos modos `deploy`
  e `rollback` — o trecho é injetado numa f-string Python de ~900 linhas, onde uma chave literal
  quebraria a renderização; por isso o bloco evita `{}` e usa `sed` em vez de expansão de parâmetro.

Estado medido em produção, para referência (nomes e comprimentos, nunca valores):

```
SENTRY_DSN=PRESENTE (len=85)   host o406996.ingest.us.sentry.io/4511140626169856
SENTRY_ENVIRONMENT=production   SENTRY_ERROR_RATE=1.0
SENTRY_TRACES_RATE=0.1          SENTRY_PROFILES_RATE=0.05
CONTAINER_SENTRY_RELEASE=[]     <- o que esta PR conserta
```

## Risco residual

O efeito só se prova **no próximo deploy de prod**: `docker exec auraxis-web-1 printenv SENTRY_RELEASE`
deve devolver o SHA, e o erro seguinte no painel deve aparecer com esse release. Se o valor sair
errado, o pior caso é um release mal rotulado — o `init` continua funcionando e nenhum evento é
perdido.

Fora de escopo, anotado como follow-up: deixar o `scripts/sentry_canary_check.py` release-aware (hoje
compara por projeto/janela). E **não existe regra de alerta** no Sentry — o canary só roda no deploy;
isso está rastreado em platform#956, fora desta PR.

Closes #1637
