### PR TITLE
fix(transactions): parar de descartar paid_at no POST /transactions

### DIFF
--- a/app/application/services/transaction/mutations.py
+++ b/app/application/services/transaction/mutations.py
@@ -6,6 +6,7 @@ orchestration (validate → call helper → persist → respond).
 Contents:
 
 - ``assert_owned_references`` — ownership enforcement for tag/account/card refs.
+- ``normalize_paid_at_for_create`` — paid_at × status invariant for creates.
 - ``normalize_paid_at_for_update`` — paid_at × status invariant for updates.
 - ``build_installment_transactions`` — build the N-row installment batch.
 - ``build_transaction_kwargs`` — map a normalised payload → ``Transaction`` ctor args.
@@ -14,7 +15,7 @@ Contents:
 
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, datetime
 from decimal import Decimal
 from typing import Any
 from uuid import UUID, uuid4
@@ -69,6 +70,14 @@ def assert_owned_references(
         raise _validation_error(message) from exc
 
 
+def _parse_paid_at(raw_value: Any) -> datetime:
+    """Coerce a ``paid_at`` value to ``datetime``, rejecting future timestamps."""
+    parsed_paid_at = coerce_datetime(raw_value, field_name="paid_at")
+    if parsed_paid_at > utc_now_compatible_with(parsed_paid_at):
+        raise _validation_error("'paid_at' não pode ser uma data futura.")
+    return parsed_paid_at
+
+
 def normalize_paid_at_for_update(normalized: dict[str, Any]) -> None:
     """Validate and coerce the ``paid_at`` field in-place for an update payload.
 
@@ -91,10 +100,40 @@ def normalize_paid_at_for_update(normalized: dict[str, Any]) -> None:
     if "paid_at" not in normalized or paid_at_value is None:
         return
 
-    parsed_paid_at = coerce_datetime(paid_at_value, field_name="paid_at")
-    if parsed_paid_at > utc_now_compatible_with(parsed_paid_at):
-        raise _validation_error("'paid_at' não pode ser uma data futura.")
-    normalized["paid_at"] = parsed_paid_at
+    normalized["paid_at"] = _parse_paid_at(paid_at_value)
+
+
+def normalize_paid_at_for_create(
+    normalized: dict[str, Any],
+    *,
+    tx_status: TransactionStatus,
+) -> None:
+    """Validate and coerce ``paid_at`` in-place for a create payload.
+
+    ``TransactionSchema`` already accepts ``paid_at`` on load, but the value used
+    to be dropped before reaching the ``Transaction`` constructor (#1659), so a
+    transaction created as PAID landed without a payment timestamp.
+
+    Same invariant as the update path for the value that *is* sent: ``paid_at``
+    only makes sense with ``status=paid`` and can never be in the future.
+    Unlike the update path, ``paid_at`` is **not** required when creating with
+    ``status=paid`` — requiring it would break existing clients that create a
+    settled transaction without one.
+    """
+    if "paid_at" not in normalized:
+        return
+
+    paid_at_value = normalized.get("paid_at")
+    if paid_at_value is None:
+        normalized.pop("paid_at")
+        return
+
+    if tx_status is not TransactionStatus.PAID:
+        raise _validation_error(
+            "'paid_at' só pode ser definido se o status for 'PAID'."
+        )
+
+    normalized["paid_at"] = _parse_paid_at(paid_at_value)
 
 
 def build_transaction_kwargs(
@@ -137,6 +176,7 @@ def build_transaction_kwargs(
         "auto_settle": bool(normalized.get("auto_settle", False)),
         "status": tx_status,
         "currency": normalize_currency(normalized.get("currency")),
+        "paid_at": normalized.get("paid_at"),
     }
 
 
@@ -181,6 +221,7 @@ def build_installment_transactions(
             auto_settle=bool(normalized.get("auto_settle", False)),
             status=tx_status,
             currency=currency,
+            paid_at=normalized.get("paid_at"),
             installment_group_id=group_id,
         )
         for idx in range(count)
@@ -247,6 +288,7 @@ __all__ = [
     "assert_owned_references",
     "build_installment_transactions",
     "build_transaction_kwargs",
+    "normalize_paid_at_for_create",
     "normalize_paid_at_for_update",
     "normalize_update_type_and_status",
 ]

--- a/app/application/services/transaction/writes.py
+++ b/app/application/services/transaction/writes.py
@@ -16,6 +16,7 @@ from app.application.services.transaction.mutations import (
     assert_owned_references,
     build_installment_transactions,
     build_transaction_kwargs,
+    normalize_paid_at_for_create,
     normalize_paid_at_for_update,
     normalize_update_type_and_status,
 )
@@ -51,6 +52,7 @@ def execute_create_transaction(
     tx_type = normalize_transaction_type(normalized.get("type"))
     tx_status = normalize_transaction_status(normalized.get("status"))
     amount = normalize_decimal_amount(normalized.get("amount"))
+    normalize_paid_at_for_create(normalized, tx_status=tx_status)
     due_date = coerce_date(
         normalized.get("due_date"), field_name="due_date", required=True
     )

--- a/tests/test_transaction_additional.py
+++ b/tests/test_transaction_additional.py
@@ -28,8 +28,8 @@ def _auth_headers(token: str, contract: str | None = None) -> dict[str, str]:
     return headers
 
 
-def _transaction_payload(**overrides: str) -> dict[str, str]:
-    payload = {
+def _transaction_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
         "title": "Conta de água",
         "amount": "120.50",
         "type": "expense",
@@ -120,6 +120,110 @@ def test_transaction_update_paid_at_future_returns_400(client) -> None:
 
     assert response.status_code == 400
     assert response.get_json()["error"]["code"] == "VALIDATION_ERROR"
+
+
+def test_transaction_create_persists_paid_at(client) -> None:
+    """POST /transactions must not swallow a validated ``paid_at`` (#1659)."""
+    token = _register_and_login(client, "create-paid-at")
+    paid_at = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+
+    response = client.post(
+        "/transactions",
+        headers=_auth_headers(token, "v2"),
+        json=_transaction_payload(status="paid", paid_at=paid_at),
+    )
+
+    assert response.status_code == 201
+    created = response.get_json()["data"]["transaction"][0]
+    assert created["paid_at"] is not None
+
+    detail = client.get(
+        f"/transactions/{created['id']}",
+        headers=_auth_headers(token, "v2"),
+    )
+    assert detail.status_code == 200
+    assert detail.get_json()["data"]["transaction"]["paid_at"] is not None
+
+
+def test_transaction_create_installments_persist_paid_at(client) -> None:
+    """The installment batch must persist ``paid_at`` too (#1659)."""
+    token = _register_and_login(client, "create-paid-at-inst")
+    paid_at = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+
+    response = client.post(
+        "/transactions",
+        headers=_auth_headers(token, "v2"),
+        json=_transaction_payload(
+            amount="300.00",
+            status="paid",
+            paid_at=paid_at,
+            is_installment=True,
+            installment_count=3,
+        ),
+    )
+
+    assert response.status_code == 201
+    transactions = response.get_json()["data"]["transactions"]
+    assert len(transactions) == 3
+    assert all(item["paid_at"] is not None for item in transactions)
+
+
+def test_transaction_create_paid_status_without_paid_at_is_accepted(client) -> None:
+    """Backward compatibility: create with status=paid and no paid_at stays 201."""
+    token = _register_and_login(client, "create-paid-no-at")
+
+    response = client.post(
+        "/transactions",
+        headers=_auth_headers(token, "v2"),
+        json=_transaction_payload(status="paid"),
+    )
+
+    assert response.status_code == 201
+    assert response.get_json()["data"]["transaction"][0]["paid_at"] is None
+
+
+def test_transaction_create_paid_at_without_paid_status_returns_400(client) -> None:
+    token = _register_and_login(client, "create-paid-at-status")
+
+    response = client.post(
+        "/transactions",
+        headers=_auth_headers(token, "v2"),
+        json=_transaction_payload(
+            status="pending",
+            paid_at=datetime.now(UTC).isoformat(),
+        ),
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"]["code"] == "VALIDATION_ERROR"
+
+
+def test_transaction_create_paid_at_future_returns_400(client) -> None:
+    token = _register_and_login(client, "create-paid-at-future")
+    future_paid_at = (datetime.now(UTC) + timedelta(days=2)).isoformat()
+
+    response = client.post(
+        "/transactions",
+        headers=_auth_headers(token, "v2"),
+        json=_transaction_payload(status="paid", paid_at=future_paid_at),
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"]["code"] == "VALIDATION_ERROR"
+
+
+def test_transaction_create_paid_at_null_is_ignored(client) -> None:
+    """An explicit ``paid_at: null`` must not trip the status invariant."""
+    token = _register_and_login(client, "create-paid-at-null")
+
+    response = client.post(
+        "/transactions",
+        headers=_auth_headers(token, "v2"),
+        json={**_transaction_payload(), "paid_at": None},
+    )
+
+    assert response.status_code == 201
+    assert response.get_json()["data"]["transaction"][0]["paid_at"] is None
 
 
 def test_transaction_update_not_found_v2(client) -> None:


### PR DESCRIPTION
## Resumo

`POST /transactions` aceitava `paid_at`, validava o campo no `TransactionSchema` e
**descartava o valor em silêncio**: `build_transaction_kwargs` nunca o repassava ao
construtor de `Transaction`. Uma transação criada com `status=paid` nascia sem data
de pagamento — e some de qualquer leitura que filtre por `paid_at` (contexto de
insight, fechamento de fatura). O mesmo acontecia no lote de parcelas
(`build_installment_transactions`).

### O que mudou

- `normalize_paid_at_for_create` — nova validação no fluxo de criação, com a mesma
  invariante já aplicada no update para o valor **enviado**: `paid_at` só faz sentido
  com `status=paid` e nunca pode ser futuro. Parsing/regra de data futura extraídos
  para `_parse_paid_at`, compartilhado com `normalize_paid_at_for_update` (sem
  duplicar regra entre create e update).
- `paid_at` passa a ser repassado nos **dois** caminhos de criação: transação única
  e lote de parcelas.
- `paid_at: null` explícito continua sendo ignorado (não dispara a invariante).

### Retrocompatibilidade

Diferente do update, **`paid_at` não vira obrigatório** quando se cria com
`status=paid` — exigir isso quebraria clientes que hoje criam transação liquidada
sem timestamp. O único payload que passa a ser rejeitado (400) é
`paid_at` + status diferente de `paid`, que antes era aceito e descartado —
combinação que o `PATCH` já rejeita e que nem web nem app enviam (verificado).
Sem mudança de contrato: o campo já estava no schema e no `openapi.json`.

## Validação

- TDD: 4 testes falhando antes do fix (persistência single, persistência parcelado,
  `paid_at` com status errado, `paid_at` futuro) + 2 de retrocompatibilidade que já
  passavam (status=paid sem `paid_at`; `paid_at: null`).
- `scripts/run_ci_quality_local.sh --local`: **2957 passed, 2 skipped**, cobertura
  **91,44%** (mínimo 85%). Ruff format/check, mypy e bandit verdes.
- Sem drift de contrato: `openapi.json` e a coleção Postman não mudam (o body do
  smoke `POST /transactions` não envia `paid_at`).

## Risco residual

Baixo. O único comportamento novo visível para cliente é o 400 descrito acima.
Transações antigas continuam com `paid_at` nulo — este PR não faz backfill.

## Escopo — o que ficou de fora (deliberado)

Este PR entrega **apenas o item 1** de #1647. O item 2 (aceitar
`source`/`external_id`/`bank_name` no load do `TransactionSchema`) é mudança de
contrato do v1 e foi **deferido pelo PO para depois do go-live 01/09**, conforme
registrado no corpo da própria issue. Por isso #1647 fica **aberta** e este PR
fecha a issue de split #1659, criada só para o bug.

Closes #1659
Refs #1647
