### PR TITLE
feat(ai): aprofundar o insight diário e impedir que ele se repita

### DIFF
--- a/app/services/ai_advisory_service.py
+++ b/app/services/ai_advisory_service.py
@@ -69,6 +69,7 @@ from app.services.financial_insight_context_builder import (
     truncate_snapshot,
 )
 from app.services.goal_projection_service import GoalProjectionService
+from app.services.insight_angle_rotation import InsightAngle, resolve_daily_angle
 from app.services.insight_evidence_validator import filter_valid_items
 from app.services.insight_fluida_builder import enrich_insight_payload
 from app.services.llm_provider import (
@@ -1648,10 +1649,21 @@ class AIAdvisoryService:
         # snapshot's transactions are scheduled commitments/income — recurring
         # occurrences materialised ahead of time — not realised history.
         forecast = period_start > timezone_utils.local_today(timezone_resolution)
+
+        # Daily readings rotate an editorial lens and carry a short memory of
+        # what was already written, so two quiet days in a row stop coming out
+        # as the same text (#1654).
+        angle, recent_titles, angle_metadata = _resolve_daily_variety(
+            user_id=self._user_id,
+            period_type=normalized_period_type,
+            anchor=period_start,
+        )
         prompt = _build_financial_insight_prompt(
             prompt_snapshot,
             period_type=normalized_period_type,
             forecast=forecast,
+            angle=angle,
+            recent_titles=recent_titles,
         )
 
         try:
@@ -1706,6 +1718,7 @@ class AIAdvisoryService:
             "snapshot_bytes_original": truncation_info["snapshot_bytes_original"],
             "snapshot_bytes_final": truncation_info["snapshot_bytes_final"],
             "truncated": bool(truncation_info["truncated"]),
+            **angle_metadata,
         }
         if truncation_info["dropped_sections"]:
             persist_metadata["dropped_sections"] = list(
@@ -2864,12 +2877,17 @@ def _build_monthly_budget_by_category(
 # lean (~3 min); weekly/monthly are deep reports (~15 min).
 _DEPTH_INSTRUCTIONS: dict[str, str] = {
     "daily": (
-        "PROFUNDIDADE ALVO: aproximadamente 3 minutos de leitura (cerca de 500 a "
-        "700 palavras no total da resposta). Vá além de uma frase por dimensão: "
+        "PROFUNDIDADE ALVO: aproximadamente 8 minutos de leitura (cerca de 1100 a "
+        "1500 palavras no total da resposta). Vá além de uma frase por dimensão: "
         "para cada dimensão com dados, escreva itens substantivos com 'message' "
-        "denso (2 a 4 frases), trazendo números concretos do snapshot, ao menos "
-        "uma comparação e uma recomendação acionável. Use markdown leve (negrito "
-        "em valores) quando ajudar a leitura. Não seja telegráfico nem repita."
+        "denso (3 a 6 frases), trazendo números concretos do snapshot. "
+        "COMPARATIVOS OBRIGATÓRIOS sempre que os dados existirem: hoje contra "
+        "ontem ('comparisons.yesterday'), contra o mesmo dia do mês anterior "
+        "('comparisons.same_day_previous_month'), contra a média do período "
+        "('daily_series') e contra os extremos do mês ('extremes'). Toda dica "
+        "precisa vir ancorada num número e apontar uma ação concreta. Use markdown "
+        "leve (negrito em valores) quando ajudar a leitura. Não seja telegráfico "
+        "nem repita."
     ),
     "weekly": (
         "PROFUNDIDADE ALVO: aproximadamente 15 minutos de leitura (cerca de 2500 a "
@@ -2890,7 +2908,7 @@ _DEPTH_INSTRUCTIONS: dict[str, str] = {
 }
 
 # Approximate reading-time word targets used by the advisory depth gate (#1481).
-_DEPTH_WORD_TARGETS: dict[str, int] = {"daily": 450, "weekly": 2200, "monthly": 2200}
+_DEPTH_WORD_TARGETS: dict[str, int] = {"daily": 950, "weekly": 2200, "monthly": 2200}
 
 
 def _snapshot_max_bytes(period_type: str) -> int:
@@ -2923,14 +2941,18 @@ def _period_model(period_type: str) -> str | None:
     Returns None to use the provider's default model.
     """
     if period_type == "daily":
-        return os.getenv("OPENAI_ADVISORY_MODEL_DAILY", "gpt-4o-mini") or None
+        # #1654: the daily reading went from a 3-minute extraction to an
+        # 8-minute analysis with mandatory comparisons, which mini could not
+        # sustain. Cost implication is in the issue — the per-user ceiling must
+        # be raised BEFORE this ships.
+        return os.getenv("OPENAI_ADVISORY_MODEL_DAILY", "gpt-4o") or None
     return None
 
 
 def _period_max_tokens(period_type: str) -> int:
     """Output token budget per period — deep reports need a much larger budget."""
     if period_type == "daily":
-        env_key, default = "AI_INSIGHT_MAX_TOKENS_DAILY", 1500
+        env_key, default = "AI_INSIGHT_MAX_TOKENS_DAILY", 2800
     else:
         env_key, default = "AI_INSIGHT_MAX_TOKENS_LONG", 6000
     try:
@@ -3012,11 +3034,158 @@ def _build_chat_prompt(
     )
 
 
+def _resolve_daily_variety(
+    *,
+    user_id: UUID,
+    period_type: str,
+    anchor: date,
+) -> tuple[InsightAngle | None, list[str], dict[str, Any]]:
+    """Resolve the lens and the short memory that keep dailies from repeating.
+
+    Weekly and monthly readings are long-form and already vary by construction,
+    so the rotation is a daily-only device.
+
+    Returns the metadata fragment ready to merge rather than a value the caller
+    has to branch on — the generator is already at the complexity ceiling.
+
+    :param user_id: Owner of the insight.
+    :param period_type: Normalized period being generated.
+    :param anchor: First day of the period.
+    :returns: The lens, the recently used titles and the metadata to persist.
+    """
+    if period_type != "daily":
+        return None, [], {}
+    angle = resolve_daily_angle(user_id, anchor)
+    # Persisted so the next generation can steer away from the same lens and so
+    # support can explain why a given day read the way it did.
+    return angle, _recent_daily_insight_titles(user_id), {"angle": angle.key}
+
+
+def _recent_daily_insight_titles(user_id: UUID, *, limit: int = 7) -> list[str]:
+    """Titles the user already read in the last few daily insights.
+
+    Fed to the prompt as a ban list, not as context: the model must not treat
+    any of it as fact. Only titles travel — the bodies would cost far more
+    tokens than the variety is worth.
+
+    :param user_id: Owner of the insights.
+    :param limit: How many previous days to look back on.
+    :returns: Titles, newest first, without duplicates or blanks.
+    """
+    rows: list[AIInsight] = (
+        db.session.query(AIInsight)
+        .filter(AIInsight.user_id == user_id)
+        .filter(AIInsight.insight_type == InsightType.daily)
+        .order_by(AIInsight.created_at.desc())
+        .limit(limit)
+        .all()
+    )
+
+    titles: list[str] = []
+    for row in rows:
+        payload = _safe_json_loads_for_titles(row.content)
+        for item in payload.get("items", []) if isinstance(payload, dict) else []:
+            if not isinstance(item, dict):
+                continue
+            title = item.get("title")
+            if isinstance(title, str) and title.strip() and title not in titles:
+                titles.append(title.strip())
+    return titles
+
+
+def _safe_json_loads_for_titles(raw: str | None) -> dict[str, Any]:
+    """Parse persisted insight content, tolerating anything unparseable.
+
+    :param raw: Serialized insight content.
+    :returns: The decoded object, or an empty dict.
+    """
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except (TypeError, ValueError):
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _has_no_new_activity(snapshot: dict[str, Any]) -> bool:
+    """True when the day brought nothing new to write about.
+
+    Deterministic on purpose: the model is told to switch register, but the
+    decision of *when* stays in our code so it can be tested.
+
+    :param snapshot: The financial snapshot handed to the model.
+    :returns: Whether nothing changed since the previous generation.
+    """
+    transactions = snapshot.get("transactions")
+    changes = (
+        transactions.get("changes_since_last_generation")
+        if isinstance(transactions, dict)
+        else None
+    )
+    if changes:
+        return False
+
+    current = snapshot.get("current_period")
+    created = current.get("created_today") if isinstance(current, dict) else None
+    count = created.get("transaction_count") if isinstance(created, dict) else None
+    return not count
+
+
+def _build_variety_instruction(
+    *,
+    angle: InsightAngle | None,
+    recent_titles: list[str],
+    no_new_activity: bool,
+) -> str:
+    """Assemble the anti-repetition block for the daily prompt (#1654).
+
+    Three layers, none of which touches the cache: the cache is already scoped
+    by ``period_label`` and never serves one day's text on another. What repeats
+    is the *writing* — same prompt over an almost identical snapshot.
+    """
+    if angle is None:
+        return ""
+
+    parts = [
+        f"LENTE DE HOJE: {angle.instruction}. Aprofunde ESTA frente com 2 ou 3 "
+        "itens extras e trate as demais dimensões obrigatórias de forma mais "
+        "concisa. A lente muda a cada dia — não escreva como se ela fosse o "
+        "assunto de sempre.\n"
+    ]
+
+    if recent_titles:
+        listed = "; ".join(f'"{title}"' for title in recent_titles)
+        parts.append(
+            "TÍTULOS JÁ USADOS NOS ÚLTIMOS DIAS: "
+            f"{listed}. É PROIBIDO repetir esses títulos ou reciclar a mesma "
+            "abertura. Esta lista serve APENAS como proibição — não é fonte "
+            "factual e nada nela deve ser citado como dado.\n"
+        )
+
+    if no_new_activity:
+        parts.append(
+            "MODO SEM MOVIMENTO: hoje não houve lançamento novo. NÃO se limite a "
+            "dizer que nada mudou — isso não ajuda ninguém. Entregue valor a "
+            "partir do que já existe no snapshot: (a) o que a ausência de gastos "
+            "faz com 'month_summary.burn_rate_daily' e "
+            "'month_summary.projected_eom_balance'; (b) a revisão de uma meta com "
+            "base em 'goals' e 'projections'; (c) a folga restante de um envelope "
+            "em 'budgets'; (d) um comparativo histórico via 'daily_series', "
+            "'extremes' ou 'comparisons'. Continua PROIBIDO inventar transações, "
+            "valores ou datas.\n"
+        )
+
+    return "".join(parts)
+
+
 def _build_financial_insight_prompt(
     snapshot: dict[str, Any],
     *,
     period_type: str,
     forecast: bool = False,
+    angle: InsightAngle | None = None,
+    recent_titles: list[str] | None = None,
 ) -> str:
     context = json.dumps(snapshot, ensure_ascii=False, default=str)
     if forecast:
@@ -3057,6 +3226,12 @@ def _build_financial_insight_prompt(
         period_type, _DEPTH_INSTRUCTIONS["daily"]
     )
 
+    variety_instruction = _build_variety_instruction(
+        angle=angle,
+        recent_titles=recent_titles or [],
+        no_new_activity=_has_no_new_activity(snapshot),
+    )
+
     insight_types = ", ".join(_SPENDING_INSIGHT_TYPES)
     contract = snapshot.get("insight_contract")
     required_dimensions_raw = (
@@ -3095,6 +3270,7 @@ def _build_financial_insight_prompt(
         "objetivos, personalizados e acionáveis.\n"
         f"{period_instruction}\n"
         f"{depth_instruction}\n"
+        f"{variety_instruction}"
         f"{coverage_instruction}"
         f"Presença de dados por domínio: {domain_presence_json}.\n"
         "Use somente os dados do snapshot fornecido. Não invente transações, metas, "

--- a/app/services/financial_insight_context_builder.py
+++ b/app/services/financial_insight_context_builder.py
@@ -71,7 +71,10 @@ _GOAL_PACE_WINDOW_DAYS = 90
 # When exceeded, `truncate_snapshot()` reduces large lists deterministically
 # while preserving the structural backbone (schema_version, current_period,
 # comparisons). Override via AI_SNAPSHOT_MAX_BYTES env for cost experiments.
-DEFAULT_MAX_SNAPSHOT_BYTES = 12 * 1024
+# #1654: the daily reading now demands comparisons against yesterday, the same
+# day last month, the daily series and the month's extremes — 12 KiB truncated
+# the very blocks those comparisons read from.
+DEFAULT_MAX_SNAPSHOT_BYTES = 16 * 1024
 DEFAULT_MAX_SNAPSHOT_BYTES_LONG = 24 * 1024
 MAX_SNAPSHOT_BYTES = int(
     os.getenv("AI_SNAPSHOT_MAX_BYTES", str(DEFAULT_MAX_SNAPSHOT_BYTES))

--- a/app/services/insight_angle_rotation.py
+++ b/app/services/insight_angle_rotation.py
@@ -1,0 +1,132 @@
+"""Editorial lens rotation for the daily AI insight.
+
+Two daily readings built from an almost identical snapshot come out almost
+identical — same prompt, same data, same opening. The fix is not in the cache
+(``_get_cached_insight_for_snapshot`` already scopes by ``period_label``, so two
+days never collide) but in the prompt: each day asks the model to go deep on a
+different dimension.
+
+The rotation is **deterministic**, not random. That buys three things random
+would not:
+
+* the same user on the same date always gets the same lens, so a test can pin it
+  with freezegun and support can explain what happened;
+* the choice is auditable — it is persisted in the insight metadata;
+* preview/contract tests stay stable.
+
+The per-user offset keeps two users from reading the same angle on the same day,
+and ten lenses means the cycle does not line up with the week (7) or the month
+(~30), so a given weekday never lands on the same lens twice in a row.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from datetime import date
+from uuid import UUID
+
+__all__ = ["InsightAngle", "INSIGHT_ANGLES", "resolve_daily_angle"]
+
+
+@dataclass(frozen=True)
+class InsightAngle:
+    """One editorial lens: an id for the metadata and a prompt instruction."""
+
+    key: str
+    instruction: str
+
+
+INSIGHT_ANGLES: tuple[InsightAngle, ...] = (
+    InsightAngle(
+        key="pendencias_e_vencimentos",
+        instruction=(
+            "compromissos em aberto: o que vence nos próximos dias, o que já "
+            "passou do prazo e quanto disso ainda cabe no que resta do mês"
+        ),
+    ),
+    InsightAngle(
+        key="categorias_e_tags",
+        instruction=(
+            "para onde o dinheiro está indo: concentração por categoria e por "
+            "tag, o que subiu e o que caiu em relação ao mês anterior"
+        ),
+    ),
+    InsightAngle(
+        key="ritmo_e_burn_rate",
+        instruction=(
+            "o ritmo de saída: burn rate diário, quanto dele já foi consumido e "
+            "onde o mês fecha se o ritmo atual continuar"
+        ),
+    ),
+    InsightAngle(
+        key="metas",
+        instruction=(
+            "as metas: distância até cada objetivo, quanto o ritmo atual antecipa "
+            "ou atrasa a data prevista e qual delas merece atenção primeiro"
+        ),
+    ),
+    InsightAngle(
+        key="orcamentos",
+        instruction=(
+            "os orçamentos: folga restante por envelope, quais estão perto do "
+            "limite e o que dá para remanejar sem apertar o resto"
+        ),
+    ),
+    InsightAngle(
+        key="cartoes",
+        instruction=(
+            "os cartões: faturas em aberto, quanto do limite está comprometido e "
+            "como as compras parceladas pesam nos próximos meses"
+        ),
+    ),
+    InsightAngle(
+        key="carteira_e_alocacao",
+        instruction=(
+            "a carteira: composição atual, como ela se compara ao CDI e ao IPCA e "
+            "se a alocação ainda combina com o perfil declarado"
+        ),
+    ),
+    InsightAngle(
+        key="projecao_e_cenarios",
+        instruction=(
+            "o horizonte: as projeções de 3, 6 e 12 meses, o que muda nelas se a "
+            "sobra atual se mantiver e o que muda se ela cair pela metade"
+        ),
+    ),
+    InsightAngle(
+        key="habitos_e_recorrencia",
+        instruction=(
+            "os hábitos: o que se repete todo mês, quanto disso é assinatura ou "
+            "recorrência e o que já não faz sentido manter"
+        ),
+    ),
+    InsightAngle(
+        key="comparativo_historico",
+        instruction=(
+            "a leitura histórica: como este mês se compara aos anteriores, quais "
+            "extremos se destacam e o que a série diária revela sobre o padrão"
+        ),
+    ),
+)
+
+
+def _user_offset(user_id: UUID | str) -> int:
+    """Stable per-user offset so two users read different angles on a given day.
+
+    :param user_id: The user the insight belongs to.
+    :returns: An integer offset derived from the id.
+    """
+    digest = hashlib.sha256(str(user_id).encode("utf-8")).hexdigest()
+    return int(digest[:8], 16)
+
+
+def resolve_daily_angle(user_id: UUID | str, anchor: date) -> InsightAngle:
+    """Pick the editorial lens for one user on one day.
+
+    :param user_id: The user the insight belongs to.
+    :param anchor: The day the insight covers.
+    :returns: The lens to emphasise in the prompt.
+    """
+    index = (anchor.toordinal() + _user_offset(user_id)) % len(INSIGHT_ANGLES)
+    return INSIGHT_ANGLES[index]

--- a/tests/test_ai_insight_anti_repetition.py
+++ b/tests/test_ai_insight_anti_repetition.py
@@ -1,0 +1,145 @@
+"""Anti-repetition guarantees for the daily insight prompt (#1654).
+
+The PO's requirement is blunt: *"Um insight diário nunca deve ser repetido,
+mesmo que o usuário não tenha registrado receitas/despesas, metas, orçamentos e
+gastos novos no cartão ou investimentos."*
+
+The cache was never the culprit — ``_get_cached_insight_for_snapshot`` scopes by
+``period_label``, so one day's text is never served on another. What repeated was
+the *writing*, and these tests pin the three prompt-level defences.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from uuid import UUID
+
+from app.services.ai_advisory_service import (
+    _build_financial_insight_prompt,
+    _has_no_new_activity,
+)
+from app.services.insight_angle_rotation import resolve_daily_angle
+
+_USER = UUID("33333333-3333-3333-3333-333333333333")
+
+_BASE_SNAPSHOT = {
+    "schema_version": "v3",
+    "data_quality": {},
+    "insight_contract": {},
+}
+
+
+def _prompt_for(
+    day: date, *, snapshot: dict | None = None, titles: list[str] | None = None
+) -> str:
+    return _build_financial_insight_prompt(
+        snapshot if snapshot is not None else dict(_BASE_SNAPSHOT),
+        period_type="daily",
+        angle=resolve_daily_angle(_USER, day),
+        recent_titles=titles or [],
+    )
+
+
+class TestLensRotation:
+    def test_consecutive_days_ask_for_different_lenses(self) -> None:
+        """Same snapshot, different days — the instruction must not match."""
+        first = _prompt_for(date(2026, 8, 1))
+        second = _prompt_for(date(2026, 8, 2))
+
+        assert "LENTE DE HOJE" in first
+        assert "LENTE DE HOJE" in second
+        assert first != second
+
+    def test_the_lens_is_absent_for_non_daily_periods(self) -> None:
+        """Weekly and monthly are already long-form; rotation is a daily device."""
+        prompt = _build_financial_insight_prompt(
+            dict(_BASE_SNAPSHOT), period_type="weekly"
+        )
+
+        assert "LENTE DE HOJE" not in prompt
+
+
+class TestShortMemory:
+    def test_recent_titles_are_injected_as_a_ban_list(self) -> None:
+        prompt = _prompt_for(
+            date(2026, 8, 1),
+            titles=["O mês fecha no azul", "Assinaturas subiram"],
+        )
+
+        assert "TÍTULOS JÁ USADOS" in prompt
+        assert "O mês fecha no azul" in prompt
+        assert "PROIBIDO repetir" in prompt
+
+    def test_the_ban_list_is_explicitly_not_a_source_of_facts(self) -> None:
+        """Without this the model could cite yesterday's headline as data."""
+        prompt = _prompt_for(date(2026, 8, 1), titles=["Sobra de R$ 2.000"])
+
+        assert "não é fonte" in prompt
+
+    def test_no_ban_list_section_when_there_is_no_history(self) -> None:
+        prompt = _prompt_for(date(2026, 8, 1), titles=[])
+
+        assert "TÍTULOS JÁ USADOS" not in prompt
+
+
+class TestQuietDayMode:
+    def test_detects_a_day_with_nothing_new(self) -> None:
+        snapshot = {
+            **_BASE_SNAPSHOT,
+            "transactions": {"changes_since_last_generation": []},
+            "current_period": {"created_today": {"transaction_count": 0}},
+        }
+
+        assert _has_no_new_activity(snapshot) is True
+
+    def test_a_new_transaction_disables_the_mode(self) -> None:
+        snapshot = {
+            **_BASE_SNAPSHOT,
+            "transactions": {"changes_since_last_generation": []},
+            "current_period": {"created_today": {"transaction_count": 3}},
+        }
+
+        assert _has_no_new_activity(snapshot) is False
+
+    def test_a_recorded_change_disables_the_mode(self) -> None:
+        snapshot = {
+            **_BASE_SNAPSHOT,
+            "transactions": {"changes_since_last_generation": [{"id": "x"}]},
+            "current_period": {"created_today": {"transaction_count": 0}},
+        }
+
+        assert _has_no_new_activity(snapshot) is False
+
+    def test_quiet_day_prompt_demands_substance_instead_of_nothing_changed(
+        self,
+    ) -> None:
+        """The whole point of the PO's request: a quiet day still owes a reading."""
+        snapshot = {
+            **_BASE_SNAPSHOT,
+            "transactions": {"changes_since_last_generation": []},
+            "current_period": {"created_today": {"transaction_count": 0}},
+        }
+
+        prompt = _prompt_for(date(2026, 8, 1), snapshot=snapshot)
+
+        assert "MODO SEM MOVIMENTO" in prompt
+        assert "NÃO se limite a dizer que nada mudou" in prompt
+        # Every source it may draw on has to be a snapshot key the evidence
+        # validator recognises, or the items get rejected downstream.
+        for key in (
+            "month_summary.burn_rate_daily",
+            "goals",
+            "budgets",
+            "daily_series",
+        ):
+            assert key in prompt
+
+    def test_busy_day_prompt_omits_the_quiet_mode(self) -> None:
+        snapshot = {
+            **_BASE_SNAPSHOT,
+            "current_period": {"created_today": {"transaction_count": 2}},
+        }
+
+        prompt = _prompt_for(date(2026, 8, 1), snapshot=snapshot)
+
+        assert "MODO SEM MOVIMENTO" not in prompt

--- a/tests/test_ai_insight_depth.py
+++ b/tests/test_ai_insight_depth.py
@@ -56,14 +56,17 @@ def _financial_llm_response(*, summary: str = "Resumo.") -> LLMResponse:
 
 
 class TestDepthPrompt:
-    def test_daily_prompt_targets_3_min_reading(self) -> None:
+    def test_daily_prompt_targets_8_min_reading(self) -> None:
         from app.services.ai_advisory_service import _build_financial_insight_prompt
 
         prompt = _build_financial_insight_prompt(
             {"schema_version": "v1", "data_quality": {}, "insight_contract": {}},
             period_type="daily",
         )
-        assert "3 minutos de leitura" in prompt
+        # #1654 took the daily reading from a 3-minute extraction to an
+        # 8-minute analysis with mandatory comparisons.
+        assert "8 minutos de leitura" in prompt
+        assert "COMPARATIVOS OBRIGATÓRIOS" in prompt
 
     def test_long_prompts_target_15_min_reading(self) -> None:
         from app.services.ai_advisory_service import _build_financial_insight_prompt
@@ -80,7 +83,7 @@ class TestPeriodMaxTokens:
     def test_daily_default_budget(self) -> None:
         from app.services.ai_advisory_service import _period_max_tokens
 
-        assert _period_max_tokens("daily") == 1500
+        assert _period_max_tokens("daily") == 2800
 
     def test_long_default_budget(self) -> None:
         from app.services.ai_advisory_service import _period_max_tokens
@@ -111,7 +114,7 @@ class TestPeriodMaxTokens:
             service.generate_financial_insights(
                 period_type="daily", anchor_date=date(2026, 5, 17)
             )
-            assert provider.generate_with_usage.call_args.kwargs["max_tokens"] == 1500
+            assert provider.generate_with_usage.call_args.kwargs["max_tokens"] == 2800
 
     def test_generate_passes_long_budget_to_provider(self, app) -> None:
         with app.app_context():
@@ -141,7 +144,7 @@ class TestDepthGate:
             from app.services.ai_advisory_service import AIAdvisoryService
 
             provider = MagicMock()
-            # Short canned response → far below the daily 450-word target.
+            # Short canned response → far below the daily 950-word target.
             provider.generate_with_usage.return_value = _financial_llm_response()
             service = AIAdvisoryService(user_id=uuid.uuid4(), llm_provider=provider)
             with patch(

--- a/tests/test_ai_snapshot_v3.py
+++ b/tests/test_ai_snapshot_v3.py
@@ -274,7 +274,8 @@ class TestPerPeriodCapsAndTrim:
 
         monkeypatch.delenv("AI_SNAPSHOT_MAX_BYTES", raising=False)
         monkeypatch.delenv("AI_SNAPSHOT_MAX_BYTES_LONG", raising=False)
-        assert _snapshot_max_bytes("daily") == 12 * 1024
+        # #1654: the daily reading needs the comparison blocks intact.
+        assert _snapshot_max_bytes("daily") == 16 * 1024
         assert _snapshot_max_bytes("weekly") == 24 * 1024
         assert _snapshot_max_bytes("monthly") == 24 * 1024
 
@@ -311,7 +312,14 @@ class TestPerPeriodModelMix:
             latency_ms=10,
         )
 
-    def test_daily_manual_generation_uses_mini_model(self, app, monkeypatch) -> None:
+    def test_daily_manual_generation_uses_the_strong_model(
+        self, app, monkeypatch
+    ) -> None:
+        """#1654 moved the daily reading off mini.
+
+        The 8-minute analysis with mandatory comparisons is not something mini
+        sustains; the per-user cost ceiling was raised to match.
+        """
         monkeypatch.delenv("OPENAI_ADVISORY_MODEL_DAILY", raising=False)
         with app.app_context():
             from app.services.ai_advisory_service import AIAdvisoryService
@@ -324,9 +332,7 @@ class TestPerPeriodModelMix:
                 period_type="daily", anchor_date=_ANCHOR
             )
 
-            assert provider.generate_with_usage.call_args.kwargs["model"] == (
-                "gpt-4o-mini"
-            )
+            assert provider.generate_with_usage.call_args.kwargs["model"] == "gpt-4o"
 
     def test_weekly_generation_uses_provider_default_model(self, app) -> None:
         with app.app_context():

--- a/tests/test_insight_angle_rotation.py
+++ b/tests/test_insight_angle_rotation.py
@@ -1,0 +1,89 @@
+"""Tests for the daily insight lens rotation (#1654)."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from uuid import UUID
+
+from app.services.insight_angle_rotation import (
+    INSIGHT_ANGLES,
+    resolve_daily_angle,
+)
+
+_USER_A = UUID("11111111-1111-1111-1111-111111111111")
+
+
+def test_same_user_and_day_always_resolve_to_the_same_angle() -> None:
+    """Determinism is what makes the choice testable and explainable."""
+    anchor = date(2026, 8, 1)
+
+    first = resolve_daily_angle(_USER_A, anchor)
+    second = resolve_daily_angle(_USER_A, anchor)
+
+    assert first is second
+
+
+def test_ten_consecutive_days_cover_every_angle_without_repeating() -> None:
+    """The point of the rotation: ten days, ten different lenses."""
+    anchor = date(2026, 8, 1)
+
+    keys = [
+        resolve_daily_angle(_USER_A, anchor + timedelta(days=offset)).key
+        for offset in range(len(INSIGHT_ANGLES))
+    ]
+
+    assert len(set(keys)) == len(INSIGHT_ANGLES)
+
+
+def test_consecutive_days_never_repeat_the_previous_angle() -> None:
+    """Day N and day N+1 must not open on the same dimension."""
+    anchor = date(2026, 8, 1)
+
+    keys = [
+        resolve_daily_angle(_USER_A, anchor + timedelta(days=offset)).key
+        for offset in range(30)
+    ]
+
+    assert all(
+        current != following for current, following in zip(keys, keys[1:], strict=False)
+    )
+
+
+def test_the_cycle_does_not_line_up_with_the_week() -> None:
+    """Ten lenses over a seven-day week: same weekday, different lens."""
+    anchor = date(2026, 8, 1)
+
+    this_week = resolve_daily_angle(_USER_A, anchor).key
+    next_week = resolve_daily_angle(_USER_A, anchor + timedelta(days=7)).key
+
+    assert this_week != next_week
+
+
+def test_the_lens_varies_across_users_on_the_same_day() -> None:
+    """Without the per-user offset the whole base would share one lens a day.
+
+    Two given users may of course collide — there are only ten lenses. What
+    must not happen is the base moving as a single block, so this asserts on
+    the spread rather than on one pair.
+    """
+    anchor = date(2026, 8, 1)
+    users = [UUID(f"{index:032x}") for index in range(1, 21)]
+
+    keys = {resolve_daily_angle(user, anchor).key for user in users}
+
+    assert len(keys) >= 5
+
+
+def test_accepts_a_string_user_id() -> None:
+    """Callers hand over whatever the request carries; both shapes must work."""
+    anchor = date(2026, 8, 1)
+
+    assert resolve_daily_angle(str(_USER_A), anchor) is resolve_daily_angle(
+        _USER_A, anchor
+    )
+
+
+def test_every_angle_carries_an_instruction() -> None:
+    """An empty instruction would silently disable the rotation for that day."""
+    assert all(angle.instruction.strip() for angle in INSIGHT_ANGLES)
+    assert len({angle.key for angle in INSIGHT_ANGLES}) == len(INSIGHT_ANGLES)


### PR DESCRIPTION
Closes #1654

> 🔴 **Pré-requisito de deploy — env ANTES do código.** Ver a seção de custo.

## As duas queixas do PO

> *"Insights diários: dar uma profundidade maior, trazer informações mais relevantes, comparativos, dicas, etc. Um insight diário nunca deve ser repetido, mesmo que o usuário não tenha registrado receitas/despesas, metas, orçamentos e gastos novos no cartão ou investimentos."*

## Parte 1 — profundidade

| Parâmetro | Antes | Agora |
|---|---|---|
| Modelo | `gpt-4o-mini` | `gpt-4o` |
| Faixa de palavras | 500-700 (~3 min) | 1100-1500 (~8 min) |
| Alvo do gate | 450 | 950 |
| Tokens de saída | 1.500 | 2.800 |
| Snapshot | 12 KiB | 16 KiB |

8 minutos, não os 15 do semanal/mensal: ninguém consome relatório de quinze minutos todo dia.

Os **comparativos agora são obrigatórios** no prompt (ontem, mesmo dia do mês anterior, média da série, extremos do mês) e toda dica precisa vir ancorada num número e apontar uma ação. O cap de 12 KiB era um problema silencioso: truncava justamente os blocos de onde esses comparativos saem.

## Parte 2 — anti-repetição

**O cache nunca foi o culpado.** `_get_cached_insight_for_snapshot` filtra por `period_label` **antes** de comparar o hash, e o diário usa `YYYY-MM-DD` — dois dias nunca colidem. O cache por hash só atua dentro do mesmo dia, que é o comportamento correto do #1546.

O que se repetia era a **escrita**: mesmo prompt, snapshot quase idêntico, mesma abertura. Logo as três defesas são todas no prompt, sem estado novo:

**1. Lente rotativa** (`insight_angle_rotation.py`) — 10 ângulos, escolhidos por `(data.toordinal() + offset(user_id)) % 10`, com offset derivado de `sha256(user_id)`.

Determinística e não aleatória de propósito: dá para pinar com freezegun, fica auditável no metadata (`persist_metadata["angle"]`) e o suporte consegue explicar por que um dia leu daquele jeito. 10 não bate com 7 nem com ~30, então o mesmo dia da semana nunca cai duas vezes seguidas na mesma lente. O offset por usuário evita que a base inteira leia o mesmo ângulo no mesmo dia.

**2. Memória curta** — os títulos dos últimos 7 diários entram como **lista de proibição** (~200 tokens), com ressalva explícita de que **não são fonte factual**. Sem essa ressalva, o modelo poderia citar a manchete de ontem como se fosse dado.

**3. Modo sem movimento** — num dia sem lançamento, em vez de "nada mudou", o insight passa a ler o que já existe: efeito no `burn_rate_daily` e no `projected_eom_balance`, revisão de meta via `projections`, folga de envelope em `budgets`, comparativo via `daily_series`/`extremes`. Todas as fontes citadas são prefixos que o `insight_evidence_validator` reconhece — senão os itens seriam rejeitados a jusante.

### O que foi descartado, e por quê

- **Subir a `temperature`**: trocaria precisão por variedade e aumentaria a rejeição do validador de evidências — no limite, `LLMProviderError` quando todos os itens caem.
- **Desativar o `context_hash` para o diário**: reintroduziria a regeneração a cada login do #1546, sem ganho — ele já é escopado por dia.
- **Embeddings/similaridade**: custo e complexidade desproporcionais, e atacaria o sintoma em vez da causa.

## 🔴 Custo — o env vem primeiro

Custo por geração no perfil novo: ~7.300 tk in × US$2,50/1M + ~2.200 tk out × US$10/1M = **US$0,0403**.

Pior caso por usuário/mês (diário todo dia + semanal + mensal + chat, que dividem o mesmo teto) ≈ **US$1,56**.

Teto hoje em produção: `AI_INSIGHTS_USER_BUDGET_PCT=0.167` → **US$0,91**. O usuário bateria 429 por volta do dia 22.

**Antes do deploy deste código:**
1. `AI_INSIGHTS_USER_BUDGET_PCT`: `0.167` → **`0.35`** (US$1,90; ~22% de folga; ainda abaixo do teto duro de 50% do ADR)
2. Definir **`AI_INSIGHTS_MONTHLY_BUDGET_USD`** — verifiquei em produção e ele está **unset**, ou seja, não existe nenhuma rede de segurança global de custo hoje

**A ordem importa.** Código novo sobre o teto antigo estoura os US$0,91 em ~22 gerações.

Contexto útil: hoje o diário é gerado **raríssimo** — 4 em 75 dias na base inteira. O custo efetivo imediato é irrisório; o teto existe para o cenário em que o insight melhor passa a ser usado de fato.

## Débito registrado

A amenda do ADR de 2026-06-09 diz que existe "downgrade automático para gpt-4o-mini quando o orçamento residual é baixo". **Isso não existe no código** — `_period_model` não olha orçamento. O único enforcement é o 429 duro. Vale uma issue.

## Validação

- `scripts/run_ci_quality_local.sh --local` **verde**: 2.945 testes, coverage **91,42%**
- `tests/test_insight_angle_rotation.py` (7 casos): determinismo, 10 dias sem repetir, dias consecutivos sempre diferentes, ciclo que não bate com a semana, dispersão entre usuários
- `tests/test_ai_insight_anti_repetition.py` (10 casos): lente presente só no diário, lista de proibição injetada e marcada como não-factual, detecção do dia parado e o modo correspondente
- **Regressão do #1546 conferida**: `test_ai_insight_change_status`, `test_ai_insight_persistence` e `test_financial_insight_context_builder` seguem verdes — o cache dentro do mesmo dia continua intacto

## Como verificar em produção (depois do env)

1. Gerar um diário → `LLMAuditLog` com `model == "gpt-4o"` e custo entre US$0,035 e 0,050
2. Conferir extensão ≥950 palavras (sem log `below_depth_target`)
3. Gerar em 3 dias consecutivos e comparar: lentes diferentes, títulos sem sobreposição, aberturas distintas
4. Conta sem lançamentos no dia → texto substantivo sobre meta/orçamento/projeção, **sem fato inventado**
5. Acompanhar `auraxis_ai_insight_cost_usd_total{period_type="daily"}` por 7 dias e extrapolar contra o teto novo