### PR TITLE
chore(ci): travar o snapshot de contrato e falhar o PR em drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,42 @@ jobs:
       - name: Bandit (SAST - high severity gate)
         run: python -m bandit -r app -lll -iii
 
+  # Contract snapshot lock (#1536). Regenerates openapi.json and the GraphQL
+  # artefacts from source and fails when the committed snapshot is stale.
+  # Deliberately has NO path filter: the dangerous case is a controller/schema
+  # change merged *without* regenerating the snapshot, which openapi-diff.yml
+  # (triggers only on openapi.json) and postman-sync.yml (push to master only)
+  # both miss. Protects the go-live freeze against silent contract drift.
+  contracts:
+    name: Contracts (OpenAPI + GraphQL snapshot)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Check contract snapshots
+        env:
+          FLASK_TESTING: "true"
+          SECURITY_ENFORCE_STRONG_SECRETS: "false"
+          DOCS_EXPOSURE_POLICY: public
+          DATABASE_URL: "sqlite:///tmp/contracts-check.sqlite3"
+          SECRET_KEY: "drift-check-key-with-64-chars-minimum-for-jwt-signing-000001"
+          JWT_SECRET_KEY: "drift-check-jwt-key-with-64-chars-minimum-for-signing-002"
+        run: bash scripts/check_contracts.sh
+
   secret-scan:
     name: Secret Scan (Gitleaks)
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,7 +112,19 @@ bash scripts/run_ci_quality_local.sh --local
 
 This runs in order: check_feature_flags → repo_hygiene → graphql_auth_config →
 alembic_single_head → security_exception_governance → pip_audit → ruff format →
