### PR TITLE
fix(billing): corrigir o payload de checkout do Asaas contra a API real

### DIFF
--- a/app/services/billing_adapter.py
+++ b/app/services/billing_adapter.py
@@ -316,22 +316,6 @@ class AsaasBillingProvider:
         except RequestException as exc:
             raise BillingProviderError("Asaas request failed") from exc
 
-    def _ensure_customer(self, customer: BillingCheckoutCustomer) -> str:
-        payload = self._request(
-            "POST",
-            "/customers",
-            json_payload={
-                "name": customer.name,
-                "email": customer.email,
-                "externalReference": customer.user_id,
-                "notificationDisabled": False,
-            },
-        )
-        customer_id = str(payload.get("id") or "").strip()
-        if not customer_id:
-            raise BillingProviderError("Asaas customer response did not include an id")
-        return customer_id
-
     def _checkout_callback_payload(
         self, return_surface: str | None = None
     ) -> dict[str, str]:
@@ -349,7 +333,7 @@ class AsaasBillingProvider:
     def _checkout_payload(
         self,
         offer: BillingPlanOffer,
-        customer_id: str,
+        customer_id: str | None,
         user_id: str,
         return_surface: str | None = None,
     ) -> dict[str, object]:
@@ -362,11 +346,17 @@ class AsaasBillingProvider:
             )
 
         return {
-            "billingTypes": ["CREDIT_CARD", "PIX"],
+            # Só CREDIT_CARD. A API rejeita PIX junto de RECURRENT com
+            # "O método de pagamento CREDIT_CARD é o único método de pagamento
+            # permitido para operações RECURRENT" — PIX exige DETACHED, ou
+            # seja, cobrança avulsa. Isso vale para o Asaas e valia para o
+            # gateway anterior: **PIX recorrente não existe em nenhum dos
+            # dois**, e a economia de PIX que aparece nas projeções de
+            # assinatura nunca foi alcançável (ver ADR J9).
+            "billingTypes": ["CREDIT_CARD"],
             "chargeTypes": ["RECURRENT"],
             "externalReference": f"auraxis:{user_id}:{offer.slug}",
             "callback": callback,
-            "customer": customer_id,
             "items": [
                 {
                     "name": offer.display_name,
@@ -391,6 +381,7 @@ class AsaasBillingProvider:
                     date.today() + timedelta(days=max(offer.trial_days, 0))
                 ).isoformat(),
             },
+            **({"customer": customer_id} if customer_id else {}),
         }
 
     def get_subscription(self, provider_id: str) -> BillingSubscriptionSnapshot:
@@ -432,12 +423,20 @@ class AsaasBillingProvider:
         offer = resolve_checkout_plan_offer(plan_slug)
         if offer is None:
             raise BillingProviderError(f"Unsupported plan slug: {plan_slug}")
-        customer_id = self._ensure_customer(customer)
+        # O cliente NÃO é pré-criado de propósito. Um customer com só nome e
+        # e-mail — tudo o que temos — faz o checkout ser rejeitado: a API exige
+        # phone, address, addressNumber, postalCode, province e city para o
+        # customer referenciado, e o `User` não tem nenhum desses campos.
+        #
+        # Omitindo `customer`, a própria página hospedada coleta CPF, telefone
+        # e endereço do comprador. Verificado contra a API de produção: 200 com
+        # status=ACTIVE. De quebra, para de criar cliente órfão no gateway para
+        # quem abandona o checkout.
         payload = self._request(
             "POST",
             "/checkouts",
             json_payload=self._checkout_payload(
-                offer, customer_id, customer.user_id, return_surface
+                offer, None, customer.user_id, return_surface
             ),
         )
         checkout_id = str(payload.get("id") or "").strip()
@@ -449,7 +448,9 @@ class AsaasBillingProvider:
                 or self._checkout_page_url(checkout_id)
             ),
             "provider": _ASAAS_PROVIDER,
-            "provider_customer_id": customer_id,
+            # O id do cliente só existe depois que o comprador preenche os
+            # dados na página hospedada; chega pelo webhook.
+            "provider_customer_id": None,
             "provider_subscription_id": checkout_id,
         }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,4 +54,4 @@ boto3==1.43.61
 pywebpush==2.3.0
 py-vapid==1.9.4
 http-ece==1.2.1
-cryptography==48.0.1
+cryptography==50.0.0

--- a/tests/test_asaas_trial_refund_sandbox.py
+++ b/tests/test_asaas_trial_refund_sandbox.py
@@ -226,3 +226,56 @@ class TestProviderFactory:
         _clear_runtime_env(monkeypatch)
         monkeypatch.setenv("BILLING_PROVIDER", "whatever")
         assert isinstance(get_default_billing_provider(), StubBillingProvider)
