### PR TITLE
feat(ai): filtrar histórico de insights por período e acabar com a query duplicada

### DIFF
--- a/app/controllers/ai/resources.py
+++ b/app/controllers/ai/resources.py
@@ -54,6 +54,10 @@ from app.services.ai_advisory_service import (
     AIInsightCostBudgetExceededError,
     _ai_chat_daily_limit,
 )
+from app.services.ai_insight_history_service import (
+    AIInsightHistoryValidationError,
+    list_user_insights,
+)
 from app.services.ai_lgpd import AIConsentRequiredError, ensure_ai_consent_granted
 from app.services.ai_monthly_report_service import (
     create_monthly_report_run,
@@ -1307,7 +1311,8 @@ class AIInsightHistoryResource(MethodResource):
         description=(
             "Retorna a lista paginada de insights gerados por IA para o usuário "  # noqa: E501
             "autenticado, ordenada do mais recente para o mais antigo. "
-            "Acessível sem entitlement premium."
+            "Acessível sem entitlement premium. Aceita filtros opcionais por "
+            "período (period_type/period_label)."
         ),
         tags=["AI Advisory"],
         security=[{"BearerAuth": []}],
@@ -1325,6 +1330,26 @@ class AIInsightHistoryResource(MethodResource):
                 "required": False,
                 "description": "Itens por página (máx. 50). Padrão: 20.",
                 "example": 20,
+            },
+            "period_type": {
+                "in": "query",
+                "type": "string",
+                "required": False,
+                "description": (
+                    "Filtra por tipo de período: daily, weekly, monthly, recap "
+                    "ou spending_patterns. Valor desconhecido devolve 400."
+                ),
+                "example": "monthly",
+            },
+            "period_label": {
+                "in": "query",
+                "type": "string",
+                "required": False,
+                "description": (
+                    "Filtra pelo rótulo do período (ex.: '2026-07' para mensal, "
+                    "'2026-W20' para semanal, '2026-07-15' para diário)."
+                ),
+                "example": "2026-07",
             },
         },
         responses={
@@ -1366,9 +1391,6 @@ class AIInsightHistoryResource(MethodResource):
     )
     @jwt_required()
     def get(self) -> Response:
-        from app.extensions.database import db
-        from app.models.ai_insight import AIInsight
-
         token_error = _guard_revoked_token()
         if token_error is not None:
             return token_error
@@ -1376,23 +1398,23 @@ class AIInsightHistoryResource(MethodResource):
         user_id = current_user_id()
 
         try:
-            page = max(1, int(request.args.get("page", 1)))
-            per_page = min(50, max(1, int(request.args.get("per_page", 20))))
-        except (ValueError, TypeError):
-            page, per_page = 1, 20
-
-        total = db.session.query(AIInsight).filter_by(user_id=user_id).count()
-        rows = (
-            db.session.query(AIInsight)
-            .filter_by(user_id=user_id)
-            .order_by(AIInsight.created_at.desc())
-            .offset((page - 1) * per_page)
-            .limit(per_page)
-            .all()
-        )
+            history = list_user_insights(
+                user_id,
+                page=request.args.get("page"),
+                per_page=request.args.get("per_page"),
+                period_type=request.args.get("period_type"),
+                period_label=request.args.get("period_label"),
+            )
+        except AIInsightHistoryValidationError as exc:
+            return compat_error_response(
+                legacy_payload={"error": exc.message},
+                status_code=400,
+                message=exc.message,
+                error_code=exc.code,
+            )
 
         items = []
-        for r in rows:
+        for r in history.items:
             summary, insight_items, context_schema_version, context_hash = (
                 _parse_history_content(r.content)
             )
@@ -1418,7 +1440,12 @@ class AIInsightHistoryResource(MethodResource):
                 }
             )
 
