### PR TITLE
fix(billing): devolver ao Asaas o trial, a revogação por estorno e o guard de sandbox

### DIFF
--- a/app/controllers/billing_webhook_parsers.py
+++ b/app/controllers/billing_webhook_parsers.py
@@ -161,6 +161,20 @@ def _build_snapshot(
     return snapshot
 
 
+# Eventos de estorno e chargeback do Asaas. Diferente do outro gateway, estes
+# são documentados e estáveis — não há chute aqui.
+# `PAYMENT_REFUND_IN_PROGRESS` entra junto de propósito: o estorno já foi
+# aceito e o dinheiro está voltando, então manter o acesso até a confirmação
+# seria dar Premium de graça durante a janela de liquidação.
+ASAAS_REFUND_EVENTS = frozenset(
+    {"PAYMENT_REFUNDED", "PAYMENT_REFUND_IN_PROGRESS", "PAYMENT_PARTIALLY_REFUNDED"}
+)
+ASAAS_CHARGEBACK_EVENTS = frozenset(
+    {"PAYMENT_CHARGEBACK_REQUESTED", "PAYMENT_CHARGEBACK_DISPUTE"}
+)
+ASAAS_REVOCATION_EVENTS = ASAAS_REFUND_EVENTS | ASAAS_CHARGEBACK_EVENTS
+
+
 class AsaasWebhookParser:
     """Asaas webhooks, plus the gateway-neutral legacy ``subscription.*`` events.
 
@@ -177,6 +191,11 @@ class AsaasWebhookParser:
         "PAYMENT_CONFIRMED": SubscriptionStatus.ACTIVE.value,
         "PAYMENT_OVERDUE": SubscriptionStatus.PAST_DUE.value,
         "SUBSCRIPTION_DELETED": SubscriptionStatus.CANCELED.value,
+        # #1598 fechou o vazamento de receita por estorno, mas só no parser do
+        # outro gateway — este ficou de fora, então um refund feito no painel
+        # do Asaas deixava o Premium ativo. CANCELED reaproveita a maquinaria
+        # de _DEGRADED_STATUSES, que revoga os entitlements sem fiação nova.
+        **dict.fromkeys(ASAAS_REVOCATION_EVENTS, SubscriptionStatus.CANCELED.value),
     }
     _LEGACY_EVENTS = {
         "subscription.activated": SubscriptionStatus.ACTIVE.value,

--- a/app/services/billing_adapter.py
+++ b/app/services/billing_adapter.py
@@ -7,9 +7,10 @@ hosted checkout flow when explicitly enabled via environment variables.
 
 from __future__ import annotations
 
+import logging
 import os
 from dataclasses import dataclass
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from typing import Protocol, TypedDict, cast, runtime_checkable
 
 import requests
@@ -20,9 +21,28 @@ from app.config.billing_plans import BillingPlanOffer, resolve_checkout_plan_off
 from app.models.subscription import BillingCycle
 from app.services.retry_wrapper import with_retry
 
+logger = logging.getLogger(__name__)
+
 _ASAAS_PROVIDER = "asaas"
 _ABACATEPAY_PROVIDER = "abacatepay"
 _STUB_PROVIDER = "stub"
+_PRODUCTION_ENV_NAMES = {"prod", "production"}
+
+
+def _is_production_runtime() -> bool:
+    """Espelha ``billing_webhook_parsers._is_production_runtime``.
+
+    Duplicado de propósito: o parser vive em ``app/controllers`` e importá-lo
+    daqui inverteria a direção da dependência (services → controllers). São
+    cinco linhas; a alternativa era um módulo compartilhado só para isto.
+    """
+    for var in ("FLASK_ENV", "APP_ENV", "AURAXIS_ENV"):
+        value = str(os.getenv(var) or "").strip().lower()
+        if value:
+            return value in _PRODUCTION_ENV_NAMES
+    return False
+
+
 _DEFAULT_ASAAS_BASE_URL = "https://api-sandbox.asaas.com/v3"
 _DEFAULT_ABACATEPAY_BASE_URL = "https://api.abacatepay.com/v2"
 # Checkouts are bill_…; the subscription only gets a subs_… id once it is paid.
@@ -276,11 +296,44 @@ class AsaasBillingProvider:
             }
         )
 
+    @property
+    def _is_sandbox(self) -> bool:
+        return "sandbox" in self._base_url.lower()
+
+    def _checkout_page_url(self, checkout_id: str) -> str:
+        """Página hospedada correspondente à base configurada.
+
+        Antes isto era ``https://www.asaas.com/c/{id}`` fixo, que manda o
+        comprador para **produção mesmo rodando em sandbox** — um teste que
+        parece passar e leva a um checkout que não existe naquele ambiente.
+        """
+        host = "sandbox.asaas.com" if self._is_sandbox else "www.asaas.com"
+        return f"https://{host}/c/{checkout_id}"
+
     def _ensure_enabled(self) -> None:
         if not self._api_key:
             raise BillingProviderError(
                 "BILLING_ASAAS_API_KEY (or AURAXIS_ASAAS_API_KEY) is required "
                 "when BILLING_PROVIDER=asaas"
+            )
+        # Guard anti-sandbox. `_DEFAULT_ASAAS_BASE_URL` é o sandbox, então
+        # esquecer `BILLING_ASAAS_BASE_URL` em produção faz a API vender para
+        # o ambiente de teste **em silêncio**: o checkout abre, o comprador
+        # "paga", e nada acontece do lado real. Foi assim que se perderam dez
+        # dias no gateway anterior (docs/wiki/PAY-AbacatePay-Setup.md), com o
+        # agravante de que lá havia chave prefixada e guard de devMode no
+        # webhook — aqui não há nenhum dos dois. Falhar alto é a única defesa.
+        if self._is_sandbox and _is_production_runtime():
+            logger.error(
+                "event=billing_sandbox_base_url_in_production provider=%s "
+                "reason=sandbox_base_url_blocked — BILLING_ASAAS_BASE_URL is "
+                "missing or points at sandbox while the app runs in production",
+                _ASAAS_PROVIDER,
+            )
+            raise BillingProviderError(
+                "BILLING_ASAAS_BASE_URL points at the Asaas sandbox while "
+                "APP_ENV is production — refusing to sell against sandbox. "
+                "Set it to https://api.asaas.com/v3"
             )
 
     def _request(
@@ -366,9 +419,21 @@ class AsaasBillingProvider:
                     "value": offer.price_cents / 100,
                 }
             ],
+            # O trial vive AQUI, no request — não num produto cadastrado no
+            # painel, como era no gateway anterior. `nextDueDate` é a data da
+            # primeira cobrança: adiá-la em `trial_days` é o que dá o período
+            # gratuito, com o cartão já tokenizado no checkout.
+            #
+            # Sem isto o trial não existe em lugar nenhum: o cadastro deixou de
+            # concedê-lo no #1569 (register_resource.py:126-131, que o moveu
+            # para o produto do gateway), então `trial_days=7` do catálogo
+            # (billing_plans.py) seria serializado para o cliente e ignorado na
+            # cobrança — o usuário veria "7 dias grátis" e seria debitado na hora.
             "subscription": {
                 "cycle": cycle,
-                "nextDueDate": date.today().isoformat(),
+                "nextDueDate": (
+                    date.today() + timedelta(days=max(offer.trial_days, 0))
+                ).isoformat(),
             },
         }
 
@@ -425,7 +490,7 @@ class AsaasBillingProvider:
         return {
             "checkout_url": (
                 str(payload.get("link") or "").strip()
-                or f"https://www.asaas.com/c/{checkout_id}"
+                or self._checkout_page_url(checkout_id)
             ),
             "provider": _ASAAS_PROVIDER,
             "provider_customer_id": customer_id,

--- a/tests/test_asaas_trial_refund_sandbox.py
+++ b/tests/test_asaas_trial_refund_sandbox.py
@@ -1,0 +1,176 @@
+"""Cobertura dos três buracos que a migração de 19/07 deixou no Asaas (#1673).
+
+Nenhum destes é uma regressão hipotética: os três só apareceriam com dinheiro
+real em produção, e dois deles já custaram caro no gateway anterior.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pytest
+
+from app.controllers.billing_webhook_parsers import (
+    ASAAS_CHARGEBACK_EVENTS,
+    ASAAS_REFUND_EVENTS,
+    AsaasWebhookParser,
+)
+from app.models.subscription import SubscriptionStatus
+from app.services.billing_adapter import (
+    AsaasBillingProvider,
+    BillingCheckoutCustomer,
+    BillingProviderError,
+)
+
+
+def _clear_runtime_env(monkeypatch) -> None:
+    for var in ("FLASK_ENV", "APP_ENV", "AURAXIS_ENV"):
+        monkeypatch.delenv(var, raising=False)
+
+
+class TestAsaasTrial:
+    """O trial vive no request do Asaas — não num produto de painel."""
+
+    @pytest.mark.parametrize(
+        ("slug", "expected_cycle"),
+        [("premium_monthly", "MONTHLY"), ("premium_annual", "YEARLY")],
+    )
+    def test_next_due_date_is_pushed_by_trial_days(
+        self, monkeypatch, slug: str, expected_cycle: str
+    ) -> None:
+        """Sem isto o comprador vê "7 dias grátis" e é debitado na hora.
+
+        O cadastro deixou de conceder trial no #1569 (moveu para o produto do
+        gateway anterior), então o request é o único lugar que resta.
+        """
+        _clear_runtime_env(monkeypatch)
+        provider = AsaasBillingProvider()
+        monkeypatch.setenv("BILLING_ASAAS_API_KEY", "asaas_test_key")
+        monkeypatch.setenv("BILLING_ASAAS_BASE_URL", "https://api.asaas.com/v3")
+        monkeypatch.setenv("BILLING_CHECKOUT_SUCCESS_URL", "https://a.com/ok")
+        monkeypatch.setenv("BILLING_CHECKOUT_CANCEL_URL", "https://a.com/no")
+
+        captured: dict[str, object] = {}
+        responses = iter([{"id": "cus_1"}, {"id": "chk_1", "link": "https://x/c/1"}])
+
+        def _fake_request(method: str, path: str, *, json_payload=None):
+            if path == "/checkouts":
+                captured.update(json_payload or {})
+            return next(responses)
+
+        monkeypatch.setattr(provider, "_request", _fake_request)
+        provider.create_checkout_session(
+            BillingCheckoutCustomer(user_id="u1", name="U", email="u@e.com"), slug
+        )
+
+        subscription = captured["subscription"]
+        assert isinstance(subscription, dict)
+        assert subscription["cycle"] == expected_cycle
+        assert (
+            subscription["nextDueDate"]
+            == (date.today() + timedelta(days=7)).isoformat()
+        ), "as duas ofertas do catálogo têm trial_days=7"
+
+    def test_next_due_date_is_today_when_offer_has_no_trial(self, monkeypatch) -> None:
+        """Trial zero não pode virar data no passado nem adiar cobrança."""
+        _clear_runtime_env(monkeypatch)
+        provider = AsaasBillingProvider()
+        monkeypatch.setenv("BILLING_ASAAS_API_KEY", "k")
+        monkeypatch.setenv("BILLING_CHECKOUT_SUCCESS_URL", "https://a.com/ok")
+        monkeypatch.setenv("BILLING_CHECKOUT_CANCEL_URL", "https://a.com/no")
+
+        from dataclasses import replace
+
+        from app.config.billing_plans import PUBLIC_BILLING_PLANS
+
+        offer = next(o for o in PUBLIC_BILLING_PLANS if o.slug == "premium_monthly")
+        no_trial = replace(offer, trial_days=0)
+
+        payload = provider._checkout_payload(no_trial, "cus_1", "u1")
+        subscription = payload["subscription"]
+        assert isinstance(subscription, dict)
+        assert subscription["nextDueDate"] == date.today().isoformat()
+
+
+class TestAsaasSandboxGuard:
+    """A base URL default é o SANDBOX — esquecê-la em prod vende para teste."""
+
+    def test_production_refuses_sandbox_base_url(self, monkeypatch) -> None:
+        monkeypatch.setenv("APP_ENV", "production")
+        monkeypatch.delenv("FLASK_ENV", raising=False)
+        monkeypatch.setenv("BILLING_ASAAS_API_KEY", "k")
+        monkeypatch.delenv("BILLING_ASAAS_BASE_URL", raising=False)
+
+        provider = AsaasBillingProvider()
+        with pytest.raises(BillingProviderError, match="sandbox"):
+            provider._ensure_enabled()
+
+    def test_production_accepts_production_base_url(self, monkeypatch) -> None:
+        monkeypatch.setenv("APP_ENV", "production")
+        monkeypatch.delenv("FLASK_ENV", raising=False)
+        monkeypatch.setenv("BILLING_ASAAS_API_KEY", "k")
+        monkeypatch.setenv("BILLING_ASAAS_BASE_URL", "https://api.asaas.com/v3")
+
+        AsaasBillingProvider()._ensure_enabled()
+
+    def test_sandbox_base_url_is_fine_outside_production(self, monkeypatch) -> None:
+        _clear_runtime_env(monkeypatch)
+        monkeypatch.setenv("BILLING_ASAAS_API_KEY", "k")
+        monkeypatch.delenv("BILLING_ASAAS_BASE_URL", raising=False)
+
+        AsaasBillingProvider()._ensure_enabled()
+
+    def test_checkout_fallback_url_follows_the_environment(self, monkeypatch) -> None:
+        """O fallback era ``www.asaas.com`` fixo — produção, mesmo em sandbox."""
+        _clear_runtime_env(monkeypatch)
+        monkeypatch.setenv("BILLING_ASAAS_API_KEY", "k")
+
+        monkeypatch.delenv("BILLING_ASAAS_BASE_URL", raising=False)
+        assert (
+            AsaasBillingProvider()._checkout_page_url("chk_1")
+            == "https://sandbox.asaas.com/c/chk_1"
+        )
+
+        monkeypatch.setenv("BILLING_ASAAS_BASE_URL", "https://api.asaas.com/v3")
+        assert (
+            AsaasBillingProvider()._checkout_page_url("chk_1")
+            == "https://www.asaas.com/c/chk_1"
+        )
+
+
+class TestAsaasRevocationEvents:
+    """Estorno no painel deixava o Premium ativo — #1598 só cobriu o outro gateway."""
+
+    @pytest.mark.parametrize(
+        "event", sorted(ASAAS_REFUND_EVENTS | ASAAS_CHARGEBACK_EVENTS)
+    )
+    def test_refund_and_chargeback_revoke_access(self, event: str) -> None:
+        parser = AsaasWebhookParser()
+        assert parser.supports_event(event), f"{event} não é reconhecido"
+
+        snapshot = parser.parse(
+            {
+                "event": event,
+                "payment": {
+                    "subscription": "sub_1",
+                    "customer": "cus_1",
+                    "externalReference": "auraxis:u1:premium_monthly",
+                },
+            }
+        )
+        assert snapshot is not None
+        assert snapshot["status"] == SubscriptionStatus.CANCELED.value
+        assert snapshot["provider"] == "asaas"
+
+    def test_refund_in_progress_revokes_immediately(self) -> None:
+        """Manter acesso durante a liquidação seria Premium de graça."""
+        assert "PAYMENT_REFUND_IN_PROGRESS" in ASAAS_REFUND_EVENTS
+
+    def test_paid_events_still_grant_access(self) -> None:
+        """Guard-rail: a revogação não pode ter contaminado o caminho feliz."""
+        parser = AsaasWebhookParser()
+        snapshot = parser.parse(
+            {"event": "PAYMENT_CONFIRMED", "payment": {"subscription": "sub_1"}}
+        )
+        assert snapshot is not None
+        assert snapshot["status"] == SubscriptionStatus.ACTIVE.value


### PR DESCRIPTION
## Contexto

O AbacatePay informou em 2026-08-03 que **não trabalha mais com cartão de crédito** — medido contra a API de produção: `CARD is not available for this store`, e `PIX Automático is not available for this store`. O gateway volta a ser o **Asaas**.

O código do Asaas nunca foi removido e está verde. Mas a migração de 19/07 levou embora três coisas que **só apareceriam com dinheiro real em produção**.

## 1. O trial tinha sumido de todo lugar

O #1569 moveu os 7 dias para o produto do gateway anterior e **removeu a concessão no cadastro** (`register_resource.py:126-131`). Do lado do Asaas, `_checkout_payload` mandava `nextDueDate: date.today()` e nunca lia `offer.trial_days`.

Com `BILLING_PROVIDER=asaas`, o resultado seria: o comprador vê **"7 dias grátis"** na tela de planos — serializado direto de `billing_plans.py` — e é **debitado na hora**. `TRIALING` viraria estado inalcançável, e `expire-trials` / `trial_ending_reminder` ficariam sem entrada.

Agora `nextDueDate = hoje + offer.trial_days`. No Asaas o trial vive no **request**, não num produto de painel — o que também elimina o passo mais frágil do gateway anterior.

## 2. Estorno deixava o Premium ativo

O #1598 fechou esse vazamento de receita **só no parser do outro gateway**. `PAYMENT_REFUNDED` e `PAYMENT_CHARGEBACK_*` nunca foram reconhecidos aqui.

`PAYMENT_REFUND_IN_PROGRESS` entra junto de propósito: o estorno já foi aceito e o dinheiro está voltando; esperar a confirmação seria dar Premium de graça durante a liquidação.

Diferente do gateway anterior, estes nomes são **documentados e estáveis** — não há chute.

## 3. A armadilha de sandbox era pior que a do AbacatePay

```python
_DEFAULT_ASAAS_BASE_URL = "https://api-sandbox.asaas.com/v3"
```

Esquecer `BILLING_ASAAS_BASE_URL` em produção faria a API **vender para o sandbox em silêncio** — o modo de falha que passou **dez dias** despercebido com o AbacatePay. Só que lá havia chave prefixada `abc_dev_` **e** guard de `devMode` no webhook. Aqui não havia **nada**.

Agora falha alto, com marcador de log estável (`event=billing_sandbox_base_url_in_production`).

O fallback de URL do checkout também apontava para `www.asaas.com` fixo — mandando quem testa em sandbox para uma página de produção que não existe naquele ambiente. Agora deriva da base configurada.

## Validação

```
14 testes novos (tests/test_asaas_trial_refund_sandbox.py)
165 na suíte de billing — 0 falhas
ruff check / ruff format / mypy / bandit — limpos
pre-commit: 16 gates, todos Passed
```

Os testes cobrem os dois ciclos (MONTHLY/YEARLY), trial zero (não pode virar data no passado), os 3 estados do guard de sandbox, o fallback de URL por ambiente, os 5 eventos de revogação, e um guard-rail de que o caminho feliz não foi contaminado.

## Fora de escopo

A **remoção do AbacatePay** vai em PR separada: ela tem restrição de ordem de deploy. A factory cai em `StubBillingProvider()` **silenciosamente** para provider desconhecido (`billing_adapter.py:631`), então remover o provider com prod ainda em `BILLING_PROVIDER=abacatepay` transformaria produção num stub sem avisar.

Closes #1673