### PR TITLE
fix(auth): recuperação de senha em prod — link do e-mail saía como "n/a"

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -187,6 +187,12 @@ class Config:
     # email_confirmation_service. Quando vazio, o serviço faz fallback para
     # a URL canônica de prod com warning de log (PR #1335).
     EMAIL_CONFIRMATION_FRONTEND_URL = os.getenv("EMAIL_CONFIRMATION_FRONTEND_URL", "")
+    # Par da chave acima, para o link de redefinição de senha. Faltava aqui, e
+    # como password_reset_service lê via runtime_config (que consulta
+    # current_app.config, não os.getenv), a variável existia no container mas
+    # nunca chegava ao serviço — todo e-mail de recuperação saía com o link
+    # literal "n/a" (#1650). tests/test_frontend_url_config.py trava o par.
+    PASSWORD_RESET_FRONTEND_URL = os.getenv("PASSWORD_RESET_FRONTEND_URL", "")
 
     DEBUG = _read_bool_env("FLASK_DEBUG", False)
 

--- a/tests/test_frontend_url_config.py
+++ b/tests/test_frontend_url_config.py
@@ -1,0 +1,96 @@
+"""Every ``*_FRONTEND_URL`` the app emails out must reach the Flask config.
+
+The services that build these links read them with ``runtime_config``, which
+looks at ``current_app.config`` — not at ``os.getenv``. A variable that exists
+in the container but is never declared in ``config/__init__.py`` therefore
+resolves to its default, and the email goes out with a dead link.
+
+That is exactly what happened to password reset (#1650): the env was correct in
+``.env.prod`` *and* in the running container, but the config never read it, so
+every recovery email shipped ``reset_url = "n/a"``. Confirmação de e-mail was
+fine only because its key happened to be declared.
+
+These tests pin the env → config → link chain for both keys.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+# Keys consumed via `runtime_config` by the email-sending services. Add a key
+# here when a new service starts emailing a frontend link.
+FRONTEND_URL_KEYS = (
+    "PASSWORD_RESET_FRONTEND_URL",
+    "EMAIL_CONFIRMATION_FRONTEND_URL",
+)
+
+
+@pytest.mark.parametrize("key", FRONTEND_URL_KEYS)
+def test_key_is_declared_in_config(key: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The config must expose the key — otherwise runtime_config sees nothing."""
+    expected = f"https://app.auraxis.com.br/rota-de-{key.lower()}"
+    monkeypatch.setenv(key, expected)
+
+    import config
+
+    importlib.reload(config)
+    assert getattr(config.Config, key, None) == expected, (
+        f"{key} is set in the environment but does not reach Flask config — "
+        "the service reading it via runtime_config will fall back to its default"
+    )
+
+
+@pytest.mark.parametrize("key", FRONTEND_URL_KEYS)
+def test_key_defaults_to_empty_string_when_unset(
+    key: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv(key, raising=False)
+
+    import config
+
+    importlib.reload(config)
+    assert getattr(config.Config, key, None) == ""
+
+
+def test_password_reset_email_carries_a_real_url(
+    app, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End of the chain: a configured env produces a clickable link.
+
+    Regression for the report where the button and the copy-paste fallback both
+    read "n/a".
+    """
+    from app.application.services.password_reset_service import (
+        _dispatch_reset_instructions,
+    )
+
+    base = "https://app.auraxis.com.br/reset-password"
+    with app.app_context():
+        app.config["PASSWORD_RESET_FRONTEND_URL"] = base
+        app.extensions.pop("password_reset_outbox", None)
+        _dispatch_reset_instructions(email="user@test.com", token="tok-123")
+        sent = app.extensions["password_reset_outbox"]
+
+    assert sent, "nothing was dispatched"
+    reset_url = sent[-1]["reset_url"]
+    assert reset_url != "n/a"
+    assert reset_url == f"{base}?token=tok-123"
+
+
+def test_password_reset_email_falls_back_only_when_unconfigured(
+    app, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """ "n/a" stays reachable — but only for a genuinely missing config."""
+    from app.application.services.password_reset_service import (
+        _dispatch_reset_instructions,
+    )
+
+    with app.app_context():
+        app.config["PASSWORD_RESET_FRONTEND_URL"] = ""
+        app.extensions.pop("password_reset_outbox", None)
+        _dispatch_reset_instructions(email="user@test.com", token="tok-123")
+        sent = app.extensions["password_reset_outbox"]
+
+    assert sent[-1]["reset_url"] == "n/a"


### PR DESCRIPTION
## Summary

Reportado com print: o e-mail "Redefina sua senha Auraxis" chega, mas o botão **"Criar nova senha"** e o link de fallback apontam para `n/a` → `DNS_PROBE_FINISHED_NXDOMAIN`. **Nenhum usuário consegue recuperar a senha hoje.**

## Causa — não era drift de env

O diagnóstico em prod mostrou a variável **correta nos dois lugares**:

```
/opt/auraxis/.env.prod       PASSWORD_RESET_FRONTEND_URL=https://app.auraxis.com.br/reset-password
docker exec auraxis-web-1    https://app.auraxis.com.br/reset-password
```

O problema é que `password_reset_service.py:71` lê com `runtime_config(...)`, que consulta `current_app.config` — **não** `os.getenv`. E `config/__init__.py` declarava só a chave irmã:

```python
EMAIL_CONFIRMATION_FRONTEND_URL = os.getenv("EMAIL_CONFIRMATION_FRONTEND_URL", "")
# PASSWORD_RESET_FRONTEND_URL nunca foi declarada
```

Sem a declaração, `runtime_config` devolve o default `""` e o serviço cai no literal `reset_url = "n/a"` (linha 76).

Isso explica os dois fatos que não fechavam: **a confirmação de e-mail sempre funcionou** (essa chave estava declarada) e **o ajuste do `.env.prod` em #1603 não mudou nada** — o valor sempre esteve certo, o código é que não o lia.

## Validation

- Teste novo cobre a cadeia inteira — env → config → link renderizado — e é **parametrizado sobre as duas chaves**, então um terceiro `*_FRONTEND_URL` declarado em só um dos lugares falha na hora. Sem o fix, ele falha exatamente com a mensagem do bug.
- Também trava o fallback: `"n/a"` continua saindo quando a config está genuinamente vazia.
- `ruff format/check`, `mypy` (482 arquivos) e a suíte completa (`-m "not schemathesis"`) verdes.

## Residual risk

Depende de deploy em prod para o usuário final sentir o efeito — a env já está lá, então basta a nova imagem. Faço em seguida com `prod-deploy` + `verify-prod-state`, e valido com um envio real de recuperação.

## Refs

Closes #1650