-        payload = {"items": items, "page": page, "per_page": per_page, "total": total}
+        payload = {
+            "items": items,
+            "page": history.page,
+            "per_page": history.per_page,
+            "total": history.total,
+        }
         return compat_success_response(
             legacy_payload=payload,
             status_code=200,

--- a/app/graphql/docs_catalog.py
+++ b/app/graphql/docs_catalog.py
@@ -879,7 +879,9 @@ GRAPHQL_OPERATION_CATALOG: tuple[GraphQLOperationDoc, ...] = (
         access="auth_required",
         summary=(
             "Retorna o histórico paginado de insights gerados por IA para o usuário "
-            "autenticado, ordenado do mais recente ao mais antigo."
+            "autenticado, ordenado do mais recente ao mais antigo. Aceita filtros "
+            "opcionais periodType/periodLabel — paridade com "
+            "GET /ai/insights/history (#1653)."
         ),
         source_module=QUERY_AI_INSIGHT_MODULE,
     ),

--- a/app/graphql/queries/ai_insight.py
+++ b/app/graphql/queries/ai_insight.py
@@ -4,9 +4,15 @@ import json
 
 import graphene
 
-from app.extensions.database import db
 from app.graphql.auth import get_current_user_required
+from app.graphql.errors import build_public_graphql_error
 from app.models.ai_insight import AIInsight
+from app.services.ai_insight_history_service import (
+    DEFAULT_PAGE,
+    DEFAULT_PER_PAGE,
+    AIInsightHistoryValidationError,
+    list_user_insights,
+)
 from app.services.ai_spending_patterns_service import read_latest_spending_patterns
 
 
@@ -76,8 +82,10 @@ class AIInsightChangeStatusType(graphene.ObjectType):
 class AIInsightQueryMixin:
     ai_insight_history = graphene.Field(
         AIInsightHistoryResultType,
-        page=graphene.Int(default_value=1),
-        per_page=graphene.Int(default_value=20),
+        page=graphene.Int(default_value=DEFAULT_PAGE),
+        per_page=graphene.Int(default_value=DEFAULT_PER_PAGE),
+        period_type=graphene.String(),
+        period_label=graphene.String(),
     )
     ai_insight_change_status = graphene.Field(
         AIInsightChangeStatusType,
@@ -132,23 +140,25 @@ class AIInsightQueryMixin:
         _info: graphene.ResolveInfo,
         page: int,
         per_page: int,
+        period_type: str | None = None,
+        period_label: str | None = None,
     ) -> AIInsightHistoryResultType:
         user = get_current_user_required()
-        user_id = user.id
 
-        total = db.session.query(AIInsight).filter_by(user_id=user_id).count()
-        rows = (
-            db.session.query(AIInsight)
-            .filter_by(user_id=user_id)
-            .order_by(AIInsight.created_at.desc())
-            .offset((page - 1) * per_page)
-            .limit(per_page)
-            .all()
-        )
+        try:
+            history = list_user_insights(
+                user.id,
+                page=page,
+                per_page=per_page,
+                period_type=period_type,
+                period_label=period_label,
+            )
+        except AIInsightHistoryValidationError as exc:
+            raise build_public_graphql_error(exc.message, code=exc.code) from exc
 
         return AIInsightHistoryResultType(
-            items=[_to_ai_insight_type(r) for r in rows],
-            page=page,
-            per_page=per_page,
-            total=total,
+            items=[_to_ai_insight_type(r) for r in history.items],
+            page=history.page,
+            per_page=history.per_page,
+            total=history.total,
         )

--- a/app/services/ai_insight_history_service.py
+++ b/app/services/ai_insight_history_service.py
@@ -1,0 +1,147 @@
+"""Shared read model for the AI insight history (#1653).
+
+`GET /ai/insights/history` and the `aiInsightHistory` GraphQL query each carried
+their own copy of the same query — same filter, same ordering, same pagination,
+written twice. That is exactly how REST/GraphQL parity rots: a filter added on
+one side silently never reaches the other.
+
+This module owns the query. Both protocols call ``list_user_insights`` and only
+serialise the rows in their own shape, so parity holds by construction.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+from uuid import UUID
+
+from app.extensions.database import db
+from app.models.ai_insight import AIInsight, InsightType
+
+DEFAULT_PAGE = 1
+DEFAULT_PER_PAGE = 20
+MAX_PER_PAGE = 50
+
+_VALID_PERIOD_TYPES = ", ".join(member.value for member in InsightType)
+PERIOD_TYPE_ERROR_MESSAGE = (
+    f"Parâmetro 'period_type' inválido. Use um de: {_VALID_PERIOD_TYPES}."
+)
+
+
+class AIInsightHistoryValidationError(ValueError):
+    """Raised when a caller passes an unsupported filter value."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.message = message
+        self.code = "VALIDATION_ERROR"
+
+
+@dataclass(frozen=True)
+class AIInsightHistoryPage:
+    """One page of insights plus the pagination echo both protocols return."""
+
+    items: list[AIInsight]
+    page: int
+    per_page: int
+    total: int
+
+
+def normalize_pagination(page: Any, per_page: Any) -> tuple[int, int]:
+    """Clamp pagination inputs to the supported window.
+
+    Invalid/absent values fall back to the defaults; ``page`` never goes below 1
+    (a negative OFFSET used to be reachable through GraphQL) and ``per_page`` is
+    capped at ``MAX_PER_PAGE``.
+    """
+    try:
+        parsed_page = max(1, int(page)) if page is not None else DEFAULT_PAGE
+    except (TypeError, ValueError):
+        parsed_page = DEFAULT_PAGE
+    try:
+        parsed_per_page = (
+            min(MAX_PER_PAGE, max(1, int(per_page)))
+            if per_page is not None
+            else DEFAULT_PER_PAGE
+        )
+    except (TypeError, ValueError):
+        parsed_per_page = DEFAULT_PER_PAGE
+    return parsed_page, parsed_per_page
+
+
+def normalize_period_type(raw_value: Any) -> InsightType | None:
+    """Map a raw ``period_type`` filter to ``InsightType`` (``None`` when absent).
+
+    Raises ``AIInsightHistoryValidationError`` for an unknown value instead of
+    silently ignoring the filter and returning the whole history.
+    """
+    if raw_value is None:
+        return None
+    value = str(raw_value).strip().lower()
+    if not value:
+        return None
+    try:
+        return InsightType(value)
+    except ValueError as exc:
+        raise AIInsightHistoryValidationError(PERIOD_TYPE_ERROR_MESSAGE) from exc
+
+
+def normalize_period_label(raw_value: Any) -> str | None:
+    if raw_value is None:
+        return None
+    value = str(raw_value).strip()
+    return value or None
+
+
+def list_user_insights(
+    user_id: UUID,
+    *,
+    page: Any = DEFAULT_PAGE,
+    per_page: Any = DEFAULT_PER_PAGE,
+    period_type: Any = None,
+    period_label: Any = None,
+) -> AIInsightHistoryPage:
+    """Return the user's insights, newest first, with optional period filters.
+
+    Both filters are additive and optional — omitting them reproduces the
+    previous behaviour exactly. ``(user_id, insight_type, period_label)`` is
+    covered by ``ix_ai_insights_user_type_period``.
+    """
+    normalized_page, normalized_per_page = normalize_pagination(page, per_page)
+    insight_type = normalize_period_type(period_type)
+    label = normalize_period_label(period_label)
+
+    query = db.session.query(AIInsight).filter(AIInsight.user_id == user_id)
+    if insight_type is not None:
+        query = query.filter(AIInsight.insight_type == insight_type)
+    if label is not None:
+        query = query.filter(AIInsight.period_label == label)
+
+    total = query.count()
+    rows = (
+        query.order_by(AIInsight.created_at.desc())
+        .offset((normalized_page - 1) * normalized_per_page)
+        .limit(normalized_per_page)
+        .all()
+    )
+
+    return AIInsightHistoryPage(
+        items=list(rows),
+        page=normalized_page,
+        per_page=normalized_per_page,
+        total=total,
+    )
+
+
+__all__ = [
+    "AIInsightHistoryPage",
+    "AIInsightHistoryValidationError",
+    "DEFAULT_PAGE",
+    "DEFAULT_PER_PAGE",
+    "MAX_PER_PAGE",
+    "PERIOD_TYPE_ERROR_MESSAGE",
+    "list_user_insights",
+    "normalize_pagination",
+    "normalize_period_label",
+    "normalize_period_type",
+]

--- a/graphql.introspection.json
+++ b/graphql.introspection.json
@@ -308,6 +308,30 @@
                     "name": "Int",
                     "ofType": null
                   }
