### PR TITLE
feat(billing): dar teto próprio ao checkout e frear no proxy o auth que faz hash de senha

### DIFF
--- a/app/middleware/rate_limit.py
+++ b/app/middleware/rate_limit.py
@@ -144,6 +144,14 @@ class RateLimiterService:
             ("/auth/login", "auth"),
             ("/auth/register", "auth"),
             ("/auth/password", "auth"),
+            # ── billing checkout (IP-keyed) ──────────────────────────────
+            # Each request holds one of the 4 gunicorn threads on a blocking
+            # HTTP call to the PSP, so the lenient `default` tier (300/window)
+            # made this a cheap way to starve the whole API. Capped at 10 —
+            # a human subscribes once, and even an indecisive one does not
+            # open ten checkouts a minute. Must stay above the webhook entry's
+            # sibling prefix so neither shadows the other (#1632).
+            ("/subscriptions/checkout", "checkout"),
             # ── billing webhook (IP-keyed) ───────────────────────────────
             # Provider callback — no JWT. Capped at 60/min per IP to absorb
             # legitimate retry bursts while blocking automated abuse.
@@ -204,6 +212,21 @@ class RateLimiterService:
                 limit=_read_int_env("RATE_LIMIT_TOKEN_REFRESH_LIMIT", 10),
                 window_seconds=_read_int_env(
                     "RATE_LIMIT_TOKEN_REFRESH_WINDOW_SECONDS", default_window
+                ),
+                key_scope=KEY_SCOPE_IP,
+            ),
+            # Billing checkout: IP-keyed on purpose, even though the endpoint
+            # requires a JWT. Keying by user would let one attacker rotate
+            # accounts to keep every gunicorn thread parked on the PSP call;
+            # keying by IP caps the whole origin. Safe because
+            # RATE_LIMIT_TRUST_PROXY_HEADERS=true in prod and nginx forwards
+            # X-Forwarded-For — without that, every request would share the
+            # proxy's address and 10/window would be a global cap (#1632).
+            "checkout": RateLimitRule(
+                name="checkout",
+                limit=_read_int_env("RATE_LIMIT_CHECKOUT_LIMIT", 10),
+                window_seconds=_read_int_env(
+                    "RATE_LIMIT_CHECKOUT_WINDOW_SECONDS", default_window
                 ),
                 key_scope=KEY_SCOPE_IP,
             ),

--- a/deploy/nginx/default.alb.conf
+++ b/deploy/nginx/default.alb.conf
@@ -3,6 +3,11 @@
 limit_req_zone $binary_remote_addr zone=graphql_auth:10m rate=100r/m;
 limit_req_zone $binary_remote_addr zone=graphql_anon:10m rate=30r/m;
 