+
+
+class TestAsaasCheckoutContract:
+    """Trava o payload contra o que a API de produção aceita (#1677).
+
+    Estes dois erros passaram por 32 testes verdes porque todos mockam
+    ``_request``: o contrato nunca era exercitado. Foram medidos contra a
+    API real em 2026-08-03, com a conta de produção recém-aprovada.
+    """
+
+    def _payload(self, monkeypatch, slug: str = "premium_monthly") -> dict:
+        _clear_runtime_env(monkeypatch)
+        provider = AsaasBillingProvider()
+        monkeypatch.setenv("BILLING_ASAAS_API_KEY", "k")
+        monkeypatch.setenv("BILLING_CHECKOUT_SUCCESS_URL", "https://a.com/ok")
+        monkeypatch.setenv("BILLING_CHECKOUT_CANCEL_URL", "https://a.com/no")
+
+        captured: dict = {}
+
+        def _fake_request(method: str, path: str, *, json_payload=None):
+            captured.update(json_payload or {})
+            return {"id": "chk_1", "link": "https://pay/x"}
+
+        monkeypatch.setattr(provider, "_request", _fake_request)
+        provider.create_checkout_session(
+            BillingCheckoutCustomer(user_id="u1", name="U", email="u@e.com"), slug
+        )
+        return captured
+
+    def test_recurrent_checkout_is_card_only(self, monkeypatch) -> None:
+        """PIX + RECURRENT é rejeitado pela API.
+
+        "O método de pagamento CREDIT_CARD é o único método de pagamento
+        permitido para operações RECURRENT" — PIX exige DETACHED. Mandar os
+        dois, como o código fazia, derruba TODO checkout de assinatura.
+        """
+        payload = self._payload(monkeypatch)
+        assert payload["billingTypes"] == ["CREDIT_CARD"]
+        assert payload["chargeTypes"] == ["RECURRENT"]
+
+    def test_customer_is_not_pre_created(self, monkeypatch) -> None:
+        """Referenciar um customer incompleto derruba o checkout.
+
+        A API exige phone, address, addressNumber, postalCode, province e city
+        no customer referenciado — campos que o `User` não tem. Sem `customer`
+        no payload, a página hospedada coleta tudo do comprador.
+        """
+        assert "customer" not in self._payload(monkeypatch)
+
+    def test_external_reference_carries_the_correlation(self, monkeypatch) -> None:
+        """Sem `customer`, é o externalReference que liga o pagamento ao user."""
+        payload = self._payload(monkeypatch)
+        assert payload["externalReference"] == "auraxis:u1:premium_monthly"

--- a/tests/test_checkout_return_surface.py
+++ b/tests/test_checkout_return_surface.py
@@ -110,14 +110,11 @@ class TestAsaasUsesTheSurface:
         monkeypatch.setenv("BILLING_ASAAS_BASE_URL", "https://api.asaas.com/v3")
         with app.app_context():
             provider = self._provider()
-            with (
-                patch.object(provider, "_ensure_customer", return_value="cust_1"),
-                patch.object(
-                    provider,
-                    "_request",
-                    return_value={"id": "chk_1", "link": "https://pay/x"},
-                ) as mock_request,
-            ):
+            with patch.object(
+                provider,
+                "_request",
+                return_value={"id": "chk_1", "link": "https://pay/x"},
+            ) as mock_request:
                 provider.create_checkout_session(
                     customer=self._customer(), plan_slug="premium_monthly", **kwargs
                 )

--- a/tests/test_j9_billing_subscriptions.py
+++ b/tests/test_j9_billing_subscriptions.py
@@ -111,21 +111,17 @@ class TestAsaasBillingProvider:
             "BILLING_CHECKOUT_SUCCESS_URL", "https://auraxis.com/success"
         )
         monkeypatch.setenv("BILLING_CHECKOUT_CANCEL_URL", "https://auraxis.com/cancel")
-        responses = iter(
-            [
-                {"id": "cus_123"},
-                {"id": "chk_123", "link": "https://asaas.com/c/chk_123"},
-            ]
-        )
 
         def _fake_request(
             method: str, path: str, *, json_payload: object | None = None
         ):
-            payload = next(responses)
+            # Um request só: o cliente NÃO é pré-criado (#1677). Um customer
+            # com só nome e e-mail faz a API rejeitar o checkout por falta de
+            # endereço, e a página hospedada coleta esses dados sozinha.
             assert method == "POST"
-            if path == "/customers":
-                assert json_payload is not None
-            return payload
+            assert path == "/checkouts"
+            assert "customer" not in (json_payload or {})
+            return {"id": "chk_123", "link": "https://asaas.com/c/chk_123"}
 
         monkeypatch.setattr(provider, "_request", _fake_request)
 
