### PR TITLE
feat(nginx): expor /v2/* no vhost api.auraxis.com.br

### DIFF
--- a/deploy/nginx/default.conf
+++ b/deploy/nginx/default.conf
@@ -104,6 +104,45 @@ server {
         proxy_buffers 8 4k;
     }
 
+    # Docker embedded DNS — required for the lazy upstream resolution below.
+    resolver 127.0.0.11 valid=30s;
+
+    # #1644 — /v2/* on the v1 hostname, so the mobile app can reach api-v2 with
+    # the single base URL it is built with (EXPO_PUBLIC_API_URL). Mirrors the
+    # block in default.tls.conf; see that file for the full rationale.
+    #
+    # proxy_pass carries no URI part on purpose: api-v2 mounts its routers under
+    # /v2 itself, so the prefix must survive the hop.
+    location /v2/ {
+        set $v2_upstream http://auraxis-v2:8001;
+        proxy_pass $v2_upstream;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Request-ID $request_id;
+        proxy_set_header Connection "";
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 60s;
+        # An import confirm issues one v1 request per row, so it needs more
+        # headroom than a plain read.
+        proxy_read_timeout 60s;
+    }
+
+    # api-v2 serves /healthz at its root, not under /v2 — this location does
+    # replace the prefix, hence the URI part in proxy_pass.
+    location = /v2/healthz {
+        set $v2_upstream http://auraxis-v2:8001;
+        proxy_pass $v2_upstream/healthz;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header Connection "";
+        proxy_connect_timeout 5s;
+        proxy_read_timeout 5s;
+        access_log off;
+    }
+
     location / {
         proxy_pass http://web:8000;
         proxy_http_version 1.1;

--- a/deploy/nginx/default.tls.conf
+++ b/deploy/nginx/default.tls.conf
@@ -91,6 +91,52 @@ server {
         proxy_set_header Connection "";
     }
 
+    # Docker embedded DNS — required for the lazy upstream resolution below.
+    resolver 127.0.0.11 valid=30s;
+
+    # #1644 — /v2/* on the v1 hostname, so the mobile app can reach api-v2 with
+    # the single base URL it is built with (EXPO_PUBLIC_API_URL). v2.conf keeps
+    # serving the same upstream on its own hostname; this is an extra door, not
+    # a move.
+    #
+    # proxy_pass carries no URI part on purpose: api-v2 mounts its routers under
+    # /v2 itself (/v2/import/detect is a real FastAPI path), so the prefix must
+    # survive the hop. Adding a URI here would strip it and 404 every route.
+    #
+    # The variable + resolver keep the upstream lazily resolved, so nginx still
+    # starts and reloads when api-v2 is down — a v2 outage cannot take the v1
+    # API with it.
+    location /v2/ {
+        set $v2_upstream http://auraxis-v2:8001;
+        proxy_pass $v2_upstream;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Request-ID $request_id;
+        proxy_set_header Connection "";
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 60s;
+        # An import confirm issues one v1 request per row (v2 has no bulk
+        # endpoint upstream), so it needs more headroom than a plain read.
+        proxy_read_timeout 60s;
+    }
+
+    # Health probe for api-v2 reachable from the v1 hostname. api-v2 serves
+    # /healthz at its root, not under /v2, so this one location does replace
+    # the prefix — hence the URI part in proxy_pass.
+    location = /v2/healthz {
+        set $v2_upstream http://auraxis-v2:8001;
+        proxy_pass $v2_upstream/healthz;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header Connection "";
+        proxy_connect_timeout 5s;
+        proxy_read_timeout 5s;
+        access_log off;
+    }
+
     location / {
         proxy_pass http://web:8000;
         proxy_http_version 1.1;

--- a/deploy/nginx/v2.conf
+++ b/deploy/nginx/v2.conf
@@ -104,6 +104,8 @@ server {
         proxy_set_header Connection "";
         proxy_connect_timeout 10s;
         proxy_send_timeout 60s;
-        proxy_read_timeout 30s;
+        # An import confirm issues one v1 request per row (no bulk endpoint
+        # upstream), so this needs more headroom than a plain read (#1644).
+        proxy_read_timeout 60s;
     }
 }

--- a/tests/test_ai_insight_generation_governance.py
+++ b/tests/test_ai_insight_generation_governance.py
@@ -14,6 +14,7 @@ Covers the systemic fixes for unwanted/duplicated LLM generation:
 from __future__ import annotations
 
 import uuid
+from collections.abc import Generator
 from datetime import date
 from decimal import Decimal
 from unittest.mock import patch
@@ -21,6 +22,10 @@ from unittest.mock import patch
 import pytest
 
 from app.services.llm_provider import StubLLMProvider
+
+# Mid-month, so the service's daily-vs-recap branch is deterministic regardless
+# of when CI runs. See ``TestReadSpendingInsights._freeze_today_midmonth``.
+_FROZEN_TODAY = date(2026, 5, 15)
 
 # ---------------------------------------------------------------------------
 # Helpers (same pattern as test_ai_chat.py)
@@ -510,6 +515,27 @@ class TestStableContextHash:
 
 
 class TestReadSpendingInsights:
+    @pytest.fixture(autouse=True)
+    def _freeze_today_midmonth(self) -> Generator[None, None, None]:
+        """Pin the service's ``date.today()`` to a deterministic mid-month day.
+
+        On the last calendar day of the month the service reads (and writes) an
+        ``InsightType.recap`` under a ``YYYY-MM-recap`` label instead of a daily
+        one under ``YYYY-MM-DD`` (``is_recap = today == end``). CI runs in UTC,
+        so every month-end run made ``test_returns_persisted_insight_of_the_day``
+        store a daily insight and then look for a recap — a calendar-driven
+        failure with nothing to do with the diff under test.
+
+        Tests that assert against "today" must use ``_FROZEN_TODAY``, not
+        ``date.today()``: this patches the symbol inside the service module, so
+        the test module's own ``date`` still resolves to the real clock. Same
+        trap and same fix as ``tests/test_ai_insight_persistence.py``.
+        """
+        with patch("app.services.ai_advisory_service.date") as mock_date:
+            mock_date.today.return_value = _FROZEN_TODAY
+            mock_date.side_effect = lambda *args, **kwargs: date(*args, **kwargs)
+            yield
+
     def setup_method(self) -> None:
         _reset_ai_counter()
 
@@ -537,7 +563,7 @@ class TestReadSpendingInsights:
             from app.models.ai_insight import InsightType
             from app.services.ai_advisory_service import _save_insight
 
-            today = date.today()
+            today = _FROZEN_TODAY
             _save_insight(
                 user_id=user_id,
                 content='[{"type":"resumo","title":"T","message":"M"}]',


### PR DESCRIPTION
## Summary

O app é buildado com uma base URL única (`EXPO_PUBLIC_API_URL`) e chama `/v2/import/*`, mas só `v2.auraxis.com.br` roteava para o api-v2. Resultado: **`api.auraxis.com.br/v2/*` responde 404** e o import do app não alcança o backend. Este PR abre a porta no vhost do v1 — o `v2.conf` continua servindo o mesmo upstream no hostname dele; isto é uma porta a mais, não uma mudança de lugar.

## Decisões

**`proxy_pass` sem parte de URI.** O api-v2 monta os routers sob `/v2` ele mesmo — `/v2/import/detect` é um path real do FastAPI (verificado em prod: responde 401, enquanto `/import/detect` dá 404). Se eu colocasse URI no `proxy_pass`, o nginx trocaria o prefixo e todas as rotas dariam 404.

**`/v2/healthz` é a exceção** e tem `location =` próprio: o api-v2 serve `/healthz` na raiz, não sob `/v2`. Esse é o único bloco que de fato substitui o prefixo.

**Upstream via variável + `resolver 127.0.0.11`**, mesmo padrão já usado no `v2.conf`: a resolução fica preguiçosa, então o nginx sobe e recarrega mesmo com o api-v2 fora do ar — uma queda do v2 não pode derrubar o v1.

**Timeout de leitura para 60s** nos caminhos que carregam import (e no `location /` do `v2.conf`): o confirm dispara uma requisição ao v1 por linha, e 30s era apertado para arquivo grande.

Aplicado em `default.tls.conf` (é o template que gera o conf de prod — prod usa `__DOMAIN__` substituído por `api.auraxis.com.br`) e em `default.conf` (variante ALB), mantendo a paridade que o próprio repo documenta.

## Validation

Testado com `nginx:1.27-alpine` (mesma imagem de prod), renderizando o template como prod renderiza e subindo upstreams stub que ecoam o path recebido:

| Requisição | Chegou como | Destino |
|---|---|---|
| `/v2/import/detect` | `/v2/import/detect` | api-v2 ✅ |
| `/v2/import/confirm` | `/v2/import/confirm` | api-v2 ✅ |
| `/v2/healthz` | `/healthz` | api-v2 ✅ |
| `/transactions` | `/transactions` | v1 ✅ |
| `/graphql` | `/graphql` | v1 ✅ |
| `/healthz` | `/healthz` | v1 ✅ |

Isolamento, com o container do api-v2 parado: `/transactions` → **200**, `/v2/import/detect` → 502, e `nginx -t` + `nginx -s reload` passam limpos. Ou seja, indisponibilidade do v2 fica contida.

`nginx -t` limpo (o único warn é pré-existente: `listen ... http2` deprecated).

## Residual risk

- **Aplicação em prod é um passo separado** (reload do nginx no EC2), com backup do conf atual antes e `nginx -t` antes do reload. Faço em seguida com autorização já dada, e rodo `verify-prod-state` depois.
- A rota `/v2/*` não passa pelas zonas de rate limit do v1; o api-v2 tem o próprio gate freemium e o rate limit do FastAPI. Vale reavaliar um `limit_req` dedicado depois do go-live.

## Refs

Closes #1644
