### PR TITLE
chore(deps): subir cryptography para 50.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -54,4 +54,4 @@ boto3==1.43.61
 pywebpush==2.3.0
 py-vapid==1.9.4
 http-ece==1.2.1
-cryptography==48.0.1
+cryptography==50.0.0


### PR DESCRIPTION
## Sintoma

`git push` falhava para **qualquer branch** do repo, no hook `pip-audit`:

```
Found 3 known vulnerabilities in 1 package
cryptography 48.0.1  CVE-2026-69248  → 49.0.0
cryptography 48.0.1  CVE-2026-69247  → 50.0.0
cryptography 48.0.1  CVE-2026-69249  → 49.0.0
```

O CI roda o mesmo gate, então nenhuma PR mergearia. Não é regressão de ninguém: `requirements.txt:57` tem `cryptography==48.0.1` na `master`, e os advisories passaram a valer sobre ela.

## Por que 50.0.0 e não 49.0.0

Dois dos três são corrigidos em 49.0.0, mas o **CVE-2026-69247 só em 50.0.0**. O piso tem de cobrir os três.

## Por que não exceção de segurança

O `security-exception-governance` existe para advisory **sem correção publicada**. Aqui a versão corrigida está no PyPI — registrar exceção esconderia algo a um bump de distância.

## Alcance e validação

`cryptography` é requerida por `pywebpush`, `py-vapid` e `http_ece` — o caminho de **push notification**, além do uso em auth/JWT.

```
pip-audit --strict -r requirements.txt  →  No known vulnerabilities found
pytest -k "auth or jwt or token or push or password"  →  415 testes verdes
imports de cryptography, pywebpush, py_vapid, http_ece  →  OK
```

Descoberto ao tentar publicar #1677 (contrato do checkout Asaas), que estava bloqueada por isto.

Closes #1678