### PR TITLE
test(load): script e runbook de launch-readiness contra produção

### DIFF
--- a/docs/runbooks/k6-launch-readiness.md
+++ b/docs/runbooks/k6-launch-readiness.md
@@ -1,0 +1,151 @@
+# Runbook — k6 launch-readiness contra produção (#1631)
+
+Mede se o `t2.micro` aguenta a carga de lançamento **antes** de pagar upgrade.
+Decisão do PO (2026-07-27): medir primeiro; `t3.small` (~US$ 15/mês) só se reprovar.
+
+> ⚠️ Este runbook aponta o k6 para **produção**. Não existe ambiente de carga
+> equivalente — o dev é outra instância e outro banco, e medir lá não responde
+> a pergunta.
+
+## Antes de rodar — pré-requisitos que não são formalidade
+
+| Pré-requisito | Como conferir | Por quê |
+|---|---|---|
+| Janela **22h30–23h30 BRT** | relógio | 1 vCPU: a carga do teste É a carga do site |
+| Alarme `CPUCreditBalance` ativo | `auraxis-prod-ec2-cpu-credit-low` no CloudWatch | plat#930 — sem ele o esgotamento é invisível |
+| SNS confirmado | plat#873 (fechada) | alarme sem inscrição não notifica ninguém |
+| Contas `qa-loadtest-*` criadas | ver abaixo | registrar durante o teste gasta o Argon2 que estamos medindo |
+| Segunda janela de terminal com o monitoramento | ver "O que observar" | o veredito depende do que acontece **durante** |
+
+## Criar as contas de carga (uma vez)
+
+```sh
+BASE=https://api.auraxis.com.br
+PASS='QaLoad@2026!k6'
+: > accounts.json.tmp
+for i in $(seq 1 5); do
+  EMAIL="qa-loadtest-${i}@auraxis.com.br"
+  curl -sS -X POST "$BASE/auth/register" \
+    -H 'Content-Type: application/json' -H 'X-API-Contract: v2' \
+    -d "{\"name\":\"qa loadtest $i\",\"email\":\"$EMAIL\",\"password\":\"$PASS\"}" \
+    -o /dev/null -w "register $EMAIL -> %{http_code}\n"
+  printf '{"email":"%s","password":"%s"}\n' "$EMAIL" "$PASS" >> accounts.json.tmp
+  sleep 5   # respeita o freio de /auth (15r/m no nginx)
+done
+python3 -c "import json,sys;print(json.dumps([json.loads(l) for l in open('accounts.json.tmp')]))" > accounts.json
+rm accounts.json.tmp
+```
+
+> `sleep 5` não é excesso de zelo: o nginx passou a limitar `/auth/(login|register|password/)`
+> a 15r/m com burst 10 (#1632). Cinco registros em rajada passam pelo burst, mas
+> encadear isso com o login do `setup()` estoura — e você perde 10 minutos
+> descobrindo que o "erro" era a proteção funcionando.
+
+⚠️ **A senha acima vai para o histórico do shell.** Use uma senha descartável e
+purgue as contas no fim.
+
+## Rodar — um cenário por vez
+
+O `read_baseline` roda sempre; o resto liga por env. Rodar tudo junto impede
+dizer qual cenário gastou o crédito de CPU.
+
+```sh
+export BASE_URL=https://api.auraxis.com.br
+export LOADTEST_ACCOUNTS="$(cat accounts.json)"
+
+# 1. piso (5 min) — se reprovar aqui, pare: nada medido depois quer dizer nada
+k6 run --summary-export=summary-baseline.json load-tests/launch-readiness.js
+
+# 2. pico de divulgação (15 min, 0→10 req/s)
+k6 run -e READ_SPIKE=true --summary-export=summary-spike.json load-tests/launch-readiness.js
+
+# 3. onde o freio pega (5 min)
+k6 run -e AUTH_PROBE=true --summary-export=summary-auth.json load-tests/launch-readiness.js
+
+# 4. checkout real — MÁXIMO 5, não segue o redirect
+k6 run -e CHECKOUT_PROBE=true --summary-export=summary-checkout.json load-tests/launch-readiness.js
+```
+
+Cada cenário selecionado roda **sozinho e começa em 0s**. Para colocar o piso de
+leitura como tráfego de fundo por baixo de outro cenário, adicione
+`-e WITH_BASELINE=true` — útil para ver a latência de leitura degradar enquanto o
+`auth_probe` consome CPU.
+
+### `auth_burst` — o único que exige mexer em produção
+
+Mede o teto do Argon2, e para isso precisa dos **dois** limitadores afrouxados.
+Com qualquer um no valor de produção, o teste mede o limitador, não a CPU.
+
+1. App: `RATE_LIMIT_AUTH_LIMIT` alto no `.env.prod` + `--force-recreate` com
+   `WEB_IMAGE` explícito (via `auraxis:prod-deploy`).
+2. Proxy: `rate=15r/m` → valor alto na zona `auth_hash` em
+   `deploy/nginx/default.tls.conf`, render + `up -d --force-recreate reverse-proxy`.
+3. `k6 run -e AUTH_BURST=true ...`
+4. **Reverter os dois em menos de 30 minutos.**
+
+**Kill-switch:** `git checkout deploy/nginx/ && ` re-render + recreate do proxy,
+e restaurar o `.env.prod` do backup que o passo 1 gerou.
+
+> A alternativa sancionada pela issue é **não** afrouxar nada e registrar que o
+> teto de auth ficou limitado pela proteção. Dado que a proteção é justamente o
+> que responde "aguentamos um flood de login?", essa é a opção recomendada —
+> use o `auth_burst` só se precisar dimensionar CPU para outra coisa.
+
+## O que observar enquanto roda
+
+```sh
+# CPU e memória do container, ao vivo
+aws ssm send-command --instance-ids i-0057e3b52162f78f8 \
+  --document-name AWS-RunShellScript \
+  --parameters 'commands=["docker stats --no-stream auraxis-web-1"]'
+
+# Conexões no banco (limite: max_connections - 10)
+... 'commands=["docker exec auraxis-db-1 psql -U auraxis -c \"select count(*) from pg_stat_activity\""]'
+
+# 429 e 5xx no nginx
+... 'commands=["docker logs --since 10m $(docker ps --filter name=reverse-proxy -q) 2>&1 | grep -cE \" (429|5[0-9][0-9]) \""]'
+```
+
+E no CloudWatch: `CPUCreditBalance` da instância — é o número que decide o
+veredito de capacidade, não a latência.
+
+## Veredito
+
+| Threshold | Aprova | Reprova ⇒ upgrade |
+|---|---|---|
+| Latência de leitura | p95 < 800 ms e p99 < 2 s @ 10 req/s | p95 > 800 ms sustentado |
+| Erro real (exclui 429/401) | < 1% | ≥ 1% |
+| 5xx | zero sustentado | > 0,5% |
+| `CPUCreditBalance` | queda ≤ 40 créditos / 15 min | projeção de exaustão < 2 h |
+| Memória | < 85% | > 90% ou OOM |
+| `pg_stat_activity` | < `max_connections` − 10 | ≥ esse valor |
+
+Reprovou em qualquer linha ⇒ abrir issue `[INFRA]` de upgrade para **t3.small**
+(~US$ 15/mês, **custo recorrente novo — decisão explícita do PO**). `t4g.small`
+sai US$ 12 mas exige rebuild arm64 das imagens.
+
+O script já classifica os 429 por camada (`auraxis_rate_limited_proxy` vs
+`auraxis_rate_limited_app`): 429 é a proteção funcionando, não falha, mas somar
+as duas camadas esconderia qual delas segurou a carga.
+
+## Depois — limpeza obrigatória
+
+```sh
+# Purgar as contas de carga (o endpoint exige a senha)
+for i in $(seq 1 5); do
+  TOKEN=$(curl -sS -X POST "$BASE_URL/auth/login" -H 'Content-Type: application/json' \
+    -d "{\"email\":\"qa-loadtest-${i}@auraxis.com.br\",\"password\":\"$PASS\"}" \
+    | python3 -c 'import json,sys;print(json.load(sys.stdin)["data"]["token"])')
+  curl -sS -X DELETE "$BASE_URL/user/me" -H "Authorization: Bearer $TOKEN" \
+    -H 'Content-Type: application/json' -d "{\"password\":\"$PASS\"}" \
+    -o /dev/null -w "purge $i -> %{http_code}\n"
+done
+rm -f accounts.json
+```
+
+As assinaturas criadas pelo `checkout_probe` ficam `pending` e **não** são
+cobradas — ninguém abre a URL de pagamento. Ainda assim, confira em
+`flask billing checkout-funnel --days 1` que elas aparecem como iniciadas e não
+concluídas, e que **não** surgiu `event=checkout_completed_unmatched`.
+
+Anexar os `summary-*.json` na issue #1631 com o veredito por threshold.

--- a/load-tests/launch-readiness.js
+++ b/load-tests/launch-readiness.js
@@ -1,0 +1,340 @@
+// k6 launch-readiness — carga realista contra PRODUÇÃO (#1631).
+//
+// ⚠️ Este script fala com produção. Leia docs/runbooks/k6-launch-readiness.md
+// antes de rodar. Resumo do que importa:
+//   - janela 22h30–23h30 BRT (fora de pico);
+//   - alvo é t2.micro, 1 vCPU / 1 GB, gunicorn 2×2 — quatro requisições em voo;
+//   - `checkout_probe` cria assinatura de verdade: no máximo 5, nunca segue o
+//     redirect, e as contas são purgadas depois.
+//
+// Uso:
+//   k6 run --summary-export=summary.json \
+//     -e BASE_URL=https://api.auraxis.com.br \
+//     -e LOADTEST_ACCOUNTS="$(cat accounts.json)" \
+//     load-tests/launch-readiness.js
+//
+// Cenários ligáveis por env (todos default OFF exceto read_baseline):
+//   -e READ_SPIKE=true  -e AUTH_PROBE=true  -e CHECKOUT_PROBE=true
+//   -e AUTH_BURST=true   ← exige janela com os DOIS limitadores afrouxados
+//
+// Rodar tudo de uma vez não é o caminho: o veredito de cada cenário depende de
+// observar CPUCreditBalance e memória enquanto ele roda, e cenários somados
+// tornam impossível dizer qual deles gastou o crédito.
+
+import http from "k6/http";
+import { check, sleep, fail } from "k6";
+import { Counter, Rate, Trend } from "k6/metrics";
+
+const BASE_URL = __ENV.BASE_URL || "http://localhost:5000";
+const ACCOUNTS_RAW = __ENV.LOADTEST_ACCOUNTS || "[]";
+
+const on = (name) => String(__ENV[name] || "").toLowerCase() === "true";
+
+// ── Métricas próprias ────────────────────────────────────────────────────
+// 429 não é falha: é a proteção funcionando. Mas 429 do nginx e 429 da
+// aplicação significam coisas diferentes, e somá-los esconde qual camada
+// segurou a carga. O 429 da app carrega X-RateLimit-Rule; o do nginx não.
+const rateLimitedByProxy = new Counter("auraxis_rate_limited_proxy");
+const rateLimitedByApp = new Counter("auraxis_rate_limited_app");
+const serverErrors = new Counter("auraxis_server_errors_5xx");
+const readLatency = new Trend("auraxis_read_latency", true);
+const readSuccess = new Rate("auraxis_read_success");
+
+/**
+ * Classifica um 429 pela camada que o emitiu.
+ *
+ * @param {object} res Resposta do k6.
+ * @returns {"proxy"|"app"|null} Camada, ou null quando não é 429.
+ */
+function classifyRateLimit(res) {
+  if (res.status !== 429) {
+    return null;
+  }
+  // Cabeçalho posto pelo after_request do middleware da aplicação.
+  const rule = res.headers["X-Ratelimit-Rule"] || res.headers["x-ratelimit-rule"];
+  return rule ? "app" : "proxy";
+}
+
+/**
+ * Registra a resposta nas métricas próprias.
+ *
+ * @param {object} res Resposta do k6.
+ * @param {boolean} isRead Se conta para as métricas de leitura.
+ */
+function record(res, isRead) {
+  const limited = classifyRateLimit(res);
+  if (limited === "app") {
+    rateLimitedByApp.add(1);
+  } else if (limited === "proxy") {
+    rateLimitedByProxy.add(1);
+  }
+  if (res.status >= 500) {
+    serverErrors.add(1);
+  }
+  if (isRead) {
+    readLatency.add(res.timings.duration);
+    readSuccess.add(res.status === 200);
+  }
+}
+
+// 429 entra como status esperado para não poluir `http_req_failed`, que é o
+// gatilho de abort. Sem isto o teste abortaria ao encostar no rate limit — ou
+// seja, exatamente quando a proteção funciona.
+http.setResponseCallback(http.expectedStatuses(200, 201, 204, 401, 429));
+
+const scenarios = {};
+
+// O runbook manda rodar UM cenário por vez — somados, é impossível dizer qual
+// gastou o crédito de CPU. Por isso cada cenário começa em 0s e o piso só entra
+// junto quando pedido explicitamente (`-e WITH_BASELINE=true`), como tráfego de
+// fundo. Sem isto, `-e CHECKOUT_PROBE=true` deixaria o k6 ocioso por 40 minutos
+// esperando um `startTime` que só faz sentido numa execução única.
+const selected = ["READ_SPIKE", "AUTH_PROBE", "AUTH_BURST", "CHECKOUT_PROBE"].some(on);
+
+// ── read_baseline — o piso ───────────────────────────────────────────────
+// 2 req/s por 5 min. Serve de controle: se a latência já estiver ruim aqui,
+// nada medido depois quer dizer alguma coisa.
+if (!selected || on("WITH_BASELINE")) {
+  scenarios.read_baseline = {
+    executor: "constant-arrival-rate",
+    rate: 2,
+    timeUnit: "1s",
+    duration: "5m",
+    preAllocatedVUs: 5,
+    maxVUs: 20,
+    exec: "readWorkload",
+    tags: { scenario: "read_baseline" },
+  };
+}
+
+// ── read_spike — o cenário de divulgação ─────────────────────────────────
+// 0→10 req/s em 15 min. ~100 visitantes simultâneos ≈ 8-10 req/s de API.
+if (on("READ_SPIKE")) {
+  scenarios.read_spike = {
+    executor: "ramping-arrival-rate",
+    startRate: 1,
+    timeUnit: "1s",
+    preAllocatedVUs: 10,
+    maxVUs: 60,
+    stages: [
+      { duration: "5m", target: 5 },
+      { duration: "5m", target: 10 },
+      { duration: "5m", target: 10 },
+    ],
+    exec: "readWorkload",
+    tags: { scenario: "read_spike" },
+  };
+}
+
+// ── auth_probe — onde o freio pega ───────────────────────────────────────
+// 0,3 req/s = 18/min. Acima do nginx (15r/m sustentado, burst 10) e abaixo do
+// limitador da app (20/min/IP). O resultado esperado NÃO é 200 em tudo: é
+// medir em que ponto o proxy começa a segurar — e confirmar que segura ELE,
+// antes do Argon2, que é o objetivo de #1632.
+if (on("AUTH_PROBE")) {
+  scenarios.auth_probe = {
+    executor: "constant-arrival-rate",
+    rate: 18,
+    timeUnit: "1m",
+    duration: "5m",
+    preAllocatedVUs: 3,
+    maxVUs: 10,
+    exec: "authWorkload",
+    tags: { scenario: "auth_probe" },
+  };
+}
+
+// ── auth_burst — só com janela controlada ────────────────────────────────
+// 1→3 req/s de login real. Mede o teto do Argon2, e por isso EXIGE os dois
+// limitadores afrouxados: o da app (RATE_LIMIT_AUTH_LIMIT) e o do nginx
+// (zone=auth_hash). Com qualquer um deles no valor de produção, isto mede o
+// limitador e não a CPU. Ver o kill-switch no runbook.
+if (on("AUTH_BURST")) {
+  scenarios.auth_burst = {
+    executor: "ramping-arrival-rate",
+    startRate: 1,
+    timeUnit: "1s",
+    preAllocatedVUs: 5,
+    maxVUs: 20,
+    stages: [
+      { duration: "4m", target: 2 },
+      { duration: "6m", target: 3 },
+    ],
+    exec: "authWorkload",
+    tags: { scenario: "auth_burst" },
+  };
+}
+
+// ── checkout_probe — 5 iterações, nunca mais ─────────────────────────────
+// Cria assinatura de verdade no gateway. `maxDuration` e `iterations` são o
+// freio; `redirects: 0` garante que paramos ao receber a URL, sem visitar a
+// página de pagamento.
+if (on("CHECKOUT_PROBE")) {
+  scenarios.checkout_probe = {
+    executor: "shared-iterations",
+    vus: 1,
+    iterations: 5,
+    maxDuration: "3m",
+    exec: "checkoutWorkload",
+    tags: { scenario: "checkout_probe" },
+  };
+}
+
+export const options = {
+  scenarios,
+  thresholds: {
+    // Aborta a execução se a taxa de erro real passar de 1% — 429 e 401 já
+    // estão fora da conta pelo responseCallback acima.
+    http_req_failed: [{ threshold: "rate<0.01", abortOnFail: true }],
+    auraxis_read_latency: ["p(95)<800", "p(99)<2000"],
+    auraxis_read_success: ["rate>0.99"],
+    auraxis_server_errors_5xx: ["count<1"],
+  },
+};
+
+/**
+ * Faz login nas contas pré-criadas e devolve os tokens.
+ *
+ * As contas são criadas fora daqui (ver runbook): registrar em massa dentro do
+ * teste gastaria o orçamento de Argon2 que estamos justamente medindo, e
+ * deixaria lixo em produção a cada execução.
+ *
+ * @returns {{tokens: string[]}} Tokens de acesso utilizáveis pelos cenários.
+ */
+export function setup() {
+  const accounts = JSON.parse(ACCOUNTS_RAW);
+  if (!Array.isArray(accounts) || accounts.length === 0) {
+    fail(
+      "LOADTEST_ACCOUNTS vazio. Crie as contas qa-loadtest-* conforme o runbook " +
+        "e passe o JSON [{email,password}] — sem elas os cenários de leitura " +
+        "mediriam apenas 401.",
+    );
+  }
+
+  const tokens = [];
+  for (const account of accounts) {
+    const res = http.post(
+      `${BASE_URL}/auth/login`,
+      JSON.stringify({ email: account.email, password: account.password }),
+      { headers: { "Content-Type": "application/json", "X-API-Contract": "v2" } },
+    );
+    const body = res.json();
+    const token = body && body.data ? body.data.token || body.data.access_token : null;
+    if (token) {
+      tokens.push(token);
+    } else {
+      console.warn(`login falhou para ${account.email}: HTTP ${res.status}`);
+    }
+  }
+
+  if (tokens.length === 0) {
+    fail("nenhuma conta de carga autenticou — abortando antes de gerar tráfego");
+  }
+  console.log(`setup: ${tokens.length}/${accounts.length} contas autenticadas`);
+  return { tokens };
+}
+
+/**
+ * Cabeçalhos autenticados de uma das contas de carga.
+ *
+ * @param {{tokens: string[]}} data Retorno do setup.
+ * @returns {object} Cabeçalhos HTTP.
+ */
+function authHeaders(data) {
+  const token = data.tokens[__VU % data.tokens.length];
+  return {
+    Authorization: `Bearer ${token}`,
+    "Content-Type": "application/json",
+    "X-API-Contract": "v2",
+  };
+}
+
+/**
+ * Sessão de leitura típica: o que um usuário abre ao entrar.
+ *
+ * @param {{tokens: string[]}} data Retorno do setup.
+ */
+export function readWorkload(data) {
+  const headers = authHeaders(data);
+  const month = new Date().toISOString().slice(0, 7);
+
+  const health = http.get(`${BASE_URL}/healthz`, { tags: { name: "GET /healthz" } });
+  check(health, { "healthz 200": (r) => r.status === 200 });
+  record(health, false);
+
+  const overview = http.get(`${BASE_URL}/dashboard/overview?month=${month}`, {
+    headers,
+    tags: { name: "GET /dashboard/overview" },
+  });
+  record(overview, true);
+
+  const transactions = http.get(`${BASE_URL}/transactions?page=1&per_page=20`, {
+    headers,
+    tags: { name: "GET /transactions" },
+  });
+  record(transactions, true);
+
+  const bootstrap = http.get(`${BASE_URL}/user/bootstrap`, {
+    headers,
+    tags: { name: "GET /user/bootstrap" },
+  });
+  record(bootstrap, true);
+}
+
+/**
+ * Login real — o caminho que paga Argon2.
+ *
+ * Usa as MESMAS contas do setup: registrar contas novas aqui encheria produção
+ * de usuários a cada execução.
+ *
+ * @param {{tokens: string[]}} data Retorno do setup (usado só para o tamanho).
+ */
+export function authWorkload(data) {
+  const accounts = JSON.parse(ACCOUNTS_RAW);
+  const account = accounts[__ITER % accounts.length];
+
+  const res = http.post(
+    `${BASE_URL}/auth/login`,
+    JSON.stringify({ email: account.email, password: account.password }),
+    {
+      headers: { "Content-Type": "application/json", "X-API-Contract": "v2" },
+      tags: { name: "POST /auth/login" },
+    },
+  );
+  record(res, false);
+  check(res, {
+    "login 200 ou 429 (freio)": (r) => r.status === 200 || r.status === 429,
+  });
+}
+
+/**
+ * Checkout real — no máximo 5 vezes, e paramos na URL.
+ *
+ * @param {{tokens: string[]}} data Retorno do setup.
+ */
+export function checkoutWorkload(data) {
+  const headers = authHeaders(data);
+
+  const res = http.post(
+    `${BASE_URL}/subscriptions/checkout`,
+    JSON.stringify({ plan_slug: "premium_monthly" }),
+    {
+      headers,
+      redirects: 0, // nunca visitar a página de pagamento
+      tags: { name: "POST /subscriptions/checkout" },
+    },
+  );
+  record(res, false);
+
+  check(res, {
+    "checkout respondeu": (r) => r.status === 200 || r.status === 201 || r.status === 429,
+  });
+
+  if (res.status === 200 || res.status === 201) {
+    const body = res.json();
+    const url = body && body.data ? body.data.checkout_url || body.data.url : null;
+    console.log(`checkout ${__ITER + 1}/5 → ${url ? "URL recebida" : "sem URL no corpo"}`);
+  }
+
+  sleep(5);
+}


### PR DESCRIPTION
## Resumo

Script e runbook do teste de carga contra produção. **A execução não está aqui** — a #1631 fixa a
janela em 22h30–23h30 BRT, e disparar uma rampa de 10 req/s contra uma instância de 1 vCPU ao meio-dia
contradiz a própria spec. A #1631 fica aberta representando exatamente o que falta: a medição.

Cinco cenários, **um por execução**: `read_baseline`, `read_spike`, `auth_probe`, `auth_burst`,
`checkout_probe`. Somados, é impossível dizer qual deles gastou o crédito de CPU — que é o número
que decide o veredito de capacidade.

## O freio que subiu hoje (#1632) mudou o desenho do teste

Duas consequências que valem registro, porque não eram óbvias antes de existir o `limit_req` no nginx:

**1. 429 deixou de ser falha e virou sinal.** Ele entra como status esperado no `responseCallback`;
sem isso o teste abortaria pelo threshold de erro **exatamente quando a proteção funciona**. E os
429 são contados por camada — o da aplicação carrega `X-RateLimit-Rule`, o do nginx não:

```js
const rule = res.headers["X-Ratelimit-Rule"];
return rule ? "app" : "proxy";
```

Somar os dois esconderia qual camada segurou a carga, que é metade da resposta.

**2. O `auth_burst` passou a exigir afrouxar DOIS limitadores, não um.** A issue previa elevar
`RATE_LIMIT_AUTH_LIMIT`; com o nginx a 15r/m na frente, isso mediria o proxy em vez da CPU. O runbook
documenta o kill-switch para os dois e **recomenda a alternativa que a issue já permite** — medir até
o limitador e registrar a limitação. Faz sentido: a pergunta "aguentamos um flood de login?" agora é
respondida pela proteção, não pelo teto do Argon2.

Por isso o `auth_probe` roda a 18 req/min de propósito: acima do nginx (15r/m sustentado, burst 10) e
abaixo do limitador da aplicação (20/min/IP). O resultado esperado **não** é 200 em tudo — é confirmar
que quem segura é o proxy, antes do Argon2.

## Validação

`k6 inspect` nas cinco combinações, com o k6 v2.1.0 instalado localmente:

```
(default)                              read_baseline start=0s
-e READ_SPIKE=true                     read_spike    start=0s
-e AUTH_PROBE=true                     auth_probe    start=0s
-e CHECKOUT_PROBE=true                 checkout_probe start=0s
-e CHECKOUT_PROBE=true,WITH_BASELINE=true   checkout_probe + read_baseline
```

**O `inspect` pegou um erro meu.** A primeira versão escalonava os cenários por `startTime`
(6m/22m/28m/40m), o que faz sentido numa execução única — mas o runbook manda rodar um por vez, e
`-e CHECKOUT_PROBE=true` deixaria o k6 **ocioso por 40 minutos** antes de disparar 3 minutos de teste.
Corrigido: todos começam em 0s, e `-e WITH_BASELINE=true` sobrepõe o piso de leitura de propósito.

Contratos conferidos contra o código, não supostos: `plan_slug` no request e `checkout_url` com HTTP
201 na resposta (`subscription_controller.py:181,248-257`); `data.token` no login
(`login_resource.py:311-318`); slug `premium_monthly` (`config/billing_plans.py:54`).

Pré-requisitos da issue confirmados hoje: alarme `auraxis-prod-ec2-cpu-credit-low` ativo (plat#930) e
SNS confirmado (plat#873).

## Risco residual

- **O `checkout_probe` cria assinatura de verdade no gateway.** Limitado a 5 iterações com
  `maxDuration: 3m` e `redirects: 0` — paramos ao receber a URL, sem visitar a página de pagamento.
  A purga das contas está no runbook e é obrigatória.
- O runbook manda criar as contas com `sleep 5` entre registros. Não é zelo: cinco registros em
  rajada passam pelo burst do nginx, mas encadeados com o login do `setup()` estouram — e se perde
  tempo achando que o "erro" é bug quando é a proteção.
- **A senha das contas de carga vai para o histórico do shell** no procedimento do runbook. Está
  avisado lá; usar senha descartável e purgar no fim.

Closes #1642
Refs #1631