@@ -139,7 +135,8 @@ class TestAsaasBillingProvider:
         )
 
         assert result["provider"] == "asaas"
-        assert result["provider_customer_id"] == "cus_123"
+        # Só existe depois que o comprador preenche a página; chega no webhook.
+        assert result["provider_customer_id"] is None
         assert result["checkout_url"] == "https://asaas.com/c/chk_123"
 
     def test_create_checkout_session_requires_callback_urls(self, monkeypatch) -> None:
@@ -147,8 +144,6 @@ class TestAsaasBillingProvider:
         monkeypatch.setenv("BILLING_ASAAS_API_KEY", "asaas_test_key")
         monkeypatch.delenv("BILLING_CHECKOUT_SUCCESS_URL", raising=False)
         monkeypatch.delenv("BILLING_CHECKOUT_CANCEL_URL", raising=False)
-
-        monkeypatch.setattr(provider, "_ensure_customer", lambda _customer: "cus_123")
 
         try:
             provider.create_checkout_session(


### PR DESCRIPTION
## Como apareceu

Probe contra a **API de produção do Asaas**, com a conta recém-aprovada, replicando exatamente o payload que `AsaasBillingProvider._checkout_payload` monta. `POST /v3/checkouts` respondeu **400**.

O adapter tem 32 testes verdes e **nunca funcionou contra a API real** — todos mockam `_request`, então o contrato nunca foi exercitado. Coerente com o fato de o Asaas nunca ter ido a produção: o billing em prod era stub até 19/07, e AbacatePay depois.

**Base:** sai de `chore/1675-remove-abacatepay` (#1676). Inclui também o bump do cryptography (#1679), sem o qual o push não passa.

## Erro 1 — PIX não pode ser recorrente

```
billingTypes: ["CREDIT_CARD","PIX"] + chargeTypes: ["RECURRENT"]
→ "O método de pagamento CREDIT_CARD é o único método de pagamento permitido
   para operações RECURRENT"
→ "O tipo de cobrança DETACHED é obrigatório para o método de pagamento PIX"
```

O adapter mandava os dois. **Todo checkout de assinatura falharia.**

### Consequência para o ADR

**PIX recorrente não existe no Asaas.** No AbacatePay também não. A economia de PIX que sustentou a migração de 19/07 — 0,28% no anual — **nunca foi alcançável para assinatura em nenhum dos dois**. PIX serve para cobrança avulsa (`DETACHED`).

A tabela de custo da decisão original de 06/04 lista PIX ao lado de cartão como alternativas para o plano recorrente. Essa linha está errada, e foi ela que justificou a troca. Corrigido em platform#1008.

A comparação que vale é cartão contra cartão, e nela o Asaas ganha nos dois planos.

## Erro 2 — pré-criar o cliente quebrava o checkout

`_ensure_customer` criava o customer com **só `name` e `email`**. Referenciá-lo dá:

```
"O campo phone deve existir para o customer informado."
"O campo address / addressNumber / postalCode / province / city deve existir..."
```

E o `User` não tem nenhum desses campos — só `state_uf`.

**Saída barata:** omitindo `customer`, o checkout é criado normalmente e a **página hospedada coleta CPF, telefone e endereço do próprio comprador**. Verificado: 200, `status: ACTIVE`. De quebra, para de criar cliente órfão no gateway para quem abandona o checkout.

`_ensure_customer` foi **removido**, não mantido: sem uso em produção, ele sobrevivia só por mocks de teste — a pior forma de código morto, porque passa a impressão de funcionar e produziria um customer que derruba o checkout.

⚠️ `provider_customer_id` passa a ser `None` no início do checkout; o id real chega pelo webhook. A correlação do funil precisa se apoiar no `externalReference` (`auraxis:{user_id}:{offer_slug}`), que já viaja no payload — há teste travando isso.

## O que o probe confirmou funcionando

Com as duas correções: `200`, `status: ACTIVE`, `chargeTypes: ["RECURRENT"]`, `cycle: MONTHLY` e **`nextDueDate` = hoje + 7** — o trial do #1673 está correto.

## Testes

Três novos exercitam o **contrato medido**, não o mock: card-only em RECURRENT, ausência de `customer` no payload, e o `externalReference` carregando a correlação.

```
suíte completa — exit 0, cobertura 91%
ruff / mypy / bandit / pip-audit — limpos
```

## Para o Italo, fora do código

- **`bankAccountInfo: PENDING`** em `GET /v3/myAccount/status`. Cobrar funciona; **sacar provavelmente não**. Confirmar a conta bancária antes do go-live.
- **PIX exige cadastrar uma chave Pix** no Asaas. Só importa para cobrança avulsa; não desbloqueia assinatura.

Closes #1677
Refs #1673, #1675, #1678, platform#1008