-ruff check → mypy → bandit → pytest (cov ≥ 85%).
+ruff check → mypy → bandit → **contracts snapshot** → pytest (cov ≥ 85%).
+
+**Contract snapshots are locked (#1536).** `openapi.json`, `schema.graphql`,
+`graphql.introspection.json` and `graphql.operations.manifest.json` are
+versionados e conferidos contra o código a cada PR pelo job
+`Contracts (OpenAPI + GraphQL snapshot)`. Mudou controller, schema ou resolver?
+Regenere e commite o snapshot na mesma PR:
+
+```bash
+npm run contracts:check                                   # detecta o drift
+flask openapi-export --output openapi.json                # corrige o REST
+python3 scripts/export_graphql_docs.py --source runtime    # corrige o GraphQL
+```
 
 **Individual checks** (when debugging a specific gate):
 ```bash

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Canonical Postman/Newman E2E runner for Auraxis API",
   "private": true,
   "scripts": {
+    "contracts:check": "bash scripts/check_contracts.sh",
+    "contracts:check:openapi": "bash scripts/check_contracts.sh --openapi",
+    "contracts:check:graphql": "bash scripts/check_contracts.sh --graphql",
     "postman:build": "python3 scripts/openapi_to_postman.py",
     "postman:local": "bash scripts/run_postman_suite.sh",
     "postman:ci": "bash scripts/run_postman_suite.sh api-tests/postman/environments/local.postman_environment.json",

--- a/scripts/check-openapi-drift.sh
+++ b/scripts/check-openapi-drift.sh
@@ -31,9 +31,12 @@ if [[ ! -f "$COMMITTED_SPEC" ]]; then
   exit 1
 fi
 
-# Resolve Python — prefer venv, fallback to system
-PYTHON_BIN="${ROOT_DIR}/.venv/bin/python3"
-if [[ ! -x "$PYTHON_BIN" ]]; then
+# Resolve Python — prefer venv, fallback to system. The venv is also probed by
+# actually running it: when the repo is mounted into a Linux container (the
+# default mode of run_ci_quality_local.sh) the committed macOS .venv binary
+# exists but cannot execute.
+PYTHON_BIN="${CONTRACTS_PYTHON_BIN:-${ROOT_DIR}/.venv/bin/python3}"
+if [[ ! -x "$PYTHON_BIN" ]] || ! "$PYTHON_BIN" -c "" > /dev/null 2>&1; then
   PYTHON_BIN="$(command -v python3 || command -v python)"
 fi
 

--- a/scripts/check_contracts.sh
+++ b/scripts/check_contracts.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# check_contracts.sh — lock the committed API contract snapshots (#1536).
+#
+# Regenerates both public contracts from the Python source and fails when the
+# versioned snapshot is stale:
+#
+#   openapi.json                     ← REST (flask-apispec)
+#   schema.graphql                   ← GraphQL SDL
+#   graphql.introspection.json       ← GraphQL introspection
+#   graphql.operations.manifest.json ← GraphQL operation catalogue
+#
+# Why a dedicated gate: `openapi-diff.yml` only runs when `openapi.json` itself
+# changes, and `postman-sync.yml` only runs on push to master. Neither catches
+# the dangerous case — a controller/schema change merged with a **stale**
+# snapshot, which silently breaks the web codegen. This script runs on every PR.
+#
+# Usage:
+#   bash scripts/check_contracts.sh          # both contracts
+#   bash scripts/check_contracts.sh --openapi
+#   bash scripts/check_contracts.sh --graphql
+#
+# To fix a failure, regenerate and commit:
+#   flask openapi-export --output openapi.json
+#   python3 scripts/export_graphql_docs.py --source runtime
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+CHECK_OPENAPI=1
+CHECK_GRAPHQL=1
+case "${1:-}" in
+  --openapi) CHECK_GRAPHQL=0 ;;
+  --graphql) CHECK_OPENAPI=0 ;;
+  "") ;;
+  *)
+    echo "[contracts] Unknown argument: $1 (use --openapi or --graphql)" >&2
+    exit 2
+    ;;
+esac
+
+# Resolve Python — prefer the repo venv, fallback to system. The venv is probed
+# by running it: inside a Linux container the mounted macOS .venv binary exists
+# but cannot execute.
+PYTHON_BIN="${CONTRACTS_PYTHON_BIN:-${ROOT_DIR}/.venv/bin/python3}"
+if [[ ! -x "$PYTHON_BIN" ]] || ! "$PYTHON_BIN" -c "" > /dev/null 2>&1; then
+  PYTHON_BIN="$(command -v python3 || command -v python)"
+fi
+
+FAILED=0
+
+if [[ "$CHECK_OPENAPI" == "1" ]]; then
+  echo "[contracts] Checking OpenAPI snapshot (openapi.json)..."
+  if bash "${ROOT_DIR}/scripts/check-openapi-drift.sh"; then
+    echo "[contracts] OpenAPI snapshot OK."
+  else
+    FAILED=1
+    echo "::error file=openapi.json::openapi.json está defasado em relação ao código." \
+      "Rode 'flask openapi-export --output openapi.json' e commite o resultado."
+  fi
+fi
+
+if [[ "$CHECK_GRAPHQL" == "1" ]]; then
+  echo "[contracts] Checking GraphQL snapshots (schema.graphql + artefatos)..."
+  if "$PYTHON_BIN" "${ROOT_DIR}/scripts/export_graphql_docs.py" --source runtime --check; then
+    echo "[contracts] GraphQL snapshots OK."
+  else
+    FAILED=1
+    echo "::error file=schema.graphql::Artefatos GraphQL defasados." \
+      "Rode 'python3 scripts/export_graphql_docs.py --source runtime' e commite o resultado."
+  fi
+fi
+
+if [[ "$FAILED" -ne 0 ]]; then
+  echo "[contracts] DRIFT DETECTED — snapshot de contrato desatualizado."
+  exit 1
+fi
+
+echo "[contracts] OK — snapshots de contrato em dia."

--- a/scripts/run_ci_quality_local.sh
+++ b/scripts/run_ci_quality_local.sh
@@ -36,6 +36,7 @@ if [[ "$MODE" == "docker" ]]; then
       python -m ruff check app tests config run.py run_without_db.py && \
       python -m mypy --no-incremental app && \
       python -m bandit -r app -lll -iii && \
+      bash scripts/check_contracts.sh && \
       pytest -m 'not schemathesis' --cov=app --cov-fail-under=85 --cov-report=term-missing"
   echo "[quality-local] All quality checks passed (Docker / Python 3.13)."
   exit 0
@@ -55,5 +56,6 @@ python3 scripts/security_exception_governance.py check
 "${PYTHON_BIN}" -m ruff check app tests config run.py run_without_db.py
 "${PYTHON_BIN}" -m mypy --no-incremental app
 "${PYTHON_BIN}" -m bandit -r app -lll -iii
+CONTRACTS_PYTHON_BIN="${PYTHON_BIN}" bash scripts/check_contracts.sh
 "${PYTHON_BIN}" -m pytest -m "not schemathesis" --cov=app --cov-fail-under=85 --cov-report=term-missing
 echo "[quality-local] All quality checks passed (local environment)."

--- a/tests/scripts/test_contracts_gate.py
+++ b/tests/scripts/test_contracts_gate.py
@@ -1,0 +1,90 @@
+"""Guards for the contract snapshot gate (#1536).
+
+The gate only protects the go-live freeze if it actually runs on every pull
+request. These tests fail if someone removes the job, stops calling the script,
+or narrows the workflow with a ``paths`` filter — which is exactly how the two
+pre-existing contract workflows ended up blind:
+
+- ``openapi-diff.yml`` runs only when ``openapi.json`` itself changes;
+- ``postman-sync.yml`` runs only on push to master.
+
+Neither catches a controller change merged with a stale snapshot.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+CONTRACTS_SCRIPT = REPO_ROOT / "scripts" / "check_contracts.sh"
+
+
+def _load_ci_workflow() -> dict[str, Any]:
+    loaded = yaml.safe_load(CI_WORKFLOW.read_text(encoding="utf-8"))
+    assert isinstance(loaded, dict)
+    return loaded
+
+
+def _triggers(workflow: dict[str, Any]) -> dict[str, Any]:
+    # ``on`` is parsed as the boolean True by the YAML 1.1 loader.
+    triggers = workflow.get("on", workflow.get(True))
+    assert isinstance(triggers, dict), "ci.yml must declare trigger mapping"
+    return triggers
+
+
+def test_contracts_job_exists_and_runs_the_script() -> None:
+    jobs = _load_ci_workflow()["jobs"]
+    assert "contracts" in jobs, "ci.yml lost the contract snapshot gate (#1536)"
+
+    steps = jobs["contracts"]["steps"]
+    commands = " ".join(str(step.get("run", "")) for step in steps)
+    assert "scripts/check_contracts.sh" in commands
+
+
+def test_contracts_gate_runs_on_every_pull_request() -> None:
+    """No ``paths`` filter — a stale snapshot must never slip through."""
+    triggers = _triggers(_load_ci_workflow())
+
+    assert "pull_request" in triggers
+    pull_request = triggers["pull_request"] or {}
+    assert isinstance(pull_request, dict)
+    assert "paths" not in pull_request
+    assert "paths-ignore" not in pull_request
+
+
+def test_contracts_job_has_no_conditional_skip() -> None:
+    contracts_job = _load_ci_workflow()["jobs"]["contracts"]
+    assert "if" not in contracts_job
+    assert "needs" not in contracts_job
+
+
+def test_script_checks_both_snapshots() -> None:
+    assert CONTRACTS_SCRIPT.exists()
+    assert os.access(CONTRACTS_SCRIPT, os.X_OK), "check_contracts.sh must be executable"
+
+    body = CONTRACTS_SCRIPT.read_text(encoding="utf-8")
+    assert "check-openapi-drift.sh" in body
+    assert "export_graphql_docs.py" in body
+
+
+def test_package_json_exposes_contracts_check() -> None:
+    package_json = json.loads((REPO_ROOT / "package.json").read_text(encoding="utf-8"))
+    assert package_json["scripts"]["contracts:check"] == (
+        "bash scripts/check_contracts.sh"
+    )
+
+
+def test_local_ci_mirror_runs_the_gate() -> None:
+    """`run_ci_quality_local.sh` claims to mirror ci.yml — keep it honest."""
+    mirror = (REPO_ROOT / "scripts" / "run_ci_quality_local.sh").read_text(
+        encoding="utf-8"
+    )
+    assert mirror.count("scripts/check_contracts.sh") >= 2, (
+        "both the docker and --local modes must run the contract gate"
+    )


### PR DESCRIPTION
## Resumo

O snapshot de contrato já era versionado (`openapi.json`, `schema.graphql`), mas
**nenhuma PR conferia se ele ainda batia com o código**:

| Gate existente | Quando roda | O que não pega |
|---|---|---|
| `openapi-diff.yml` | PR que altera `openapi.json` | PR que **não** altera o snapshot (o caso perigoso) |
| `postman-sync.yml` | push em `master` | qualquer coisa antes do merge |
| `graphql-breaking-change.yml` | PR que toca `app/graphql/**` | (o GraphQL já estava coberto) |

Ou seja: mudar um controller/schema e esquecer de regenerar o spec passava batido
no CI e só aparecia depois do merge — quebrando o codegen do web em silêncio.
Exatamente o risco que o freeze de go-live (24-30/08) não pode correr.

### O que mudou

- **`scripts/check_contracts.sh`** — regenera os dois contratos a partir do código
  e falha quando o snapshot commitado está defasado (REST via
  `check-openapi-drift.sh`, GraphQL via `export_graphql_docs.py --check`).
  Aceita `--openapi` / `--graphql` para rodar um lado só.
- **Job `Contracts (OpenAPI + GraphQL snapshot)` no `ci.yml`**, deliberadamente
  **sem filtro de `paths`** e sem `needs`/`if` — o gate não pode depender de a PR
  ter tocado o próprio snapshot.
- **`npm run contracts:check`** (+ `:openapi` / `:graphql`) para rodar local.
- **`run_ci_quality_local.sh`** roda o mesmo passo nos dois modos (docker e
  `--local`), mantendo o espelho do CI honesto.
- `check-openapi-drift.sh` agora **testa** o Python do venv antes de usá-lo — no
  modo docker o `.venv` macOS montado existe mas não executa.

## Validação

- Drift simulado (alterei um `summary` de controller sem regenerar o spec):
  o gate imprimiu o diff, o `::error` e **saiu com código 1**. Revertido em
  seguida; sem drift, sai 0.
- 6 testes novos em `tests/scripts/test_contracts_gate.py` blindam o próprio gate:
  job presente, script chamado, **sem `paths`/`paths-ignore`**, sem `if`/`needs`,
  script executável cobrindo os dois contratos, npm script e espelho local.
- `scripts/run_ci_quality_local.sh --local` (já com o passo novo): **2957 passed,
  2 skipped**, cobertura **91,43%**.

## Risco residual

O job adiciona ~1min ao CI (setup Python + `pip install -r requirements.txt` +
geração do spec). PRs que mudarem contrato passam a **exigir** o snapshot
regenerado na mesma PR — o comando está no erro do gate e documentado no
CLAUDE.md.

Closes #1536