+# #1632 — freio de proxy nos endpoints de auth que fazem hash de senha.
+# Argon2 no login/registro e PBKDF2 600k no caminho de e-mail inexistente
+# custam CPU antes de qualquer regra do app; 1 vCPU não absorve rajada.
+limit_req_zone $binary_remote_addr zone=auth_hash:10m rate=15r/m;
+
 server {
     listen 80;
     server_name __DOMAIN__;
@@ -13,6 +18,25 @@ server {
     location /graphql {
         limit_req zone=graphql_anon burst=10 nodelay;
         limit_req zone=graphql_auth burst=20 nodelay;
+        limit_req_status 429;
+
+        proxy_pass http://web:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Port $http_x_forwarded_port;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+        proxy_set_header X-Request-ID $request_id;
+        proxy_set_header Connection "";
+    }
+
+    # #1632 — /auth/refresh fica FORA de propósito: não faz hash de senha,
+    # e o app já o limita a 10/min/IP (tier token_refresh), mais estrito que
+    # este freio. Incluí-lo aqui só encolheria a folga de quem está logado.
+    location ~ ^/auth/(login|register|password/) {
+        limit_req zone=auth_hash burst=10 nodelay;
         limit_req_status 429;
 
         proxy_pass http://web:8000;

--- a/deploy/nginx/default.alb_dual.conf
+++ b/deploy/nginx/default.alb_dual.conf
@@ -3,6 +3,11 @@
 limit_req_zone $binary_remote_addr zone=graphql_auth:10m rate=100r/m;
 limit_req_zone $binary_remote_addr zone=graphql_anon:10m rate=30r/m;
 
+# #1632 — freio de proxy nos endpoints de auth que fazem hash de senha.
+# Argon2 no login/registro e PBKDF2 600k no caminho de e-mail inexistente
+# custam CPU antes de qualquer regra do app; 1 vCPU não absorve rajada.
+limit_req_zone $binary_remote_addr zone=auth_hash:10m rate=15r/m;
+
 server {
     listen 80;
     server_name __DOMAIN__;
@@ -13,6 +18,25 @@ server {
     location /graphql {
         limit_req zone=graphql_anon burst=10 nodelay;
         limit_req zone=graphql_auth burst=20 nodelay;
+        limit_req_status 429;
+
+        proxy_pass http://web:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Port $http_x_forwarded_port;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+        proxy_set_header X-Request-ID $request_id;
+        proxy_set_header Connection "";
+    }
+
+    # #1632 — /auth/refresh fica FORA de propósito: não faz hash de senha,
+    # e o app já o limita a 10/min/IP (tier token_refresh), mais estrito que
+    # este freio. Incluí-lo aqui só encolheria a folga de quem está logado.
+    location ~ ^/auth/(login|register|password/) {
+        limit_req zone=auth_hash burst=10 nodelay;
         limit_req_status 429;
 
         proxy_pass http://web:8000;
@@ -82,6 +106,23 @@ server {
     location /graphql {
         limit_req zone=graphql_anon burst=10 nodelay;
         limit_req zone=graphql_auth burst=20 nodelay;
+        limit_req_status 429;
+
+        proxy_pass http://web:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Request-ID $request_id;
+        proxy_set_header Connection "";
+    }
+
+    # #1632 — /auth/refresh fica FORA de propósito: não faz hash de senha,
+    # e o app já o limita a 10/min/IP (tier token_refresh), mais estrito que
+    # este freio. Incluí-lo aqui só encolheria a folga de quem está logado.
+    location ~ ^/auth/(login|register|password/) {
+        limit_req zone=auth_hash burst=10 nodelay;
         limit_req_status 429;
 
         proxy_pass http://web:8000;

--- a/deploy/nginx/default.conf
+++ b/deploy/nginx/default.conf
@@ -4,6 +4,11 @@
 limit_req_zone $binary_remote_addr zone=graphql_auth:10m rate=100r/m;
 limit_req_zone $binary_remote_addr zone=graphql_anon:10m rate=30r/m;
 
+# #1632 — freio de proxy nos endpoints de auth que fazem hash de senha.
+# Argon2 no login/registro e PBKDF2 600k no caminho de e-mail inexistente
+# custam CPU antes de qualquer regra do app; 1 vCPU não absorve rajada.
+limit_req_zone $binary_remote_addr zone=auth_hash:10m rate=15r/m;
+
 server {
     listen 80;
     server_name api.auraxis.com.br;
@@ -60,6 +65,28 @@ server {
     location /graphql {
         limit_req zone=graphql_anon burst=10 nodelay;
         limit_req zone=graphql_auth burst=20 nodelay;
+        limit_req_status 429;
+
+        proxy_pass http://web:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Request-ID $request_id;
+        proxy_set_header Connection "";
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 30s;
+        proxy_buffer_size 4k;
+        proxy_buffers 8 4k;
+    }
+
+    # #1632 — /auth/refresh fica FORA de propósito: não faz hash de senha,
+    # e o app já o limita a 10/min/IP (tier token_refresh), mais estrito que
+    # este freio. Incluí-lo aqui só encolheria a folga de quem está logado.
+    location ~ ^/auth/(login|register|password/) {
+        limit_req zone=auth_hash burst=10 nodelay;
         limit_req_status 429;
 
         proxy_pass http://web:8000;

--- a/deploy/nginx/default.http.conf
+++ b/deploy/nginx/default.http.conf
@@ -1,3 +1,12 @@
+# #1632 — freio de proxy nos endpoints de auth que fazem hash de senha.
+# Argon2 no login/registro e PBKDF2 600k no caminho de e-mail inexistente
+# custam CPU antes de qualquer regra do app; 1 vCPU não absorve rajada.
+#
+# Este é o conf de fallback: serve enquanto não existe certificado (emissão
+# inicial ou renovação falhada). É um estado degradado mas VIVO e exposto à
+# internet — e até agora o único sem limite nenhum, nem o de /graphql.
+limit_req_zone $binary_remote_addr zone=auth_hash:10m rate=15r/m;
+
 server {
     listen 80;
     server_name __DOMAIN__;
@@ -6,6 +15,23 @@ server {
 
     location /.well-known/acme-challenge/ {
         root /var/www/certbot;
+    }
+
+    # /auth/refresh fica FORA de propósito: não faz hash de senha, e o app já o
+    # limita a 10/min/IP (tier token_refresh), mais estrito que este freio.
+    # Incluí-lo aqui só encolheria a folga de quem está logado.
+    location ~ ^/auth/(login|register|password/) {
+        limit_req zone=auth_hash burst=10 nodelay;
+        limit_req_status 429;
+
+        proxy_pass http://web:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Request-ID $request_id;
+        proxy_set_header Connection "";
     }
 
     location / {

--- a/deploy/nginx/default.tls.conf
+++ b/deploy/nginx/default.tls.conf
@@ -3,6 +3,11 @@
 limit_req_zone $binary_remote_addr zone=graphql_auth:10m rate=100r/m;
 limit_req_zone $binary_remote_addr zone=graphql_anon:10m rate=30r/m;
 
+# #1632 — freio de proxy nos endpoints de auth que fazem hash de senha.
+# Argon2 no login/registro e PBKDF2 600k no caminho de e-mail inexistente
+# custam CPU antes de qualquer regra do app; 1 vCPU não absorve rajada.
+limit_req_zone $binary_remote_addr zone=auth_hash:10m rate=15r/m;
+
 server {
     listen 80;
     server_name __DOMAIN__;
@@ -57,6 +62,23 @@ server {
     location /graphql {
         limit_req zone=graphql_anon burst=10 nodelay;
         limit_req zone=graphql_auth burst=20 nodelay;
+        limit_req_status 429;
+
+        proxy_pass http://web:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Request-ID $request_id;
+        proxy_set_header Connection "";
+    }
+
+    # #1632 — /auth/refresh fica FORA de propósito: não faz hash de senha,
+    # e o app já o limita a 10/min/IP (tier token_refresh), mais estrito que
+    # este freio. Incluí-lo aqui só encolheria a folga de quem está logado.
+    location ~ ^/auth/(login|register|password/) {
+        limit_req zone=auth_hash burst=10 nodelay;
         limit_req_status 429;
 
         proxy_pass http://web:8000;

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -143,3 +143,53 @@ def test_graphql_query_does_not_use_mutation_rule(client: Any) -> None:
         resp = client.post("/graphql", json=query_payload)
         assert resp.status_code == 200
         assert resp.headers.get("X-RateLimit-Rule") == "graphql"
+
+
+def test_checkout_uses_dedicated_tier_not_the_lenient_default(client: Any) -> None:
+    """POST /subscriptions/checkout must resolve to the `checkout` tier.
+
+    Before #1632 it fell through to `default` (300/window). Each checkout holds
+    one of the four gunicorn threads on a blocking call to the PSP, so the
+    lenient tier made it a cheap way to starve the whole API.
+    """
+    limiter = _rate_limiter(client)
+    limiter.set_rule("checkout", limit=10, window_seconds=60)
+
+    response = client.post("/subscriptions/checkout", json={})
+
+    assert response.headers.get("X-RateLimit-Rule") == "checkout"
+
+
+def test_checkout_blocks_after_threshold(client: Any) -> None:
+    """The 11th call in the window is refused — the AC of #1632."""
+    limiter = _rate_limiter(client)
+    limiter.set_rule("checkout", limit=10, window_seconds=60)
+
+    statuses = [
+        client.post("/subscriptions/checkout", json={}).status_code for _ in range(10)
+    ]
+    blocked = client.post("/subscriptions/checkout", json={})
+
+    assert 429 not in statuses
+    assert blocked.status_code == 429
+    assert blocked.get_json()["details"]["rule"] == "checkout"
+
+
+def test_checkout_tier_does_not_shadow_the_webhook_tier(client: Any) -> None:
+    """Sibling prefixes under /subscriptions must keep separate buckets.
+
+    A regression here is silent and expensive: the provider's retries would be
+    refused by a budget spent on checkouts, and a refused webhook means someone
+    paid without receiving Premium.
+    """
+    limiter = _rate_limiter(client)
+    limiter.set_rule("checkout", limit=1, window_seconds=60)
+    limiter.set_rule("webhook", limit=60, window_seconds=60)
+
+    client.post("/subscriptions/checkout", json={})
+    exhausted = client.post("/subscriptions/checkout", json={})
+    webhook = client.post("/subscriptions/webhook/abacatepay", json={})
+
+    assert exhausted.status_code == 429
+    assert webhook.status_code != 429
+    assert webhook.headers.get("X-RateLimit-Rule") == "webhook"


### PR DESCRIPTION
## Resumo

Fecha os dois furos de proteção que o levantamento pré-go-live encontrou.

### 1. `/subscriptions/checkout` caía no tier permissivo

`_route_rule_order` só mapeava `/subscriptions/webhook`, então o checkout herdava o `default` —
**300 requisições por janela**. Cada checkout segura uma das 4 threads do gunicorn numa chamada HTTP
bloqueante ao PSP, o que fazia do endpoint que gera receita o jeito mais barato de travar a API
inteira.

Tier próprio de **10 por janela**, chaveado por **IP**. Por IP e não por usuário de propósito:
chavear por usuário deixaria um atacante rodar contas para manter todas as threads paradas no PSP.

⚠️ Isso só é seguro por uma razão que **verifiquei no host antes de escolher a chave**:
`RATE_LIMIT_TRUST_PROXY_HEADERS=true` no `.env.prod` e o nginx encaminha `X-Forwarded-For`. Se
fosse `false`, todo request compartilharia o endereço do proxy e um limite de 10 por IP viraria um
**teto global** — checkout morto para todo mundo depois de dez tentativas.

### 2. O nginx não freava os endpoints de auth

Só havia `limit_req` em `/graphql`. Login, registro e reset chegavam ao gunicorn sem freio de proxy
e pagavam **Argon2** — e PBKDF2 600k no caminho de e-mail inexistente — antes de qualquer regra do
app. Numa instância de 1 vCPU, esse é o gargalo real.

Zona `auth_hash` a **15r/m com burst 10 nodelay**, por regex em `/auth/login`, `/auth/register` e
`/auth/password/`.

**`/auth/refresh` ficou de fora de propósito** — deliberado, não esquecimento. Não faz hash de senha,
e o app já o limita a 10/min/IP (tier `token_refresh`), que é **mais estrito** que este freio.
Incluí-lo no mesmo balde só encolheria a folga de quem está logado, sem adicionar proteção: quem
compartilha IP (NAT corporativo, CGNAT de operadora) começaria a tomar 429 no refresh.

### Nas cinco fontes de conf, não nas duas da issue

`deploy/nginx/default.conf` é **artefato gerado** — o deploy renderiza a variante ativa por cima
dele (`render_tls_config()` etc. em `aws_deploy_i6.py`). E `default.http.conf`, que é o fallback
servido enquanto não há certificado, era o **único sem limite nenhum**, nem o de `/graphql`: estado
degradado, mas vivo e exposto à internet.

O bloco novo foi derivado do bloco `/graphql` de cada arquivo, para os `proxy_set_header` ficarem
idênticos. Um `location` que esquecesse `X-Forwarded-For` faria o app cair no endereço do nginx e
converter **todo** limite por IP num limite global — ou seja, derrubaria o login.

## Validação

- `bash scripts/run_ci_quality_local.sh --local` → **verde**: 2918 passed, 2 skipped, cobertura
  **91,40%**.
- 3 testes novos, incluindo o AC da issue (11ª chamada → 429) e uma regressão para os prefixos
  irmãos sob `/subscriptions`: um balde vazando no outro seria silencioso e caro — webhook recusado
  é gente que pagou e não recebeu Premium.
- **`nginx -t` real** (container `nginx:alpine`, com certificado autoassinado) nas **cinco** confs:
  todas OK.
- **Prova funcional do comportamento**, com upstream real:

  ```
  LOGIN:   200 ×11, depois 429 ×19     (1 + burst 10, como desenhado)
  REFRESH: 200 ×30                     (intocado)
  ```

  E o roteamento de `location`, conferido rota a rota:

  ```
  /auth/login /auth/register /auth/password/forgot /auth/password/reset  -> bloco auth
  /auth/refresh /auth/logout /auth/sessions /auth/email/confirm          -> location /
  ```

  > Nota de método: a primeira versão desse teste usava `return 200` no lugar do `proxy_pass` e
  > mostrou **30×200**, como se o limite não existisse. `return` roda na fase de *rewrite*, antes da
  > fase *preaccess* onde o `limit_req` é avaliado — o harness estava errado, não a config. Trocar
  > por um upstream real revelou o comportamento correto.

## Risco residual

- O freio do nginx (15r/m sustentado) passa a ser **mais restritivo que o do app** (20/min) para
  login e registro. É intencional — cortar antes do Argon2 é o objetivo —, mas significa que quem
  compartilha IP tem menos folga que antes nesses três caminhos. `/auth/refresh`, que é o de uso
  contínuo, não mudou.
- **Só vale em prod depois do deploy**: a conf do nginx é renderizada e o `reverse-proxy` recriado
  pelo `aws_deploy_i6.py`. Validar com `auraxis:verify-prod-state` e um 429 provocado de propósito.
- Anotado e **não corrigido aqui**: `aws_deploy_i6.py` tem cópias inline de bootstrap das confs
  (`if [ ! -f ... ]`) que estão desatualizadas — não disparam enquanto os arquivos existirem no
  repo, mas são uma armadilha para o dia em que dispararem.

Closes #1632
