### PR TITLE
fix(radar): cron não falha mais por ausência de despesa e passa a nomear o erro da v2

### DIFF
--- a/app/services/ai_spending_patterns_service.py
+++ b/app/services/ai_spending_patterns_service.py
@@ -41,6 +41,10 @@ _TIMEOUT_SECONDS = 30.0
 _PERIOD_DAYS = 90
 _DEFAULT_MODEL = "v2-spending-patterns"
 _EXPENSE_PAGE_SIZE = 500
+# Longest upstream description kept in the exception message / cron log.
+_MAX_UPSTREAM_DETAIL_CHARS = 200
+# Validation errors reported per failure — enough to diagnose, not a dump.
+_MAX_VALIDATION_ERRORS = 3
 
 
 class SpendingPatternsUpstreamError(RuntimeError):
@@ -153,6 +157,17 @@ def generate_and_persist_spending_patterns(
     start = anchor_date - timedelta(days=_PERIOD_DAYS)
     transactions = _build_expense_payload(user_id=user_id, start=start, end=end)
 
+    if not transactions:
+        # v2 requires at least one transaction (``min_length=1``); posting an
+        # empty list earns a 422 that used to surface as a generic domain error
+        # and turned "nothing to analyse" into a failed weekly job (#1596).
+        log.info(
+            "spending_patterns.no_expenses user=%s period=%s",
+            user_id,
+            anchor_date.isoformat(),
+        )
+        return _no_analysis_result()
+
     # Server-to-server token for the internal v2 call. The token_use=service
     # claim tells v2 to skip its per-user session (active_jti) revocation — this
     # cron token has no user session — while signature and account-block checks
@@ -168,21 +183,21 @@ def generate_and_persist_spending_patterns(
     )
 
     if status_code >= 400:
+        # The cron's only trace of this failure is the exception message, so it
+        # has to name the cause. #1596 stayed open for eight days because a 401
+        # "Token revoked." from v2 looked exactly like a 422 or a 500 in the job
+        # log, in the diagnostics artifact and in the auto-opened issue.
+        summary = _describe_upstream_failure(status_code, body)
+        log.warning("spending_patterns.v2_rejected %s", summary)
         raise SpendingPatternsUpstreamError(
-            "Falha ao gerar o radar de gastos.",
+            f"Falha ao gerar o radar de gastos ({summary}).",
             status_code=status_code,
         )
 
     patterns = body.get("patterns")
     if not isinstance(patterns, list) or not patterns:
         # Nothing actionable returned — do not persist an empty analysis.
-        return {
-            "patterns": [],
-            "cost_usd": 0.0,
-            "tokens_used": 0,
-            "cached": False,
-            "persisted": False,
-        }
+        return _no_analysis_result()
 
     cost_usd = _safe_float(body.get("cost_usd"))
     tokens_used = _safe_int(body.get("tokens_used") or body.get("tokens_total"))
@@ -213,6 +228,53 @@ def generate_and_persist_spending_patterns(
 # ---------------------------------------------------------------------------
 
 
+def _no_analysis_result() -> dict[str, Any]:
+    """Result for "there is nothing to cache" — not an error, nothing persisted."""
+    return {
+        "patterns": [],
+        "cost_usd": 0.0,
+        "tokens_used": 0,
+        "cached": False,
+        "persisted": False,
+    }
+
+
+def _describe_upstream_failure(status_code: int, body: dict[str, Any]) -> str:
+    """Summarise a v2 rejection for the cron log — never echoing request data.
+
+    FastAPI's 422 body repeats the rejected ``input`` (transaction amounts), so
+    only the error ``type`` and the field ``loc`` are reported; a plain string
+    ``detail`` (``"Token revoked."``) is safe and is the most useful signal.
+    """
+    detail = body.get("detail")
+    summary = ""
+
+    if isinstance(detail, str):
+        summary = detail.strip()
+    elif isinstance(detail, list):
+        summary = "; ".join(
+            described
+            for item in detail[:_MAX_VALIDATION_ERRORS]
+            if (described := _describe_validation_error(item))
+        )
+
+    if not summary:
+        return f"HTTP {status_code}"
+    return f"HTTP {status_code}: {summary[:_MAX_UPSTREAM_DETAIL_CHARS]}"
+
+
+def _describe_validation_error(item: object) -> str:
+    """Render one pydantic error as ``field.path: error_type`` (no values)."""
+    if not isinstance(item, dict):
+        return ""
+    location = item.get("loc")
+    error_type = str(item.get("type") or "invalid")
+    if not isinstance(location, list | tuple) or not location:
+        return error_type
+    parts = [str(part) for part in location if str(part) != "body"]
+    return f"{'.'.join(parts)}: {error_type}" if parts else error_type
+
+
 def _build_expense_payload(
     *,
     user_id: UUID,
@@ -222,7 +284,9 @@ def _build_expense_payload(
     """Return an LGPD-safe list of expense rows for the v2 detector.
 
     Only the fields v2 needs are forwarded: amount, occurred_on, category. No
-    titles, descriptions or free-text are sent.
+    titles, descriptions or free-text are sent. Rows v2 would reject (it declares
+    ``amount: float = Field(gt=0)``) are dropped here — otherwise a single zeroed
+    expense 422s the whole user's radar.
     """
     from sqlalchemy import desc
 
@@ -239,15 +303,27 @@ def _build_expense_payload(
 
     payload: list[dict[str, Any]] = []
     for expense in result["expenses"]:
+        amount = _positive_amount(expense["amount"])
+        if amount is None:
+            continue
         payload.append(
             {
-                "amount": expense["amount"],
+                "amount": amount,
                 "occurred_on": expense["due_date"],
                 "category": expense.get("category"),
                 "kind": "expense",
             }
         )
     return payload
+
+
+def _positive_amount(value: object) -> float | None:
+    """Coerce to a strictly positive float, or ``None`` when v2 would reject it."""
+    try:
+        amount = float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+    return amount if amount > 0 else None
 
 
 def _persist(

--- a/tests/test_ai_spending_patterns_latest.py
+++ b/tests/test_ai_spending_patterns_latest.py
@@ -65,6 +65,38 @@ def _grant_premium(app, token: str) -> _uuid.UUID:
     return user_id
 
 
+def _seed_expense(
+    app,
+    user_id: _uuid.UUID,
+    *,
+    amount: str = "42.90",
+    due_date: date | None = None,
+    category: str | None = "alimentacao",
+) -> None:
+    """Insert one EXPENSE inside the radar's 90-day window."""
+    from decimal import Decimal
+
+    from app.extensions.database import db
+    from app.models.transaction import (
+        Transaction,
+        TransactionCategory,
+        TransactionType,
+    )
+
+    with app.app_context():
+        db.session.add(
+            Transaction(
+                user_id=user_id,
+                title="Cafeteria",
+                amount=Decimal(amount),
+                type=TransactionType.EXPENSE,
+                due_date=due_date or (date(2026, 6, 5) - timedelta(days=3)),
+                category=TransactionCategory(category) if category else None,
+            )
+        )
+        db.session.commit()
+
+
 def _seed_cached_radar(app, user_id: _uuid.UUID, *, period_label: str) -> None:
     from app.extensions.database import db
     from app.models.ai_insight import AIInsight, InsightType
@@ -212,6 +244,7 @@ def test_generate_mints_service_token(app, client, monkeypatch) -> None:
 
     token = _register_and_login(client)
     user_id = _grant_premium(app, token)
+    _seed_expense(app, user_id)
 
     captured: dict[str, str] = {}
 
@@ -234,6 +267,7 @@ def test_generate_mints_service_token(app, client, monkeypatch) -> None:
 def test_generate_persists_insight(app, client, monkeypatch) -> None:
     token = _register_and_login(client)
     user_id = _grant_premium(app, token)
+    _seed_expense(app, user_id)
 
     _patch_v2(
         monkeypatch,
@@ -263,6 +297,7 @@ def test_generate_persists_insight(app, client, monkeypatch) -> None:
 def test_generate_does_not_persist_when_empty(app, client, monkeypatch) -> None:
     token = _register_and_login(client)
     user_id = _grant_premium(app, token)
+    _seed_expense(app, user_id)
 
     _patch_v2(monkeypatch, status=200, body={"patterns": []})
 
@@ -278,6 +313,7 @@ def test_generate_does_not_persist_when_empty(app, client, monkeypatch) -> None:
 def test_generate_raises_on_upstream_error(app, client, monkeypatch) -> None:
     token = _register_and_login(client)
     user_id = _grant_premium(app, token)
+    _seed_expense(app, user_id)
 
     _patch_v2(monkeypatch, status=502, body={"error": "boom"})
 
@@ -293,8 +329,164 @@ def test_generate_raises_on_upstream_error(app, client, monkeypatch) -> None:
 
 
 # ---------------------------------------------------------------------------
+# #1596 — the weekly cron failed for 8 days with an unreadable error
+# ---------------------------------------------------------------------------
+
+
+def test_generate_skips_v2_when_user_has_no_expenses(app, client, monkeypatch) -> None:
+    """A Premium user with no expenses in the window must not hit v2.
+
+    v2 declares ``transactions: min_length=1``; posting an empty list earns a
+    422 that v1 used to surface as a generic "Falha ao gerar o radar de gastos.",
+    turning "nothing to analyse" into a red weekly job. Regression for #1596.
+    """
+    token = _register_and_login(client)
+    user_id = _grant_premium(app, token)
+
+    def _boom(**_kwargs):  # noqa: ANN003
+        raise AssertionError("v2 must not be called with an empty payload")
+
+    monkeypatch.setattr(sps_service, "call_v2_spending_patterns", _boom)
+
+    with app.app_context():
+        result = sps_service.generate_and_persist_spending_patterns(
+            user_id, anchor_date=date(2026, 6, 5)
+        )
+
+    assert result["persisted"] is False
+    assert result["patterns"] == []
+
+
+def test_generate_drops_amounts_v2_would_reject(app, client, monkeypatch) -> None:
+    """v2 declares ``amount: float = Field(gt=0)``.
+
+    One zeroed row used to 422 the whole user; filter it out instead.
+    """
+    token = _register_and_login(client)
+    user_id = _grant_premium(app, token)
+    _seed_expense(app, user_id, amount="0.00")
+    _seed_expense(app, user_id, amount="42.90")
+
+    captured: dict[str, object] = {}
+
+    def _capture(*, transactions, period_days, auth_header):  # noqa: ANN001
+        captured["transactions"] = transactions
+        return 200, {"patterns": []}
+
+    monkeypatch.setattr(sps_service, "call_v2_spending_patterns", _capture)
+
+    with app.app_context():
+        sps_service.generate_and_persist_spending_patterns(
+            user_id, anchor_date=date(2026, 6, 5)
+        )
+
+    forwarded = captured["transactions"]
+    assert [row["amount"] for row in forwarded] == [42.90]
+
+
+def test_upstream_error_names_the_status_and_detail(app, client, monkeypatch) -> None:
+    """The cron's only output is ``error={exc}`` — it must name the cause.
+
+    #1596 stayed open for 8 days because a 401 ``Token revoked.`` from v2 was
+    indistinguishable from a 422 or a 500 in the job log and in the auto-opened
+    issue.
+    """
+    token = _register_and_login(client)
+    user_id = _grant_premium(app, token)
+    _seed_expense(app, user_id)
+
+    _patch_v2(monkeypatch, status=401, body={"detail": "Token revoked."})
+
+    with app.app_context():
+        try:
+            sps_service.generate_and_persist_spending_patterns(
+                user_id, anchor_date=date(2026, 6, 5)
+            )
+        except sps_service.SpendingPatternsUpstreamError as exc:
+            assert exc.status_code == 401
+            assert "401" in str(exc)
+            assert "Token revoked." in str(exc)
+        else:  # pragma: no cover - guard
+            raise AssertionError("expected SpendingPatternsUpstreamError")
+
+
+def test_upstream_error_never_echoes_validation_input(app, client, monkeypatch) -> None:
+    """A 422 body carries the rejected ``input`` — amounts are user data (LGPD).
+
+    Report the field location and the error type, never the value.
+    """
+    token = _register_and_login(client)
+    user_id = _grant_premium(app, token)
+    _seed_expense(app, user_id)
+
+    _patch_v2(
+        monkeypatch,
+        status=422,
+        body={
+            "detail": [
+                {
+                    "type": "greater_than",
+                    "loc": ["body", "transactions", 0, "amount"],
+                    "msg": "Input should be greater than 0",
+                    "input": "1234.56",
+                }
+            ]
+        },
+    )
+
+    with app.app_context():
+        try:
+            sps_service.generate_and_persist_spending_patterns(
+                user_id, anchor_date=date(2026, 6, 5)
+            )
+        except sps_service.SpendingPatternsUpstreamError as exc:
+            message = str(exc)
+            assert "422" in message
+            assert "greater_than" in message
+            assert "transactions.0.amount" in message
+            assert "1234.56" not in message
+        else:  # pragma: no cover - guard
+            raise AssertionError("expected SpendingPatternsUpstreamError")
+
+
+def test_describe_upstream_failure_degrades_to_the_status_alone() -> None:
+    """An unparseable body must still yield a message that names the status."""
+    describe = sps_service._describe_upstream_failure
+
+    assert describe(502, {}) == "HTTP 502"
+    assert describe(500, {"error": "boom"}) == "HTTP 500"
+    assert describe(422, {"detail": ["not-a-dict"]}) == "HTTP 422"
+    assert describe(422, {"detail": [{"loc": [], "type": "missing"}]}) == (
+        "HTTP 422: missing"
+    )
+    assert describe(422, {"detail": [{"loc": ["body"]}]}) == "HTTP 422: invalid"
+
+
+def test_cli_counts_user_without_expenses_as_skipped(app, client, monkeypatch) -> None:
+    """No expenses is not a failure — the weekly job must stay green."""
+    token = _register_and_login(client)
+    _grant_premium(app, token)
+
+    def _boom(**_kwargs):  # noqa: ANN003
+        raise AssertionError("v2 must not be called with an empty payload")
+
+    monkeypatch.setattr(sps_service, "call_v2_spending_patterns", _boom)
+
+    result = _invoke_cli(app)
+    assert result.exit_code == 0, result.output
+    assert "failures=0" in result.output
+    assert "skipped=1" in result.output
+
+
+# ---------------------------------------------------------------------------
 # CLI — flask ai spending-patterns
 # ---------------------------------------------------------------------------
+
+
+def _brt_today() -> date:
+    from app.cli.ai_insights_cli import _brt_today as _impl
+
+    return _impl()
 
 
 def _invoke_cli(app, *args: str) -> object:
@@ -326,6 +518,7 @@ def test_cli_dry_run_does_not_call_v2(app, client, monkeypatch) -> None:
 def test_cli_generates_for_premium_user(app, client, monkeypatch) -> None:
     token = _register_and_login(client)
     user_id = _grant_premium(app, token)
+    _seed_expense(app, user_id, due_date=_brt_today() - timedelta(days=3))
 
     _patch_v2(
         monkeypatch,


### PR DESCRIPTION
## Causa raiz

O radar falhava por **duas** camadas — a segunda escondida pela primeira, e ambas invisíveis no output do job.

### Camada A — a v2 nunca chegou a rodar o fix do token de serviço (fora deste repo)

`api-v2#98` (exenção de revogação para `token_use=service`) foi mergeado em **25/07 22:57** e o `Deploy` reportou sucesso — mas o `docker compose up -d` da v2 compara o **nome** da imagem (`auraxis-api-v2:current`), não o digest, e **não recriou o container** (`api-v2#121`). A v2 seguiu servindo código pré-#98 por 8 dias, então todo `v1 → v2` do radar levava `401 Token revoked.` e os 3 usuários Premium falhavam.

Foi corrigido manualmente em 02/08 (`--force-recreate`). Verificado agora:

| run | resultado |
|---|---|
| [30691198037](https://github.com/italofelipe/auraxis-api/actions/runs/30691198037) (01/08, agendado) | `processed=0 failures=3` |
| [30769517035](https://github.com/italofelipe/auraxis-api/actions/runs/30769517035) (02/08, dispatch de verificação) | `processed=2 failures=1` ✅ |

Confirmado também por inspeção do container em prod: o `deps.py` que está no ar hoje já contém o `token_use` (3 ocorrências), e o container foi recriado em `2026-08-02T14:02`.

### Camada B — o que esta PR conserta (é nosso, v1)

Sobrou **1 falha**. Consultando o banco de prod, o usuário `cba40e6d` tem, na janela de 90 dias, **1 receita e zero despesas**. O v1 monta `transactions: []` e posta assim mesmo; a v2 declara `transactions: Field(min_length=1)` → **422** → o batch conta como falha → o workflow reabre a issue todo sábado. Ou seja: mesmo com a auth curada, o job continuaria vermelho — "não há o que analisar" estava sendo tratado como erro.

E o motivo de a Camada A ter levado **8 dias e três diagnósticos**: o v1 descartava status e corpo da resposta da v2 e imprimia só `error=Falha ao gerar o radar de gastos.`. No log do job, no artifact e na issue automática, um 401 é idêntico a um 422 e a um 500.

## O que mudou

`app/services/ai_spending_patterns_service.py`:

1. **Não chamar a v2 com payload que ela rejeita.** Sem despesas na janela → retorna sem persistir (o CLI conta `skipped`, exit 0) em vez de estourar. Linhas com `amount <= 0` são descartadas no builder — a v2 declara `amount: float = Field(gt=0)`, então uma despesa zerada derrubava o radar inteiro daquele usuário.
2. **O erro passa a se nomear.** A mensagem vira `Falha ao gerar o radar de gastos (HTTP 401: Token revoked.)` e vai também para `log.warning`. Para 422 reporta `loc` + `type` (`transactions.0.amount: greater_than`) e **nunca** o campo `input` do corpo da v2 — ele repete o valor da transação (LGPD).

## Como validei

- **6 testes novos, fail-first verificado** (rodados contra o código antigo antes do fix: os 5 de comportamento falham).
  - v2 não é chamada quando o usuário não tem despesa — reproduz exatamente o `failures=1` que sobrou em prod;
  - linha com `amount = 0` é descartada;
  - a mensagem cita status e `detail` (401 `Token revoked.`);
  - a mensagem de 422 traz `greater_than` e `transactions.0.amount` e **não** traz o valor rejeitado;
  - `_describe_upstream_failure` degrada para `HTTP <status>` com corpo inutilizável;
  - CLI: usuário sem despesa vira `skipped=1`, `failures=0`, exit 0.
- Testes pré-existentes que mockavam a v2 com usuário **sem nenhuma transação** agora semeiam uma despesa real — eles passavam por acidente, escondendo justamente este bug.
- `scripts/run_ci_quality_local.sh --local`: **2950 passed, 2 skipped**, cobertura total **91.42%** (gate 85%).
- Prod (somente leitura, via SSM): estado do container v2, presença do fix na imagem no ar e contagem de transações do usuário que falhou.

## Risco residual

- **Baixo.** O caminho on-demand (`POST /ai/insights/spending-patterns`, `spending_patterns_proxy.py`) não é tocado: ele chama `call_v2_spending_patterns` direto e monta a própria resposta; a mensagem alterada é levantada só no caminho do cron.
- `amount` passa a ser enviado como `float` em vez de `str` — a v2 já declarava `float` e coagia, então nada muda do outro lado.
- Um usuário Premium sem despesa deixa de gerar radar **e deixa de gritar**. É o comportamento correto, mas se a intenção for enxergar esses casos, o `log.info spending_patterns.no_expenses` cobre.
- **Não fecha `api-v2#121`** (o `up -d` sem `--force-recreate`), que é a causa da Camada A e continua aberto no outro repo. Enquanto ele existir, qualquer fix da v2 pode "deployar" sem entrar em produção.

Closes #1596