+                },
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "periodType",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "deprecationReason": null,
+                  "description": null,
+                  "isDeprecated": false,
+                  "name": "periodLabel",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
                 }
               ],
               "deprecationReason": null,

--- a/graphql.operations.manifest.json
+++ b/graphql.operations.manifest.json
@@ -740,7 +740,7 @@
     "name": "aiInsightHistory",
     "operation_type": "query",
     "source_module": "app.graphql.queries.ai_insight",
-    "summary": "Retorna o histórico paginado de insights gerados por IA para o usuário autenticado, ordenado do mais recente ao mais antigo."
+    "summary": "Retorna o histórico paginado de insights gerados por IA para o usuário autenticado, ordenado do mais recente ao mais antigo. Aceita filtros opcionais periodType/periodLabel — paridade com GET /ai/insights/history (#1653)."
   },
   {
     "access": "auth_required",

--- a/openapi.json
+++ b/openapi.json
@@ -2121,7 +2121,7 @@
     },
     "/ai/insights/history": {
       "get": {
-        "description": "Retorna a lista paginada de insights gerados por IA para o usuário autenticado, ordenada do mais recente para o mais antigo. Acessível sem entitlement premium.",
+        "description": "Retorna a lista paginada de insights gerados por IA para o usuário autenticado, ordenada do mais recente para o mais antigo. Acessível sem entitlement premium. Aceita filtros opcionais por período (period_type/period_label).",
         "parameters": [
           {
             "description": "Número da página (base 1). Padrão: 1.",
@@ -2138,6 +2138,22 @@
             "name": "per_page",
             "required": false,
             "type": "integer"
+          },
+          {
+            "description": "Filtra pelo rótulo do período (ex.: '2026-07' para mensal, '2026-W20' para semanal, '2026-07-15' para diário).",
+            "example": "2026-07",
+            "in": "query",
+            "name": "period_label",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "Filtra por tipo de período: daily, weekly, monthly, recap ou spending_patterns. Valor desconhecido devolve 400.",
+            "example": "monthly",
+            "in": "query",
+            "name": "period_type",
+            "required": false,
+            "type": "string"
           }
         ],
         "responses": {

--- a/schema.graphql
+++ b/schema.graphql
@@ -13,7 +13,7 @@ type Query {
   creditCards: CreditCardListType
   creditCardBill(cardId: UUID!, month: String!): CreditCardBillType
   creditCardUtilization(cardId: UUID!): CreditCardUtilizationType
-  aiInsightHistory(page: Int = 1, perPage: Int = 20): AIInsightHistoryResultType
+  aiInsightHistory(page: Int = 1, perPage: Int = 20, periodType: String, periodLabel: String): AIInsightHistoryResultType
   aiInsightChangeStatus(periodType: String!, anchorDate: String): AIInsightChangeStatusType
   spendingPatternsLatest: SpendingPatternsLatestType
   accounts: AccountListType

--- a/tests/test_ai_insight_history_filters.py
+++ b/tests/test_ai_insight_history_filters.py
@@ -1,0 +1,335 @@
+"""Period filters + REST↔GraphQL parity for the AI insight history (#1653).
+
+`GET /ai/insights/history` and the `aiInsightHistory` query used to carry two
+copies of the same query. Both now read through
+``app.services.ai_insight_history_service``, so these tests assert:
+
+- the new optional filters (`period_type`, `period_label`) on both protocols;
+- an invalid `period_type` fails loudly (400 / GraphQL error) instead of
+  silently returning everything;
+- pagination clamping is identical on both protocols;
+- both protocols return the same rows for the same filters (parity).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime, timezone
+from typing import Any
+
+from app.extensions.database import db
+from app.models.ai_insight import AIInsight, InsightType
+
+_GQL_HISTORY = """
+query AiInsightHistory(
+  $page: Int
+  $perPage: Int
+  $periodType: String
+  $periodLabel: String
+) {
+  aiInsightHistory(
+    page: $page
+    perPage: $perPage
+    periodType: $periodType
+    periodLabel: $periodLabel
+  ) {
+    items {
+      id
+      periodLabel
+      insightType
+    }
+    page
+    perPage
+    total
+  }
+}
+"""
+
+
+def _register_and_login(client, prefix: str = "hist-filter") -> str:
+    suffix = uuid.uuid4().hex[:8]
+    email = f"{prefix}-{suffix}@test.com"
+    reg = client.post(
+        "/auth/register",
+        json={
+            "name": f"{prefix}-{suffix}",
+            "email": email,
+            "password": "StrongPass@123",
+        },
+    )
+    assert reg.status_code == 201
+    login = client.post(
+        "/auth/login", json={"email": email, "password": "StrongPass@123"}
+    )
+    assert login.status_code == 200
+    return login.get_json()["token"]
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}", "X-API-Contract": "v2"}
+
+
+def _graphql(
+    client,
+    variables: dict[str, Any] | None = None,
+    token: str | None = None,
+) -> Any:
+    headers: dict[str, str] = {}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return client.post(
+        "/graphql",
+        json={"query": _GQL_HISTORY, "variables": variables or {}},
+        headers=headers,
+    )
+
+
+def _user_id(app, token: str) -> uuid.UUID:
+    with app.app_context():
+        from flask_jwt_extended import decode_token
+
+        return uuid.UUID(decode_token(token)["sub"])
+
+
+def _seed(
+    app,
+    user_id: uuid.UUID,
+    *,
+    insight_type: InsightType,
+    period_label: str,
+    created_at: datetime,
+) -> None:
+    with app.app_context():
+        db.session.add(
+            AIInsight(
+                user_id=user_id,
+                content=f"conteudo {period_label}",
+                insight_type=insight_type,
+                period_label=period_label,
+                period_start=date(2026, 7, 1),
+                period_end=date(2026, 7, 31),
+                model="gpt-4o-mini",
+                tokens_used=100,
+                cost_usd=0.00001,
+            )
+        )
+        db.session.commit()
+        row = (
+            db.session.query(AIInsight)
+            .filter_by(user_id=user_id, period_label=period_label)
+            .one()
+        )
+        row.created_at = created_at
+        db.session.commit()
+
+
+def _seed_month_mix(app, token: str) -> uuid.UUID:
+    user_id = _user_id(app, token)
+    _seed(
+        app,
+        user_id,
+        insight_type=InsightType.monthly,
+        period_label="2026-07",
+        created_at=datetime(2026, 8, 1, 3, 0, 0, tzinfo=timezone.utc).replace(
+            tzinfo=None
+        ),
+    )
+    _seed(
+        app,
+        user_id,
+        insight_type=InsightType.monthly,
+        period_label="2026-06",
+        created_at=datetime(2026, 7, 1, 3, 0, 0, tzinfo=timezone.utc).replace(
+            tzinfo=None
+        ),
+    )
+    _seed(
+        app,
+        user_id,
+        insight_type=InsightType.daily,
+        period_label="2026-07-15",
+        created_at=datetime(2026, 7, 15, 3, 0, 0, tzinfo=timezone.utc).replace(
+            tzinfo=None
+        ),
+    )
+    return user_id
+
+
+def _rest_items(response) -> list[dict[str, Any]]:
+    payload = response.get_json()
+    return (payload.get("data") or {}).get("items") or []
+
+
+class TestRestHistoryFilters:
+    def test_filters_by_period_type_and_label(self, app, client) -> None:
+        token = _register_and_login(client)
+        _seed_month_mix(app, token)
+
+        response = client.get(
+            "/ai/insights/history?period_type=monthly&period_label=2026-07",
+            headers=_auth(token),
+        )
+
+        assert response.status_code == 200
+        items = _rest_items(response)
+        assert len(items) == 1
+        assert items[0]["period_label"] == "2026-07"
+        assert items[0]["period_type"] == "monthly"
+        assert (response.get_json()["data"])["total"] == 1
+
+    def test_filters_by_period_type_only(self, app, client) -> None:
+        token = _register_and_login(client)
+        _seed_month_mix(app, token)
+
+        response = client.get(
+            "/ai/insights/history?period_type=monthly",
+            headers=_auth(token),
+        )
+
+        assert response.status_code == 200
+        items = _rest_items(response)
+        assert [item["period_label"] for item in items] == ["2026-07", "2026-06"]
+
+    def test_no_filter_keeps_returning_everything(self, app, client) -> None:
+        token = _register_and_login(client)
+        _seed_month_mix(app, token)
+
+        response = client.get("/ai/insights/history", headers=_auth(token))
+
+        assert response.status_code == 200
+        assert len(_rest_items(response)) == 3
+
+    def test_invalid_period_type_returns_400(self, app, client) -> None:
+        token = _register_and_login(client)
+
+        response = client.get(
+            "/ai/insights/history?period_type=quarterly",
+            headers=_auth(token),
+        )
+
+        assert response.status_code == 400
+        body = response.get_json()
+        assert body["error"]["code"] == "VALIDATION_ERROR"
+        assert "period_type" in body["message"]
+
+    def test_unknown_period_label_returns_empty_page(self, app, client) -> None:
+        token = _register_and_login(client)
+        _seed_month_mix(app, token)
+
+        response = client.get(
+            "/ai/insights/history?period_type=monthly&period_label=1999-01",
+            headers=_auth(token),
+        )
+
+        assert response.status_code == 200
+        assert _rest_items(response) == []
+        assert response.get_json()["data"]["total"] == 0
+
+
+class TestGraphqlHistoryFilters:
+    def test_filters_by_period_type_and_label(self, app, client) -> None:
+        token = _register_and_login(client)
+        _seed_month_mix(app, token)
+
+        response = _graphql(
+            client,
+            variables={"periodType": "monthly", "periodLabel": "2026-07"},
+            token=token,
+        )
+
+        body = response.get_json()
+        assert "errors" not in body
+        result = body["data"]["aiInsightHistory"]
+        assert result["total"] == 1
+        assert result["items"][0]["periodLabel"] == "2026-07"
+
+    def test_invalid_period_type_returns_error(self, app, client) -> None:
+        token = _register_and_login(client)
+
+        response = _graphql(client, variables={"periodType": "quarterly"}, token=token)
+
+        body = response.get_json()
+        assert body.get("errors")
+        assert "period_type" in body["errors"][0]["message"]
+        assert body["errors"][0]["extensions"]["code"] == "VALIDATION_ERROR"
+
+    def test_pagination_is_clamped_like_rest(self, app, client) -> None:
+        """Page < 1 used to produce a negative OFFSET on GraphQL only."""
+        token = _register_and_login(client)
+        _seed_month_mix(app, token)
+
+        # Slim selection: the complexity guard rejects a wide query multiplied
+        # by a large perPage before the resolver ever runs.
+        response = client.post(
+            "/graphql",
+            json={
+                "query": (
+                    "query H($page: Int, $perPage: Int) {"
+                    "  aiInsightHistory(page: $page, perPage: $perPage) {"
+                    "    items { id } page perPage total } }"
+                ),
+                "variables": {"page": 0, "perPage": 51},
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        body = response.get_json()
+        assert "errors" not in body
+        result = body["data"]["aiInsightHistory"]
+        assert result["page"] == 1
+        assert result["perPage"] == 50
+        assert result["total"] == 3
+
+
+class TestServiceNormalizers:
+    def test_pagination_falls_back_on_garbage(self) -> None:
+        from app.services.ai_insight_history_service import (
+            DEFAULT_PAGE,
+            DEFAULT_PER_PAGE,
+            MAX_PER_PAGE,
+            normalize_pagination,
+        )
+
+        assert normalize_pagination(None, None) == (DEFAULT_PAGE, DEFAULT_PER_PAGE)
+        assert normalize_pagination("abc", "xyz") == (DEFAULT_PAGE, DEFAULT_PER_PAGE)
+        assert normalize_pagination("-3", "0") == (1, 1)
+        assert normalize_pagination("2", "999") == (2, MAX_PER_PAGE)
+
+    def test_period_type_normalization(self) -> None:
+        import pytest
+
+        from app.services.ai_insight_history_service import (
+            AIInsightHistoryValidationError,
+            normalize_period_label,
+            normalize_period_type,
+        )
+
+        assert normalize_period_type(None) is None
+        assert normalize_period_type("  ") is None
+        assert normalize_period_type(" Monthly ") is InsightType.monthly
+        assert normalize_period_label("  2026-07 ") == "2026-07"
+        assert normalize_period_label("   ") is None
+        with pytest.raises(AIInsightHistoryValidationError):
+            normalize_period_type("quarterly")
+
+
+class TestRestGraphqlParity:
+    def test_same_rows_for_same_filters(self, app, client) -> None:
+        token = _register_and_login(client)
+        _seed_month_mix(app, token)
+
+        rest = client.get(
+            "/ai/insights/history?period_type=monthly",
+            headers=_auth(token),
+        )
+        gql = _graphql(client, variables={"periodType": "monthly"}, token=token)
+
+        rest_body = rest.get_json()["data"]
+        gql_body = gql.get_json()["data"]["aiInsightHistory"]
+
+        assert rest_body["total"] == gql_body["total"]
+        assert rest_body["page"] == gql_body["page"]
+        assert rest_body["per_page"] == gql_body["perPage"]
+        assert [item["id"] for item in rest_body["items"]] == [
+            item["id"] for item in gql_body["items"]
+        ]


### PR DESCRIPTION
## Resumo

`GET /ai/insights/history` não aceitava filtro nenhum — para achar o fechamento de
um mês específico o cliente tinha que paginar às cegas. E a mesma query estava
escrita **duas vezes**: inline no `AIInsightHistoryResource` e de novo no resolver
`aiInsightHistory`. Duas cópias da mesma regra é como a paridade REST/GraphQL se perde
— e este PR é a prova: os dois lados já tinham divergido em paginação sem ninguém notar.

### O que mudou

- **Novo `app/services/ai_insight_history_service.py`** — dono único da query
  (filtro por usuário, ordenação, paginação). REST e GraphQL passam a consumir
  `list_user_insights(...)` e só serializam no formato de cada protocolo.
- **Filtros aditivos e opcionais**: `period_type` (validado contra `InsightType`)
  e `period_label`. Omitir os dois reproduz exatamente o comportamento anterior.
- **`period_type` inválido falha alto**: 400 `VALIDATION_ERROR` no REST e erro
  GraphQL com o mesmo código — em vez de ignorar o filtro e devolver o histórico
  inteiro, que é o pior desfecho possível para quem pediu um mês.
- **Divergência corrigida de brinde**: o REST já limitava `page ≥ 1` e
  `per_page ≤ 50`; o GraphQL não fazia nada disso — `page: 0` virava `OFFSET`
  negativo e `perPage` não tinha teto. A normalização agora vive no service e
  vale para os dois.

`(user_id, insight_type, period_label)` já é coberto por
`ix_ai_insights_user_type_period`, então o filtro novo não custa scan.

## Validação

- 11 testes novos em `tests/test_ai_insight_history_filters.py`: filtros no REST,
  filtros no GraphQL, 400/erro para `period_type` desconhecido, clamp de paginação
  e um **teste de paridade** que compara ids, total e paginação dos dois protocolos
  para o mesmo filtro. Cobertura do service novo: **100%**.
- `scripts/run_ci_quality_local.sh --local`: **2962 passed, 2 skipped**, cobertura
  **91,46%**. Ruff, mypy e bandit verdes.
- Artefatos de contrato regenerados no commit separado (`openapi.json`,
  `schema.graphql`, `graphql.introspection.json`, `graphql.operations.manifest.json`).
  A coleção Postman foi regenerada e **não mudou**.

## Risco residual

Baixo e aditivo: nenhum campo removido ou renomeado, nenhum parâmetro novo é
obrigatório. O único comportamento que muda sem filtro é o clamp de paginação no
GraphQL — `page: 0` antes devolvia erro de OFFSET negativo/página inconsistente e
agora devolve a página 1.

Aceite da issue conferido: `?period_type=monthly&period_label=2026-07` devolve
apenas o fechamento daquele mês (coberto por teste).

Closes #1653
